### PR TITLE
Add manifest and script to deploy to PaaS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,12 @@ env:
   - secure: kyCYOisfZhZUYgg7XqOydUObKgxxwZkc5JCA+lzgrCY8d71hyX8uSh2jEnSE4A7Tq+4BR6oFg2C9kKSyq6G3wkKkRQKroWvQD5ylNWn2vdhyCRcUKqOu4VStNq6th/1FVZHlSf5MumLtULVsWgvkDt7pwEHAJawKISMpVnM5RGO3VHlF40UfVfM9GQN5T/yEXm0FbdZ8k0wFQ0VHE0vskW8BgWi/U13GyqQB9pl/fr3I6Fbhk0u++UksSrEZhwfz/oXezcJ4wuSwYtBnLFHFIJiZas5Cwy1uJTvsP6bzYl4llDvhWwCojJtlumBIq0EYti66CQRytUQU0wbNyzhdFe33cWwodPOs2nrb44QYWhEbXLDqaZ2tVDaIMFugKWuWru+jwbIQfng6irIS7vbewpW83l7tg5BfSS4Br4KKS+/xNQpbJ6lm5PUuE7pgnGPFLI8/SEcwkhjNv9A0NEr3pmVI+LNUkdDcrz1t62x35GNkJ4B0OoOXjNmEEshI7oWKvGKFhQZoYdgTRYp9aFkeShgu+JLbhSoaJLDsxkHAmfyRLbxyy4miLDx7XqiAcWOz9qSZYxG5BrAmwf4xMihNuVQFjGe5VY/GYQXBgXPfP1GeD6JaaYRLf7WXbL53hzWS/xQqinbeL+EcXX9rLCTUnVLr5xzK3IvEygy+uoHIIKE=
 
 before_deploy:
-- travis_retry cf install-plugin autopilot -f -r CF-Community
+  - export PATH=$HOME:$PATH
+  # Install CloudFoundry
+  - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&source=github"
+  - tar xzvf $HOME/cf.tgz -C $HOME
+  # Install Autopilot for zero-downtime-deploy plugin
+  - travis_retry cf install-plugin autopilot -f -r CF-Community
 
 deploy:
   script: "./bin/deploy-travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,18 @@
 language: ruby
 script: bundle exec middleman build
+
+env:
+  global:
+  - CF_API="https://api.cloud.service.gov.uk"
+  - CF_ORG="govuk-design-system"
+  - CF_SPACE="production"
+  - CF_USERNAME="govuk-design-system-deploy-production@digital.cabinet-office.gov.uk"
+  # CF_PASSWORD
+  - secure: kyCYOisfZhZUYgg7XqOydUObKgxxwZkc5JCA+lzgrCY8d71hyX8uSh2jEnSE4A7Tq+4BR6oFg2C9kKSyq6G3wkKkRQKroWvQD5ylNWn2vdhyCRcUKqOu4VStNq6th/1FVZHlSf5MumLtULVsWgvkDt7pwEHAJawKISMpVnM5RGO3VHlF40UfVfM9GQN5T/yEXm0FbdZ8k0wFQ0VHE0vskW8BgWi/U13GyqQB9pl/fr3I6Fbhk0u++UksSrEZhwfz/oXezcJ4wuSwYtBnLFHFIJiZas5Cwy1uJTvsP6bzYl4llDvhWwCojJtlumBIq0EYti66CQRytUQU0wbNyzhdFe33cWwodPOs2nrb44QYWhEbXLDqaZ2tVDaIMFugKWuWru+jwbIQfng6irIS7vbewpW83l7tg5BfSS4Br4KKS+/xNQpbJ6lm5PUuE7pgnGPFLI8/SEcwkhjNv9A0NEr3pmVI+LNUkdDcrz1t62x35GNkJ4B0OoOXjNmEEshI7oWKvGKFhQZoYdgTRYp9aFkeShgu+JLbhSoaJLDsxkHAmfyRLbxyy4miLDx7XqiAcWOz9qSZYxG5BrAmwf4xMihNuVQFjGe5VY/GYQXBgXPfP1GeD6JaaYRLf7WXbL53hzWS/xQqinbeL+EcXX9rLCTUnVLr5xzK3IvEygy+uoHIIKE=
+
+before_deploy:
+- travis_retry cf install-plugin autopilot -f -r CF-Community
+
+deploy:
+  script: "./bin/deploy-travis"
+  skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ before_deploy:
 deploy:
   script: "./bin/deploy-travis"
   skip_cleanup: true
+  on:
+    branch: auto-deploy-to-paas

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ before_deploy:
   - travis_retry cf install-plugin autopilot -f -r CF-Community
 
 deploy:
-  script: "./bin/deploy-travis"
+  provider: script
+  script: ./bin/deploy-travis
   skip_cleanup: true
   on:
     branch: auto-deploy-to-paas

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ deploy:
   script: ./bin/deploy-travis
   skip_cleanup: true
   on:
-    branch: auto-deploy-to-paas
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_deploy:
   # Install CloudFoundry
   - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&source=github"
   - tar xzvf $HOME/cf.tgz -C $HOME
-  # Install Autopilot for zero-downtime-deploy plugin
+  # Install Autopilot plugin for zero-downtime-push
   - travis_retry cf install-plugin autopilot -f -r CF-Community
 
 deploy:

--- a/bin/deploy-travis
+++ b/bin/deploy-travis
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+# Parse app name from manifest to ensure it matches up
+APP_NAME=$(ruby -e "require 'yaml'; config = YAML.load_file('manifest.yaml'); puts config['applications'][0]['name']")
+
+echo "Deploying ${APP_NAME} to ${CF_ORG}/${CF_SPACE}..."
+
+# CF_USERNAME and CF_PASSWORD are provided as encrypted Travis variables
+cf login --a $CF_API --u $CF_USERNAME --p $CF_PASSWORD --o $CF_ORG -s $CF_SPACE
+
+# Zero downtime push comes from "Autopilot" which is installed in before_deploy
+# step in Travis
+cf zero-downtime-push $APP_NAME -f manifest.yml

--- a/bin/deploy-travis
+++ b/bin/deploy-travis
@@ -7,7 +7,7 @@ APP_NAME=$(ruby -e "require 'yaml'; config = YAML.load_file('manifest.yml'); put
 echo "Deploying ${APP_NAME} to ${CF_ORG}/${CF_SPACE}..."
 
 # CF_USERNAME and CF_PASSWORD are provided as encrypted Travis variables
-cf login --a $CF_API --u $CF_USERNAME --p $CF_PASSWORD --o $CF_ORG -s $CF_SPACE
+cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
 
 # Zero downtime push comes from "Autopilot" which is installed in before_deploy
 # step in Travis

--- a/bin/deploy-travis
+++ b/bin/deploy-travis
@@ -2,7 +2,7 @@
 set -e
 
 # Parse app name from manifest to ensure it matches up
-APP_NAME=$(ruby -e "require 'yaml'; config = YAML.load_file('manifest.yaml'); puts config['applications'][0]['name']")
+APP_NAME=$(ruby -e "require 'yaml'; config = YAML.load_file('manifest.yml'); puts config['applications'][0]['name']")
 
 echo "Deploying ${APP_NAME} to ${CF_ORG}/${CF_SPACE}..."
 

--- a/bin/deploy-travis
+++ b/bin/deploy-travis
@@ -6,7 +6,7 @@ APP_NAME=$(ruby -e "require 'yaml'; config = YAML.load_file('manifest.yml'); put
 
 echo "Deploying ${APP_NAME} to ${CF_ORG}/${CF_SPACE}..."
 
-# CF_USERNAME and CF_PASSWORD are provided as encrypted Travis variables
+# $CF env variables are set by Travis and configured in ../.travis.yml
 cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
 
 # Zero downtime push comes from "Autopilot" which is installed in before_deploy

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+---
+applications:
+- name: govuk-design-system-production
+  memory: 64M
+  path: ./build
+  buildpack: staticfile_buildpack


### PR DESCRIPTION
This sets Travis up to automatically deploy to the [PaaS](https://docs.cloud.service.gov.uk) (a CloudFoundry installation) whenever master changes.

By default when deploying to PaaS there is a [brief period of downtime](https://docs.cloud.service.gov.uk/#404s-after-commands-that-restart-the-app) when the old container is destroyed but the new one is not serving yet. We're using a plugin called [Autopilot](https://github.com/contraband/autopilot) to work around this by renaming apps and altering routes to provide a zero downtime deploy.

This means that we cannot use the 'built in' CloudFoundry Travis provider, and instead we need to use our own script. The config for this (api, org, space, username, password) is set using environment variables and the password is encrypted.