### PR TITLE
Prevent robots indexing the design system

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="robots" content="noindex, nofollow">
     <title>GOV.UK Design System</title>
   </head>
   <body>


### PR DESCRIPTION
Until this goes into public beta we don’t want it to appear in Google’s search results