### PR TITLE
Update copyright in license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Government Digital Service
+Copyright (c) 2017 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The Copyright is Crown Copyright; "Government Digital Service" should go in brackets – as per https://github.com/alphagov/styleguides/blob/master/licensing.md