### PR TITLE
Enable Design System to use govuk-frontend private packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 deploy/public
 /node_modules
 package-lock.json
+.npmrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 deploy/public
 /node_modules
-package-lock.json
 .npmrc
+.sass-cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 deploy/public
+/node_modules
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 script:
   - bundle exec rspec
   - bundle exec middleman build
-cache: bundler
 
 env:
   global:
@@ -14,16 +13,22 @@ env:
   - secure: UYvRRq3/WSAF5udIroJRoN0i4ha04K9tWf5ozXAidP9oF1o3kAdz7dMlb/UWE10KCki8WwYSKufsJknSC7yygg6BgkajpUFWZc36XWUgyIlXEti3kxjq8GhHUtVQpdH/Mp702DgzJCgA4Bwj9TlfkyP+PIYW4PfljRllJtPzqgxSur++23Q+kMmvA8T/GOEyab72ZjEMQmonl0Vxf6UWx/y7/4+XLj34OTzoYQ18utWfH9o9i1KUA8dYFCT3oCauGXF8Ra6iOPmNhBjvKrT9+foyYvfbwtL+o+tcbyBQM+p2toWUC2E5e+gIyed+woNnUMFGjGzkwzRe5evhH7RbssGMnkAHn19EGht+Ycdo5Wqh06kmb6sGVFa5EfvuX8AUHaOJrjBjS4ojHA9rmrkCrLvXpKECJi/NK2if5mk39ULtmtUzBBAjgPY3ZY34wweKrRgKz1Q2+Z59nJuX4/UM/KP3lrG0IWKIqdcrnoRaXsWADmf512zFw699+3rre6Bv7h08cyJZWAPWFhZiFibFOQXpT7uVeGyF2VcNrDjVzOiUFOWb7+5IRLi3Volp9o5OHuH1aOw3vNb2KqbIvJAFcQJF4l7c8Jopp6obeyBtXsupAVOTKZQnc9rokwDvyLbCNfseXXWNPekRD9+Ey8asSM+NauWLASFIWxNrRj6M5m0=
   # NPM_TOKEN
   - secure: UjlOHWUc2dM0IQMngQKjsuBGCg+CvnRLS+VOGf8EcKY2RUZupmFea/PVGmTAlCmP8tsK80BNTdkKP7tfQD1fYNwv9Ppbbp8c8Ukcm2z3Xaa4CYIiCGj4VZO5/VEQycklMFkiw4lwCAaGulesKAu5UHEdGGXtr9HyZmgvSgEY+DEWjvHe112jZGF7+pkZ3v/WgtBtcmEAwumA97yqq5YlAiGgyktFf0oq/dtompMgA6MtTH93ZyGK0mCqrn1zzknVnlf7UYYnsIuYJ9D//+GVU7ASDD6wSb/QaF8Wy3rzFQgSbh2Mm0lFMFFqrCejBT7TXXanEFObvOd65sn2rwNvYe6XRFPqyKsSiQGBF/K9HIXqXCR19+inqN4Ip27gPlf0Y64Lw4IL69Xbak0SkhVEYyzKMAmEdZnPwLiTuF8Vex7pzxMABwHfR4Xt9BHSY0A8LMB5539UCwEsN62RB2mckuHEPbilyCo/7A42yy45YfnSadxC0h8BV1ylwWWnyCkwjGYC7GXsSEFuWzjp6Kp+NkkU9NvD3BgXJn2sgK312wgltzdNo3gZUFuedBviqnSSlVxluS9F3B23st51jdZWfreHpoFpfwiVuHF1IS//0y8yB6sfBrAj4c10Qhrrks/VWohBEI3cDhRfMMEITTb7bb9/8SkeVp4RFNKj0i+XZmE=
+
 before_install:
-- npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+  - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+
 install:
-- bundle install --jobs=3 --retry=3
-- npm install
+  - bundle install --jobs=3 --retry=3
+  - npm install
+
 before_deploy:
-- export PATH=$HOME:$PATH
-- travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&source=github"
-- tar xzvf $HOME/cf.tgz -C $HOME
-- travis_retry cf install-plugin autopilot -f -r CF-Community
+  - export PATH=$HOME:$PATH
+  # Install CloudFoundry
+  - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&source=github"
+  - tar xzvf $HOME/cf.tgz -C $HOME
+  # Install Autopilot plugin for zero-downtime-push
+  - travis_retry cf install-plugin autopilot -f -r CF-Community
+
 deploy:
   provider: script
   script: "./bin/deploy-travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ env:
   # CF_PASSWORD
   - secure: UYvRRq3/WSAF5udIroJRoN0i4ha04K9tWf5ozXAidP9oF1o3kAdz7dMlb/UWE10KCki8WwYSKufsJknSC7yygg6BgkajpUFWZc36XWUgyIlXEti3kxjq8GhHUtVQpdH/Mp702DgzJCgA4Bwj9TlfkyP+PIYW4PfljRllJtPzqgxSur++23Q+kMmvA8T/GOEyab72ZjEMQmonl0Vxf6UWx/y7/4+XLj34OTzoYQ18utWfH9o9i1KUA8dYFCT3oCauGXF8Ra6iOPmNhBjvKrT9+foyYvfbwtL+o+tcbyBQM+p2toWUC2E5e+gIyed+woNnUMFGjGzkwzRe5evhH7RbssGMnkAHn19EGht+Ycdo5Wqh06kmb6sGVFa5EfvuX8AUHaOJrjBjS4ojHA9rmrkCrLvXpKECJi/NK2if5mk39ULtmtUzBBAjgPY3ZY34wweKrRgKz1Q2+Z59nJuX4/UM/KP3lrG0IWKIqdcrnoRaXsWADmf512zFw699+3rre6Bv7h08cyJZWAPWFhZiFibFOQXpT7uVeGyF2VcNrDjVzOiUFOWb7+5IRLi3Volp9o5OHuH1aOw3vNb2KqbIvJAFcQJF4l7c8Jopp6obeyBtXsupAVOTKZQnc9rokwDvyLbCNfseXXWNPekRD9+Ey8asSM+NauWLASFIWxNrRj6M5m0=
 
+before_install:
+  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
+
+install:
+  - npm install
+
 before_deploy:
   - export PATH=$HOME:$PATH
   # Install CloudFoundry

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 script:
   - bundle exec rspec
   - bundle exec middleman build
+cache: bundler
 
 env:
   global:
@@ -11,24 +12,21 @@ env:
   - CF_USERNAME="design-system-deploy-production@digital.cabinet-office.gov.uk"
   # CF_PASSWORD
   - secure: UYvRRq3/WSAF5udIroJRoN0i4ha04K9tWf5ozXAidP9oF1o3kAdz7dMlb/UWE10KCki8WwYSKufsJknSC7yygg6BgkajpUFWZc36XWUgyIlXEti3kxjq8GhHUtVQpdH/Mp702DgzJCgA4Bwj9TlfkyP+PIYW4PfljRllJtPzqgxSur++23Q+kMmvA8T/GOEyab72ZjEMQmonl0Vxf6UWx/y7/4+XLj34OTzoYQ18utWfH9o9i1KUA8dYFCT3oCauGXF8Ra6iOPmNhBjvKrT9+foyYvfbwtL+o+tcbyBQM+p2toWUC2E5e+gIyed+woNnUMFGjGzkwzRe5evhH7RbssGMnkAHn19EGht+Ycdo5Wqh06kmb6sGVFa5EfvuX8AUHaOJrjBjS4ojHA9rmrkCrLvXpKECJi/NK2if5mk39ULtmtUzBBAjgPY3ZY34wweKrRgKz1Q2+Z59nJuX4/UM/KP3lrG0IWKIqdcrnoRaXsWADmf512zFw699+3rre6Bv7h08cyJZWAPWFhZiFibFOQXpT7uVeGyF2VcNrDjVzOiUFOWb7+5IRLi3Volp9o5OHuH1aOw3vNb2KqbIvJAFcQJF4l7c8Jopp6obeyBtXsupAVOTKZQnc9rokwDvyLbCNfseXXWNPekRD9+Ey8asSM+NauWLASFIWxNrRj6M5m0=
-
+  # NPM_TOKEN
+  - secure: UjlOHWUc2dM0IQMngQKjsuBGCg+CvnRLS+VOGf8EcKY2RUZupmFea/PVGmTAlCmP8tsK80BNTdkKP7tfQD1fYNwv9Ppbbp8c8Ukcm2z3Xaa4CYIiCGj4VZO5/VEQycklMFkiw4lwCAaGulesKAu5UHEdGGXtr9HyZmgvSgEY+DEWjvHe112jZGF7+pkZ3v/WgtBtcmEAwumA97yqq5YlAiGgyktFf0oq/dtompMgA6MtTH93ZyGK0mCqrn1zzknVnlf7UYYnsIuYJ9D//+GVU7ASDD6wSb/QaF8Wy3rzFQgSbh2Mm0lFMFFqrCejBT7TXXanEFObvOd65sn2rwNvYe6XRFPqyKsSiQGBF/K9HIXqXCR19+inqN4Ip27gPlf0Y64Lw4IL69Xbak0SkhVEYyzKMAmEdZnPwLiTuF8Vex7pzxMABwHfR4Xt9BHSY0A8LMB5539UCwEsN62RB2mckuHEPbilyCo/7A42yy45YfnSadxC0h8BV1ylwWWnyCkwjGYC7GXsSEFuWzjp6Kp+NkkU9NvD3BgXJn2sgK312wgltzdNo3gZUFuedBviqnSSlVxluS9F3B23st51jdZWfreHpoFpfwiVuHF1IS//0y8yB6sfBrAj4c10Qhrrks/VWohBEI3cDhRfMMEITTb7bb9/8SkeVp4RFNKj0i+XZmE=
 before_install:
-  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
-
+- npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
 install:
-  - npm install
-
+- bundle install --jobs=3 --retry=3
+- npm install
 before_deploy:
-  - export PATH=$HOME:$PATH
-  # Install CloudFoundry
-  - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&source=github"
-  - tar xzvf $HOME/cf.tgz -C $HOME
-  # Install Autopilot plugin for zero-downtime-push
-  - travis_retry cf install-plugin autopilot -f -r CF-Community
-
+- export PATH=$HOME:$PATH
+- travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&source=github"
+- tar xzvf $HOME/cf.tgz -C $HOME
+- travis_retry cf install-plugin autopilot -f -r CF-Community
 deploy:
   provider: script
-  script: ./bin/deploy-travis
+  script: "./bin/deploy-travis"
   skip_cleanup: true
   on:
     branch: master

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ bundle exec rspec
 
 [rspec]: https://relishapp.com/rspec  
 
+## GOV.UK Frontend packages
+
+Design System consumes [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) packages via [NPM](https://www.npmjs.com/).
+These are defined in the [package.json](package.json) file.
+
+---------------------
+**NOTE:**
+For the time being we are consuming private packages. To access private packages, you will first need to log in to NPM with
+
+`npm login`
+
+--------------------
+
 ## Automated Checks
 
 When changes are pushed to GitHub [Travis][travis] will:

--- a/config.rb
+++ b/config.rb
@@ -1,4 +1,9 @@
+
+::Sass.load_paths << File.join(root, "node_modules")
+
 set :build_dir, 'deploy/public'
+set :css_dir,   '/stylesheets'
+set :js_dir,    '/javascripts'
 
 # Activate and configure extensions
 # https://middlemanapp.com/advanced/configuration/#configuring-extensions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,261 @@
+{
+  "name": "govuk_design_system",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@govuk-frontend/all": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.11-alpha.tgz",
+      "integrity": "sha512-yT8xhiynbVZNuG/xjn29fR82TgRxYtx9PWUQhKzr1k2E2SciVxYf2qfJcVnYsQO6b8/nGuKAGLnH2gCdSjNbwQ==",
+      "requires": {
+        "@govuk-frontend/breadcrumb": "0.0.11-alpha",
+        "@govuk-frontend/button": "0.0.11-alpha",
+        "@govuk-frontend/checkbox": "0.0.11-alpha",
+        "@govuk-frontend/cookie-banner": "0.0.11-alpha",
+        "@govuk-frontend/date": "0.0.11-alpha",
+        "@govuk-frontend/details": "0.0.11-alpha",
+        "@govuk-frontend/error-message": "0.0.11-alpha",
+        "@govuk-frontend/error-summary": "0.0.11-alpha",
+        "@govuk-frontend/fieldset": "0.0.11-alpha",
+        "@govuk-frontend/file-upload": "0.0.11-alpha",
+        "@govuk-frontend/icons": "0.0.11-alpha",
+        "@govuk-frontend/input": "0.0.11-alpha",
+        "@govuk-frontend/inset-text": "0.0.11-alpha",
+        "@govuk-frontend/label": "0.0.11-alpha",
+        "@govuk-frontend/legal-text": "0.0.11-alpha",
+        "@govuk-frontend/link": "0.0.11-alpha",
+        "@govuk-frontend/list": "0.0.11-alpha",
+        "@govuk-frontend/panel": "0.0.11-alpha",
+        "@govuk-frontend/phase-banner": "0.0.11-alpha",
+        "@govuk-frontend/phase-tag": "0.0.11-alpha",
+        "@govuk-frontend/radio": "0.0.11-alpha",
+        "@govuk-frontend/select-box": "0.0.11-alpha",
+        "@govuk-frontend/table": "0.0.11-alpha",
+        "@govuk-frontend/textarea": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/breadcrumb": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumb/-/breadcrumb-0.0.11-alpha.tgz",
+      "integrity": "sha512-Zz/8eBThm+6PHmq5oWeLMxWODSnUuIDt1YMK24M52Asi4h66r/aKYrzZdCnv3RDwXI9kvqe98v5wPZQhwYKjZw==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha",
+        "@govuk-frontend/icons": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/button": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.11-alpha.tgz",
+      "integrity": "sha512-JivR/tBA++660rxPYP72MmTGobgO1WeXgdd5FWeJVjYpIe0n3BFesyzc/yw8wGAyhS4uezOryXmrdIUQTi117g==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha",
+        "@govuk-frontend/icons": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/checkbox": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkbox/-/checkbox-0.0.11-alpha.tgz",
+      "integrity": "sha512-ZWzGLaa9xo+sEnOh9+esp6jiFE7h0G201Y5hphAWUbTb/2RqwzG5XBb4FTYNQy4ECXuOb+tivq6qk+xsMFeoOw==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/cookie-banner": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/cookie-banner/-/cookie-banner-0.0.11-alpha.tgz",
+      "integrity": "sha512-4UDvLV8j72/aRvwPlxeijS0nZ/BeAsA1PpFQs6M3Q9yqwfvlwi6KwQXiNZ6F0zp3WOqJNa3guxuNhUexkA+Wxg==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha",
+        "@govuk-frontend/site-width-container": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/date": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/date/-/date-0.0.11-alpha.tgz",
+      "integrity": "sha512-7n+70M6liVgPvQQUlX4v2Fdxzctk1mnCsnLNtQshW0nXpp6kNr9aJ9BeV6q6ERMeIpfgeBS+F9zZ2dXAHvb6yg==",
+      "requires": {
+        "@govuk-frontend/error-message": "0.0.11-alpha",
+        "@govuk-frontend/globals": "0.0.11-alpha",
+        "@govuk-frontend/label": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/details": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.11-alpha.tgz",
+      "integrity": "sha512-geSA0fvNy6KPuctWMCq7pdtT130cg3z9q3W7xTUsxvVf5twxUMCOx4lzkkbxfcyi2BbWdQVs/pL0okgj9ywuJA==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/error-message": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.11-alpha.tgz",
+      "integrity": "sha512-dsw2z6YjtNjyOLOFbFH6sxNJzZh+R4aoxZlzxH6q8N3LnOqYuamU6LaNDb24HGwWHh8VSUYmUHO7QvJacroDCQ==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/error-summary": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.11-alpha.tgz",
+      "integrity": "sha512-QV4Vntb4TjaEMabSfLVVL2vS/78H0e801UUDz/UH1vU2rEcsLfh0OtJJl015faj09LczQJ76puFX5WkC2Aazfw==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha",
+        "@govuk-frontend/list": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/fieldset": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.11-alpha.tgz",
+      "integrity": "sha512-Qi9YAr4QNIWI2BHzIU/lpikoeVKgJyNq3/lL5Q0l19u7wIWQXrh1i5bly8I9Wq0qXsFUvYy6puCU6oq4nEFTfQ==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/file-upload": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.11-alpha.tgz",
+      "integrity": "sha512-dXzPO5YY4EGPB1M6qpgieqqK4+X8ygBKjRxMIjo4LvBE3dvB4dbs/DX/m0E7I0LUcnDAFlwyWnUF0PVx8kIo0w==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/globals": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.11-alpha.tgz",
+      "integrity": "sha512-ZQeWIxsYcHbrPp3+2JMcCkPsZHcEtI18LTplzBCZ0alrMB8hfH+NtD3/M39ZBnOqtKxUoaqyRwL4x+N6neuoug==",
+      "requires": {
+        "sass-mq": "3.3.2"
+      }
+    },
+    "@govuk-frontend/icons": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.11-alpha.tgz",
+      "integrity": "sha512-rp9BftTl5zVVfcIAM7fP931z2c9TTSV6Fsh0byjWNjdz1WlReJtQFvi0z1PlZpmeDWI5YOw0LE6c1EQO/M63jg=="
+    },
+    "@govuk-frontend/input": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.11-alpha.tgz",
+      "integrity": "sha512-35nLb4n9y0s85TVss1NtIqXrlOqFSMyrr7f7+ZFZZ/QR0T57OAHxsqOHvG+wuvEZylxylERPnbhpoDCErItLtg==",
+      "requires": {
+        "@govuk-frontend/error-message": "0.0.11-alpha",
+        "@govuk-frontend/globals": "0.0.11-alpha",
+        "@govuk-frontend/label": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/inset-text": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/inset-text/-/inset-text-0.0.11-alpha.tgz",
+      "integrity": "sha512-+6Pr8U8KwqqB3vrt1RUjoKcyKaml7n6zY2Fk8F0LtzTwtaD4oluBWUDQ878OPOaoTYQfnaAW6vQQqYyOxgQpBw==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/label": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.11-alpha.tgz",
+      "integrity": "sha512-1g+CgBl7jTfAepZfhPenu2GxnzfDc7ZYiMoVFv7/I15ulO1Ddwf25D+64Y1XK/i452XAVnAvjQVHjNRW0myERQ==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/legal-text": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/legal-text/-/legal-text-0.0.11-alpha.tgz",
+      "integrity": "sha512-by8chLq3Nun4ZxiKjlYyg4AtxcPX/Ln+6JlFHqfTkjiOPlNCkmmle45BJg9hmx3v1yH8nhBFrFNAOQuZW95xaw==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/link": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/link/-/link-0.0.11-alpha.tgz",
+      "integrity": "sha512-9lcQPszhyfwnSO9e1QOQVotCHKAJ1mIvIOQr+ZINnFGbpjhAYKE1uKAnQspYj0rou855OJ4z745hUWfgJhNbmA==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/list": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/list/-/list-0.0.11-alpha.tgz",
+      "integrity": "sha512-fdLXu+y/q4PQ4uNYGUVWD9d4RFtDw3vcMYPUA8o+iRA1KTNhAKpT3TiodR6EvDhptx1Bl+/lqnjp4IOXdUGBtw==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/panel": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.11-alpha.tgz",
+      "integrity": "sha512-fbg3U/xLMIgy73q2fZyH9peI0gkKERImF5lKOgC9T8ZZoER6pcuA8X61zbj97H5aV3lKUuqdTypB6RI3YeOzKA==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/phase-banner": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.11-alpha.tgz",
+      "integrity": "sha512-hhDg6nmmagSAYpmM5+TNYC6KitLFMiNaWfk4LQppwWMzKOnA9uW2st0iL3fEfAFeHRWHiHO8GmlLQvFxM2XL+Q==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha",
+        "@govuk-frontend/phase-tag": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/phase-tag": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-tag/-/phase-tag-0.0.11-alpha.tgz",
+      "integrity": "sha512-Uvx6b21zwXua9N0+XNkUuMR9Qt0JPzfxQM6b3214WKqgIqfSnmJQaoMdnCS+I0WUcyt+TJ1A0px6HIOa79LL9Q==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/radio": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/radio/-/radio-0.0.11-alpha.tgz",
+      "integrity": "sha512-S7yerpxAIS0Wluzm1pHpnvMmjv8BDsReBgAa3SuLTgaSDxh0hfZW+BBGkXOtWTx0lP/rwsmd1hph0wiZcxGslA==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/select-box": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/select-box/-/select-box-0.0.11-alpha.tgz",
+      "integrity": "sha512-5b9P/LLgZTXtnGPUOjggCR9MYlsyy5UCsKVwB8/rm6b+X8vWrmYJ0BmzHf6ZmwvpB2f3sc7eKGJPymHd4pn1Ew==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha",
+        "@govuk-frontend/label": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/site-width-container": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/site-width-container/-/site-width-container-0.0.11-alpha.tgz",
+      "integrity": "sha512-O53iQm8szgo8xd9OY+bhlBBnI9MejnA1YFBUSYp+E1asmQdIZt+AglSqklm3dMGsY7igETjDka2Yoe1y66pCEg==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/table": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.11-alpha.tgz",
+      "integrity": "sha512-Aw/Ud8gOJc+evd3Juxo0xi1NpJUPEijX30kyi8fixK03RvMZ7LdlnsrRqxuN7BBE6tqQ4RmP23MWggvgy3D0ag==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.11-alpha"
+      }
+    },
+    "@govuk-frontend/textarea": {
+      "version": "0.0.11-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.11-alpha.tgz",
+      "integrity": "sha512-Gpen64VFUeYV2mU2wZygFDiPEm8wb5SBTpeNA2nChAVysQV+O/fd8t0KyKSiQGHnBI4MWmV+LJZENp8PQutJ7A==",
+      "requires": {
+        "@govuk-frontend/error-message": "0.0.11-alpha",
+        "@govuk-frontend/globals": "0.0.11-alpha",
+        "@govuk-frontend/label": "0.0.11-alpha"
+      }
+    },
+    "sass-mq": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-3.3.2.tgz",
+      "integrity": "sha1-NHLgTDGkMrzVWztgTtxyrppN7xo="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "govuk_design_system",
+  "private": true,
+  "description": "GOV.UK Design System",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alphagov/govuk-design-system.git"
+  },
+  "author": "Government Digital Service developers",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/alphagov/govuk-design-system/issues"
+  },
+  "homepage": "https://github.com/alphagov/govuk-design-system#readme",
+  "dependencies": {
+    "@govuk-frontend/all": "0.0.11-alpha"
+  }
+}

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,1 +1,1 @@
-<h1>GOV.UK Design System</h1>
+<h1 class="heading-large">GOV.UK Design System</h1>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="robots" content="noindex, nofollow">
     <title>GOV.UK Design System</title>
+    <%= stylesheet_link_tag :main, media: 'all' %>
   </head>
   <body>
     <%= yield %>

--- a/source/stylesheets/main.css.scss
+++ b/source/stylesheets/main.css.scss
@@ -1,0 +1,2 @@
+@import '@govuk-frontend/globals/font-face';
+@import '@govuk-frontend/globals/typography';


### PR DESCRIPTION
* create package.json file where we install `@govuk-frontend` packages
* add `/node_modules`, `package-lock.json` and `.npmrc` file to `.gitignore`
* config application to load and import frontend packages from `node_modules`
* setup Travis to install private npm packages
* add npm token to the travis environment variables
* add documentation on how to install GOV.UK Frontend packages

[Trello card](https://trello.com/c/fHKlkwD6)