### PR TITLE
Update frontend packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,251 +4,262 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@govuk-frontend/all": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.11-alpha.tgz",
-      "integrity": "sha512-yT8xhiynbVZNuG/xjn29fR82TgRxYtx9PWUQhKzr1k2E2SciVxYf2qfJcVnYsQO6b8/nGuKAGLnH2gCdSjNbwQ==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.18-alpha.tgz",
+      "integrity": "sha512-l9ZzjP+qARFXCWA1w5y6HhHLf+ao2rQXaChg2NyIH0FA9RBTgFMFDspBiMocWaq+l+N9wzqO2VzDAN0rU1eJnw==",
       "requires": {
-        "@govuk-frontend/breadcrumb": "0.0.11-alpha",
-        "@govuk-frontend/button": "0.0.11-alpha",
-        "@govuk-frontend/checkbox": "0.0.11-alpha",
-        "@govuk-frontend/cookie-banner": "0.0.11-alpha",
-        "@govuk-frontend/date": "0.0.11-alpha",
-        "@govuk-frontend/details": "0.0.11-alpha",
-        "@govuk-frontend/error-message": "0.0.11-alpha",
-        "@govuk-frontend/error-summary": "0.0.11-alpha",
-        "@govuk-frontend/fieldset": "0.0.11-alpha",
-        "@govuk-frontend/file-upload": "0.0.11-alpha",
-        "@govuk-frontend/icons": "0.0.11-alpha",
-        "@govuk-frontend/input": "0.0.11-alpha",
-        "@govuk-frontend/inset-text": "0.0.11-alpha",
-        "@govuk-frontend/label": "0.0.11-alpha",
-        "@govuk-frontend/legal-text": "0.0.11-alpha",
-        "@govuk-frontend/link": "0.0.11-alpha",
-        "@govuk-frontend/list": "0.0.11-alpha",
-        "@govuk-frontend/panel": "0.0.11-alpha",
-        "@govuk-frontend/phase-banner": "0.0.11-alpha",
-        "@govuk-frontend/phase-tag": "0.0.11-alpha",
-        "@govuk-frontend/radio": "0.0.11-alpha",
-        "@govuk-frontend/select-box": "0.0.11-alpha",
-        "@govuk-frontend/table": "0.0.11-alpha",
-        "@govuk-frontend/textarea": "0.0.11-alpha"
+        "@govuk-frontend/breadcrumb": "0.0.18-alpha",
+        "@govuk-frontend/button": "0.0.18-alpha",
+        "@govuk-frontend/checkbox": "0.0.18-alpha",
+        "@govuk-frontend/cookie-banner": "0.0.18-alpha",
+        "@govuk-frontend/date-input": "0.0.18-alpha",
+        "@govuk-frontend/details": "0.0.18-alpha",
+        "@govuk-frontend/error-message": "0.0.18-alpha",
+        "@govuk-frontend/error-summary": "0.0.18-alpha",
+        "@govuk-frontend/fieldset": "0.0.18-alpha",
+        "@govuk-frontend/file-upload": "0.0.18-alpha",
+        "@govuk-frontend/icons": "0.0.17-alpha",
+        "@govuk-frontend/input": "0.0.18-alpha",
+        "@govuk-frontend/inset-text": "0.0.18-alpha",
+        "@govuk-frontend/label": "0.0.18-alpha",
+        "@govuk-frontend/legal-text": "0.0.18-alpha",
+        "@govuk-frontend/link": "0.0.18-alpha",
+        "@govuk-frontend/list": "0.0.18-alpha",
+        "@govuk-frontend/panel": "0.0.18-alpha",
+        "@govuk-frontend/phase-banner": "0.0.18-alpha",
+        "@govuk-frontend/previous-next": "0.0.18-alpha",
+        "@govuk-frontend/radio": "0.0.18-alpha",
+        "@govuk-frontend/select": "0.0.18-alpha",
+        "@govuk-frontend/skip-link": "0.0.18-alpha",
+        "@govuk-frontend/table": "0.0.18-alpha",
+        "@govuk-frontend/tag": "0.0.18-alpha",
+        "@govuk-frontend/textarea": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/breadcrumb": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumb/-/breadcrumb-0.0.11-alpha.tgz",
-      "integrity": "sha512-Zz/8eBThm+6PHmq5oWeLMxWODSnUuIDt1YMK24M52Asi4h66r/aKYrzZdCnv3RDwXI9kvqe98v5wPZQhwYKjZw==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumb/-/breadcrumb-0.0.18-alpha.tgz",
+      "integrity": "sha512-y5qz7ojR65svhBVaen2x5MqZsasdGcdw3Pn3i8eEkafM55m853ueOSysqphgQ8bPF9zyOKw0pKFH1rUXY1IyEA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha",
-        "@govuk-frontend/icons": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha",
+        "@govuk-frontend/icons": "0.0.17-alpha"
       }
     },
     "@govuk-frontend/button": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.11-alpha.tgz",
-      "integrity": "sha512-JivR/tBA++660rxPYP72MmTGobgO1WeXgdd5FWeJVjYpIe0n3BFesyzc/yw8wGAyhS4uezOryXmrdIUQTi117g==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.18-alpha.tgz",
+      "integrity": "sha512-psvcTyAVY9Ze36qnWV051AxiW0+jC1eY3AxOTggUvI4f4b3RHADX5ieb+0vt44sGi1IlYPpHnF+2ZAnnttqVrA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha",
-        "@govuk-frontend/icons": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha",
+        "@govuk-frontend/icons": "0.0.17-alpha"
       }
     },
     "@govuk-frontend/checkbox": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkbox/-/checkbox-0.0.11-alpha.tgz",
-      "integrity": "sha512-ZWzGLaa9xo+sEnOh9+esp6jiFE7h0G201Y5hphAWUbTb/2RqwzG5XBb4FTYNQy4ECXuOb+tivq6qk+xsMFeoOw==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkbox/-/checkbox-0.0.18-alpha.tgz",
+      "integrity": "sha512-new1PBai+IK7stTZpooVVkqUpHtrig/2+KfjnTAY24hdOXBu9f/JyZUaIRrS5zKjTBx2N68AK5wFGsU1KyXmrg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha",
+        "@govuk-frontend/label": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/cookie-banner": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/cookie-banner/-/cookie-banner-0.0.11-alpha.tgz",
-      "integrity": "sha512-4UDvLV8j72/aRvwPlxeijS0nZ/BeAsA1PpFQs6M3Q9yqwfvlwi6KwQXiNZ6F0zp3WOqJNa3guxuNhUexkA+Wxg==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/cookie-banner/-/cookie-banner-0.0.18-alpha.tgz",
+      "integrity": "sha512-eZPfA5SYMV8HQPWBC/z+dc9QYNB4p8++oD3SwMqrTmJhdkyHPvR60Inu/efH9io+Mk/0qIgDmzLaIA68KaUd8g==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha",
-        "@govuk-frontend/site-width-container": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
-    "@govuk-frontend/date": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/date/-/date-0.0.11-alpha.tgz",
-      "integrity": "sha512-7n+70M6liVgPvQQUlX4v2Fdxzctk1mnCsnLNtQshW0nXpp6kNr9aJ9BeV6q6ERMeIpfgeBS+F9zZ2dXAHvb6yg==",
+    "@govuk-frontend/date-input": {
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.18-alpha.tgz",
+      "integrity": "sha512-HKXDeZ5THs0SNFDuSVvOhEXEGNCLb9UiL03txnsyyT+AxAEimSDFrXQ0xCvsiM2NjtccITlB0lRdLG7e3QzLiA==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.11-alpha",
-        "@govuk-frontend/globals": "0.0.11-alpha",
-        "@govuk-frontend/label": "0.0.11-alpha"
+        "@govuk-frontend/error-message": "0.0.18-alpha",
+        "@govuk-frontend/globals": "0.0.18-alpha",
+        "@govuk-frontend/label": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/details": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.11-alpha.tgz",
-      "integrity": "sha512-geSA0fvNy6KPuctWMCq7pdtT130cg3z9q3W7xTUsxvVf5twxUMCOx4lzkkbxfcyi2BbWdQVs/pL0okgj9ywuJA==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.18-alpha.tgz",
+      "integrity": "sha512-Aob0Fjb+Gy+1oxLLJ2tHmjK6Ysa4s497IM+oYaUqCkAPiriA/7RV9COtBCnnewDtx0OsHo+9dIE5OMupvCs9iA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/error-message": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.11-alpha.tgz",
-      "integrity": "sha512-dsw2z6YjtNjyOLOFbFH6sxNJzZh+R4aoxZlzxH6q8N3LnOqYuamU6LaNDb24HGwWHh8VSUYmUHO7QvJacroDCQ==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.18-alpha.tgz",
+      "integrity": "sha512-P6BRrimNSG4qnslilSb6OPktQ5otSEJXmgMcvKnLJ4Ok/xYmiXaRphDFq2z6/JO4J/LTkEkCFFjf+bVhd1FmzA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/error-summary": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.11-alpha.tgz",
-      "integrity": "sha512-QV4Vntb4TjaEMabSfLVVL2vS/78H0e801UUDz/UH1vU2rEcsLfh0OtJJl015faj09LczQJ76puFX5WkC2Aazfw==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.18-alpha.tgz",
+      "integrity": "sha512-BIuiK9durQFljSid10h9Wi7yaQEEx4tbsvbYi0He7TyavpuxCtSAdGnCBmZWVprcSBHe2fjl86cEg7eWHHCphg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha",
-        "@govuk-frontend/list": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha",
+        "@govuk-frontend/list": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/fieldset": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.11-alpha.tgz",
-      "integrity": "sha512-Qi9YAr4QNIWI2BHzIU/lpikoeVKgJyNq3/lL5Q0l19u7wIWQXrh1i5bly8I9Wq0qXsFUvYy6puCU6oq4nEFTfQ==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.18-alpha.tgz",
+      "integrity": "sha512-jQOx4J4Oz7xzYLqgnBRi8D41pcn11jy2y4F15v5SvbZjfZmVMSn3S0+Y1R55U/29TUlh74lDQ+G65UEc728q6w==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/file-upload": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.11-alpha.tgz",
-      "integrity": "sha512-dXzPO5YY4EGPB1M6qpgieqqK4+X8ygBKjRxMIjo4LvBE3dvB4dbs/DX/m0E7I0LUcnDAFlwyWnUF0PVx8kIo0w==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.18-alpha.tgz",
+      "integrity": "sha512-KzIqBpWdDVvnjVrdwYmpeldMgDOxMnaYOnAUOe69Ko84mw3S/z8XxxtUTq8LnUk8ZtvxpKr9JjyZFMmEkbZUBw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/globals": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.11-alpha.tgz",
-      "integrity": "sha512-ZQeWIxsYcHbrPp3+2JMcCkPsZHcEtI18LTplzBCZ0alrMB8hfH+NtD3/M39ZBnOqtKxUoaqyRwL4x+N6neuoug==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.18-alpha.tgz",
+      "integrity": "sha512-Razfe/ZK7FfB1I7uR1jOjVokUtbjJ0L8ua49vPGvowL7FlXlYp3JezPkS3PgqYIi0gls4bTEL53if4XW5d2S1g==",
       "requires": {
         "sass-mq": "3.3.2"
       }
     },
     "@govuk-frontend/icons": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.11-alpha.tgz",
-      "integrity": "sha512-rp9BftTl5zVVfcIAM7fP931z2c9TTSV6Fsh0byjWNjdz1WlReJtQFvi0z1PlZpmeDWI5YOw0LE6c1EQO/M63jg=="
+      "version": "0.0.17-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.17-alpha.tgz",
+      "integrity": "sha512-l4hmyJBMyOShIqrMWCYnDTc1S2u+aCduCSLLlcTEk41nAHsGeJRD8vpIkHXnyu0r7lVcP/1XMoOi4H9if79i4w=="
     },
     "@govuk-frontend/input": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.11-alpha.tgz",
-      "integrity": "sha512-35nLb4n9y0s85TVss1NtIqXrlOqFSMyrr7f7+ZFZZ/QR0T57OAHxsqOHvG+wuvEZylxylERPnbhpoDCErItLtg==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.18-alpha.tgz",
+      "integrity": "sha512-VH0dn1PziIKLBIrgZRgxR3QNc7zfPfjXqb7T0b+gDHMC+YmBbqZYtmPGp7s/7H5/g921zMvoUKVniK7R6oCOyg==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.11-alpha",
-        "@govuk-frontend/globals": "0.0.11-alpha",
-        "@govuk-frontend/label": "0.0.11-alpha"
+        "@govuk-frontend/error-message": "0.0.18-alpha",
+        "@govuk-frontend/globals": "0.0.18-alpha",
+        "@govuk-frontend/label": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/inset-text": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/inset-text/-/inset-text-0.0.11-alpha.tgz",
-      "integrity": "sha512-+6Pr8U8KwqqB3vrt1RUjoKcyKaml7n6zY2Fk8F0LtzTwtaD4oluBWUDQ878OPOaoTYQfnaAW6vQQqYyOxgQpBw==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/inset-text/-/inset-text-0.0.18-alpha.tgz",
+      "integrity": "sha512-T0f1xoVXnwRyaxnyB5mDqzgdq/sA5ZRdQ+bp2xIxYzgtxL73iHKiTmdpDxo9UvPlmEz/MMIvD4/amUoPg/zRTw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/label": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.11-alpha.tgz",
-      "integrity": "sha512-1g+CgBl7jTfAepZfhPenu2GxnzfDc7ZYiMoVFv7/I15ulO1Ddwf25D+64Y1XK/i452XAVnAvjQVHjNRW0myERQ==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.18-alpha.tgz",
+      "integrity": "sha512-nRFUEznafBX1mw/ViHN8gZ8Vyo/0mxuwZd3j1pI0D3J/5/S+KdwCneSvGqvlkYhytSB7pKnfqSzBL/uWp6wJTQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/legal-text": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/legal-text/-/legal-text-0.0.11-alpha.tgz",
-      "integrity": "sha512-by8chLq3Nun4ZxiKjlYyg4AtxcPX/Ln+6JlFHqfTkjiOPlNCkmmle45BJg9hmx3v1yH8nhBFrFNAOQuZW95xaw==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/legal-text/-/legal-text-0.0.18-alpha.tgz",
+      "integrity": "sha512-5vlNaCW9VW9rRd4a9iBfeipShZLPKC3qPZSc0cFf0883loyhca5Ml/in2RNLvww2ReZdG2Z2F4ndmK2wqBoXxQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/link": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/link/-/link-0.0.11-alpha.tgz",
-      "integrity": "sha512-9lcQPszhyfwnSO9e1QOQVotCHKAJ1mIvIOQr+ZINnFGbpjhAYKE1uKAnQspYj0rou855OJ4z745hUWfgJhNbmA==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/link/-/link-0.0.18-alpha.tgz",
+      "integrity": "sha512-FAxUzx3jlsdEBsyHFZgs00THfJb48y6KFlmddrGem6tOHGjNbRaQAaDt+ldjwfUq1ULtwgYjN6NhDW68mJ3NYg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/list": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/list/-/list-0.0.11-alpha.tgz",
-      "integrity": "sha512-fdLXu+y/q4PQ4uNYGUVWD9d4RFtDw3vcMYPUA8o+iRA1KTNhAKpT3TiodR6EvDhptx1Bl+/lqnjp4IOXdUGBtw==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/list/-/list-0.0.18-alpha.tgz",
+      "integrity": "sha512-G/0I6VUpscgrxRkomykAd2eb+O+ZzyeRF2ccIlyWctgRxfzvm9u+Kqcnv31iZCy8tNQgftr85zAXRxJ7S1V7lg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/panel": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.11-alpha.tgz",
-      "integrity": "sha512-fbg3U/xLMIgy73q2fZyH9peI0gkKERImF5lKOgC9T8ZZoER6pcuA8X61zbj97H5aV3lKUuqdTypB6RI3YeOzKA==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.18-alpha.tgz",
+      "integrity": "sha512-tr9DpbyX1rvNiyzR5Kgtzyp9bArKI1WjVBTLyzGJC8CQrNscT5D6GGQuYZJp5emLb3GJVT3wo29Ab7mqZIfLXw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/phase-banner": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.11-alpha.tgz",
-      "integrity": "sha512-hhDg6nmmagSAYpmM5+TNYC6KitLFMiNaWfk4LQppwWMzKOnA9uW2st0iL3fEfAFeHRWHiHO8GmlLQvFxM2XL+Q==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.18-alpha.tgz",
+      "integrity": "sha512-zZ8hBg66fReMc8hv0l14xiEv168XdBiX/7H7s9YweWBp+TX1dX/rmSUrSa1i+ovsj4l8RZldaVRIhtKOR/DAEA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha",
-        "@govuk-frontend/phase-tag": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha",
+        "@govuk-frontend/tag": "0.0.18-alpha"
       }
     },
-    "@govuk-frontend/phase-tag": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-tag/-/phase-tag-0.0.11-alpha.tgz",
-      "integrity": "sha512-Uvx6b21zwXua9N0+XNkUuMR9Qt0JPzfxQM6b3214WKqgIqfSnmJQaoMdnCS+I0WUcyt+TJ1A0px6HIOa79LL9Q==",
+    "@govuk-frontend/previous-next": {
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/previous-next/-/previous-next-0.0.18-alpha.tgz",
+      "integrity": "sha512-K8GZVm+ocnXGRd1fl6d1OZOXzaAMLUBEr4Qb/aB/0LJJ+Jk2GYW2PXiRI0jRNaNwsitjSNYDkRBoTTF9e+PsPw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/radio": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/radio/-/radio-0.0.11-alpha.tgz",
-      "integrity": "sha512-S7yerpxAIS0Wluzm1pHpnvMmjv8BDsReBgAa3SuLTgaSDxh0hfZW+BBGkXOtWTx0lP/rwsmd1hph0wiZcxGslA==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/radio/-/radio-0.0.18-alpha.tgz",
+      "integrity": "sha512-V/iJTE3GHd3YakWm2ezVuosvCtSaiqVgB0CHWMwxNPFL8Iilocw7d7ghFJU9PWS6cCXD51jA20VWu7X9R9d/Bw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha",
+        "@govuk-frontend/label": "0.0.18-alpha"
       }
     },
-    "@govuk-frontend/select-box": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/select-box/-/select-box-0.0.11-alpha.tgz",
-      "integrity": "sha512-5b9P/LLgZTXtnGPUOjggCR9MYlsyy5UCsKVwB8/rm6b+X8vWrmYJ0BmzHf6ZmwvpB2f3sc7eKGJPymHd4pn1Ew==",
+    "@govuk-frontend/select": {
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.18-alpha.tgz",
+      "integrity": "sha512-wXTbNKOInsxIbcejNiBTpqQkxG8Oj1+zf5Qk3hnD4KhjQ7vmbNme566wrX+53rtSSy6Vn6lJ3P572dwDhTGt0A==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha",
-        "@govuk-frontend/label": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha",
+        "@govuk-frontend/label": "0.0.18-alpha"
       }
     },
-    "@govuk-frontend/site-width-container": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/site-width-container/-/site-width-container-0.0.11-alpha.tgz",
-      "integrity": "sha512-O53iQm8szgo8xd9OY+bhlBBnI9MejnA1YFBUSYp+E1asmQdIZt+AglSqklm3dMGsY7igETjDka2Yoe1y66pCEg==",
+    "@govuk-frontend/skip-link": {
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.18-alpha.tgz",
+      "integrity": "sha512-nDQuyaHQExyjdHp8m0LzggJOONmJW/X6hx1JSeSr+tORX/QfG73Aiv8QjCF2XS6QIO11aSNf2+RTE4IAWjO16Q==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/table": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.11-alpha.tgz",
-      "integrity": "sha512-Aw/Ud8gOJc+evd3Juxo0xi1NpJUPEijX30kyi8fixK03RvMZ7LdlnsrRqxuN7BBE6tqQ4RmP23MWggvgy3D0ag==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.18-alpha.tgz",
+      "integrity": "sha512-YvFQcNDUPfmTPlI93Pf+JzwSgklcYBvAv/3Zs3AHDQLLut3K8cf4HsvZoALQfUa64yOo1kUA4QDrD9G5YBS3Bw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.11-alpha"
+        "@govuk-frontend/globals": "0.0.18-alpha"
+      }
+    },
+    "@govuk-frontend/tag": {
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.18-alpha.tgz",
+      "integrity": "sha512-46S1l0RnR7XDqHgqY/73qXu3BM5ACRGR8W0Qj65Ac/j9AL6e8050Uiwgeui5OCxJxgOJJ8IUveEIqL2n4o9yfg==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.18-alpha"
       }
     },
     "@govuk-frontend/textarea": {
-      "version": "0.0.11-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.11-alpha.tgz",
-      "integrity": "sha512-Gpen64VFUeYV2mU2wZygFDiPEm8wb5SBTpeNA2nChAVysQV+O/fd8t0KyKSiQGHnBI4MWmV+LJZENp8PQutJ7A==",
+      "version": "0.0.18-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.18-alpha.tgz",
+      "integrity": "sha512-oTl8eY7ngorM8OIcpYLifwLyTFeCeQ9m93YIXnW817cmQHy1gF78ZL1OLC4GJahtGc8YrO3AvFtu6AbqGHLZ/Q==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.11-alpha",
-        "@govuk-frontend/globals": "0.0.11-alpha",
-        "@govuk-frontend/label": "0.0.11-alpha"
+        "@govuk-frontend/error-message": "0.0.18-alpha",
+        "@govuk-frontend/globals": "0.0.18-alpha",
+        "@govuk-frontend/label": "0.0.18-alpha"
       }
     },
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "gulp scss:lint"
   },
   "dependencies": {
-    "@govuk-frontend/all": "0.0.11-alpha"
+    "@govuk-frontend/all": "^0.0.18-alpha"
   },
   "devDependencies": {
     "gulp": "^3.9.1",

--- a/source/stylesheets/main.css.scss
+++ b/source/stylesheets/main.css.scss
@@ -1,2 +1,1 @@
-@import "@govuk-frontend/globals/font-face";
-@import "@govuk-frontend/globals/typography";
+@import "@govuk-frontend/all/all";


### PR DESCRIPTION
Updated GOV.Uk Frontend packages have been published so we need to update our dependencies.
This PR 
* updates dependency version of `@govuk-frontend/all`
* imports the "all" package instead of individual imports