### PR TITLE
Add skip-link and main content container

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -9,6 +9,7 @@
     <!--[if lt IE 9]><%= javascript_include_tag "ie.js" %><![endif]-->
   </head>
   <body class="govuk-u-font-smoothing">
+    <a href="#content" class="govuk-c-skip-link">Skip to main content</a>
     <%= partial 'components/header' %>
     <%= yield %>
   </body>


### PR DESCRIPTION
Basic accessibility set up:
* A 'skip to main content' link appears on the first use of the tab key
* When activated by keyboard or mouse the skip to main content link shifts the focus to the content body, bypassing the navigation
* The focus state is highlighted using the standard GOV.UK style (yellow background)
