### PR TITLE
Replicate DS homepage from DS prototype

### DIFF
--- a/source/components/_divider.erb
+++ b/source/components/_divider.erb
@@ -1,0 +1,1 @@
+<hr class="app-c-divider">

--- a/source/components/_masthead.erb
+++ b/source/components/_masthead.erb
@@ -1,0 +1,10 @@
+<div class="app-c-masthead govuk-u-pt-5 govuk-u-pb-5 govuk-u-mb-5">
+  <div class="govuk-o-site-width-container app-c-site-width-container">
+      <div class="govuk-o-grid">
+        <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+            <h1 class="app-c-masthead__title">Design your service using GOV.UK styles, components and patterns</h1>
+            <p class="app-c-masthead__description govuk-u-mb-2">Use this design system to make your service consistent with other government services. Learn from the research and experience of other service teams and avoid repeating work that’s already been done.</p>
+        </div>
+    </div>
+  </div>
+</div>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,1 +1,31 @@
-<h1 class="heading-large">GOV.UK Design System</h1>
+<main id="content" role="main">
+  <%= partial 'components/masthead' %>
+  <div class="govuk-mb-5 govuk-u-core-19">
+    <div class="govuk-o-site-width-container app-c-site-width-container">
+        <div class="govuk-o-grid">
+          <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-u-mb-5">
+            <h2 class="heading-large">Styles</h2>
+            <p>The core styles that will make your service look and feel like GOV.UK.  This includes <a href="/design-patterns/patterns/styles/colour/">Colour</a>, <a href="/design-patterns/patterns/styles/typography/">Typography</a> and <a href="/design-patterns/patterns/styles/layout/">Layout</a>.</p>
+            <p class="govuk-u-mb-0"><a href="/design-patterns/patterns/styles">See all styles</a></p>
+          </div>
+          <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-u-mb-5">
+            <h2 class="heading-large">Components</h2>
+            <p>Re-usable parts of the user interface. From small form elements like <a href="/design-patterns/patterns/components/radio-buttons/">Radio buttons</a> to larger ones such as <a href="/design-patterns/patterns/components/autocomplete/">Autocomplete</a>.</p>
+            <p class="govuk-u-mb-0"><a href="/design-patterns/patterns/components">See all components</a></p>
+          </div>
+          <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-u-mb-5">
+            <h2 class="heading-large">Patterns</h2>
+            <p>Best practice design solutions for specific user-focused tasks and scenarios such as <a href="/design-patterns/patterns/patterns/asking-for/addresses/">asking for addresses</a> or <a href="/design-patterns/patterns/patterns/helping-users/feedback-pages/">getting user feedback</a>.</p>
+            <p class="govuk-u-mb-0"><a href="/design-patterns/patterns/patterns">See all patterns</a></p>
+          </div>
+          <div class="govuk-o-grid__item govuk-o-grid__item--full">
+            <%= partial 'components/divider' %>
+          </div>
+          <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+            <h2 class="heading-large">Get in touch</h2>
+            <p>If you’ve got a question, idea or suggestion share it in <a href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>) or <a href="#">email the Design System team</a></p>
+          </div>
+        </div>
+    </div>
+  </div>
+</main>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -8,7 +8,7 @@
     <%= stylesheet_link_tag :main, media: 'all' %>
     <!--[if lt IE 9]><%= javascript_include_tag "ie.js" %><![endif]-->
   </head>
-  <body>
+  <body class="govuk-u-font-smoothing">
     <%= partial 'components/header' %>
     <%= yield %>
   </body>

--- a/source/stylesheets/components/_divider.scss
+++ b/source/stylesheets/components/_divider.scss
@@ -1,0 +1,5 @@
+.app-c-divider {
+  height: 1px;
+  border: 0;
+  background-color: $govuk-grey-2;
+}

--- a/source/stylesheets/components/_masthead.scss
+++ b/source/stylesheets/components/_masthead.scss
@@ -1,0 +1,13 @@
+.app-c-masthead {
+  color: $govuk-white;
+  background-color: $govuk-blue;
+}
+
+.app-c-masthead__title {
+  @include govuk-bold-48;
+  margin-top: 0; // Note: on Elements this is included in h1
+}
+
+.app-c-masthead__description {
+  @include govuk-core-24;
+}

--- a/source/stylesheets/main.css.scss
+++ b/source/stylesheets/main.css.scss
@@ -2,7 +2,39 @@
 
 // App-specific components
 @import "components/header";
+@import "components/divider";
+@import "components/masthead";
 
 body {
   margin: 0;
+}
+
+// Mirrors Bootstrap 4 - open for discussion
+$mq-breakpoint-widescreen: 1200px;
+
+// This will be coming to FE later but making it app specific for now
+.app-c-site-width-container {
+  @media (min-width: $mq-breakpoint-widescreen) {
+    max-width: 1100px;
+  }
+}
+
+// This is consistent with Elements - will be changed in FE
+.govuk-o-grid__item {
+  @include mq($until: desktop) {
+    padding: 0 $govuk-gutter-half;
+  }
+}
+
+// This is consistent with Elements - will be changed in FE
+.govuk-o-grid__item--one-third,
+.govuk-o-grid__item--two-thirds {
+  @include mq($until: desktop) {
+    width: 100%;
+  }
+}
+
+// Note: on Elements this is included on the body - we will review in FE how to best add font smoothing
+.govuk-u-font-smoothing {
+  @include font-smoothing;
 }


### PR DESCRIPTION
Create masthead, three-blocks and divider components. Add grid styles, site
width container style and large screen breakpoint that will later move to FE.

I think the three grid blocks are unique enough to be a component but the single block ("Get in touch") isn't.

There are outstanding decisions on spacing and typography so these will need to
be reviewed again on the homepage at a later point.