### PR TITLE
Update Travis to use Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
-language: ruby
+language: node_js
+
+node_js:
+- 8
+
 script:
-  - bundle exec rspec
   - npm run lint
-  - bundle exec middleman build
+  - npm run build
+
+sudo: false
 
 env:
   global:
@@ -16,11 +21,11 @@ env:
   - secure: UjlOHWUc2dM0IQMngQKjsuBGCg+CvnRLS+VOGf8EcKY2RUZupmFea/PVGmTAlCmP8tsK80BNTdkKP7tfQD1fYNwv9Ppbbp8c8Ukcm2z3Xaa4CYIiCGj4VZO5/VEQycklMFkiw4lwCAaGulesKAu5UHEdGGXtr9HyZmgvSgEY+DEWjvHe112jZGF7+pkZ3v/WgtBtcmEAwumA97yqq5YlAiGgyktFf0oq/dtompMgA6MtTH93ZyGK0mCqrn1zzknVnlf7UYYnsIuYJ9D//+GVU7ASDD6wSb/QaF8Wy3rzFQgSbh2Mm0lFMFFqrCejBT7TXXanEFObvOd65sn2rwNvYe6XRFPqyKsSiQGBF/K9HIXqXCR19+inqN4Ip27gPlf0Y64Lw4IL69Xbak0SkhVEYyzKMAmEdZnPwLiTuF8Vex7pzxMABwHfR4Xt9BHSY0A8LMB5539UCwEsN62RB2mckuHEPbilyCo/7A42yy45YfnSadxC0h8BV1ylwWWnyCkwjGYC7GXsSEFuWzjp6Kp+NkkU9NvD3BgXJn2sgK312wgltzdNo3gZUFuedBviqnSSlVxluS9F3B23st51jdZWfreHpoFpfwiVuHF1IS//0y8yB6sfBrAj4c10Qhrrks/VWohBEI3cDhRfMMEITTb7bb9/8SkeVp4RFNKj0i+XZmE=
 
 before_install:
+  - if [[ `npm -v | cut -d. -f1` -lt 5 ]]; then npm i -g npm@latest; fi
   - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
 
 install:
-  - bundle install --jobs=3 --retry=3
-  - npm install
+  - npm install --no-optional
 
 before_deploy:
   - export PATH=$HOME:$PATH


### PR DESCRIPTION
This PR:
- updates Travis CI to use Node.js ~~v7~~ v8
- removes Ruby testing script `bundle exec rspec` as it's no longer relevant
- updates build script `npm run build`
- ensure use of latest npm version

**Note to reviewer:**
~~This PR fails as it depends on https://github.com/alphagov/govuk-design-system/pull/79 to be merged first.~~