### PR TITLE
link to prototype kit site

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -19,6 +19,13 @@
       <div class="govuk-o-grid__item govuk-o-grid__item--full">
         {% include "../views/partials/_divider.njk" %}
       </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds govuk-!-mb-r6">
+        <h2 class="govuk-heading-l govuk-!-mt-r6">Using the Design System</h2>
+        <p class="govuk-body govuk-!-mb-r0">To use the code in the Design System to make prototypes, download the <a href="https://govuk-prototype-kit-beta.herokuapp.com">private beta version of the GOV.UK Prototype Kit</a>.</p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--full">
+        {% include "../views/partials/_divider.njk" %}
+      </div>
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds govuk-!-mb-r4">
         <h2 class="govuk-heading-l govuk-!-mt-r6">Get in touch</h2>
         <p class="govuk-body govuk-!-mb-r0">If you’ve got a question, idea or suggestion share it in <a href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>) or <a href="#">email the Design System team</a></p>


### PR DESCRIPTION
1. Add a link to the prototype kit site in the footer
1. Add a new section to the home page: 'Other design resources', with all the links from the footer. This is repetition, but the footer is easily overlooked, and I think these links are important.

![image](https://user-images.githubusercontent.com/1132904/33676811-a3aa67c8-daae-11e7-9c39-4f2d70ae320f.png)
