### PR TITLE
Include partials without specifying the entire path

### DIFF
--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -13,11 +13,11 @@
     <a href="#content" class="govuk-c-skip-link">Skip to main content</a>
     <div class="app-o-pane">
       <div class="app-o-pane__header">
-        {% include "../partials/_header.njk" %}
+        {% include "_header.njk" %}
       </div>
       <div class="app-o-pane__body">
         <div class="app-o-pane__toc">
-          {% include "../partials/_toc.njk" %}
+          {% include "_toc.njk" %}
         </div>
         <div class="app-o-pane__content">
           <main id="content" class="app-c-content" role="main">
@@ -29,7 +29,7 @@
               {{ contents | safe }}
             {% endblock %}
           </main>
-          {% include "../partials/_footer.njk" %}
+          {% include "_footer.njk" %}
         </div>
       </div>
     </div>

--- a/views/layouts/layout.njk
+++ b/views/layouts/layout.njk
@@ -13,7 +13,7 @@
     <a href="#content" class="govuk-c-skip-link">Skip to main content</a>
     <div class="app-o-pane">
       <div class="app-o-pane__header">
-        {% include "../partials/_header.njk" %}
+        {% include "_header.njk" %}
       </div>
       <div class="app-o-pane__content">
         <main id="content" role="main">
@@ -21,7 +21,7 @@
           {{ contents | safe }}
         {% endblock %}
         </main>
-      {% include "../partials/_footer.njk" %}
+      {% include "_footer.njk" %}
       </div>
     </div>
   </body>


### PR DESCRIPTION
This PR removes the path when importing a partial file.
Partial files are [already included in the Nunjucks paths](https://github.com/alphagov/govuk-design-system/blob/master/lib/metalsmith.js#L17), so there's no need to specify the entire path.