### PR TITLE
Page styling

### DIFF
--- a/src/stylesheets/components/_highlight.scss
+++ b/src/stylesheets/components/_highlight.scss
@@ -1,0 +1,94 @@
+// GitHub code highlight
+.hljs {
+  display: block;
+  padding: .5em;
+  overflow-x: auto;
+  color: #333;
+  background: #f8f8f8;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #998;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-subst {
+  color: #333;
+  font-weight: bold;
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag .hljs-attr {
+  color: #008080;
+}
+
+.hljs-string,
+.hljs-doctag {
+  color: #d14;
+}
+
+.hljs-title,
+.hljs-section,
+.hljs-selector-id {
+  color: #900;
+  font-weight: bold;
+}
+
+.hljs-subst {
+  font-weight: normal;
+}
+
+.hljs-type,
+.hljs-class .hljs-title {
+  color: #458;
+  font-weight: bold;
+}
+
+.hljs-tag,
+.hljs-name,
+.hljs-attribute {
+  color: #000080;
+  font-weight: normal;
+}
+
+.hljs-regexp,
+.hljs-link {
+  color: #009926;
+}
+
+.hljs-symbol,
+.hljs-bullet {
+  color: #990073;
+}
+
+.hljs-built_in,
+.hljs-builtin-name {
+  color: #0086b3;
+}
+
+.hljs-meta {
+  color: #999;
+  font-weight: bold;
+}
+
+.hljs-deletion {
+  background: #fdd;
+}
+
+.hljs-addition {
+  background: #dfd;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -1,7 +1,7 @@
 @import "@govuk-frontend/all/all";
 
 // App-specific variables
-$app-light-grey: #f3f3f3;
+$app-light-grey: #f8f8f8;
 
 // App-specific components
 @import "components/header";
@@ -14,6 +14,7 @@ $app-light-grey: #f3f3f3;
 @import "components/pane";
 @import "components/example";
 @import "components/tabs";
+@import "components/highlight";
 
 body {
   margin: 0;

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -77,6 +77,19 @@ $mq-breakpoint-widescreen: 1200px;
 .app-c-content {
   padding: $govuk-gutter;
   @include govuk-core-19;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  ul:not(.app-c-tabs),
+  ol,
+  img {
+    max-width: 38em;
+  }
 }
 
 .app-c-content__header {


### PR DESCRIPTION
This PR:
 - 3b965cb adds styles to code blocks to highlight the syntax (uses GitHub highlight, we might want to change it to [Pygments](http://pygments.org/) if we want to be consistent with the GDS tech docs)
 - cdb9cba limits the element (`<h*>`, `<p>`, `<ul>`, `<ol>`, `<img>`) inside `.app-c-content` (these can be placed inside `.prose` instead) in width (`38em`) for a better legibility

[Trello card](https://trello.com/c/ScbV1vsM)