### PR TITLE
Add basic auth for private beta

### DIFF
--- a/src/Staticfile.auth
+++ b/src/Staticfile.auth
@@ -1,0 +1,1 @@
+designsystem:$apr1$F1Crj11o$htY5aGcSSV8ENGwle8pKh0


### PR DESCRIPTION
The authentication exists to ensure that users do not start using the Design System instead of the current resources - there is still a lot of work to do to get to a place where we’d want this to be happening.

There’s no need to keep the credentials ‘secret’ as they’re only there as a deterrent, which is why it’s OK to commit the encrypted htpasswd details to a public git repository.

https://trello.com/c/GVZduH2J/481-add-basic-authentication-to-the-production-design-system