### PR TITLE
Update components, partials and scss to use Frontend 0.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,262 +4,252 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@govuk-frontend/all": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.18-alpha.tgz",
-      "integrity": "sha512-l9ZzjP+qARFXCWA1w5y6HhHLf+ao2rQXaChg2NyIH0FA9RBTgFMFDspBiMocWaq+l+N9wzqO2VzDAN0rU1eJnw==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.19-alpha.tgz",
+      "integrity": "sha512-wfTwhfV9efPCr3QZmHD4KZXUErnBmA2EVNzKEdRwKzu7fMbXLPS/3jZhZVw7RCk7kNvR6zwMM+xfLXNjeXpvfg==",
       "requires": {
-        "@govuk-frontend/breadcrumb": "0.0.18-alpha",
-        "@govuk-frontend/button": "0.0.18-alpha",
-        "@govuk-frontend/checkbox": "0.0.18-alpha",
-        "@govuk-frontend/cookie-banner": "0.0.18-alpha",
-        "@govuk-frontend/date-input": "0.0.18-alpha",
-        "@govuk-frontend/details": "0.0.18-alpha",
-        "@govuk-frontend/error-message": "0.0.18-alpha",
-        "@govuk-frontend/error-summary": "0.0.18-alpha",
-        "@govuk-frontend/fieldset": "0.0.18-alpha",
-        "@govuk-frontend/file-upload": "0.0.18-alpha",
-        "@govuk-frontend/icons": "0.0.17-alpha",
-        "@govuk-frontend/input": "0.0.18-alpha",
-        "@govuk-frontend/inset-text": "0.0.18-alpha",
-        "@govuk-frontend/label": "0.0.18-alpha",
-        "@govuk-frontend/legal-text": "0.0.18-alpha",
-        "@govuk-frontend/link": "0.0.18-alpha",
-        "@govuk-frontend/list": "0.0.18-alpha",
-        "@govuk-frontend/panel": "0.0.18-alpha",
-        "@govuk-frontend/phase-banner": "0.0.18-alpha",
-        "@govuk-frontend/previous-next": "0.0.18-alpha",
-        "@govuk-frontend/radio": "0.0.18-alpha",
-        "@govuk-frontend/select": "0.0.18-alpha",
-        "@govuk-frontend/skip-link": "0.0.18-alpha",
-        "@govuk-frontend/table": "0.0.18-alpha",
-        "@govuk-frontend/tag": "0.0.18-alpha",
-        "@govuk-frontend/textarea": "0.0.18-alpha"
+        "@govuk-frontend/back-link": "0.0.19-alpha",
+        "@govuk-frontend/breadcrumbs": "0.0.19-alpha",
+        "@govuk-frontend/button": "0.0.19-alpha",
+        "@govuk-frontend/checkbox": "0.0.19-alpha",
+        "@govuk-frontend/cookie-banner": "0.0.19-alpha",
+        "@govuk-frontend/date-input": "0.0.19-alpha",
+        "@govuk-frontend/details": "0.0.19-alpha",
+        "@govuk-frontend/error-message": "0.0.19-alpha",
+        "@govuk-frontend/error-summary": "0.0.19-alpha",
+        "@govuk-frontend/fieldset": "0.0.19-alpha",
+        "@govuk-frontend/file-upload": "0.0.19-alpha",
+        "@govuk-frontend/icons": "0.0.19-alpha",
+        "@govuk-frontend/input": "0.0.19-alpha",
+        "@govuk-frontend/label": "0.0.19-alpha",
+        "@govuk-frontend/legal-text": "0.0.19-alpha",
+        "@govuk-frontend/link": "0.0.19-alpha",
+        "@govuk-frontend/panel": "0.0.19-alpha",
+        "@govuk-frontend/phase-banner": "0.0.19-alpha",
+        "@govuk-frontend/previous-next": "0.0.19-alpha",
+        "@govuk-frontend/radio": "0.0.19-alpha",
+        "@govuk-frontend/select": "0.0.19-alpha",
+        "@govuk-frontend/skip-link": "0.0.19-alpha",
+        "@govuk-frontend/table": "0.0.19-alpha",
+        "@govuk-frontend/tag": "0.0.19-alpha",
+        "@govuk-frontend/textarea": "0.0.19-alpha"
       }
     },
-    "@govuk-frontend/breadcrumb": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumb/-/breadcrumb-0.0.18-alpha.tgz",
-      "integrity": "sha512-y5qz7ojR65svhBVaen2x5MqZsasdGcdw3Pn3i8eEkafM55m853ueOSysqphgQ8bPF9zyOKw0pKFH1rUXY1IyEA==",
+    "@govuk-frontend/back-link": {
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.19-alpha.tgz",
+      "integrity": "sha512-BKHSRfDs3UfclcNqQDd0cZgQYh2r211YQVIi4HB1vfzhFzt8YzWQsJxhdbs3Gyas+MsqFPX7H/SS0dfarNW3Pg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha",
-        "@govuk-frontend/icons": "0.0.17-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
+      }
+    },
+    "@govuk-frontend/breadcrumbs": {
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.19-alpha.tgz",
+      "integrity": "sha512-EPWyTMCWYA2iH53FiIyQSuKQ+T6GGJbsSCqEfzBDhHpVKvnRPTd5LhSBL4ZvEwoyZ0RGC8hc/qu6iJ29vAOX7g==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.19-alpha",
+        "@govuk-frontend/icons": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/button": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.18-alpha.tgz",
-      "integrity": "sha512-psvcTyAVY9Ze36qnWV051AxiW0+jC1eY3AxOTggUvI4f4b3RHADX5ieb+0vt44sGi1IlYPpHnF+2ZAnnttqVrA==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.19-alpha.tgz",
+      "integrity": "sha512-oQodTXrRvOjKuYO+3g7B0pMDRHeP/0uBvsoQRljJyfy32LoOt6HICNfsb/YkMuIu6TwlIX6qoraGJGYxFHLMUA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha",
-        "@govuk-frontend/icons": "0.0.17-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha",
+        "@govuk-frontend/icons": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/checkbox": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkbox/-/checkbox-0.0.18-alpha.tgz",
-      "integrity": "sha512-new1PBai+IK7stTZpooVVkqUpHtrig/2+KfjnTAY24hdOXBu9f/JyZUaIRrS5zKjTBx2N68AK5wFGsU1KyXmrg==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkbox/-/checkbox-0.0.19-alpha.tgz",
+      "integrity": "sha512-1EC8DyZIExSXmisyKYlOh29Yf4Zcq4m2M/K+ErZp1CMwsK9bvT5iwUrCdC0DVN5hqUsWa6OwVkvex3DkmgJ6ZA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha",
-        "@govuk-frontend/label": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha",
+        "@govuk-frontend/label": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/cookie-banner": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/cookie-banner/-/cookie-banner-0.0.18-alpha.tgz",
-      "integrity": "sha512-eZPfA5SYMV8HQPWBC/z+dc9QYNB4p8++oD3SwMqrTmJhdkyHPvR60Inu/efH9io+Mk/0qIgDmzLaIA68KaUd8g==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/cookie-banner/-/cookie-banner-0.0.19-alpha.tgz",
+      "integrity": "sha512-yqHq8TopJXD8KuWNua++McuqQsXtlchs23mjNZ6m23Y/Wn6z+j98G/qokutuW6tjR1EGzWBQqwDzFOe6GlKuyw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/date-input": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.18-alpha.tgz",
-      "integrity": "sha512-HKXDeZ5THs0SNFDuSVvOhEXEGNCLb9UiL03txnsyyT+AxAEimSDFrXQ0xCvsiM2NjtccITlB0lRdLG7e3QzLiA==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.19-alpha.tgz",
+      "integrity": "sha512-FsgEPrs5mwGnKk8S8qchTItgTHfs0IOgM0JPQ6sWfHHZeGArblUxrjgUlKg7p1wP/4s8V1kNKoyYnl9io3b7jA==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.18-alpha",
-        "@govuk-frontend/globals": "0.0.18-alpha",
-        "@govuk-frontend/label": "0.0.18-alpha"
+        "@govuk-frontend/error-message": "0.0.19-alpha",
+        "@govuk-frontend/globals": "0.0.19-alpha",
+        "@govuk-frontend/label": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/details": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.18-alpha.tgz",
-      "integrity": "sha512-Aob0Fjb+Gy+1oxLLJ2tHmjK6Ysa4s497IM+oYaUqCkAPiriA/7RV9COtBCnnewDtx0OsHo+9dIE5OMupvCs9iA==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.19-alpha.tgz",
+      "integrity": "sha512-Vcea4hUgD3BvGPooLMnnQZUAHn7rlVFvQgACYUMIy+nv2J65ExNuwWBUA8Vxf5Z8Sv1R6SkQq0r/bFlQWEE6Og==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/error-message": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.18-alpha.tgz",
-      "integrity": "sha512-P6BRrimNSG4qnslilSb6OPktQ5otSEJXmgMcvKnLJ4Ok/xYmiXaRphDFq2z6/JO4J/LTkEkCFFjf+bVhd1FmzA==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.19-alpha.tgz",
+      "integrity": "sha512-lrLGiEtM4DWe0HeBucf8iRIzexCwKAD8o/epM0/VZ9Q/su2RrCfpJgcK2AS9QuwHPVsnX5cMKrp3YTWQUvFfew==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/error-summary": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.18-alpha.tgz",
-      "integrity": "sha512-BIuiK9durQFljSid10h9Wi7yaQEEx4tbsvbYi0He7TyavpuxCtSAdGnCBmZWVprcSBHe2fjl86cEg7eWHHCphg==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.19-alpha.tgz",
+      "integrity": "sha512-OPhVvxUlBwI/4eRY4sVqufIGnukqT+sleaZuUJFcHefvPZTrL5gadti/srzfQ/Wiv96k3DYtjqucaNrhDk+oaA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha",
-        "@govuk-frontend/list": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/fieldset": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.18-alpha.tgz",
-      "integrity": "sha512-jQOx4J4Oz7xzYLqgnBRi8D41pcn11jy2y4F15v5SvbZjfZmVMSn3S0+Y1R55U/29TUlh74lDQ+G65UEc728q6w==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.19-alpha.tgz",
+      "integrity": "sha512-5o3UXUH/vAe9/Q1jLXnZgJeqAb1mcDM8oJdrVOYhzr/DtKGtRNvnNNUo75s49Lyz5J8unDTt6BvZKtTA6OqbwQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/file-upload": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.18-alpha.tgz",
-      "integrity": "sha512-KzIqBpWdDVvnjVrdwYmpeldMgDOxMnaYOnAUOe69Ko84mw3S/z8XxxtUTq8LnUk8ZtvxpKr9JjyZFMmEkbZUBw==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.19-alpha.tgz",
+      "integrity": "sha512-ldlCbZy+AqOsyTfWgvIqervA5Y7hiO7zBlbt1fvjYA/tHZSEDrHW6c/OCCKum0Rs4ft3LlKwLBy2PQXT/hTztg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/globals": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.18-alpha.tgz",
-      "integrity": "sha512-Razfe/ZK7FfB1I7uR1jOjVokUtbjJ0L8ua49vPGvowL7FlXlYp3JezPkS3PgqYIi0gls4bTEL53if4XW5d2S1g==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.19-alpha.tgz",
+      "integrity": "sha512-y6Y7PQgzOzcFa/6UyZbTs5nKnkVoo951DzcSzLAhBqVRdXGMpP1dvLB6qZWYoIF2muSnjFoaNwo4qmbSHSRo3Q==",
       "requires": {
         "sass-mq": "3.3.2"
       }
     },
     "@govuk-frontend/icons": {
-      "version": "0.0.17-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.17-alpha.tgz",
-      "integrity": "sha512-l4hmyJBMyOShIqrMWCYnDTc1S2u+aCduCSLLlcTEk41nAHsGeJRD8vpIkHXnyu0r7lVcP/1XMoOi4H9if79i4w=="
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.19-alpha.tgz",
+      "integrity": "sha512-ADn/E3/hLiNyA2+oTWH5CdxaWTZ9jSu8d23OXgsSFNwF5TCuvPVD6TDxV3MvrwBsPou7yz4m0as3C7Oq6jn65Q=="
     },
     "@govuk-frontend/input": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.18-alpha.tgz",
-      "integrity": "sha512-VH0dn1PziIKLBIrgZRgxR3QNc7zfPfjXqb7T0b+gDHMC+YmBbqZYtmPGp7s/7H5/g921zMvoUKVniK7R6oCOyg==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.19-alpha.tgz",
+      "integrity": "sha512-pDIHihkHuSRdAfh/CI/LC9rxVaWK/2GZstAdPsmDhDDUA104T4XdcmMAJlW4LuSoJPl4epu6ZTiRAMbHerI4wg==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.18-alpha",
-        "@govuk-frontend/globals": "0.0.18-alpha",
-        "@govuk-frontend/label": "0.0.18-alpha"
-      }
-    },
-    "@govuk-frontend/inset-text": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/inset-text/-/inset-text-0.0.18-alpha.tgz",
-      "integrity": "sha512-T0f1xoVXnwRyaxnyB5mDqzgdq/sA5ZRdQ+bp2xIxYzgtxL73iHKiTmdpDxo9UvPlmEz/MMIvD4/amUoPg/zRTw==",
-      "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/error-message": "0.0.19-alpha",
+        "@govuk-frontend/globals": "0.0.19-alpha",
+        "@govuk-frontend/label": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/label": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.18-alpha.tgz",
-      "integrity": "sha512-nRFUEznafBX1mw/ViHN8gZ8Vyo/0mxuwZd3j1pI0D3J/5/S+KdwCneSvGqvlkYhytSB7pKnfqSzBL/uWp6wJTQ==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.19-alpha.tgz",
+      "integrity": "sha512-NLjgKGz+Gfrswbf5AF6z0W5jygIaurhqiKXOfK7fOtxmRSfg4Y/pFP6cp5cA/w8BSs8ApK4eOAciTnNSfiFGRQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/legal-text": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/legal-text/-/legal-text-0.0.18-alpha.tgz",
-      "integrity": "sha512-5vlNaCW9VW9rRd4a9iBfeipShZLPKC3qPZSc0cFf0883loyhca5Ml/in2RNLvww2ReZdG2Z2F4ndmK2wqBoXxQ==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/legal-text/-/legal-text-0.0.19-alpha.tgz",
+      "integrity": "sha512-zJr5EqHlzzpPmnZKknSgKZd8pZA2J1PNflsuyQAZM4M2aBMSngyWB8ilV4kNQXXECX4aPmZe54LFIziJRIK6zA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/link": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/link/-/link-0.0.18-alpha.tgz",
-      "integrity": "sha512-FAxUzx3jlsdEBsyHFZgs00THfJb48y6KFlmddrGem6tOHGjNbRaQAaDt+ldjwfUq1ULtwgYjN6NhDW68mJ3NYg==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/link/-/link-0.0.19-alpha.tgz",
+      "integrity": "sha512-IjpkL15XPWVRi+I6LiZjw5fvk8EioAsglJKna0X+WMpZqWO4S+9wYRELEmet6m2cpLjpehn4WQmR4qSxAqUKZg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
-      }
-    },
-    "@govuk-frontend/list": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/list/-/list-0.0.18-alpha.tgz",
-      "integrity": "sha512-G/0I6VUpscgrxRkomykAd2eb+O+ZzyeRF2ccIlyWctgRxfzvm9u+Kqcnv31iZCy8tNQgftr85zAXRxJ7S1V7lg==",
-      "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/panel": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.18-alpha.tgz",
-      "integrity": "sha512-tr9DpbyX1rvNiyzR5Kgtzyp9bArKI1WjVBTLyzGJC8CQrNscT5D6GGQuYZJp5emLb3GJVT3wo29Ab7mqZIfLXw==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.19-alpha.tgz",
+      "integrity": "sha512-wV4YqL4dH1CDN4q3fMqd1IwoVGcL7yNZTM9AYdKTekOm8iOTgV4CSp/dYgnb67oJJ8PVonZhyffx47AMzyYFRQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/phase-banner": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.18-alpha.tgz",
-      "integrity": "sha512-zZ8hBg66fReMc8hv0l14xiEv168XdBiX/7H7s9YweWBp+TX1dX/rmSUrSa1i+ovsj4l8RZldaVRIhtKOR/DAEA==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.19-alpha.tgz",
+      "integrity": "sha512-M8tW/tVLwG4pWAVmNJw4QN71Q3Zu+Z06zfLPZzDn8vSYDMqPTac9v7fzOX979MEMX2fCBO+fKhKq30TSRw8YuQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha",
-        "@govuk-frontend/tag": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha",
+        "@govuk-frontend/tag": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/previous-next": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/previous-next/-/previous-next-0.0.18-alpha.tgz",
-      "integrity": "sha512-K8GZVm+ocnXGRd1fl6d1OZOXzaAMLUBEr4Qb/aB/0LJJ+Jk2GYW2PXiRI0jRNaNwsitjSNYDkRBoTTF9e+PsPw==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/previous-next/-/previous-next-0.0.19-alpha.tgz",
+      "integrity": "sha512-NFm07zk9NXk3PPXXi8PjTepldbS/FuHLAaY06AE3mVm5aYpptBHtT4jAndc0t53ImI85ULlnalbJKHnPz0ImtA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/radio": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/radio/-/radio-0.0.18-alpha.tgz",
-      "integrity": "sha512-V/iJTE3GHd3YakWm2ezVuosvCtSaiqVgB0CHWMwxNPFL8Iilocw7d7ghFJU9PWS6cCXD51jA20VWu7X9R9d/Bw==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/radio/-/radio-0.0.19-alpha.tgz",
+      "integrity": "sha512-C1jS5dJaEG8R5AfJRbBYBiq6PUglC8vBnlw8PcM+/fpbWm8sFBmQ7NbmC1qlnUUasOC5vF1JxP+IcaNEuWM1DQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha",
-        "@govuk-frontend/label": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha",
+        "@govuk-frontend/label": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/select": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.18-alpha.tgz",
-      "integrity": "sha512-wXTbNKOInsxIbcejNiBTpqQkxG8Oj1+zf5Qk3hnD4KhjQ7vmbNme566wrX+53rtSSy6Vn6lJ3P572dwDhTGt0A==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.19-alpha.tgz",
+      "integrity": "sha512-K5Itl4Ce0BSWQ+SjPvQExmiCwEtMT57AKSgqZBFIBj9vBM4WEaFAujcOZPZokUY5v790G/hC4CDKYuN1J0x0PA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha",
-        "@govuk-frontend/label": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha",
+        "@govuk-frontend/label": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/skip-link": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.18-alpha.tgz",
-      "integrity": "sha512-nDQuyaHQExyjdHp8m0LzggJOONmJW/X6hx1JSeSr+tORX/QfG73Aiv8QjCF2XS6QIO11aSNf2+RTE4IAWjO16Q==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.19-alpha.tgz",
+      "integrity": "sha512-RquYj6p1e5JAYMgivtRSRdHe/0tH95plF9fvUM56zN/LusbKhqO4K43zzq1U5Ku1uhEXXDW8t8XTdZpVfq+6Aw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/table": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.18-alpha.tgz",
-      "integrity": "sha512-YvFQcNDUPfmTPlI93Pf+JzwSgklcYBvAv/3Zs3AHDQLLut3K8cf4HsvZoALQfUa64yOo1kUA4QDrD9G5YBS3Bw==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.19-alpha.tgz",
+      "integrity": "sha512-eTt0Ix2Wrc26NGzU7uqAUqEzhYSb1c5I+I8TVWK49LglT91d2nnZQ5XB31T3SpWKBv72xBjrI8yXEMu74If9lg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/tag": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.18-alpha.tgz",
-      "integrity": "sha512-46S1l0RnR7XDqHgqY/73qXu3BM5ACRGR8W0Qj65Ac/j9AL6e8050Uiwgeui5OCxJxgOJJ8IUveEIqL2n4o9yfg==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.19-alpha.tgz",
+      "integrity": "sha512-6iuYCMU4NFr0G7KiExZDbIY48bi+OX5pI3ApEnvSVY5DbRzyjzx5pVuT6x9fb0oRpErS7tj2tREfbj6l4GGGQQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.18-alpha"
+        "@govuk-frontend/globals": "0.0.19-alpha"
       }
     },
     "@govuk-frontend/textarea": {
-      "version": "0.0.18-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.18-alpha.tgz",
-      "integrity": "sha512-oTl8eY7ngorM8OIcpYLifwLyTFeCeQ9m93YIXnW817cmQHy1gF78ZL1OLC4GJahtGc8YrO3AvFtu6AbqGHLZ/Q==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.19-alpha.tgz",
+      "integrity": "sha512-Hr5uHSlAEDh8m8ZrWxi9pofrJzX544ctLamEmnxqPCDigW1GcNtkpj9QSQIN38UfmuNv1R+vZu8KIGnYgB8skw==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.18-alpha",
-        "@govuk-frontend/globals": "0.0.18-alpha",
-        "@govuk-frontend/label": "0.0.18-alpha"
+        "@govuk-frontend/error-message": "0.0.19-alpha",
+        "@govuk-frontend/globals": "0.0.19-alpha",
+        "@govuk-frontend/label": "0.0.19-alpha"
       }
     },
     "a-sync-waterfall": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "gulp scss:lint"
   },
   "dependencies": {
-    "@govuk-frontend/all": "^0.0.18-alpha"
+    "@govuk-frontend/all": "0.0.19-alpha"
   },
   "devDependencies": {
     "gulp": "^3.9.1",

--- a/src/components/breadcrumbs/default.md.njk
+++ b/src/components/breadcrumbs/default.md.njk
@@ -1,9 +1,9 @@
 ---
 layout: layout-example.njk
 ---
-{% from "breadcrumb/macro.njk" import govukBreadcrumb %}
+{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
-{{ govukBreadcrumb({
+{{ govukBreadcrumbs({
   "items": [
     {
       "text": "Home",

--- a/src/errors/404.html
+++ b/src/errors/404.html
@@ -1,6 +1,6 @@
 <main id="content" class="app-c-content" role="main">
-  <div class="govuk-o-site-width-container app-c-site-width-container--constraint">
-    <h1 class="heading-xlarge">Page not found</h1>
+  <div class="govuk-o-width-container app-c-site-width-container--constraint">
+    <h1 class="govuk-heading-xl">Page not found</h1>
     <p>If you entered a web address please check it was correct.</p>
   </div>
 </main>

--- a/src/errors/generic.html
+++ b/src/errors/generic.html
@@ -1,5 +1,5 @@
 <main id="content" class="app-c-content" role="main">
-  <div class="govuk-o-site-width-container app-c-site-width-container--constraint">
-    <h1 class="heading-xlarge">Something went wrong</h1>
+  <div class="govuk-o-width-container app-c-site-width-container--constraint">
+    <h1 class="govuk-heading-xl">Something went wrong</h1>
   </div>
 </main>

--- a/src/index.njk
+++ b/src/index.njk
@@ -1,29 +1,27 @@
 {% include "../views/partials/_masthead.njk" %}
-<div class="govuk-mb-5 govuk-u-core-19">
-  <div class="govuk-o-site-width-container app-c-site-width-container">
-      <div class="govuk-o-grid">
-        <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-u-mb-5">
-          <h2 class="heading-large">Styles</h2>
-          <p>The core styles that will make your service look and feel like GOV.UK.  This includes <a href="/styles/colour/">Colour</a>, <a href="/styles/typography/">Typography</a> and <a href="/styles/layout/">Layout</a>.</p>
-          <p class="govuk-u-mb-0"><a href="/styles/">See all styles</a></p>
-        </div>
-        <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-u-mb-5">
-          <h2 class="heading-large">Components</h2>
-          <p>Re-usable parts of the user interface. From small form elements like <a href="/components/radio-buttons/">Radio buttons</a> to larger ones such as <a href="/components/autocomplete/">Autocomplete</a>.</p>
-          <p class="govuk-u-mb-0"><a href="/components/">See all components</a></p>
-        </div>
-        <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-u-mb-5">
-          <h2 class="heading-large">Patterns</h2>
-          <p>Best practice design solutions for specific user-focused tasks and scenarios such as <a href="/patterns/asking-for/addresses/">asking for addresses</a> or <a href="/patterns/helping-users/feedback-pages/">getting user feedback</a>.</p>
-          <p class="govuk-u-mb-0"><a href="/patterns/">See all patterns</a></p>
-        </div>
-        <div class="govuk-o-grid__item govuk-o-grid__item--full">
-          {% include "../views/partials/_divider.njk" %}
-        </div>
-        <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-          <h2 class="heading-large">Get in touch</h2>
-          <p>If you’ve got a question, idea or suggestion share it in <a href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>) or <a href="#">email the Design System team</a></p>
-        </div>
+<div class="govuk-o-width-container app-c-site-width-container">
+    <div class="govuk-o-grid govuk-o-main-wrapper">
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r4 govuk-!-mb-r6">
+        <h2 class="govuk-heading-l">Styles</h2>
+        <p class="govuk-body">The core styles that will make your service look and feel like GOV.UK.  This includes <a href="/styles/colour/">Colour</a>, <a href="/styles/typography/">Typography</a> and <a href="/styles/layout/">Layout</a>.</p>
+        <p class="govuk-body govuk-!-mb-r0"><a href="/styles/">See all styles</a></p>
       </div>
-  </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r4 govuk-!-mb-r6">
+        <h2 class="govuk-heading-l">Components</h2>
+        <p class="govuk-body">Re-usable parts of the user interface. From small form elements like <a href="/components/radio-buttons/">Radio buttons</a> to larger ones such as <a href="/components/autocomplete/">Autocomplete</a>.</p>
+        <p class="govuk-body govuk-!-mb-r0"><a href="/components/">See all components</a></p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r4 govuk-!-mb-r6">
+        <h2 class="govuk-heading-l">Patterns</h2>
+        <p class="govuk-body">Best practice design solutions for specific user-focused tasks and scenarios such as <a href="/patterns/asking-for/addresses/">asking for addresses</a> or <a href="/patterns/helping-users/feedback-pages/">getting user feedback</a>.</p>
+        <p class="govuk-body govuk-!-mb-r0"><a href="/patterns/">See all patterns</a></p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--full">
+        {% include "../views/partials/_divider.njk" %}
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds govuk-!-mb-r4">
+        <h2 class="govuk-heading-l govuk-!-mt-r6">Get in touch</h2>
+        <p class="govuk-body govuk-!-mb-r0">If you’ve got a question, idea or suggestion share it in <a href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>) or <a href="#">email the Design System team</a></p>
+      </div>
+    </div>
 </div>

--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -1,13 +1,15 @@
 // Example styles
 .app-c-example {
+  @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+
   position: relative;
-  margin: $govuk-gutter 0;
   border: 1px solid $govuk-border-colour;
   background: $govuk-grey-3;
 }
 
 .app-c-example--tabs {
-  margin-bottom: 0;
+  @include govuk-responsive-margin($govuk-spacing-responsive-0, "bottom");
+
   @include mq($from: desktop) {
     margin-bottom: -1px;
   }
@@ -17,8 +19,8 @@
   position: absolute;
   top: 0;
   left: 0;
-  padding: 5px $govuk-gutter / 2;
-  @include govuk-core-14;
+  padding: 5px $govuk-spacing-scale-6 / 2;
+  @include govuk-font-regular-14;
   background: $govuk-grey-3;
 
   a {
@@ -27,7 +29,7 @@
   }
 
   &:before {
-    @include govuk-core-14;
+    @include govuk-font-regular-14;
     content: "EXAMPLE";
     margin-right: 10px;
   }
@@ -44,7 +46,7 @@
 
 .app-c-example__frame--resizable {
   min-width: 230px;
-  min-height: $govuk-gutter * 2;
+  min-height: $govuk-spacing-scale-6 * 2;
   overflow: auto;
   resize: both;
 }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -7,13 +7,12 @@
 
   .app-c-footer {
     display: block;
-    margin-top: $govuk-spacing-scale-1;
-    padding: $govuk-gutter $govuk-gutter-half ($govuk-gutter * 2);
+    padding: $govuk-gutter $govuk-spacing-scale-3 ($govuk-gutter * 2);
     border-top: 1px solid $govuk-footer-border-top;
     color: $govuk-footer-text;
     background: $govuk-footer-background;
     @include mq($from: desktop) {
-      padding: $govuk-gutter;
+      padding: $govuk-spacing-scale-6;
     }
 
     a:link,
@@ -24,6 +23,13 @@
     a:hover,
     a:active {
       color: $govuk-footer-link-hover;
+    }
+  }
+
+  .app-c-footer__navigation {
+
+    @include mq($until: desktop) {
+      margin-bottom: $govuk-spacing-scale-6;
     }
   }
 
@@ -46,7 +52,7 @@
     a {
       display: inline-block;
       margin-top: $govuk-spacing-scale-2;
-      @include govuk-core-16;
+      @include govuk-font-regular-16;
     }
   }
 
@@ -80,12 +86,12 @@
 
   .app-c-footer__licence-description {
     display: inline-block;
-    @include govuk-core-16;
+    @include govuk-font-regular-16;
     margin: 0;
   }
 
   .app-c-footer__copyright {
-    @include govuk-core-16;
+    @include govuk-font-regular-16;
     margin-top: $govuk-spacing-scale-5;
     @include mq ($from: desktop) {
       display: inline-block;

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -35,24 +35,18 @@
   }
 
   .app-c-header__title {
-    @include govuk-core-24;
-    @include font-smoothing;
+    @include govuk-font-regular-24;
   }
 
   .app-c-header__link {
     // Font size needs to be set on the link so that the box sizing is correct
     // in Firefox
-    @include _core-font-generator(
-      $font-size: 30px,
-      $font-size-640: 30px,
-      $font-size-print: 30px,
-      $line-height: 30px,
-      $line-height-640: 30px,
-      $font-weight: 700
-    );
-    @include font-smoothing;
-
+    @include govuk-typography-common;
+    @include govuk-typography-weight-bold;
     display: inline-block;
+
+    font-size: 30px; // We don't have a mixin that produces 30px font size\
+    line-height: 30px;
 
     &:link,
     &:visited {

--- a/src/stylesheets/components/_masthead.scss
+++ b/src/stylesheets/components/_masthead.scss
@@ -1,13 +1,16 @@
 .app-c-masthead {
+  @include govuk-responsive-padding($govuk-spacing-responsive-6, "top");
+  @include govuk-responsive-padding($govuk-spacing-responsive-6, "bottom");
   color: $govuk-white;
   background-color: $govuk-blue;
 }
 
 .app-c-masthead__title {
-  @include govuk-bold-48;
-  margin-top: 0; // Note: on Elements this is included in h1
+  color: $govuk-white;
+  @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
 }
 
 .app-c-masthead__description {
-  @include govuk-core-24;
+  @include govuk-font-regular-24;
+  margin-bottom: 0;
 }

--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -24,9 +24,8 @@
 
 
   & > li {
-    @include govuk-bold-19;
-    @include font-smoothing;
-    font-family: $govuk-font-stack;
+    @include govuk-typography-common;
+    @include govuk-typography-weight-bold;
     font-size: 19px; // We don't have a font mixin that produces 19px on mobile
 
     & > a {
@@ -59,7 +58,7 @@
 
   & > li {
     & > a {
-      @include govuk-core-19;
+      @include govuk-font-regular-19;
       display: block;
       padding: $govuk-spacing-scale-2 $govuk-spacing-scale-4;
 
@@ -80,7 +79,7 @@
   margin: 0;
   padding: $govuk-spacing-scale-4 $govuk-spacing-scale-4 $govuk-spacing-scale-1 $govuk-spacing-scale-4;
   color: $govuk-grey-1;
-  @include govuk-core-19;
+  @include govuk-font-regular-19;
   text-transform: uppercase;
 }
 
@@ -91,7 +90,7 @@
   background-color: $govuk-white;
 
   & > li {
-    @include govuk-core-19;
+    @include govuk-font-regular-19;
 
     & > a {
       display: block;

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -3,9 +3,7 @@
   padding-right: $govuk-spacing-scale-3;
   padding-left: $govuk-spacing-scale-3;
   background-color: $app-light-grey;
-  font-family: $govuk-font-stack;
-  @include font-smoothing;
-  @include govuk-bold-19;
+  @include govuk-font-bold-19;
 
   @include mq($until: desktop) {
     display: none;

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -20,7 +20,7 @@
   a {
     display: block;
     margin-top: -1px;
-    padding: $govuk-gutter-half;
+    padding: $govuk-spacing-scale-3;
     border-top: 2px solid transparent;
     border-bottom: 2px solid transparent;
     color: $govuk-link-colour;
@@ -44,7 +44,7 @@
     display: none;
     position: relative;
     z-index: 2;
-    padding: $govuk-gutter-half;
+    padding: $govuk-spacing-scale-3;
     border: 1px solid $govuk-border-colour;
     border-top: 0;
     color: $govuk-link-colour;
@@ -78,14 +78,14 @@
 }
 
 .app-c-tabs__container pre {
-  padding-bottom: $govuk-gutter;
+  padding-bottom: $govuk-spacing-scale-6;
   border: 0;
 }
 
 // Close container button
 .app-c-link--close {
   position: absolute;
-  right: $govuk-gutter-half;
-  bottom: $govuk-gutter-half / 2;
+  right: $govuk-spacing-scale-3;
+  bottom: $govuk-spacing-scale-3 / 2;
   text-decoration: none;
 }

--- a/src/stylesheets/components/_toc.scss
+++ b/src/stylesheets/components/_toc.scss
@@ -1,12 +1,12 @@
 @include exports("toc") {
 
   .app-c-toc {
-    padding: 0 $govuk-gutter-half;
-    @include govuk-core-16;
+    padding: 0 $govuk-spacing-scale-3;
+    @include govuk-font-regular-16;
   }
 
   .app-c-toc__section {
-    margin: $govuk-gutter-half 0;
+    margin: $govuk-spacing-scale-3 0;
     padding: 0;
     list-style-type: none;
 
@@ -14,7 +14,7 @@
     a:link,
     a:visited {
       display: block;
-      padding: 8px ($govuk-gutter * 2) 8px $gutter-one-third;
+      padding: 8px ($govuk-spacing-scale-6 * 2) 8px $govuk-spacing-scale-2;
       border-left: 4px solid transparent;
       color: $govuk-link-colour;
       background: inherit;

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -69,14 +69,10 @@ $mq-breakpoint-widescreen: 1200px;
   }
 }
 
-// Note: on Elements this is included on the body - we will review in FE how to best add font smoothing
-.govuk-u-font-smoothing {
-  @include font-smoothing;
-}
-
 .app-c-content {
-  padding: $govuk-gutter;
-  @include govuk-core-19;
+  @include govuk-font-regular-19;
+
+  @include govuk-responsive-padding($govuk-spacing-responsive-6);
 
   h1,
   h2,
@@ -90,15 +86,16 @@ $mq-breakpoint-widescreen: 1200px;
   img {
     max-width: 38em;
   }
+
 }
 
 .app-c-content__header {
-  @include govuk-core-24;
+  @include govuk-font-regular-24;
 }
 
 .app-c-content__heading {
   margin-top: 0;
-  margin-bottom: $govuk-gutter;
+  margin-bottom: $govuk-spacing-scale-6;
 }
 
 .app-c-content__section-heading {
@@ -108,16 +105,16 @@ $mq-breakpoint-widescreen: 1200px;
 }
 
 .app-o-example-page {
-  padding: $govuk-gutter * 2 $govuk-gutter $govuk-gutter;
+  padding: $govuk-spacing-scale-6 * 2 $govuk-spacing-scale-6 $govuk-spacing-scale-6;
 
   &:before {
     content: "Resize";
     position: absolute;
     z-index: 2;
-    right: $govuk-gutter-half;
+    right: $govuk-spacing-scale-3;
     bottom: 0;
     color: $govuk-secondary-text-colour;
-    @include govuk-core-16;
+    @include govuk-font-regular-16;
   }
 }
 
@@ -151,8 +148,8 @@ $mq-breakpoint-widescreen: 1200px;
   &:hover {
     position: absolute;
     z-index: 1;
-    top: $govuk-gutter-half;
-    right: $govuk-gutter-half;
+    top: $govuk-spacing-scale-3;
+    right: $govuk-spacing-scale-3;
     padding: 4px 10px 0;
     border: 1px solid $govuk-button-colour;
     color: $govuk-button-colour;
@@ -165,7 +162,7 @@ $mq-breakpoint-widescreen: 1200px;
 pre {
   position: relative;
   margin: 0;
-  padding: $govuk-gutter-half;
+  padding: $govuk-spacing-scale-3;
   overflow: auto;
   border: 1px solid $govuk-border-colour;
   background-color: $app-light-grey;

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -12,7 +12,7 @@
     <script src="/javascripts/vendor/modernizr.js"></script>
     {% include "../partials/_tracking-head.njk" %}
   </head>
-  <body class="govuk-u-font-smoothing">
+  <body>
     {% include "../partials/_tracking-body.njk" %}
     <a href="#content" class="govuk-c-skip-link">Skip to main content</a>
     <div class="app-o-pane">

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -9,7 +9,7 @@
     <!--[if lt IE 9]><script src="/javascripts/ie.js"></script><![endif]-->
     <script src="/javascripts/application.js"></script>
   </head>
-  <body class="govuk-u-font-smoothing app-o-example-page">
+  <body class="app-o-example-page">
     {% block body %}
       {{ contents | safe }}
     {% endblock %}

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -9,15 +9,18 @@
   <div class="app-o-pane__content">
     <main id="content" class="app-c-content" role="main">
       <div class="app-c-content__header">
-        <p class="app-c-content__section-heading">
+        <h1 class="govuk-heading-xl">
+          <span class="govuk-caption-xl">
           {% if theme %}
               {{ theme }}
             {% else %}
               {{ section }}
           {% endif %}
-        </p>
-        <h1 class="app-c-content__heading heading-xlarge">{{ title }}</h1>
+          </span>
+          {{ title }}
+        </h1>
       </div>
+
       {{ contents | safe }}
     </main>
     {# No JS fallback to show overview #}

--- a/views/partials/_footer.njk
+++ b/views/partials/_footer.njk
@@ -1,8 +1,8 @@
 <footer class="app-c-footer">
   <div class="app-c-footer__navigation govuk-o-grid">
-    <div class="govuk-o-grid__item govuk-u-mb-5 govuk-o-grid__item--one-quarter">
-      <h2 class="app-c-footer__heading heading-medium">Other design resources</h2>
-      <ul class="app-c-footer__list govuk-c-list">
+    <div class="govuk-o-grid__item govuk-o-grid__item--one-quarter">
+      <h2 class="app-c-footer__heading govuk-heading-m">Other design resources</h2>
+      <ul class="app-c-footer__list govuk-list">
         <li class="app-c-footer__list-item"><a href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a></li>
         <li class="app-c-footer__list-item"><a href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a></li>
       </ul>

--- a/views/partials/_masthead.njk
+++ b/views/partials/_masthead.njk
@@ -1,9 +1,9 @@
-<div class="app-c-masthead govuk-u-pt-5 govuk-u-pb-5 govuk-u-mb-5">
-  <div class="govuk-o-site-width-container app-c-site-width-container">
+<div class="app-c-masthead">
+  <div class="govuk-o-width-container app-c-site-width-container">
       <div class="govuk-o-grid">
         <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-            <h1 class="app-c-masthead__title">Design your service using GOV.UK styles, components and patterns</h1>
-            <p class="app-c-masthead__description govuk-u-mb-2">Use this design system to make your service consistent with other government services. Learn from the research and experience of other service teams and avoid repeating work that’s already been done.</p>
+            <h1 class="govuk-heading-xl app-c-masthead__title">Design your service using GOV.UK styles, components and patterns</h1>
+            <p class="app-c-masthead__description">Use this design system to make your service consistent with other government services. Learn from the research and experience of other service teams and avoid repeating work that’s already been done.</p>
         </div>
     </div>
   </div>

--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -1,5 +1,3 @@
-{% from "breadcrumb/macro.njk" import govukBreadcrumb %}
-
 <nav id="app-c-mobile-nav" class="app-c-mobile-nav js-app-mobile-nav" role="navigation">
   <ul class="app-c-mobile-nav__list">
     <li>

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -1,4 +1,4 @@
-<nav class="app-c-navigation govuk-u-clearfix">
+<nav class="app-c-navigation govuk-h-clearfix">
   <ul class="app-c-navigation__list">
     <li{% if path == '' %}  class="app-c-navigation--current-page"{% endif %}>
       <a href="/">About</a>


### PR DESCRIPTION
This PR updates the Design System to 0.19 with the following:

1. Build:

   - Change `package.json` to use Frontend version 0.19-alpha

2. Styles:

   - Remove references to `font-smoothing` and `font-stack` mixins and `govuk-u-font-smoothing` class as these are now included by `govuk-typography-common`.
   - Add responsive margins to some components as 0.19 removes top margins from typography so this needs now to be accounted for in component styles.
   - Halve `app-c-content` padding as 0.19 uses a 15px, not 30px gutter.
   - Now use the spacing scale instead of the gutter spacing wherever possible - coupling spacing with gutters only makes sense in very layout-y classes.

3. Components/partials/layout:

   - Remove `govuk-u-font-smoothing` classes as this is now handled by `govuk-typography-common`.
   - Remove override classes where a specific component/partial class is in use and move override styles into that component/partial.
   - Change references to `breadcrumb` components to `breadcrumbs`. Also remove reference to `breadcrumb` from mobile-navigation as this is no longer used in the partial.

Notes to reviewer:

- It's probably easiest to review this PR by reviewing the commits which are organised into the above groupings.
- The Travis build succeeding is dependent on #95 - I'll rebase it into this branch once it's merged into master.