### PR TITLE
Enable autoescape option for Nunjucks

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -72,7 +72,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     pattern: '**/*.njk',
     engineOptions: {
       path: views,
-      autoescape: false, // output with dangerous characters are not escaped automatically
+      autoescape: true, // escape all output by default
       noCache: true, // never use a cache and recompile templates each time
       trimBlocks: true, // automatically remove trailing newlines from a block/tag
       lstripBlocks: true, // automatically remove leading whitespace from a block/tag

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -20,7 +20,7 @@
 <div class="app-c-tabs__heading"><a href="#{{examplePrefix}}html" role="tab" aria-controls="{{examplePrefix}}html">HTML</a></div>
 <div class="app-c-tabs__container" id="{{examplePrefix}}html" role="tabpanel">
   ```html
-  {{ getHTMLCode(examplePath) }}
+  {{ getHTMLCode(examplePath) | safe }}
   ```
 </div>
 {% endif %}
@@ -29,7 +29,7 @@
 <div class="app-c-tabs__heading"><a href="#{{examplePrefix}}nunjucks" role="tab" aria-controls="{{examplePrefix}}nunjucks">Nunjucks</a></div>
 <div class="app-c-tabs__container" id="{{examplePrefix}}nunjucks" role="tabpanel">
   ```js
-  {{ getNunjucksCode(examplePath) }}
+  {{ getNunjucksCode(examplePath) | safe }}
   ```
 </div>
 {% endif %}


### PR DESCRIPTION
This was disabled when the examples work was done, but means that Frontend components do not behave as expected (`text` arguments not being escaped)

We can re-enable it, but we need to manually mark the code blocks for use within the examples as safe using the `safe` filter.