### PR TITLE
Add image styling to Design System

### DIFF
--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -87,6 +87,15 @@ $mq-breakpoint-widescreen: 1200px;
     max-width: 38em;
   }
 
+  img {
+    box-sizing: border-box;
+    width: 100%;
+    height: auto;
+    padding: $govuk-spacing-scale-2;
+    @include govuk-responsive-margin($govuk-spacing-responsive-2, "top");
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+    border: 1px solid $govuk-border-colour;
+  }
 }
 
 .app-c-content__header {


### PR DESCRIPTION
This PR adds styling and responsiveness to images within `app-c-content`

- Adds border
- Adds padding (static)
- Makes image responsive
- Adds margin

**Known issue**
Currently images are rendered from markdown are inside a `<p>` tag. The margin in this update has been applied as if this `<p>` tag has been removed, so it's ready for that PR. That means this PR will look incorrect.
  
https://trello.com/c/kkrDD7G8/485-design-system-add-image-styling-and-responsive-sizing-to-the-design-system
  