### PR TITLE
Add prose scope style to example pages

### DIFF
--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -1,7 +1,10 @@
 // Example styles
-.app-c-example {
+.app-c-example-wrapper {
+  @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+}
 
+.app-c-example {
   position: relative;
   border: 1px solid $govuk-border-colour;
   background: $govuk-grey-3;

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -9,6 +9,11 @@
   @include mq($until: desktop) {
     display: none;
   }
+
+  .govuk-prose-scope & { // A specific selector to reset .govuk-prose-scope ul
+    margin-bottom: 0;
+    padding: 0;
+  }
 }
 
 .app-c-tabs__item {
@@ -27,6 +32,10 @@
     background: inherit;
     font-weight: bold;
     text-decoration: none;
+  }
+
+  .govuk-prose-scope & { // A specific selector to reset .govuk-prose-scope ul li
+    margin: 0;
   }
 }
 

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -21,7 +21,10 @@
         </h1>
       </div>
 
-      {{ contents | safe }}
+      <div class="govuk-prose-scope">
+        {{ contents | safe }}
+      </div>
+
     </main>
     {# No JS fallback to show overview #}
     <div class="app-o-pane__toc-mobile-overview app-u-hide-desktop">

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -4,34 +4,36 @@
 {% set exampleURL = "/" + params.group + "/" + params.item + "/" + params.example + "/index.html" %}
 {% set examplePrefix = params.item + "-" + params.example + "-" %}
 
-<div class="app-c-example app-c-example--tabs">
-  <span class="app-c-example__new-window"><a href="{{ exampleURL }}" target="_blank">(open in new window)</a></span>
-  <iframe class="app-c-example__frame app-c-example__frame--resizable js-example__frame" src="{{ exampleURL }}"></iframe>
-</div>
+<div class="app-c-example-wrapper">
+  <div class="app-c-example {{ "app-c-example--tabs" if params.html or params.nunjucks }}">
+    <span class="app-c-example__new-window"><a href="{{ exampleURL }}" target="_blank">(open in new window)</a></span>
+    <iframe class="app-c-example__frame app-c-example__frame--resizable js-example__frame" src="{{ exampleURL }}"></iframe>
+  </div>
 
-{% if (params.html and params.nunjucks) %}
-<ul class="app-c-tabs" role="tablist">
-  <li class="app-c-tabs__item" role="presentation"><a href="#{{examplePrefix}}html" role="tab" aria-controls="{{examplePrefix}}html"{% if (params.open) %}open{% endif %}>HTML</a></li>
-  <li class="app-c-tabs__item" role="presentation"><a href="#{{examplePrefix}}nunjucks" role="tab" aria-controls="{{examplePrefix}}nunjucks">Nunjucks</a></li>
-</ul>
-{% endif %}
+  {%- if (params.html and params.nunjucks) %}
+  <ul class="app-c-tabs" role="tablist">
+    <li class="app-c-tabs__item" role="presentation"><a href="#{{examplePrefix}}html" role="tab" aria-controls="{{examplePrefix}}html"{% if (params.open) %}open{% endif %}>HTML</a></li>
+    <li class="app-c-tabs__item" role="presentation"><a href="#{{examplePrefix}}nunjucks" role="tab" aria-controls="{{examplePrefix}}nunjucks">Nunjucks</a></li>
+  </ul>
+  {% endif %}
 
-{% if (params.html) %}
-<div class="app-c-tabs__heading"><a href="#{{examplePrefix}}html" role="tab" aria-controls="{{examplePrefix}}html">HTML</a></div>
-<div class="app-c-tabs__container" id="{{examplePrefix}}html" role="tabpanel">
-  ```html
-  {{ getHTMLCode(examplePath) | safe }}
-  ```
-</div>
-{% endif %}
+  {%- if (params.html) %}
+  <div class="app-c-tabs__heading"><a href="#{{examplePrefix}}html" role="tab" aria-controls="{{examplePrefix}}html">HTML</a></div>
+  <div class="app-c-tabs__container" id="{{examplePrefix}}html" role="tabpanel">
+    ```html
+    {{ getHTMLCode(examplePath) | safe }}
+    ```
+  </div>
+  {% endif %}
 
-{% if (params.nunjucks) %}
-<div class="app-c-tabs__heading"><a href="#{{examplePrefix}}nunjucks" role="tab" aria-controls="{{examplePrefix}}nunjucks">Nunjucks</a></div>
-<div class="app-c-tabs__container" id="{{examplePrefix}}nunjucks" role="tabpanel">
-  ```js
-  {{ getNunjucksCode(examplePath) | safe }}
-  ```
+  {%- if (params.nunjucks) %}
+  <div class="app-c-tabs__heading"><a href="#{{examplePrefix}}nunjucks" role="tab" aria-controls="{{examplePrefix}}nunjucks">Nunjucks</a></div>
+  <div class="app-c-tabs__container" id="{{examplePrefix}}nunjucks" role="tabpanel">
+    ```js
+    {{ getNunjucksCode(examplePath) | safe }}
+    ```
+  </div>
+  {% endif %}
 </div>
-{% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
This PR adds `govuk-prose-scope` to the example pages:

- Add `.app-c-example--tabs` only when there are tabs below it to control bottom
margin. 

- Use Nunjucks Whitespace Control (`{%-`) to strip whitespaces to stop them being converted into blank paragraph tags.

- Add `.app-c-example-wrapper` around examples to control bottom margin. Move bottom
margin there from `.app-c-example`. Add top margin as requested by @dashouse.

- Reset `.govuk-prose-scope` styles that broke example tabs.

- Add `.govuk-prose-scope` to example page contents. There's no need for a
conditional for the class in `layout-pane` as the layouts (components/patterns)
using this page template are to be merged shortly.
  
  
  