### PR TITLE
Add error component pages

### DIFF
--- a/src/components/error-message/default.njk
+++ b/src/components/error-message/default.njk
@@ -1,0 +1,9 @@
+---
+layout: layout-example.njk
+---
+
+{% from "error-message/macro.njk" import govukErrorMessage %}
+
+{{ govukErrorMessage({
+  "text": "Error message goes here"
+}) }}

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -1,0 +1,40 @@
+---
+title: Error message
+description:
+section: Components
+aliases:
+layout: layout-pane.njk
+---
+
+{% from "_example.njk" import example %}
+
+{{ example({group: 'components', item: 'error-message', example: 'default'}) }}
+
+## When to use this component
+
+Show an error message next to the form input when there is a validation error with the information a user has entered.
+
+## How it works
+
+For each error:
+
+- write a message that helps the user to understand why the error occurred and how to correct it
+- put the message, in red, in the question’s `<label>` or `<legend>`, after the question text
+- use a red border to visually connect the message and the question it belongs to
+- if the error relates to specific text fields within the question, give these a red border as well
+
+You must also summarise all errors at the top of the page the user is on using an [Error summary](../error-summary).
+
+There are 2 ways to use the Error message component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](Insert prototype kit URL), you can use the Error message macro.
+
+### Legend
+
+{{ example({group: 'components', item: 'error-message', example: 'legend', html: true, nunjucks: true, open: true}) }}
+
+### Label
+
+{{ example({group: 'components', item: 'error-message', example: 'label', html: true, nunjucks: true, open: false}) }}
+
+## Research on this component
+
+If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.

--- a/src/components/error-message/label.njk
+++ b/src/components/error-message/label.njk
@@ -1,0 +1,17 @@
+---
+layout: layout-example.njk
+---
+
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  "label": {
+    "text": "National Insurance number",
+    "hintHtml": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+  },
+  "id": "national-insurance-number",
+  "name": "national-insurance-number",
+  "errorMessage": {
+    "text": "Error message goes here"
+  }
+}) }}

--- a/src/components/error-message/legend.njk
+++ b/src/components/error-message/legend.njk
@@ -1,0 +1,29 @@
+---
+layout: layout-example.njk
+---
+
+{% from "date-input/macro.njk" import govukDateInput %}
+
+{{ govukDateInput({
+  fieldset: {
+    legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',
+    legendHintText: 'For example, 31 3 1980'
+  },
+  "errorMessage": {
+    "text": "Error message goes here"
+  },
+  id: 'dob',
+  name: 'dob',
+  items:[
+    {
+      name: 'day'
+    },
+    {
+      name: 'month'
+    },
+    {
+      name: 'year'
+    }
+  ]
+  })
+}}

--- a/src/components/error-summary/default.njk
+++ b/src/components/error-summary/default.njk
@@ -7,7 +7,6 @@ layout: layout-example.njk
 {{ govukErrorSummary({
   "titleText": "Message to alert the user to a problem goes here",
   "descriptionText": "Optional description of the errors and how to correct them",
-  "classes": "optional-extra-class",
   "errorList": [
     {
       "text": "Descriptive link to the question with an error",

--- a/src/components/error-summary/default.njk
+++ b/src/components/error-summary/default.njk
@@ -1,0 +1,21 @@
+---
+layout: layout-example.njk
+---
+
+{% from "error-summary/macro.njk" import govukErrorSummary %}
+
+{{ govukErrorSummary({
+  "titleText": "Message to alert the user to a problem goes here",
+  "descriptionText": "Optional description of the errors and how to correct them",
+  "classes": "optional-extra-class",
+  "errorList": [
+    {
+      "text": "Descriptive link to the question with an error",
+      "href": "#example-error-1"
+    },
+    {
+      "html": "Descriptive link to the question with an error",
+      "href": "#example-error-1"
+    }
+  ]
+}) }}

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -1,0 +1,35 @@
+---
+title: Error summary
+description:
+section: Components
+aliases:
+layout: layout-pane.njk
+---
+
+{% from "_example.njk" import example %}
+
+{{ example({group: 'components', item: 'error-summary', example: 'default'}) }}
+
+## When to use this component
+
+You must always show an error summary when there is a validation error with the information that a user has entered, even if there’s only one.
+
+## How it works
+
+You must:
+
+- show an error summary at the top of a page
+- include a heading to alert the user to the error
+- link to each of the problematic questions
+
+Additionally, you should reflect that there has been an error in the `<title>` by prefixing the existing title with `“Error:”`. This will make sure that screen readers are alerted to errors as soon as possible.
+
+You must also show an [error message](../components/error-message) alongside the specific input or inputs which have errors.
+
+There are 2 ways to use the Error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](Insert prototype kit URL), you can use the Error summary macro.
+
+{{ example({group: 'components', item: 'error-summary', example: 'default', html: true, nunjucks: true, open: true}) }}
+
+## Research on this component
+
+If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.


### PR DESCRIPTION
Adds examples and pages for `error-summary` and `error-message`