### PR TITLE
Allow for additional stylesheets per example

### DIFF
--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -7,6 +7,12 @@
     <title>{{ title }}</title>
     <link href="/stylesheets/main.css" rel="stylesheet" media="all" />
     <!--[if lt IE 9]><script src="/javascripts/ie.js"></script><![endif]-->
+
+    {#- Include any additional stylesheets specified in the example frontmatter #}
+    {% for stylesheet in stylesheets %}
+    <link href="{{ stylesheet }}" rel="stylesheet" media="all" />
+    {%- endfor %}
+
     <script src="/javascripts/application.js"></script>
   </head>
   <body class="app-o-example-page">


### PR DESCRIPTION
For some examples (at the minute specifically the layout examples) we need to add additional styling to add borders or backgrounds to highlight individual elements within the example.

At the minute this is being done by adding additional classes to the example (not yet committed), but this means that the app stylesheet is full of styles affecting only single examples, and the HTML and Nunjucks code includes extra classes which we would not want users to be copying into their own app.

By allowing users to include additional stylesheets, the additional styling can exist in the same directory as the example and included from there.

As an example, you might add the following to an example's frontmatter:

```
---
layout: layout-example.njk
stylesheets:
- annotate-layout.css
---
```

https://trello.com/c/aKo1JrH1/546-allow-inclusion-of-extra-stylesheets-for-individual-examples
  