### PR TITLE
Update tabs on examples component

### DIFF
--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -7,17 +7,29 @@
 
     // Reset tabs and containers
     resetTabs: function (id) {
+      // Check if we have an id
+      if (!id) {
+        console.error('id is undefined')
+        return
+      }
+
       var $example = $(id).parent()
 
       // Reset state
-      $example.find('.app-c-tabs__item').removeClass('app-c-tabs__item--current')
-      $example.find('.app-c-tabs__heading').removeClass('app-c-tabs__heading--current')
-      $example.find('.app-c-tabs__item a').removeAttr('aria-selected')
-      $example.find('.app-c-tabs__container').hide().attr('aria-hidden', 'true')
+      $example.find('.js-tabs__item').removeClass('app-c-tabs__item--current')
+      $example.find('.js-tabs__heading').removeClass('app-c-tabs__heading--current')
+      $example.find('.js-tabs__item a').removeAttr('aria-selected')
+      $example.find('.js-tabs__container').hide().attr('aria-hidden', 'true')
     },
 
     // Activate current tab
     activateCurrentTab: function (id) {
+      // Check if we have an id
+      if (!id) {
+        console.error('id is undefined')
+        return
+      }
+
       // Reset tabs
       GOVUK.tabs.resetTabs(id)
 
@@ -58,31 +70,31 @@
       GOVUK.tabs.resetTabs('#' + id)
     },
 
-    init: function () {
+    init: function (selector) {
       // If more than one container
-      var $examples = $('.app-c-example-wrapper')
+      var $examples = $(selector)
       $.each($examples, function (key, obj) {
-        if ($(obj).find('.app-c-tabs__container').length > 1) {
+        if ($(obj).find('.js-tabs__container').length > 1) {
           // Hide all containers
-          $(obj).find('.app-c-tabs__container').hide()
+          $(obj).find('.js-tabs__container').hide()
 
           // Add close button to each container
-          $(obj).find('.app-c-tabs__container').append('<a class="app-c-link--close app-o-chevron--top" href="#close">Close</a>')
-          $(obj).find('.app-c-tabs__container').addClass('app-c-tabs__container--with-close-button')
+          $(obj).find('.js-tabs__container').append('<a class="app-c-link--close js-link--close app-o-chevron--top" href="#close">Close</a>')
+          $(obj).find('.js-tabs__container').addClass('app-c-tabs__container--with-close-button')
         }
       })
 
       // Bind tab item click
-      $('.app-c-tabs__item a').click(GOVUK.tabs.clickTabItem)
+      $('.js-tabs__item a').click(GOVUK.tabs.clickTabItem)
 
       // Bind accordion item click
-      $('.app-c-tabs__heading a').click(GOVUK.tabs.clickTabItem)
+      $('.js-tabs__heading a').click(GOVUK.tabs.clickTabItem)
 
       // Bind close container link
-      $('.app-c-link--close').click(GOVUK.tabs.clickCloseContainer)
+      $('.js-link--close').click(GOVUK.tabs.clickCloseContainer)
 
       // Show open containers
-      $('.app-c-tabs__heading a[open]').click()
+      $('.js-tabs__heading--open a').click()
     }
   }
 

--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -5,20 +5,23 @@
 
   GOVUK.tabs = {
 
-    // Tabs mode
-    clickTabItem: function (e) {
-      e.preventDefault()
-
-      // Get tab container ID
-      var id = $(this).attr('href')
+    // Reset tabs and containers
+    resetTabs: function (id) {
+      var $example = $(id).parent()
 
       // Reset state
-      $('.app-c-tabs__item').removeClass('app-c-tabs__item--current')
-      $('.app-c-tabs__heading').removeClass('app-c-tabs__heading--current')
-      $('.app-c-tabs__item a').removeAttr('aria-selected')
-      $('.app-c-tabs__container').hide().attr('aria-hidden', 'true')
+      $example.find('.app-c-tabs__item').removeClass('app-c-tabs__item--current')
+      $example.find('.app-c-tabs__heading').removeClass('app-c-tabs__heading--current')
+      $example.find('.app-c-tabs__item a').removeAttr('aria-selected')
+      $example.find('.app-c-tabs__container').hide().attr('aria-hidden', 'true')
+    },
 
-      // Set current active tab
+    // Activate current tab
+    activateCurrentTab: function (id) {
+      // Reset tabs
+      GOVUK.tabs.resetTabs(id)
+
+      // Set current active tab for both tabs and accordion links
       $('[href="' + id + '"]').attr('aria-selected', 'true')
       var $parents = $('[href="' + id + '"]').parent()
       $.each($parents, function (key, obj) {
@@ -33,45 +36,53 @@
       $(id).show().removeAttr('aria-hidden')
     },
 
-    // Accordion mode
-    clickAccordionItem: function (e) {
+    // Tabs mode
+    clickTabItem: function (e) {
       e.preventDefault()
 
+      // Get tab container ID
       var id = $(this).attr('href')
 
-      // Let the main tabs deal with the states
-      $('.app-c-tabs__item a[href="' + id + '"]').click()
+      // Activate current tab
+      GOVUK.tabs.activateCurrentTab(id)
     },
 
     // Close current container on click
     clickCloseContainer: function (e) {
       e.preventDefault()
-      $('.app-c-tabs__item').removeClass('app-c-tabs__item--current')
-      $('.app-c-tabs__heading').removeClass('app-c-tabs__heading--current')
-      $('.app-c-tabs__container').hide().attr('aria-selected', 'true')
+
+      // Get tab container ID and save example object
+      var id = $(this).parent().attr('id')
+
+      // Reset tabs
+      GOVUK.tabs.resetTabs('#' + id)
     },
 
     init: function () {
       // If more than one container
-      if ($('.app-c-tabs__container').length > 1) {
-        // Hide all containers
-        $('.app-c-tabs__container').hide()
+      var $examples = $('.app-c-example-wrapper')
+      $.each($examples, function (key, obj) {
+        if ($(obj).find('.app-c-tabs__container').length > 1) {
+          // Hide all containers
+          $(obj).find('.app-c-tabs__container').hide()
 
-        // Add close button to each container
-        $('.app-c-tabs__container').append('<a class="app-c-link--close app-o-chevron--top" href="#close">Close</a>')
-      }
+          // Add close button to each container
+          $(obj).find('.app-c-tabs__container').append('<a class="app-c-link--close app-o-chevron--top" href="#close">Close</a>')
+          $(obj).find('.app-c-tabs__container').addClass('app-c-tabs__container--with-close-button')
+        }
+      })
 
       // Bind tab item click
       $('.app-c-tabs__item a').click(GOVUK.tabs.clickTabItem)
 
       // Bind accordion item click
-      $('.app-c-tabs__heading a').click(GOVUK.tabs.clickAccordionItem)
+      $('.app-c-tabs__heading a').click(GOVUK.tabs.clickTabItem)
 
       // Bind close container link
       $('.app-c-link--close').click(GOVUK.tabs.clickCloseContainer)
 
       // Show open containers
-      $('.app-c-tabs a[open]').click()
+      $('.app-c-tabs__heading a[open]').click()
     }
   }
 

--- a/src/javascripts/main.js
+++ b/src/javascripts/main.js
@@ -3,7 +3,7 @@ $(document).ready(function () {
   GOVUK.example.init('.js-example__frame')
 
   // Initialise tabs
-  GOVUK.tabs.init()
+  GOVUK.tabs.init('.js-example')
 
   // Add copy to clipboard to code blocks inside tab containers
   GOVUK.copy.init('.app-c-tabs__container pre')

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -87,8 +87,11 @@
 }
 
 .app-c-tabs__container pre {
-  padding-bottom: $govuk-spacing-scale-6;
   border: 0;
+}
+
+.app-c-tabs__container--with-close-button pre {
+  padding-bottom: $govuk-spacing-scale-6;
 }
 
 // Close container button

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -7,7 +7,7 @@
   {% set exampleId = exampleId + '-open' %}
 {% endif %}
 
-<div class="app-c-example-wrapper" id="{{ exampleId }}">
+<div class="app-c-example-wrapper js-example" id="{{ exampleId }}">
   <div class="app-c-example {{ "app-c-example--tabs" if params.html or params.nunjucks }}">
     <span class="app-c-example__new-window"><a href="{{ exampleURL }}" target="_blank">(open in new window)</a></span>
     <iframe class="app-c-example__frame app-c-example__frame--resizable js-example__frame" src="{{ exampleURL }}"></iframe>
@@ -15,14 +15,14 @@
 
   {%- if (params.html and params.nunjucks) %}
   <ul class="app-c-tabs" role="tablist">
-    <li class="app-c-tabs__item" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html"{{ " open" if (params.open) }}>HTML</a></li>
-    <li class="app-c-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks">Nunjucks</a></li>
+    <li class="app-c-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html">HTML</a></li>
+    <li class="app-c-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks">Nunjucks</a></li>
   </ul>
   {% endif %}
 
   {%- if (params.html) %}
-  <div class="app-c-tabs__heading"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html"{{ " open" if (params.open) }}>HTML</a></div>
-  <div class="app-c-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
+  <div class="app-c-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html">HTML</a></div>
+  <div class="app-c-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
     ```html
     {{ getHTMLCode(examplePath) | safe }}
     ```
@@ -30,8 +30,8 @@
   {% endif %}
 
   {%- if (params.nunjucks) %}
-  <div class="app-c-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks">Nunjucks</a></div>
-  <div class="app-c-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
+  <div class="app-c-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks">Nunjucks</a></div>
+  <div class="app-c-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
     ```js
     {{ getNunjucksCode(examplePath) | safe }}
     ```

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -2,9 +2,12 @@
 
 {% set examplePath = "src/" + params.group + "/" + params.item + "/" + params.example + ".njk" %}
 {% set exampleURL = "/" + params.group + "/" + params.item + "/" + params.example + "/index.html" %}
-{% set examplePrefix = params.item + "-" + params.example + "-" %}
+{% set exampleId = "example-" + params.example %}
+{% if params.open %}
+  {% set exampleId = exampleId + '-open' %}
+{% endif %}
 
-<div class="app-c-example-wrapper">
+<div class="app-c-example-wrapper" id="{{ exampleId }}">
   <div class="app-c-example {{ "app-c-example--tabs" if params.html or params.nunjucks }}">
     <span class="app-c-example__new-window"><a href="{{ exampleURL }}" target="_blank">(open in new window)</a></span>
     <iframe class="app-c-example__frame app-c-example__frame--resizable js-example__frame" src="{{ exampleURL }}"></iframe>
@@ -12,14 +15,14 @@
 
   {%- if (params.html and params.nunjucks) %}
   <ul class="app-c-tabs" role="tablist">
-    <li class="app-c-tabs__item" role="presentation"><a href="#{{examplePrefix}}html" role="tab" aria-controls="{{examplePrefix}}html"{% if (params.open) %}open{% endif %}>HTML</a></li>
-    <li class="app-c-tabs__item" role="presentation"><a href="#{{examplePrefix}}nunjucks" role="tab" aria-controls="{{examplePrefix}}nunjucks">Nunjucks</a></li>
+    <li class="app-c-tabs__item" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html"{{ " open" if (params.open) }}>HTML</a></li>
+    <li class="app-c-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks">Nunjucks</a></li>
   </ul>
   {% endif %}
 
   {%- if (params.html) %}
-  <div class="app-c-tabs__heading"><a href="#{{examplePrefix}}html" role="tab" aria-controls="{{examplePrefix}}html">HTML</a></div>
-  <div class="app-c-tabs__container" id="{{examplePrefix}}html" role="tabpanel">
+  <div class="app-c-tabs__heading"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html"{{ " open" if (params.open) }}>HTML</a></div>
+  <div class="app-c-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
     ```html
     {{ getHTMLCode(examplePath) | safe }}
     ```
@@ -27,8 +30,8 @@
   {% endif %}
 
   {%- if (params.nunjucks) %}
-  <div class="app-c-tabs__heading"><a href="#{{examplePrefix}}nunjucks" role="tab" aria-controls="{{examplePrefix}}nunjucks">Nunjucks</a></div>
-  <div class="app-c-tabs__container" id="{{examplePrefix}}nunjucks" role="tabpanel">
+  <div class="app-c-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks">Nunjucks</a></div>
+  <div class="app-c-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
     ```js
     {{ getNunjucksCode(examplePath) | safe }}
     ```


### PR DESCRIPTION
This PR
- makes use of the `app-c-example-wrapper` container for isolating the examples
- allows an example to be used with/without the tabs opened on the same page
- handles padding if the code block does/doesn't have a close button (single/multiple tab case)

[Trello card](https://trello.com/c/ZcaEdfyq)
  