### PR TITLE
Sync primary navigation with mobile menu button

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -5,7 +5,7 @@
   background-color: $app-light-grey;
   @include govuk-font-bold-19;
 
-  @include mq($until: desktop) {
+  @include mq($until: tablet) {
     display: none;
   }
 


### PR DESCRIPTION
Set the primary navigation to be displayed from tablet as the mobile menu button is being hidden from the same breakpoint.

The opther option is to move the breakpoint from `tablet` to `desktop` for both.

_Note: at the moment we don't have a primary navigation from `tablet` to `desktop`._