### PR TITLE
Add phase banner and get in touch page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,252 +4,252 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@govuk-frontend/all": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.19-alpha.tgz",
-      "integrity": "sha512-wfTwhfV9efPCr3QZmHD4KZXUErnBmA2EVNzKEdRwKzu7fMbXLPS/3jZhZVw7RCk7kNvR6zwMM+xfLXNjeXpvfg==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.21-alpha.tgz",
+      "integrity": "sha512-KnMoTj4MqzsdAnUf64Z3Ke2CAroTRfk5uWvXiXsOPJVRXLVta7htfn1y5s7lVCp8W3209heAn7SYQjfhmW2fkQ==",
       "requires": {
-        "@govuk-frontend/back-link": "0.0.19-alpha",
-        "@govuk-frontend/breadcrumbs": "0.0.19-alpha",
-        "@govuk-frontend/button": "0.0.19-alpha",
-        "@govuk-frontend/checkbox": "0.0.19-alpha",
-        "@govuk-frontend/cookie-banner": "0.0.19-alpha",
-        "@govuk-frontend/date-input": "0.0.19-alpha",
-        "@govuk-frontend/details": "0.0.19-alpha",
-        "@govuk-frontend/error-message": "0.0.19-alpha",
-        "@govuk-frontend/error-summary": "0.0.19-alpha",
-        "@govuk-frontend/fieldset": "0.0.19-alpha",
-        "@govuk-frontend/file-upload": "0.0.19-alpha",
-        "@govuk-frontend/icons": "0.0.19-alpha",
-        "@govuk-frontend/input": "0.0.19-alpha",
-        "@govuk-frontend/label": "0.0.19-alpha",
-        "@govuk-frontend/legal-text": "0.0.19-alpha",
-        "@govuk-frontend/link": "0.0.19-alpha",
-        "@govuk-frontend/panel": "0.0.19-alpha",
-        "@govuk-frontend/phase-banner": "0.0.19-alpha",
-        "@govuk-frontend/previous-next": "0.0.19-alpha",
-        "@govuk-frontend/radio": "0.0.19-alpha",
-        "@govuk-frontend/select": "0.0.19-alpha",
-        "@govuk-frontend/skip-link": "0.0.19-alpha",
-        "@govuk-frontend/table": "0.0.19-alpha",
-        "@govuk-frontend/tag": "0.0.19-alpha",
-        "@govuk-frontend/textarea": "0.0.19-alpha"
+        "@govuk-frontend/back-link": "0.0.21-alpha",
+        "@govuk-frontend/breadcrumbs": "0.0.21-alpha",
+        "@govuk-frontend/button": "0.0.21-alpha",
+        "@govuk-frontend/checkboxes": "0.0.21-alpha",
+        "@govuk-frontend/cookie-banner": "0.0.21-alpha",
+        "@govuk-frontend/date-input": "0.0.21-alpha",
+        "@govuk-frontend/details": "0.0.21-alpha",
+        "@govuk-frontend/error-message": "0.0.21-alpha",
+        "@govuk-frontend/error-summary": "0.0.21-alpha",
+        "@govuk-frontend/fieldset": "0.0.21-alpha",
+        "@govuk-frontend/file-upload": "0.0.21-alpha",
+        "@govuk-frontend/icons": "0.0.21-alpha",
+        "@govuk-frontend/input": "0.0.21-alpha",
+        "@govuk-frontend/label": "0.0.21-alpha",
+        "@govuk-frontend/legal-text": "0.0.21-alpha",
+        "@govuk-frontend/link": "0.0.21-alpha",
+        "@govuk-frontend/panel": "0.0.21-alpha",
+        "@govuk-frontend/phase-banner": "0.0.21-alpha",
+        "@govuk-frontend/previous-next": "0.0.21-alpha",
+        "@govuk-frontend/radios": "0.0.21-alpha",
+        "@govuk-frontend/select": "0.0.21-alpha",
+        "@govuk-frontend/skip-link": "0.0.21-alpha",
+        "@govuk-frontend/table": "0.0.21-alpha",
+        "@govuk-frontend/tag": "0.0.21-alpha",
+        "@govuk-frontend/textarea": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/back-link": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.19-alpha.tgz",
-      "integrity": "sha512-BKHSRfDs3UfclcNqQDd0cZgQYh2r211YQVIi4HB1vfzhFzt8YzWQsJxhdbs3Gyas+MsqFPX7H/SS0dfarNW3Pg==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.21-alpha.tgz",
+      "integrity": "sha512-o67rxAu7xESMO0X5auAMH5/4wMmNVFGTtHWWGdjvxspDOLcwKcsb6tnhGEnqW2Q5cwdFzAPINw11CWVRCz2piQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/breadcrumbs": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.19-alpha.tgz",
-      "integrity": "sha512-EPWyTMCWYA2iH53FiIyQSuKQ+T6GGJbsSCqEfzBDhHpVKvnRPTd5LhSBL4ZvEwoyZ0RGC8hc/qu6iJ29vAOX7g==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.21-alpha.tgz",
+      "integrity": "sha512-DNTOvRdJiFqIw3dZh+ZnEiZyUIEdhT+0W02aaHl8RJ4R1B9Juv2TAYuhsZXIUa+hCXV02jqHDG6o7jZwLDgn7g==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha",
-        "@govuk-frontend/icons": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha",
+        "@govuk-frontend/icons": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/button": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.19-alpha.tgz",
-      "integrity": "sha512-oQodTXrRvOjKuYO+3g7B0pMDRHeP/0uBvsoQRljJyfy32LoOt6HICNfsb/YkMuIu6TwlIX6qoraGJGYxFHLMUA==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.21-alpha.tgz",
+      "integrity": "sha512-pYPV4e943ehjmZDMIjECevu2k5ADRpdQzfh6BaDOGICjrcZb050KTsnlCp05VwMUpeTNP5eK63R0VfHaHzbnkw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha",
-        "@govuk-frontend/icons": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha",
+        "@govuk-frontend/icons": "0.0.21-alpha"
       }
     },
-    "@govuk-frontend/checkbox": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkbox/-/checkbox-0.0.19-alpha.tgz",
-      "integrity": "sha512-1EC8DyZIExSXmisyKYlOh29Yf4Zcq4m2M/K+ErZp1CMwsK9bvT5iwUrCdC0DVN5hqUsWa6OwVkvex3DkmgJ6ZA==",
+    "@govuk-frontend/checkboxes": {
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.21-alpha.tgz",
+      "integrity": "sha512-lysFnDlN6OSWcTQIcg+vpQ3l3b4n8+X+co/LKDZ0yoJQwXpses1hLG0C3nEo8Gb49ewbaBeAoqCw6hScvJDVEA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha",
-        "@govuk-frontend/label": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha",
+        "@govuk-frontend/label": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/cookie-banner": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/cookie-banner/-/cookie-banner-0.0.19-alpha.tgz",
-      "integrity": "sha512-yqHq8TopJXD8KuWNua++McuqQsXtlchs23mjNZ6m23Y/Wn6z+j98G/qokutuW6tjR1EGzWBQqwDzFOe6GlKuyw==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/cookie-banner/-/cookie-banner-0.0.21-alpha.tgz",
+      "integrity": "sha512-/V4qhw5v6kAz9z57C68MIoDwBiF6ott7kwj6XyFqxgWsUl9+7hXGmxFeRv8qgzfi1w2HVfTNPuKc9K1qPlbtIA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/date-input": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.19-alpha.tgz",
-      "integrity": "sha512-FsgEPrs5mwGnKk8S8qchTItgTHfs0IOgM0JPQ6sWfHHZeGArblUxrjgUlKg7p1wP/4s8V1kNKoyYnl9io3b7jA==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.21-alpha.tgz",
+      "integrity": "sha512-1PGHtwkGGjHjDNVDzfl5HW5BHxqqqf/cwx0pwPMtocyahgnLUBn+aY49miy9ZYI/E1gQmAvRjiogyuOL6Q6UtQ==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.19-alpha",
-        "@govuk-frontend/globals": "0.0.19-alpha",
-        "@govuk-frontend/label": "0.0.19-alpha"
+        "@govuk-frontend/error-message": "0.0.21-alpha",
+        "@govuk-frontend/globals": "0.0.21-alpha",
+        "@govuk-frontend/label": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/details": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.19-alpha.tgz",
-      "integrity": "sha512-Vcea4hUgD3BvGPooLMnnQZUAHn7rlVFvQgACYUMIy+nv2J65ExNuwWBUA8Vxf5Z8Sv1R6SkQq0r/bFlQWEE6Og==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.21-alpha.tgz",
+      "integrity": "sha512-Jnsiyr7KVRfLPQ1jeHGfb6p5TsRl9MaaTCxHKxGd4g5QWhB2JviLGAIqvYg382zi6pT9jHOX4+r5IlF8EK1ReQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/error-message": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.19-alpha.tgz",
-      "integrity": "sha512-lrLGiEtM4DWe0HeBucf8iRIzexCwKAD8o/epM0/VZ9Q/su2RrCfpJgcK2AS9QuwHPVsnX5cMKrp3YTWQUvFfew==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.21-alpha.tgz",
+      "integrity": "sha512-xMkvwqCq+MQ/XFTJqfx6xoOK+rbCOQV46Lvoh7hdz2qZ/WQ28565X+LB6e3JbXszgc9LESN7U5NTY2EC1dVeZw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/error-summary": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.19-alpha.tgz",
-      "integrity": "sha512-OPhVvxUlBwI/4eRY4sVqufIGnukqT+sleaZuUJFcHefvPZTrL5gadti/srzfQ/Wiv96k3DYtjqucaNrhDk+oaA==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.21-alpha.tgz",
+      "integrity": "sha512-i9DcmSpxDDRO4MNEptoDJ2oyAKHGrnY1RNmpL7H4hPp75oyq+3P2/Cq++WZorWGPwf02WVgP6Zt/ob7zlyVuKw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/fieldset": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.19-alpha.tgz",
-      "integrity": "sha512-5o3UXUH/vAe9/Q1jLXnZgJeqAb1mcDM8oJdrVOYhzr/DtKGtRNvnNNUo75s49Lyz5J8unDTt6BvZKtTA6OqbwQ==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.21-alpha.tgz",
+      "integrity": "sha512-Nb69e1wheDjHXwd4oaFYvKYbcHtBPquWDIzILwhyuO9PdFHPJZi5xhcsNN2SlPHRdYpJ0lNtuauqp2sdEgn2fg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/file-upload": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.19-alpha.tgz",
-      "integrity": "sha512-ldlCbZy+AqOsyTfWgvIqervA5Y7hiO7zBlbt1fvjYA/tHZSEDrHW6c/OCCKum0Rs4ft3LlKwLBy2PQXT/hTztg==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.21-alpha.tgz",
+      "integrity": "sha512-pMBstOjBOlYFmyDpBwa7BimgphJURydHupuaCK8IzZuuRdtL6fIQuc6001eGQSrt8+LD6TeOlZ3l6nF9boq66A==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/globals": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.19-alpha.tgz",
-      "integrity": "sha512-y6Y7PQgzOzcFa/6UyZbTs5nKnkVoo951DzcSzLAhBqVRdXGMpP1dvLB6qZWYoIF2muSnjFoaNwo4qmbSHSRo3Q==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.21-alpha.tgz",
+      "integrity": "sha512-hEbht6uP6arAxpNTxOwARTEDcwXooc6FnCCDLscIYzg5ztEvKx+nCkzYNWrwC7+wsdihGTgCcRZeodm8MsjwWQ==",
       "requires": {
         "sass-mq": "3.3.2"
       }
     },
     "@govuk-frontend/icons": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.19-alpha.tgz",
-      "integrity": "sha512-ADn/E3/hLiNyA2+oTWH5CdxaWTZ9jSu8d23OXgsSFNwF5TCuvPVD6TDxV3MvrwBsPou7yz4m0as3C7Oq6jn65Q=="
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.21-alpha.tgz",
+      "integrity": "sha512-ZsT2wIz4x0ssNgFR1v/8InQmJSXJHIqV0hI2k83bgDOT2HP/HLKVehTyx3ZrtwtK10BcCRPCOfWBb2oFzXfETw=="
     },
     "@govuk-frontend/input": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.19-alpha.tgz",
-      "integrity": "sha512-pDIHihkHuSRdAfh/CI/LC9rxVaWK/2GZstAdPsmDhDDUA104T4XdcmMAJlW4LuSoJPl4epu6ZTiRAMbHerI4wg==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.21-alpha.tgz",
+      "integrity": "sha512-lYj4qSA4jcY5yYoj2soALQCfkQAFK4FbPhd9Uo+kCnrJCounpSHvHzkUSq/YLpKZrqWxHUdZAC6Kh6SJxgVOUA==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.19-alpha",
-        "@govuk-frontend/globals": "0.0.19-alpha",
-        "@govuk-frontend/label": "0.0.19-alpha"
+        "@govuk-frontend/error-message": "0.0.21-alpha",
+        "@govuk-frontend/globals": "0.0.21-alpha",
+        "@govuk-frontend/label": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/label": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.19-alpha.tgz",
-      "integrity": "sha512-NLjgKGz+Gfrswbf5AF6z0W5jygIaurhqiKXOfK7fOtxmRSfg4Y/pFP6cp5cA/w8BSs8ApK4eOAciTnNSfiFGRQ==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.21-alpha.tgz",
+      "integrity": "sha512-iCHC6+FXVG6qgMQR4OxTYyeUPeCTOPKgBIVKTD4g62027GC8RNquBxGciO6sMtvRcOseZnmDLHGXGX/qsNv5PQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/legal-text": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/legal-text/-/legal-text-0.0.19-alpha.tgz",
-      "integrity": "sha512-zJr5EqHlzzpPmnZKknSgKZd8pZA2J1PNflsuyQAZM4M2aBMSngyWB8ilV4kNQXXECX4aPmZe54LFIziJRIK6zA==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/legal-text/-/legal-text-0.0.21-alpha.tgz",
+      "integrity": "sha512-8HFBXinwueKgXKaPosGaZFv36jgJexv0swHzNDu5IlaCmsPjNET601b5PydP2ggzNxY8gT4EQMR1OEfsFZgyEQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/link": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/link/-/link-0.0.19-alpha.tgz",
-      "integrity": "sha512-IjpkL15XPWVRi+I6LiZjw5fvk8EioAsglJKna0X+WMpZqWO4S+9wYRELEmet6m2cpLjpehn4WQmR4qSxAqUKZg==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/link/-/link-0.0.21-alpha.tgz",
+      "integrity": "sha512-f3aqm5UMTa3GsCf0TNGIvRQ89c7+Su71jnsFyt0TjrO+A2FHASqv1VPFkaZ7/1XdDsK9fZwfWtyPsobg5ibRmQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/panel": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.19-alpha.tgz",
-      "integrity": "sha512-wV4YqL4dH1CDN4q3fMqd1IwoVGcL7yNZTM9AYdKTekOm8iOTgV4CSp/dYgnb67oJJ8PVonZhyffx47AMzyYFRQ==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.21-alpha.tgz",
+      "integrity": "sha512-AToa9g7nA7+CkvVM2yprdTdsYPn4HAGgxK+nPS8ZRMlotv6A5iYvcaG48qtK1xrRmkEWW3SS3HlX83x8Ud8wSg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/phase-banner": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.19-alpha.tgz",
-      "integrity": "sha512-M8tW/tVLwG4pWAVmNJw4QN71Q3Zu+Z06zfLPZzDn8vSYDMqPTac9v7fzOX979MEMX2fCBO+fKhKq30TSRw8YuQ==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.21-alpha.tgz",
+      "integrity": "sha512-ba5nIXDR/Qt+qhe95mfYWf4mOaDLvlBDOClb/7bqJ1eyZbtn1F6rjrwr2ufaNweWHDsVljtxZxlVZutJgd+a8A==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha",
-        "@govuk-frontend/tag": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha",
+        "@govuk-frontend/tag": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/previous-next": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/previous-next/-/previous-next-0.0.19-alpha.tgz",
-      "integrity": "sha512-NFm07zk9NXk3PPXXi8PjTepldbS/FuHLAaY06AE3mVm5aYpptBHtT4jAndc0t53ImI85ULlnalbJKHnPz0ImtA==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/previous-next/-/previous-next-0.0.21-alpha.tgz",
+      "integrity": "sha512-xxHlAqTygB20zJGytCxeVI2N/mHqr+wjU45uG3t1s9oU7LQdrB2jhhZTRuEI+xroubbNos2O8vYNyVTUzhwx6A==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
-    "@govuk-frontend/radio": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/radio/-/radio-0.0.19-alpha.tgz",
-      "integrity": "sha512-C1jS5dJaEG8R5AfJRbBYBiq6PUglC8vBnlw8PcM+/fpbWm8sFBmQ7NbmC1qlnUUasOC5vF1JxP+IcaNEuWM1DQ==",
+    "@govuk-frontend/radios": {
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.21-alpha.tgz",
+      "integrity": "sha512-pI3fVNQE2fO5Uo2t2vujiLi596DwQI23nGyxIZGikCLGd/+NogHxQFP+0GLH3mKfmfker4/g1mkOscQ5PTBFVQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha",
-        "@govuk-frontend/label": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha",
+        "@govuk-frontend/label": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/select": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.19-alpha.tgz",
-      "integrity": "sha512-K5Itl4Ce0BSWQ+SjPvQExmiCwEtMT57AKSgqZBFIBj9vBM4WEaFAujcOZPZokUY5v790G/hC4CDKYuN1J0x0PA==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.21-alpha.tgz",
+      "integrity": "sha512-0RsYkmtjmf5xhYUeeowOFYXt5/Hne863IIJuu4zMZaS7/x/T4gAKKAmr1aRU2/TXBea15JBMMtdl6s8rGSuZ+g==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha",
-        "@govuk-frontend/label": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha",
+        "@govuk-frontend/label": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/skip-link": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.19-alpha.tgz",
-      "integrity": "sha512-RquYj6p1e5JAYMgivtRSRdHe/0tH95plF9fvUM56zN/LusbKhqO4K43zzq1U5Ku1uhEXXDW8t8XTdZpVfq+6Aw==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.21-alpha.tgz",
+      "integrity": "sha512-eiKXOUFmyK5garLdKJnkk0NxpzWkMNSMHmBnvlX1t09993opVOrMZ4wf/JRTclbV0xF2gtMA867xz/drICcBBw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/table": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.19-alpha.tgz",
-      "integrity": "sha512-eTt0Ix2Wrc26NGzU7uqAUqEzhYSb1c5I+I8TVWK49LglT91d2nnZQ5XB31T3SpWKBv72xBjrI8yXEMu74If9lg==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.21-alpha.tgz",
+      "integrity": "sha512-HEe9LKt+v1Kvjzp08ZG2+HSVHX6Ih8F27+lLcFBzsHCB7KCCCzxxonvGjhVfY7Ye+1W1hC9PCREhXQ7tIR7IcQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/tag": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.19-alpha.tgz",
-      "integrity": "sha512-6iuYCMU4NFr0G7KiExZDbIY48bi+OX5pI3ApEnvSVY5DbRzyjzx5pVuT6x9fb0oRpErS7tj2tREfbj6l4GGGQQ==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.21-alpha.tgz",
+      "integrity": "sha512-Ts9EYgIeJEXGrXjdK8McAfMIlSbjtZ7I7ZlsXHl/otvnLYpgZ22m51gdl9XFmpNP0DsL3Tt8zmcwd/wJFXpg+w==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.19-alpha"
+        "@govuk-frontend/globals": "0.0.21-alpha"
       }
     },
     "@govuk-frontend/textarea": {
-      "version": "0.0.19-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.19-alpha.tgz",
-      "integrity": "sha512-Hr5uHSlAEDh8m8ZrWxi9pofrJzX544ctLamEmnxqPCDigW1GcNtkpj9QSQIN38UfmuNv1R+vZu8KIGnYgB8skw==",
+      "version": "0.0.21-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.21-alpha.tgz",
+      "integrity": "sha512-KSq/O/xYJkPOyeU7dSL9lIqGfSehERgD3mhXG7+7TeoqiuHGqVndQlG+I+n6ixl4xc5Oxy9uk/VHIZnnqjxrlg==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.19-alpha",
-        "@govuk-frontend/globals": "0.0.19-alpha",
-        "@govuk-frontend/label": "0.0.19-alpha"
+        "@govuk-frontend/error-message": "0.0.21-alpha",
+        "@govuk-frontend/globals": "0.0.21-alpha",
+        "@govuk-frontend/label": "0.0.21-alpha"
       }
     },
     "a-sync-waterfall": {
@@ -4612,8 +4612,7 @@
     "js-base64": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
-      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
-      "dev": true
+      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA=="
     },
     "js-tokens": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "gulp scss:lint"
   },
   "dependencies": {
-    "@govuk-frontend/all": "0.0.19-alpha",
+    "@govuk-frontend/all": "0.0.21-alpha",
     "scss-to-json": "^2.0.0"
   },
   "devDependencies": {

--- a/src/components/checkboxes/default.njk
+++ b/src/components/checkboxes/default.njk
@@ -2,9 +2,9 @@
 layout: layout-example.njk
 ---
 
-{% from 'checkbox/macro.njk' import govukCheckbox %}
+{% from 'checkboxes/macro.njk' import govukCheckboxes %}
 
-{{ govukCheckbox({
+{{ govukCheckboxes({
   "idPrefix": "nationality",
   "name": "nationality",
   "fieldset": {

--- a/src/components/radios/default.njk
+++ b/src/components/radios/default.njk
@@ -2,9 +2,9 @@
 layout: layout-example.njk
 ---
 
-{% from 'radio/macro.njk' import govukRadio %}
+{% from 'radios/macro.njk' import govukRadios %}
 
-{{ govukRadio({
+{{ govukRadios({
   "idPrefix": "changed-name",
   "name": "changed-name",
   "fieldset": {

--- a/src/get-in-touch.njk
+++ b/src/get-in-touch.njk
@@ -1,0 +1,16 @@
+<div class="govuk-o-width-container app-c-site-width-container">
+    <div class="govuk-o-grid govuk-o-main-wrapper">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+         <h1 class="govuk-heading-xl">Get in touch</h1>
+
+         <p class="govuk-body-l">If you’ve got a question, idea or suggestion get in touch with the Design System team.</p>
+
+         <h2 class="govuk-heading-l">Private beta Slack channel</h2>
+
+         <p class="govuk-body">Use <a href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>)</a></p>
+
+         <h2 class="govuk-heading-l">Email</h2>
+         <p class="govuk-body">Email the Design System team on <a href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">govuk-design-system-support@digital.cabinet-office.gov.uk</a></p>
+      </div>
+    </div>
+</div>

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -40,3 +40,13 @@
   </div>
   {# </div> #}
 </header>
+
+{% from "phase-banner/macro.njk" import govukPhaseBanner %}
+
+{{ govukPhaseBanner({
+  "tag": {
+    "text": "beta"
+  },
+  "classes": "govuk-!-pl-r3 govuk-!-pr-r3",
+  "html": "This is a new service – your <a href=\"/get-in-touch\">feedback</a> will help us to improve it."
+}) }}


### PR DESCRIPTION
This adds the BETA phase banner with a simple `mailto:` link to our support email.

Couldn't use the macro with this one. I needed to add extra padding because we have a full width header and the macro isn't allowing classes to be passed to the parent container as par as I can see.

https://trello.com/c/YZaDRwVL/558-add-beta-banner-to-the-design-system 