### PR TITLE
Add get in touch panel

### DIFF
--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -34,4 +34,4 @@ There are 2 ways to use the Back link component. You can use HTML or, if you are
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/breadcrumbs/index.md.njk
+++ b/src/components/breadcrumbs/index.md.njk
@@ -32,4 +32,4 @@ There are 2 ways to use the Breadcrumbs component. You can use HTML or, if you a
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -41,4 +41,4 @@ Only use disabled buttons if research shows it makes the user interface easier t
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -41,6 +41,6 @@ Check that a valid date is entered by the user. Invalid dates should be shown to
 
 ## Research on this pattern
 
-If you’ve used this pattern, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this pattern, get in touch to share your user research findings.
 
 More research is needed to determine the extent to which users struggle to enter months as numbers, and whether allowing them to enter months as text is helpful.

--- a/src/components/details/index.md.njk
+++ b/src/components/details/index.md.njk
@@ -34,4 +34,4 @@ Make the link text short and descriptive so users can quickly work out if they n
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -37,4 +37,4 @@ There are 2 ways to use the Error message component. You can use HTML or, if you
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -32,4 +32,4 @@ There are 2 ways to use the Error summary component. You can use HTML or, if you
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/fieldset/index.md.njk
+++ b/src/components/fieldset/index.md.njk
@@ -32,4 +32,4 @@ Include any general help text which is important for filling in the form and can
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -34,4 +34,4 @@ There are 2 ways to use the Panel component. You can use HTML or, if you are usi
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -32,4 +32,4 @@ Use a ‘feedback’ link to collect on-page feedback about your service. This c
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/skip-link/index.md.njk
+++ b/src/components/skip-link/index.md.njk
@@ -30,4 +30,4 @@ There are 2 ways to use the Skip link component. You can use HTML or, if you are
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -42,4 +42,4 @@ When comparing columns of numbers, align the numbers to the right in table cells
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -22,4 +22,4 @@ There are 2 ways to use the Tag component. You can use HTML or, if you are using
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -42,4 +42,4 @@ Users often need to copy and paste information into a text input, so you shouldn
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -40,4 +40,4 @@ Users will often need to copy and paste information into a textarea, so you shou
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.

--- a/src/index.njk
+++ b/src/index.njk
@@ -28,7 +28,7 @@
       </div>
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds govuk-!-mb-r4">
         <h2 class="govuk-heading-l govuk-!-mt-r6">Get in touch</h2>
-        <p class="govuk-body govuk-!-mb-r0">If you’ve got a question, idea or suggestion share it in <a href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>) or <a href="#">email the Design System team</a></p>
+        <p class="govuk-body govuk-!-mb-r0">If you’ve got a question, idea or suggestion share it in <a href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>) or <a href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">email the Design System team</a></p>
       </div>
     </div>
 </div>

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -91,4 +91,4 @@ Textareas let users enter an address in any format and make it easy to copy and 
 
 ## Research on this pattern
 
-If you’ve used this pattern, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this pattern, get in touch to share your user research findings.

--- a/src/patterns/confirm-an-email-address/index.md.njk
+++ b/src/patterns/confirm-an-email-address/index.md.njk
@@ -92,4 +92,4 @@ For ‘non-blocking loops’, if a user signs in before activating their account
 When a user clicks on the link in the activation email, send them to a page that confirms they’ve activated their account. You may or may not require them to sign in at this stage, depending on where in the flow the ‘activate your account’ screen appears.
 
 ## Research on this pattern
-If you’ve used this pattern, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this pattern, get in touch to share your user research findings.

--- a/src/patterns/create-a-username/index.md.njk
+++ b/src/patterns/create-a-username/index.md.njk
@@ -43,4 +43,4 @@ Whatever approach to usernames you take, make sure you let people change their e
 
 ## Research on this pattern
 
-If you’ve used this pattern, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this pattern, get in touch to share your user research findings.

--- a/src/patterns/create-accounts/index.md.njk
+++ b/src/patterns/create-accounts/index.md.njk
@@ -59,4 +59,4 @@ You shouldn’t use National Insurance numbers to verify a user’s identity. Fi
 
 ## Research on this pattern
 
-If you’ve used this pattern, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this pattern, get in touch to share your user research findings.

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -78,6 +78,6 @@ See the [GOV.UK style for writing dates](https://www.gov.uk/guidance/style-guide
 
 ## Research on this pattern
 
-If you’ve used this pattern, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this pattern, get in touch to share your user research findings.
 
 More research is needed to determine the extent to which users struggle to enter months as numbers, and whether allowing them to enter months as text is helpful.

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -63,4 +63,4 @@ However, these are disruptive and should be avoided as far as possible.
 
 ## Research on this pattern
 
-If you’ve used this pattern, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this pattern, get in touch to share your user research findings.

--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -64,7 +64,7 @@ Remember to correctly use people’s names in any resulting correspondence.
 
 ## Research on this pattern
 
-If you’ve used this pattern, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this pattern, get in touch to share your user research findings.
 
 You can also read these articles to learn more about asking for users’ names:
 

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -37,4 +37,4 @@ You should:
 
 ## Research on this pattern
 
-If you’ve used this pattern, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this pattern, get in touch to share your user research findings.

--- a/src/patterns/passwords/index.md.njk
+++ b/src/patterns/passwords/index.md.njk
@@ -109,6 +109,6 @@ You shouldn’t use password reminders because they:
 
 ## Research on this pattern
 
-If you’ve used this pattern, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this pattern, get in touch to share your user research findings.
 
 [Read the National Cyber Security Centre’s guidance on passwords](https://www.ncsc.gov.uk/index/guidance?f%5B0%5D=field_topics%253Aname%3AIdentity%20and%20passwords).

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -77,4 +77,4 @@ When asking users questions, you should:
 
 ## Research on this pattern
 
-If you’ve used this pattern, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this pattern, get in touch to share your user research findings.

--- a/src/stylesheets/components/_contact-panel.scss
+++ b/src/stylesheets/components/_contact-panel.scss
@@ -1,0 +1,29 @@
+
+.app-c-contact-panel {
+  @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");
+  @include govuk-responsive-padding($govuk-spacing-responsive-3);
+  background-color: $govuk-blue;
+
+  .app-c-contact-panel__heading,
+  .app-c-contact-panel__body,
+  .app-c-contact-panel__link {
+    color: $govuk-white;
+  }
+
+  .app-c-contact-panel__link:hover {
+    color: lighten($govuk-light-blue, 45%);
+  }
+
+  .app-c-contact-panel__link:focus {
+    color: $govuk-blue;
+  }
+}
+
+.app-c-contact-panel__heading {
+  @extend .govuk-heading-m;
+}
+
+.app-c-contact-panel__body {
+  @include govuk-font-regular-19
+  margin: 0;
+}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -15,6 +15,7 @@ $app-light-grey: #f8f8f8;
 @import "components/example";
 @import "components/tabs";
 @import "components/highlight";
+@import "components/contact-panel";
 
 body {
   margin: 0;

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -23,7 +23,9 @@
       <div class="govuk-prose-scope">
         {{ contents | safe }}
       </div>
-
+      {% if section %}
+        {% include "_contact-panel.njk" %}
+      {% endif %}
     </main>
     {# No JS fallback to show overview #}
     <div class="app-o-pane__subnav-mobile-overview app-u-hide-desktop">

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -1,0 +1,4 @@
+<div class="app-c-contact-panel">
+  <h2 class="app-c-contact-panel__heading">Get in touch</h2>
+  <p class="app-c-contact-panel__body">If you’ve got a question, idea or suggestion share it in <a class="app-c-contact-panel__link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a> on cross-government Slack (<a class="app-c-contact-panel__link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6">open in app</a>) or <a class="app-c-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">email the Design System team</a></p>
+</div>


### PR DESCRIPTION
This creates the get in touch panel and adds it to the majority of pages.

This uses the correct contact email address but the current link to public cross-gov slack channel

As part of https://trello.com/c/2c3cDlyO/531-add-get-in-touch-panel-to-design-system