### PR TITLE
Update example states

### DIFF
--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -8,7 +8,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'back-link', example: 'default'}) }}
+{{ example({group: 'components', item: 'back-link', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 Use the Back link component to help users go back to the previous page in a multi-page transaction.
 

--- a/src/components/breadcrumbs/index.md.njk
+++ b/src/components/breadcrumbs/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 The Breadcrumbs component helps users to understand where they are within a website’s structure and move between levels.
 
-{{ example({group: 'components', item: 'breadcrumbs', example: 'default'}) }}
+{{ example({group: 'components', item: 'breadcrumbs', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 

--- a/src/components/button/disabled.njk
+++ b/src/components/button/disabled.njk
@@ -21,7 +21,7 @@ layout: layout-example.njk
 <h3 class="govuk-heading-m">&lt;button&gt;</h3>
 
 {{ govukButton({
-  "text": "Disabled &lt;button&gt;",
+  "text": "Disabled <button>",
   "element": "button",
   "disabled": true
 }) }}

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -29,7 +29,7 @@ There are 2 ways to use the Button component. You can use HTML or, if you are us
 
 Use a start button as the main call to action on your service’s start page.
 
-{{ example({group: 'components', item: 'button', example: 'start', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'components', item: 'button', example: 'start', html: true, nunjucks: true, open: true}) }}
 
 ### Disabled buttons
 
@@ -37,7 +37,7 @@ Disabled buttons have poor contrast and can confuse some users, so avoid them if
 
 Only use disabled buttons if research shows it makes the user interface easier to understand.
 
-{{ example({group: 'components', item: 'button', example: 'disabled', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'components', item: 'button', example: 'disabled', html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -8,7 +8,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'button', example: 'default'}) }}
+{{ example({group: 'components', item: 'button', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -8,7 +8,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'checkboxes', example: 'default'}) }}
+{{ example({group: 'components', item: 'checkboxes', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 Let users select one or more options by using the Checkboxes component.
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 Use the Date input component to help users enter a memorable date.
 
-{{ example({group: 'components', item: 'date-input', example: 'default'}) }}
+{{ example({group: 'components', item: 'date-input', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 

--- a/src/components/details/index.md.njk
+++ b/src/components/details/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 Make a page easier to scan by letting users reveal more detailed information only if they need it.
 
-{{ example({group: 'components', item: 'details', example: 'default'}) }}
+{{ example({group: 'components', item: 'details', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -33,7 +33,7 @@ There are 2 ways to use the Error message component. You can use HTML or, if you
 
 ### Label
 
-{{ example({group: 'components', item: 'error-message', example: 'label', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'components', item: 'error-message', example: 'label', html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -8,7 +8,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'error-summary', example: 'default'}) }}
+{{ example({group: 'components', item: 'error-summary', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 

--- a/src/components/fieldset/index.md.njk
+++ b/src/components/fieldset/index.md.njk
@@ -8,7 +8,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'fieldset', example: 'default'}) }}
+{{ example({group: 'components', item: 'fieldset', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 Use the Fieldset component to group related form inputs.
 
@@ -16,7 +16,7 @@ Use the Fieldset component to group related form inputs.
 
 Use the Fieldset component when you need to show a relationship between multiple form inputs. For example, you may need to group a set of text inputs into a single fieldset when [asking for an address](../../patterns/addresses).
 
-{{ example({group: 'components', item: 'fieldset', example: 'address-group', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'components', item: 'fieldset', example: 'address-group', html: true, open: true}) }}
 
 If you’re using the examples or macros for [Radios](../radios), [Checkboxes](../checkboxes) or [Date input](../date-input), the fieldset will already be included.
 
@@ -24,11 +24,11 @@ If you’re using the examples or macros for [Radios](../radios), [Checkboxes](.
 
 The first element inside a fieldset must be a `legend` which describes the group of inputs. This could be a question, such as ‘What is your current address?’ or a statement like ‘Personal details’.
 
-{{ example({group: 'components', item: 'fieldset', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'components', item: 'fieldset', example: 'default', html: true, nunjucks: true, open: true}) }}
 
 On [Question pages](../../patterns/question-pages) containing a group of inputs, including the question as the legend helps users of screenreaders to understand that the inputs are all related to that question.
 
-Include any general help text which is important for filling in the form and can’t be written as [hint text](Link to hint text section of help users Fill in a form) in the legend, but try to keep it as concise as possible.
+Include any general help text which is important for filling in the form and can’t be written as [hint text](../../patterns/fill-in-a-form#hint-text) in the legend, but try to keep it as concise as possible.
 
 ## Research on this component
 

--- a/src/components/file-upload/index.md.njk
+++ b/src/components/file-upload/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 Help users select and upload a file.
 
-{{ example({group: 'components', item: 'file-upload', example: 'default'}) }}
+{{ example({group: 'components', item: 'file-upload', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 

--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 The Panel component is a visible container used on confirmation or results pages to highlight important content.
 
-{{ example({group: 'components', item: 'panel', example: 'default'}) }}
+{{ example({group: 'components', item: 'panel', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 

--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 Use the Phase banner component to show users your service is still being worked on.
 
-{{ example({group: 'components', item: 'phase-banner', example: 'default'}) }}
+{{ example({group: 'components', item: 'phase-banner', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -8,7 +8,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'radios', example: 'default'}) }}
+{{ example({group: 'components', item: 'radios', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 

--- a/src/components/select/index.md.njk
+++ b/src/components/select/index.md.njk
@@ -8,7 +8,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'select', example: 'default'}) }}
+{{ example({group: 'components', item: 'select', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 

--- a/src/components/skip-link/index.md.njk
+++ b/src/components/skip-link/index.md.njk
@@ -8,7 +8,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'skip-link', example: 'default'}) }}
+{{ example({group: 'components', item: 'skip-link', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 Use the Skip link component to help keyboard-only users skip to the main content on a page.
 

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 Use the Table component to make information easier to compare and scan for users.
 
-{{ example({group: 'components', item: 'table', example: 'default'}) }}
+{{ example({group: 'components', item: 'table', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -38,7 +38,7 @@ There are 2 ways to use the Table component. You can use HTML or, if you are usi
 
 When comparing columns of numbers, align the numbers to the right in table cells.
 
-{{ example({group: 'components', item: 'table', example: 'numbers', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'components', item: 'table', example: 'numbers', html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -8,7 +8,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'tag', example: 'default'}) }}
+{{ example({group: 'components', item: 'tag', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 # When to use this component
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -8,7 +8,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'text-input', example: 'default'}) }}
+{{ example({group: 'components', item: 'text-input', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -8,7 +8,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'textarea', example: 'default'}) }}
+{{ example({group: 'components', item: 'textarea', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -39,7 +39,7 @@ When using an address lookup, you should:
 
 ## Multiple text inputs
 
-{{ example({group: 'patterns', item: 'addresses', example: 'multiple', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'patterns', item: 'addresses', example: 'multiple', html: true, nunjucks: false, open: true}) }}
 
 ### When to use multiple text inputs
 
@@ -72,7 +72,7 @@ Royal Mail doesn’t need a county as long as the town and postcode are included
 
 ## Text areas
 
-{{ example({group: 'patterns', item: 'addresses', example: 'textarea', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'patterns', item: 'addresses', example: 'textarea', html: true, nunjucks: true, open: true}) }}
 
 ### When to use text areas
 

--- a/src/patterns/check-answers/index.md.njk
+++ b/src/patterns/check-answers/index.md.njk
@@ -55,9 +55,11 @@ Add hidden text to the ‘Change’ links, so that they make sense when read out
 
 For example:
 
+<div class="govuk-!-mb-r6">
 ```html
 <a href="/renew/name/edit">Change<span class="visually-hidden"> name</span></a>
 ```
+</div>
 
 ## Research on this pattern
 

--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Let users know they’ve completed a transaction.
 
-{{ example({group: 'patterns', item: 'confirmation-pages', example: 'default'}) }}
+{{ example({group: 'patterns', item: 'confirmation-pages', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 See an [example of this page](https://govuk-prototype-kit.herokuapp.com/docs/examples/confirmation-page) in the [GOV.UK prototype kit](https://govuk-prototype-kit.herokuapp.com/docs).
 

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Help users enter or select a date.
 
-{{ example({group: 'patterns', item: 'dates', example: 'default'}) }}
+{{ example({group: 'patterns', item: 'dates', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 
@@ -33,7 +33,7 @@ In some cases, you might need users to pick a date.
 
 Ask for memorable dates, like dates of birth using the [Date input component](../../components/date-input).
 
-{{ example({group: 'patterns', item: 'dates', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'patterns', item: 'dates', example: 'default', html: true, nunjucks: true, open: true}) }}
 
 ### Asking for dates from documents and cards
 

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'patterns', item: 'email-addresses', example: 'default'}) }}
+{{ example({group: 'patterns', item: 'email-addresses', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 

--- a/src/patterns/fill-in-a-form/index.md.njk
+++ b/src/patterns/fill-in-a-form/index.md.njk
@@ -97,21 +97,19 @@ When writing help text, you should:
 - focus on the action the user must do - make it relevant to their current situation
 - avoid giving background information that’s useless to users, like ‘this used to be called X but in 2008 it was changed to Y’
 
-Hint text is short, clear text positioned immediately next to the part of the page it relates to. You can use hint text for help that’s relevant to the majority of your users, for example:
+ <a name="hint-text"></a>Hint text is short, clear text positioned immediately next to the part of the page it relates to. You can use hint text for help that’s relevant to the majority of your users, for example:
 
-{{ example({group: 'patterns', item: 'fill-in-a-form', example: 'hint', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'patterns', item: 'fill-in-a-form', example: 'hint', html: true, nunjucks: true, open: true}) }}
 
 You should place inline help for form fields between the label and the field so sighted users and screenreaders can read it before they get to the field itself.
 
 If you need to provide information that only some users will need, you can use the Details component. This is a short link that expands into more detailed help when a user clicks on it, for example:
 
-{{ example({group: 'patterns', item: 'fill-in-a-form', example: 'details', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'patterns', item: 'fill-in-a-form', example: 'details', html: true, nunjucks: true, open: true}) }}
 
 Use the Details component to make your page easier to scan, but don’t hide help if a majority of users will need it.
 
 Make sure the link text is written so that users can quickly work out if they need to click on it.
-
-
 
 
 ### Using progress indicators
@@ -120,7 +118,7 @@ Start by testing your form without a progress indicator to see if it’s simple 
 
 Try improving the order, type or number of questions before adding a progress indicator. If people still have difficulty, try adding a simple step or question indicator like this one.
 
-{{ example({group: 'patterns', item: 'fill-in-a-form', example: 'progress', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'patterns', item: 'fill-in-a-form', example: 'progress', html: true, nunjucks: true, open: true}) }}
 
 Only include the total number of questions if you can do so reliably. As the user moves through the form, make sure the indicator updates to tell them which question they are on and the total number remaining.
 

--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'patterns', item: 'names', example: 'default'}) }}
+{{ example({group: 'patterns', item: 'names', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Ask users to provide their National Insurance number.
 
-{{ example({group: 'patterns', item: 'national-insurance-numbers', example: 'default'}) }}
+{{ example({group: 'patterns', item: 'national-insurance-numbers', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -41,13 +41,13 @@ If you’re only asking for one piece of information on a page, make the questio
 
 For example ‘What is your home postcode?’
 
-{{ example({group: 'patterns', item: 'question-pages', example: 'postcode', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'patterns', item: 'question-pages', example: 'postcode', html: true, nunjucks: true, open: true}) }}
 
 If you need to ask for multiple related things on a page, use a statement as the heading.
 
 This example uses ‘Passport details’ to describe the related questions:
 
-{{ example({group: 'patterns', item: 'question-pages', example: 'passport', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'patterns', item: 'question-pages', example: 'passport', html: true, nunjucks: true, open: true}) }}
 
 Don’t duplicate the same page heading across multiple pages.
 
@@ -55,7 +55,7 @@ The page heading should relate specifically to the information being asked for o
 
 If you need to show the high-level section, you can use the 'secondary-heading' style. For example, ‘About you’:
 
-{{ example({group: 'patterns', item: 'question-pages', example: 'section-headings', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'patterns', item: 'question-pages', example: 'section-headings', html: true, nunjucks: true, open: true}) }}
 
 ### Continue button
 

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -28,7 +28,7 @@ If your layout is defined using explicit widths on `<main>` and `<aside>`, you n
 
 This will be the container for your main content. This wrapper adds responsive padding to the top and bottom of the page.
 
-{{ example({group: 'styles', item: 'layout', example: 'layout-wrappers', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'styles', item: 'layout', example: 'layout-wrappers', html: true, open: true}) }}
 
 ## Grid system
 
@@ -48,31 +48,31 @@ The widths available are as follows:
 
 ### Full width
 
-{{ example({group: 'styles', item: 'layout', example: 'full-width', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'styles', item: 'layout', example: 'full-width', html: true, open: true}) }}
 
 ### One-half
 
-{{ example({group: 'styles', item: 'layout', example: 'one-half', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'styles', item: 'layout', example: 'one-half', html: true, open: true}) }}
 
 ### One-third
 
-{{ example({group: 'styles', item: 'layout', example: 'one-third', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'styles', item: 'layout', example: 'one-third', html: true, open: true}) }}
 
 ### Two-thirds
 
-{{ example({group: 'styles', item: 'layout', example: 'two-thirds', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'styles', item: 'layout', example: 'two-thirds', html: true, open: true}) }}
 
 ### One-quarter
 
-{{ example({group: 'styles', item: 'layout', example: 'one-quarter', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'styles', item: 'layout', example: 'one-quarter', html: true, open: true}) }}
 
 ### Example combinations
 
-{{ example({group: 'styles', item: 'layout', example: 'combinations', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'styles', item: 'layout', example: 'combinations', html: true, open: true}) }}
 
 ### Nested grids
 
-{{ example({group: 'styles', item: 'layout', example: 'nested', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'styles', item: 'layout', example: 'nested', html: true, open: true}) }}
 
 ## Spacing override classes
 
@@ -167,4 +167,4 @@ If you need to constrain the width of an element independently of the grid syste
 
 As with the spacing-override classes the width-override classes start with `govuk-!-`. The second part of the class name signifies the width on larger screen sizes, for example `govuk-!-width-one-half`  will apply a width of 50%,  `govuk-!-width-two-thirds`will apply a width of 66.66%.
 
-{{ example({group: 'styles', item: 'layout', example: 'input-width', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'styles', item: 'layout', example: 'input-width', html: true, open: true}) }}

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -23,13 +23,13 @@ Markup headings semantically using the appropriate <h#> level HTML element and u
 
 Write all headings in sentence case.
 
-{{ example({group: 'styles', item: 'typography', example: 'headings', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'styles', item: 'typography', example: 'headings', html: true, open: true}) }}
 
 ### Headings with captions
 
 Sometimes you may need to make it clear that a heading is part of a larger section or group. You can use a heading with a caption, for this.
 
-{{ example({group: 'styles', item: 'typography', example: 'captions', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'styles', item: 'typography', example: 'captions', html: true, open: true}) }}
 
 ## Paragraphs
 
@@ -37,7 +37,7 @@ Sometimes you may need to make it clear that a heading is part of a larger secti
 
 The default paragraph font-size is 19px on large screens and 16px on small screens.
 
-{{ example({group: 'styles', item: 'typography', example: 'body', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'styles', item: 'typography', example: 'body', html: true, open: true}) }}
 
 You can also add classes to create lead paragraphs and smaller body copy to convey hierarchy in your page.
 
@@ -45,7 +45,7 @@ You can also add classes to create lead paragraphs and smaller body copy to conv
 
 A lead paragraph is an introductory paragraph that you can use to summarise the content of the page below. Lead paragraphs use 24px type on desktop and should only be used once per page if needed.
 
-{{ example({group: 'styles', item: 'typography', example: 'lead', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'styles', item: 'typography', example: 'lead', html: true, open: true}) }}
 
 ### Body small
 
@@ -55,7 +55,7 @@ Generally, you should only use body small for supporting content like the ‘Rel
 
 The majority of your body copy should use the standard 19px paragraph size.
 
-{{ example({group: 'styles', item: 'typography', example: 'small', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'styles', item: 'typography', example: 'small', html: true, open: true}) }}
 
 ## Font override classes and typography mixins
 
@@ -65,31 +65,31 @@ You might need to set the font size or font weight of an element outside of the 
 
 The full GOV.UK typography scale goes from 14px up to 80px on large screens. You can add these font-size override classes to any other typographic class or element and they will change the font size.
 
-{{ example({group: 'styles', item: 'typography', example: 'font-size', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'styles', item: 'typography', example: 'font-size', html: true, open: true}) }}
 
 ### Font weight
 
 As with the font size, you can add a font-weight override class to any other typographic class or element to change the font weight to regular or bold weight.
 
-{{ example({group: 'styles', item: 'typography', example: 'font-weight', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'styles', item: 'typography', example: 'font-weight', html: true, open: true}) }}
 
 ## Links
 
 Links are blue and underlined by default. If your link is at the end of a sentence or paragraph, make sure that the linked text doesn’t include the full stop.
 
-{{ example({group: 'styles', item: 'typography', example: 'link', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'styles', item: 'typography', example: 'link', html: true, open: true}) }}
 
 ## Lists
 
 Use lists to make blocks of text easier to read, and to break information into smaller, manageable chunks.
 
-{{ example({group: 'styles', item: 'typography', example: 'list', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'styles', item: 'typography', example: 'list', html: true, open: true}) }}
 
 ### Bulleted lists
 
 Introduce bulleted lists with a lead in line ending in a colon. Start each item with a lowercase letter, and don’t use a full stop at the end.
 
-{{ example({group: 'styles', item: 'typography', example: 'list-bullet', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'styles', item: 'typography', example: 'list-bullet', html: true, open: true}) }}
 
 ### Numbered lists
 
@@ -97,7 +97,7 @@ Use numbered lists instead of bulleted lists when the order of the items is rele
 
 You don’t need to use a lead-in line for numbered lists. Items in a numbered list should end in a full stop because each should be a complete sentence.
 
-{{ example({group: 'styles', item: 'typography', example: 'list-number', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'styles', item: 'typography', example: 'list-number', html: true, open: true}) }}
 
 ## Prose scope
 
@@ -112,7 +112,7 @@ govuk-prose-scope will apply GOV.UK styles to:
 - bold text
 - lists
 
-{{ example({group: 'styles', item: 'typography', example: 'prose-scope', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'styles', item: 'typography', example: 'prose-scope', html: true, open: true}) }}
 
 
 

--- a/src/styles/typography/prose-scope.njk
+++ b/src/styles/typography/prose-scope.njk
@@ -3,26 +3,26 @@ layout: layout-example.njk
 ---
 
 <div class="govuk-prose-scope">
-<h1>H1 heading</h1>
+  <h1>H1 heading</h1>
 
-<p>A paragraph. This includes even more text to give a good representation of a more average length paragraph. That way you can see more than one line wrapping.</p>
+  <p>A paragraph. This includes even more text to give a good representation of a more average length paragraph. That way you can see more than one line wrapping.</p>
 
-<h2>H2 heading</h2>
+  <h2>H2 heading</h2>
 
-<p>A paragraph. This includes even more text to give a good representation of a more average length paragraph. That way you can see more than one line wrapping.</p>
+  <p>A paragraph. This includes even more text to give a good representation of a more average length paragraph. That way you can see more than one line wrapping.</p>
 
-<p>Unordered list (ul):</p>
-<ul>
-  <li>apples</li>
-  <li>oranges</li>
-  <li>pears</li>
-</ul>
+  <p>Unordered list (ul):</p>
+  <ul>
+    <li>apples</li>
+    <li>oranges</li>
+    <li>pears</li>
+  </ul>
 
-<p>Ordered list (ol):</p>
+  <p>Ordered list (ol):</p>
 
-<ol>
-  <li>Register your details.</li>
-  <li>Make your application.</li>
-  <li>Send your application.</li>
-</ol>
+  <ol>
+    <li>Register your details.</li>
+    <li>Make your application.</li>
+    <li>Send your application.</li>
+  </ol>
 </div>


### PR DESCRIPTION
This PR touches all content pages so it looks very large.

However on the most part this is just:

- Removing nunjucks tab when there is no nunjucks code
- Components + Patterns : Setting a closed state on the first example and open on the examples  within the content (With the exception of very similar variants next to each other)

There's also a couple of fixups and link url changes

https://trello.com/c/chDSoHva/571-update-example-states-in-the-design-system