### PR TITLE
Add links to Github backlog

### DIFF
--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -3,6 +3,7 @@ title: Back link
 description: Use the Back link component to help users go back to the previous page in a multi-page transaction.
 section: Components
 aliases:
+backlog_issue_id: 32
 layout: layout-pane.njk
 ---
 

--- a/src/components/breadcrumbs/index.md.njk
+++ b/src/components/breadcrumbs/index.md.njk
@@ -3,6 +3,7 @@ title: Breadcrumbs
 description: Help users orientate themselves and navigate pages within a hierarchical structure.
 section: Components
 aliases: navigation path, cookie crumb
+backlog_issue_id: 33
 layout: layout-pane.njk
 ---
 

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -3,6 +3,7 @@ title: Button
 description: GOV.UK Button
 section: Components
 aliases:
+backlog_issue_id: 34
 layout: layout-pane.njk
 ---
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -3,6 +3,7 @@ title: Checkboxes
 description: Let users select one or more options by using the Checkboxes component.
 section: Components
 aliases:
+backlog_issue_id: 37
 layout: layout-pane.njk
 ---
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -3,6 +3,7 @@ title: Date input
 description: Use the Date input component to help users enter a memorable date.
 section: Components
 aliases:
+backlog_issue_id: 42
 layout: layout-pane.njk
 ---
 

--- a/src/components/details/index.md.njk
+++ b/src/components/details/index.md.njk
@@ -3,6 +3,7 @@ title: Details
 description: Make a page easier to scan by letting users reveal more detailed information only if they need it.
 section: Components
 aliases:
+backlog_issue_id: 44
 layout: layout-pane.njk
 ---
 

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -3,6 +3,7 @@ title: Error message
 description:
 section: Components
 aliases:
+backlog_issue_id: 47
 layout: layout-pane.njk
 ---
 

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -3,6 +3,7 @@ title: Error summary
 description:
 section: Components
 aliases:
+backlog_issue_id: 46
 layout: layout-pane.njk
 ---
 

--- a/src/components/fieldset/index.md.njk
+++ b/src/components/fieldset/index.md.njk
@@ -3,6 +3,7 @@ title: Fieldset
 description: Use the Fieldset component to group related form inputs.
 section: Components
 aliases:
+backlog_issue_id: 48
 layout: layout-pane.njk
 ---
 

--- a/src/components/file-upload/index.md.njk
+++ b/src/components/file-upload/index.md.njk
@@ -3,6 +3,7 @@ title: File upload
 description: Help users select and upload a file.
 section: Components
 aliases:
+backlog_issue_id: 49
 layout: layout-pane.njk
 ---
 

--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -3,6 +3,7 @@ title: Panel
 description: The Panel component is a visible container used on confirmation or results pages.
 section: Components
 aliases:
+backlog_issue_id: 55
 layout: layout-pane.njk
 ---
 

--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -3,6 +3,7 @@ title: Phase banner
 description: Use the Phase banner component to show users your service is still being worked on.
 section: Components
 aliases:
+backlog_issue_id: 57
 layout: layout-pane.njk
 ---
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -3,6 +3,7 @@ title: Radios
 description: Let users select a single option from a list using the Radios component.
 section: Components
 aliases:
+backlog_issue_id: 59
 layout: layout-pane.njk
 ---
 

--- a/src/components/select/index.md.njk
+++ b/src/components/select/index.md.njk
@@ -3,6 +3,7 @@ title: Select
 description: Help users select an item from a dropdown list.
 section: Components
 aliases:
+backlog_issue_id: 60
 layout: layout-pane.njk
 ---
 

--- a/src/components/skip-link/index.md.njk
+++ b/src/components/skip-link/index.md.njk
@@ -3,6 +3,7 @@ title: Skip link
 description: Use the Skip link component to help keyboard-only users skip to the main content on a page.
 section: Components
 aliases:
+backlog_issue_id: 66
 layout: layout-pane.njk
 ---
 

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -3,6 +3,7 @@ title: Table
 description: Use the Table component to make information easier to compare and scan for users.
 section: Components
 aliases:
+backlog_issue_id: 61
 layout: layout-pane.njk
 ---
 

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -3,6 +3,7 @@ title: Tag
 description: indicate the status of something, such as an item on a Task list or a Phase banner.
 section: Components
 aliases:
+backlog_issue_id: 62
 layout: layout-pane.njk
 ---
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -3,6 +3,7 @@ title: Text input
 description: Help users enter information with the Text input component.
 section: Components
 aliases:
+backlog_issue_id: 51
 layout: layout-pane.njk
 ---
 

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -3,6 +3,7 @@ title: Textarea
 description: Help users provide detailed information using the Textarea component.
 section: Components
 aliases:
+backlog_issue_id: 65
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -4,6 +4,7 @@ description: Help users provide an address.
 section: Patterns
 theme: Ask users for...
 aliases:
+backlog_issue_id: 31
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/check-a-service-is-suitable/index.md.njk
+++ b/src/patterns/check-a-service-is-suitable/index.md.njk
@@ -4,6 +4,7 @@ description: Ask users questions to help them work out if they can or should use
 section: Patterns
 theme: Help users to...
 aliases:
+backlog_issue_id: 35
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/check-answers/index.md.njk
+++ b/src/patterns/check-answers/index.md.njk
@@ -4,6 +4,7 @@ description: Let users check their answers before submitting information to a se
 section: Patterns
 theme: Help users to...
 aliases:
+backlog_issue_id: 36
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/confirm-an-email-address/index.md.njk
+++ b/src/patterns/confirm-an-email-address/index.md.njk
@@ -4,6 +4,7 @@ description: Use an email confirmation loop to check that a user has access to a
 section: Patterns
 theme: Help users to...
 aliases:
+backlog_issue_id: 39
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -4,6 +4,7 @@ description: Let users know they’ve completed a transaction.
 section: Patterns
 theme: Pages
 aliases:
+backlog_issue_id: 40
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/create-a-username/index.md.njk
+++ b/src/patterns/create-a-username/index.md.njk
@@ -4,6 +4,7 @@ description: Help users to create a unique and memorable username to sign into a
 section: Patterns
 theme: Help users to...
 aliases:
+backlog_issue_id: 63
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/create-accounts/index.md.njk
+++ b/src/patterns/create-accounts/index.md.njk
@@ -4,6 +4,7 @@ description: Help users create an account for your service.
 section: Patterns
 theme: Help users to...
 aliases:
+backlog_issue_id: 41
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -4,6 +4,7 @@ description: Help users enter or select a date.
 section: Patterns
 theme: Ask users for...
 aliases:
+backlog_issue_id: 43
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -4,6 +4,7 @@ description: Help users enter a valid email address.
 section: Patterns
 theme: Ask users for...
 aliases:
+backlog_issue_id: 45
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/fill-in-a-form/index.md.njk
+++ b/src/patterns/fill-in-a-form/index.md.njk
@@ -4,6 +4,7 @@ description: Help users complete a form by only asking for critical information,
 section: Patterns
 theme: Help users to...
 aliases:
+backlog_issue_id: 50
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -4,6 +4,7 @@ description: Help users correctly enter their name.
 section: Patterns
 theme: Ask users for...
 aliases:
+backlog_issue_id: 53
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -4,6 +4,7 @@ description: Ask users to provide their National Insurance number.
 section: Patterns
 theme: Ask users for...
 aliases:
+backlog_issue_id: 54
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/passwords/index.md.njk
+++ b/src/patterns/passwords/index.md.njk
@@ -4,6 +4,7 @@ description: Help users to create and enter secure and memorable passwords.
 section: Patterns
 theme: Ask users for...
 aliases:
+backlog_issue_id: 56
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -4,6 +4,7 @@ description: Follow this pattern whenever you need to ask users questions within
 section: Patterns
 theme: Pages
 aliases:
+backlog_issue_id: 58
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/task-list/index.md.njk
+++ b/src/patterns/task-list/index.md.njk
@@ -4,6 +4,7 @@ description:
 section: Patterns
 theme: Pages
 aliases:
+backlog_issue_id: 72
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because <a href="#next-steps">more research</a> is needed to validate it.

--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -3,6 +3,7 @@ title: Colour
 description:
 section: Styles
 aliases:
+backlog_issue_id: 38
 layout: layout-pane.njk
 ---
 

--- a/src/styles/images/index.md.njk
+++ b/src/styles/images/index.md.njk
@@ -2,6 +2,7 @@
 title: Images
 description: GOV.UK Images
 section: Styles
+backlog_issue_id: 70
 layout: layout-pane.njk
 ---
 

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -3,6 +3,7 @@ title: Layout
 description: Help users orientate themselves and navigate pages within a hierarchical structure.
 section: Styles
 aliases: navigation path, cookie crumb
+backlog_issue_id: 52
 layout: layout-pane.njk
 ---
 

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -2,6 +2,7 @@
 title: Typography
 description: GOV.UK Typography
 section: Styles
+backlog_issue_id: 64
 layout: layout-pane.njk
 ---
 

--- a/src/stylesheets/components/_contact-panel.scss
+++ b/src/stylesheets/components/_contact-panel.scss
@@ -1,6 +1,7 @@
 
 .app-c-contact-panel {
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");
+  @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
   @include govuk-responsive-padding($govuk-spacing-responsive-3);
   background-color: $govuk-blue;
 

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -33,6 +33,9 @@
       {% if section %}
         {% include "_contact-panel.njk" %}
       {% endif %}
+      {% if backlog_issue_id %}
+        <p class="govuk-body govuk-!-mb-r0"><a href="https://github.com/alphagov/govuk-design-system-backlog/issues/{{backlog_issue_id}}">Discuss ‘{{title}}’ on Github</a></p>
+      {% endif %}
     </main>
     {# No JS fallback to show overview #}
     <div class="app-o-pane__subnav-mobile-overview app-u-hide-desktop">


### PR DESCRIPTION
This PR adds links on all Styles, Components and Patterns pages to their associated issue on the [govuk-design-system-backlog](https://github.com/alphagov/govuk-design-system-backlog/projects/1) repo

https://trello.com/c/uqLCfj3B/597-add-links-to-github-backlog