### PR TITLE
Indicate when built as a preview a of PR

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -10,6 +10,7 @@ const sass = require('metalsmith-sass')             // convert Sass files to CSS
 
 const debug = require('./debug')                    // debug plugin
 const navigation = require('./navigation.js')       // navigation plugin
+const env = require('metalsmith-env');              // environment vars plugin
 
 const paths = require('../config/paths.json')       // specify paths to main working directories
 const colours = require('../lib/colours.js')        // get colours data
@@ -40,6 +41,10 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
 
   // clean destination before build
   .clean(true)
+
+  // Include environment variables as metalsmith metadata
+  // Used to e.g. detect when we're building in a preview environment
+  .use(env())
 
   // convert *.scss files to *.css
   .use(sass({

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "metalsmith-assets": "^0.1.0",
     "metalsmith-browser-sync": "^1.1.1",
     "metalsmith-concat": "^6.0.0",
+    "metalsmith-env": "^2.0.0",
     "metalsmith-in-place": "^3.0.1",
     "metalsmith-layouts": "^1.8.1",
     "metalsmith-markdown": "^0.2.1",

--- a/src/stylesheets/components/_tag.scss
+++ b/src/stylesheets/components/_tag.scss
@@ -1,0 +1,3 @@
+.app-c-tag--review {
+  background-color: $govuk-red;
+}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -4,18 +4,19 @@
 $app-light-grey: #f8f8f8;
 
 // App-specific components
-@import "components/header";
-@import "components/navigation";
-@import "components/mobile-navigation";
-@import "components/divider";
-@import "components/masthead";
-@import "components/footer";
-@import "components/subnav";
-@import "components/pane";
-@import "components/example";
-@import "components/tabs";
-@import "components/highlight";
 @import "components/contact-panel";
+@import "components/divider";
+@import "components/example";
+@import "components/footer";
+@import "components/header";
+@import "components/highlight";
+@import "components/masthead";
+@import "components/mobile-navigation";
+@import "components/navigation";
+@import "components/pane";
+@import "components/subnav";
+@import "components/tabs";
+@import "components/tag";
 
 body {
   margin: 0;

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -18,6 +18,7 @@
     <div class="app-o-pane">
       <div class="app-o-pane__header">
         {% include "_header.njk" %}
+        {% include "_banner.njk" %}
       </div>
       <div class="app-o-pane__nav">
         {% include "_navigation.njk" %}

--- a/views/partials/_banner.njk
+++ b/views/partials/_banner.njk
@@ -1,10 +1,7 @@
 {% from "phase-banner/macro.njk" import govukPhaseBanner %}
 
 {% if PULL_REQUEST %}
-  {# Extract the PR number from Netlify's DEPLOY_PRIME_URL, which looks like
-      https://deploy-preview-137--govuk-design-system-preview.netlify.com/ #}
-  {% set pr_number = DEPLOY_PRIME_URL | replace(r/.*deploy\-preview\-([0-9]*).*/, "$1") %}
-  {% set pr_url = "https://github.com/alphagov/govuk-design-system/pull/" + pr_number %}
+  {% set pr_url = "https://github.com/alphagov/govuk-design-system/pull/" + REVIEW_ID %}
 
   {{ govukPhaseBanner({
     "tag": {

--- a/views/partials/_banner.njk
+++ b/views/partials/_banner.njk
@@ -1,0 +1,25 @@
+{% from "phase-banner/macro.njk" import govukPhaseBanner %}
+
+{% if PULL_REQUEST %}
+  {# Extract the PR number from Netlify's DEPLOY_PRIME_URL, which looks like
+      https://deploy-preview-137--govuk-design-system-preview.netlify.com/ #}
+  {% set pr_number = DEPLOY_PRIME_URL | replace(r/.*deploy\-preview\-([0-9]*).*/, "$1") %}
+  {% set pr_url = "https://github.com/alphagov/govuk-design-system/pull/" + pr_number %}
+
+  {{ govukPhaseBanner({
+    "tag": {
+      "text": "preview",
+      "classes": "app-c-tag--review"
+    },
+    "classes": "govuk-!-pl-r3 govuk-!-pr-r3",
+    "html": "This is a preview of a <a href=\"" + pr_url  + "\">proposed change</a> to the <a href=\"https://govuk-design-system-production.cloudapps.digital\">Design System</a>."
+  }) }}
+{% else %}
+  {{ govukPhaseBanner({
+    "tag": {
+      "text": "beta"
+    },
+    "classes": "govuk-!-pl-r3 govuk-!-pr-r3",
+    "html": "This is a new service – your <a href=\"/get-in-touch\">feedback</a> will help us to improve it."
+  }) }}
+{% endif %}

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -40,13 +40,3 @@
   </div>
   {# </div> #}
 </header>
-
-{% from "phase-banner/macro.njk" import govukPhaseBanner %}
-
-{{ govukPhaseBanner({
-  "tag": {
-    "text": "beta"
-  },
-  "classes": "govuk-!-pl-r3 govuk-!-pr-r3",
-  "html": "This is a new service – your <a href=\"/get-in-touch\">feedback</a> will help us to improve it."
-}) }}


### PR DESCRIPTION
Use the build environment variables that Netlify give us to detect when a build happens as part of a PR preview, and clearly mark it as such by replacing the beta banner with a suitable summary.

![screen shot 2018-01-18 at 16 09 59](https://user-images.githubusercontent.com/121939/35107966-3cb48f16-fc6a-11e7-9674-3da9da2d16f1.png)

https://trello.com/c/VzFEH5eR/549-review-apps-should-be-clearly-identified-as-previews