### PR TITLE
Update DS to use FE 0.0.22-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,252 +4,243 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@govuk-frontend/all": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.21-alpha.tgz",
-      "integrity": "sha512-KnMoTj4MqzsdAnUf64Z3Ke2CAroTRfk5uWvXiXsOPJVRXLVta7htfn1y5s7lVCp8W3209heAn7SYQjfhmW2fkQ==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.22-alpha.tgz",
+      "integrity": "sha512-Y1x8n7JkFPV92RioI9gOMlAAY/d+NI2Q1/w6DNtTKWicmjrqMddk+jeIHKSF+UlSQ49TbnWU/rXvhPBrJWx2yg==",
       "requires": {
-        "@govuk-frontend/back-link": "0.0.21-alpha",
-        "@govuk-frontend/breadcrumbs": "0.0.21-alpha",
-        "@govuk-frontend/button": "0.0.21-alpha",
-        "@govuk-frontend/checkboxes": "0.0.21-alpha",
-        "@govuk-frontend/cookie-banner": "0.0.21-alpha",
-        "@govuk-frontend/date-input": "0.0.21-alpha",
-        "@govuk-frontend/details": "0.0.21-alpha",
-        "@govuk-frontend/error-message": "0.0.21-alpha",
-        "@govuk-frontend/error-summary": "0.0.21-alpha",
-        "@govuk-frontend/fieldset": "0.0.21-alpha",
-        "@govuk-frontend/file-upload": "0.0.21-alpha",
-        "@govuk-frontend/icons": "0.0.21-alpha",
-        "@govuk-frontend/input": "0.0.21-alpha",
-        "@govuk-frontend/label": "0.0.21-alpha",
-        "@govuk-frontend/legal-text": "0.0.21-alpha",
-        "@govuk-frontend/link": "0.0.21-alpha",
-        "@govuk-frontend/panel": "0.0.21-alpha",
-        "@govuk-frontend/phase-banner": "0.0.21-alpha",
-        "@govuk-frontend/previous-next": "0.0.21-alpha",
-        "@govuk-frontend/radios": "0.0.21-alpha",
-        "@govuk-frontend/select": "0.0.21-alpha",
-        "@govuk-frontend/skip-link": "0.0.21-alpha",
-        "@govuk-frontend/table": "0.0.21-alpha",
-        "@govuk-frontend/tag": "0.0.21-alpha",
-        "@govuk-frontend/textarea": "0.0.21-alpha"
+        "@govuk-frontend/back-link": "0.0.22-alpha",
+        "@govuk-frontend/breadcrumbs": "0.0.22-alpha",
+        "@govuk-frontend/button": "0.0.22-alpha",
+        "@govuk-frontend/checkboxes": "0.0.22-alpha",
+        "@govuk-frontend/cookie-banner": "0.0.22-alpha",
+        "@govuk-frontend/date-input": "0.0.22-alpha",
+        "@govuk-frontend/details": "0.0.22-alpha",
+        "@govuk-frontend/error-message": "0.0.22-alpha",
+        "@govuk-frontend/error-summary": "0.0.22-alpha",
+        "@govuk-frontend/fieldset": "0.0.22-alpha",
+        "@govuk-frontend/file-upload": "0.0.22-alpha",
+        "@govuk-frontend/icons": "0.0.22-alpha",
+        "@govuk-frontend/input": "0.0.22-alpha",
+        "@govuk-frontend/label": "0.0.22-alpha",
+        "@govuk-frontend/panel": "0.0.22-alpha",
+        "@govuk-frontend/phase-banner": "0.0.22-alpha",
+        "@govuk-frontend/previous-next": "0.0.22-alpha",
+        "@govuk-frontend/radios": "0.0.22-alpha",
+        "@govuk-frontend/select": "0.0.22-alpha",
+        "@govuk-frontend/skip-link": "0.0.22-alpha",
+        "@govuk-frontend/table": "0.0.22-alpha",
+        "@govuk-frontend/tag": "0.0.22-alpha",
+        "@govuk-frontend/textarea": "0.0.22-alpha",
+        "@govuk-frontend/warning-text": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/back-link": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.21-alpha.tgz",
-      "integrity": "sha512-o67rxAu7xESMO0X5auAMH5/4wMmNVFGTtHWWGdjvxspDOLcwKcsb6tnhGEnqW2Q5cwdFzAPINw11CWVRCz2piQ==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.22-alpha.tgz",
+      "integrity": "sha512-h/G1djG7Ugc6G6dAeWukQnj5OaXdx9YHcrsTjH4Jn0dl+7pEMQlwEf7AdyEg502Vs2EURE9E0+UGwISSkepIfQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/breadcrumbs": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.21-alpha.tgz",
-      "integrity": "sha512-DNTOvRdJiFqIw3dZh+ZnEiZyUIEdhT+0W02aaHl8RJ4R1B9Juv2TAYuhsZXIUa+hCXV02jqHDG6o7jZwLDgn7g==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.22-alpha.tgz",
+      "integrity": "sha512-yaz2PfsisqlGIXqgKtORDKvsmv7Tiyk5l8kzaglc2Vbnda+HLyvpjDdX++zp/18hlTS6g9xVxIG/ZxFsk78Kbg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha",
-        "@govuk-frontend/icons": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha",
+        "@govuk-frontend/icons": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/button": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.21-alpha.tgz",
-      "integrity": "sha512-pYPV4e943ehjmZDMIjECevu2k5ADRpdQzfh6BaDOGICjrcZb050KTsnlCp05VwMUpeTNP5eK63R0VfHaHzbnkw==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.22-alpha.tgz",
+      "integrity": "sha512-G9tK3H4GShkSA5Q0rBx6yXhg/T2oNlKjlXS0OAs9BH9KE311Ri0aZ2iWVSBTPRMDOgPJd3QkzTZjwzze3u4Cyw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha",
-        "@govuk-frontend/icons": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha",
+        "@govuk-frontend/icons": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/checkboxes": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.21-alpha.tgz",
-      "integrity": "sha512-lysFnDlN6OSWcTQIcg+vpQ3l3b4n8+X+co/LKDZ0yoJQwXpses1hLG0C3nEo8Gb49ewbaBeAoqCw6hScvJDVEA==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.22-alpha.tgz",
+      "integrity": "sha512-qRX2GgoWkKKMoOojezm2k15SqEhVkVOwiDRGNl3xQlCZAa2YoMms6F+p/oAC3iheZXwg+SXMq9FRnQyNHdWxBA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha",
-        "@govuk-frontend/label": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha",
+        "@govuk-frontend/label": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/cookie-banner": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/cookie-banner/-/cookie-banner-0.0.21-alpha.tgz",
-      "integrity": "sha512-/V4qhw5v6kAz9z57C68MIoDwBiF6ott7kwj6XyFqxgWsUl9+7hXGmxFeRv8qgzfi1w2HVfTNPuKc9K1qPlbtIA==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/cookie-banner/-/cookie-banner-0.0.22-alpha.tgz",
+      "integrity": "sha512-rPI8sWQp3nwTqjzBLmuUwYWBKi7pv3Ki2D3I9O7+2oeIRxc21ycGrLeXV4RtMoAFzEJQLveHMpmPmAAISAPGcg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/date-input": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.21-alpha.tgz",
-      "integrity": "sha512-1PGHtwkGGjHjDNVDzfl5HW5BHxqqqf/cwx0pwPMtocyahgnLUBn+aY49miy9ZYI/E1gQmAvRjiogyuOL6Q6UtQ==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.22-alpha.tgz",
+      "integrity": "sha512-NtpQxZ+KsSPYgHHWnFVNyHZ9s8pZ389di8XUQsMbFXvD14vG8gJT6esfxjWSEL2lk71IlQvAC4TdPFpHrvCfdw==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.21-alpha",
-        "@govuk-frontend/globals": "0.0.21-alpha",
-        "@govuk-frontend/label": "0.0.21-alpha"
+        "@govuk-frontend/error-message": "0.0.22-alpha",
+        "@govuk-frontend/globals": "0.0.22-alpha",
+        "@govuk-frontend/label": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/details": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.21-alpha.tgz",
-      "integrity": "sha512-Jnsiyr7KVRfLPQ1jeHGfb6p5TsRl9MaaTCxHKxGd4g5QWhB2JviLGAIqvYg382zi6pT9jHOX4+r5IlF8EK1ReQ==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.22-alpha.tgz",
+      "integrity": "sha512-q7/6L8/ZzHrIgMz9vD88JRPl1ZfDEQFFm5v0eRN0Te7Bw7L5APorhjdMeJ1Vz1G3eR81mBub7VkEmv0ueYG1Zw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/error-message": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.21-alpha.tgz",
-      "integrity": "sha512-xMkvwqCq+MQ/XFTJqfx6xoOK+rbCOQV46Lvoh7hdz2qZ/WQ28565X+LB6e3JbXszgc9LESN7U5NTY2EC1dVeZw==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.22-alpha.tgz",
+      "integrity": "sha512-XVCoTTtHs23EcD8+5rraTLxqZ2IiYUrwIIAGn9OoYtPtN4AUb5b7iwEF3Y5MDRboBQLrKG95//bAW0e7KiJzhw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/error-summary": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.21-alpha.tgz",
-      "integrity": "sha512-i9DcmSpxDDRO4MNEptoDJ2oyAKHGrnY1RNmpL7H4hPp75oyq+3P2/Cq++WZorWGPwf02WVgP6Zt/ob7zlyVuKw==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.22-alpha.tgz",
+      "integrity": "sha512-qRj/D7vh6izKtbS/+mLGNtFELHB2VlsBJqENlS9M+A2GhB99+zPrRG0P+1bviFcSr4c2p1Y9XxGhlwJ9f4FA9A==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/fieldset": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.21-alpha.tgz",
-      "integrity": "sha512-Nb69e1wheDjHXwd4oaFYvKYbcHtBPquWDIzILwhyuO9PdFHPJZi5xhcsNN2SlPHRdYpJ0lNtuauqp2sdEgn2fg==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.22-alpha.tgz",
+      "integrity": "sha512-FXyZjADSYTs5bDH2Ajd38PEKe7qOV6a+HCrrxcEm3nwZcpm6xLLVOaftY+edZbaKpNo4Z0cbAU7TgFPys9z4pA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/file-upload": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.21-alpha.tgz",
-      "integrity": "sha512-pMBstOjBOlYFmyDpBwa7BimgphJURydHupuaCK8IzZuuRdtL6fIQuc6001eGQSrt8+LD6TeOlZ3l6nF9boq66A==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.22-alpha.tgz",
+      "integrity": "sha512-V+kZIoXEweq4sIlQSL+Ja9xXBk7Uh0nPlpSlymKCE1Zlbyb0j+dcJuFkd7DM1qa7Si4UTlqgdPnf+gVbvIaDwQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/globals": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.21-alpha.tgz",
-      "integrity": "sha512-hEbht6uP6arAxpNTxOwARTEDcwXooc6FnCCDLscIYzg5ztEvKx+nCkzYNWrwC7+wsdihGTgCcRZeodm8MsjwWQ==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.22-alpha.tgz",
+      "integrity": "sha512-ixC9uOVXCWgSdHa3zQSDzHi1/E8swsNYszMYK2m7QGioJi2b9yU3OhUCcDEvG/IU6zb8my3WYcdTmtod3Y+rEA==",
       "requires": {
         "sass-mq": "3.3.2"
       }
     },
     "@govuk-frontend/icons": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.21-alpha.tgz",
-      "integrity": "sha512-ZsT2wIz4x0ssNgFR1v/8InQmJSXJHIqV0hI2k83bgDOT2HP/HLKVehTyx3ZrtwtK10BcCRPCOfWBb2oFzXfETw=="
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.22-alpha.tgz",
+      "integrity": "sha512-q0KrKkoAV/d/QOHR7BQDwYwL5KrDhBgCdoljbZAjWgzdLz15EeWKeBtyvSmug3hUIFMr0Pvle1V8q7B1DiyLNQ=="
     },
     "@govuk-frontend/input": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.21-alpha.tgz",
-      "integrity": "sha512-lYj4qSA4jcY5yYoj2soALQCfkQAFK4FbPhd9Uo+kCnrJCounpSHvHzkUSq/YLpKZrqWxHUdZAC6Kh6SJxgVOUA==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.22-alpha.tgz",
+      "integrity": "sha512-W2sfC3Ag9JqLDFD60anL5WpwdXt4X+WmxHywMn7ri5jPVkoU4/MjY/0wPmybA9qzRyY20Ldd7C97yUfSKLvElg==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.21-alpha",
-        "@govuk-frontend/globals": "0.0.21-alpha",
-        "@govuk-frontend/label": "0.0.21-alpha"
+        "@govuk-frontend/error-message": "0.0.22-alpha",
+        "@govuk-frontend/globals": "0.0.22-alpha",
+        "@govuk-frontend/label": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/label": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.21-alpha.tgz",
-      "integrity": "sha512-iCHC6+FXVG6qgMQR4OxTYyeUPeCTOPKgBIVKTD4g62027GC8RNquBxGciO6sMtvRcOseZnmDLHGXGX/qsNv5PQ==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.22-alpha.tgz",
+      "integrity": "sha512-CqXVIjRPLpr7tfgSfq5rjU0fOU9RvVaTjI9LtUYjkaPVJI+UBYe4/CwsRujEVK95NURqhBBbKzIgHV5Sx0i5UQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
-      }
-    },
-    "@govuk-frontend/legal-text": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/legal-text/-/legal-text-0.0.21-alpha.tgz",
-      "integrity": "sha512-8HFBXinwueKgXKaPosGaZFv36jgJexv0swHzNDu5IlaCmsPjNET601b5PydP2ggzNxY8gT4EQMR1OEfsFZgyEQ==",
-      "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
-      }
-    },
-    "@govuk-frontend/link": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/link/-/link-0.0.21-alpha.tgz",
-      "integrity": "sha512-f3aqm5UMTa3GsCf0TNGIvRQ89c7+Su71jnsFyt0TjrO+A2FHASqv1VPFkaZ7/1XdDsK9fZwfWtyPsobg5ibRmQ==",
-      "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/panel": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.21-alpha.tgz",
-      "integrity": "sha512-AToa9g7nA7+CkvVM2yprdTdsYPn4HAGgxK+nPS8ZRMlotv6A5iYvcaG48qtK1xrRmkEWW3SS3HlX83x8Ud8wSg==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.22-alpha.tgz",
+      "integrity": "sha512-pD22TGsVLMXjcHAkQhwo4rgL1SKLFjm3Es6jFDqUrL8Vjp7texkagbLe4R/HBDlfcc/67ZqmTEkROT9cFZvtFA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/phase-banner": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.21-alpha.tgz",
-      "integrity": "sha512-ba5nIXDR/Qt+qhe95mfYWf4mOaDLvlBDOClb/7bqJ1eyZbtn1F6rjrwr2ufaNweWHDsVljtxZxlVZutJgd+a8A==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.22-alpha.tgz",
+      "integrity": "sha512-GTL1lQhgBmPBqeP/gdWagKGIYZ+f/lYuc+HrEXBwKV4q1GxUUrY5JWUJOFnT/tO+MvdVN8Bp10OdtXAjKW3X0Q==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha",
-        "@govuk-frontend/tag": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha",
+        "@govuk-frontend/tag": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/previous-next": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/previous-next/-/previous-next-0.0.21-alpha.tgz",
-      "integrity": "sha512-xxHlAqTygB20zJGytCxeVI2N/mHqr+wjU45uG3t1s9oU7LQdrB2jhhZTRuEI+xroubbNos2O8vYNyVTUzhwx6A==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/previous-next/-/previous-next-0.0.22-alpha.tgz",
+      "integrity": "sha512-LMN8/cdrPzNP84a4OikyJkthnE6Cp4/0vXXBn2I6fiVs7IZJioJXUqftZz2LlHmZaCYzcRzHhyVTwS3LZzvuqg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/radios": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.21-alpha.tgz",
-      "integrity": "sha512-pI3fVNQE2fO5Uo2t2vujiLi596DwQI23nGyxIZGikCLGd/+NogHxQFP+0GLH3mKfmfker4/g1mkOscQ5PTBFVQ==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.22-alpha.tgz",
+      "integrity": "sha512-35o+tQNTuFyvERA9XoCCahCGtxXtrP+RnAuEfASl/fSGUop5lHTx9yoXAnVrt2CwSAzxr9+cPN4zFmbDfG1GKQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha",
-        "@govuk-frontend/label": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha",
+        "@govuk-frontend/label": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/select": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.21-alpha.tgz",
-      "integrity": "sha512-0RsYkmtjmf5xhYUeeowOFYXt5/Hne863IIJuu4zMZaS7/x/T4gAKKAmr1aRU2/TXBea15JBMMtdl6s8rGSuZ+g==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.22-alpha.tgz",
+      "integrity": "sha512-V7+tpAkcAE3glotvtstA+G+R8c5mpHO+BGkMB911ukkxu8sgSD3HAPRSiihVzfgp/liDjD6sLgc+ctWvp0VzPQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha",
-        "@govuk-frontend/label": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha",
+        "@govuk-frontend/label": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/skip-link": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.21-alpha.tgz",
-      "integrity": "sha512-eiKXOUFmyK5garLdKJnkk0NxpzWkMNSMHmBnvlX1t09993opVOrMZ4wf/JRTclbV0xF2gtMA867xz/drICcBBw==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.22-alpha.tgz",
+      "integrity": "sha512-3G0VAPe7bFv+3uj3gZGpoSeJemXtzy7ncvmeh0q7xbb2jqb96u1eYE6WDKact2MqZiJVB9wPIegjjz1C9v3VJw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/table": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.21-alpha.tgz",
-      "integrity": "sha512-HEe9LKt+v1Kvjzp08ZG2+HSVHX6Ih8F27+lLcFBzsHCB7KCCCzxxonvGjhVfY7Ye+1W1hC9PCREhXQ7tIR7IcQ==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.22-alpha.tgz",
+      "integrity": "sha512-SwAZqy2zC5tHXIu/yQgGw2jRPDmWTOG8Ln9I6l06Vpv1alS2JPQPjBbUUPa9yc9bZvlm/nLuRkWkaHAC3WM34g==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/tag": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.21-alpha.tgz",
-      "integrity": "sha512-Ts9EYgIeJEXGrXjdK8McAfMIlSbjtZ7I7ZlsXHl/otvnLYpgZ22m51gdl9XFmpNP0DsL3Tt8zmcwd/wJFXpg+w==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.22-alpha.tgz",
+      "integrity": "sha512-VFpSwjkrP2yn9pCJX++uXhe1w/2ugEqJAf4tvttOKeTLtcKAkw7HAnnmFweibG6bZ5Jz5VQNz/ih/hqaYwFECQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.21-alpha"
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "@govuk-frontend/textarea": {
-      "version": "0.0.21-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.21-alpha.tgz",
-      "integrity": "sha512-KSq/O/xYJkPOyeU7dSL9lIqGfSehERgD3mhXG7+7TeoqiuHGqVndQlG+I+n6ixl4xc5Oxy9uk/VHIZnnqjxrlg==",
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.22-alpha.tgz",
+      "integrity": "sha512-aiTwWtohD+8rHKeWOhK+yMhGHQQIJZ8K929MZodVBk1LDLmrPCqjteOYNbv0hXZ19YwzKAjRDSSfsm4rPpiL4A==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.21-alpha",
-        "@govuk-frontend/globals": "0.0.21-alpha",
-        "@govuk-frontend/label": "0.0.21-alpha"
+        "@govuk-frontend/error-message": "0.0.22-alpha",
+        "@govuk-frontend/globals": "0.0.22-alpha",
+        "@govuk-frontend/label": "0.0.22-alpha"
+      }
+    },
+    "@govuk-frontend/warning-text": {
+      "version": "0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/warning-text/-/warning-text-0.0.22-alpha.tgz",
+      "integrity": "sha512-CTuOIJVXm3kTI8g1RcfAVC/nxHFFEHaou+WvprlaULjNilpvjJeryGbbERxjErMJlqgUCP4DxVVluZtVqkXCFg==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.22-alpha"
       }
     },
     "a-sync-waterfall": {
@@ -5402,6 +5393,15 @@
         "inputformat-to-jstransformer": "1.2.1",
         "is-utf8": "0.2.1",
         "jstransformer": "1.0.0"
+      }
+    },
+    "metalsmith-env": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/metalsmith-env/-/metalsmith-env-2.0.0.tgz",
+      "integrity": "sha1-++APTTNdUXkBw02m68d4cSZNpjU=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1"
       }
     },
     "metalsmith-in-place": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "gulp scss:lint"
   },
   "dependencies": {
-    "@govuk-frontend/all": "0.0.21-alpha",
+    "@govuk-frontend/all": "0.0.22-alpha",
     "scss-to-json": "^2.0.0"
   },
   "devDependencies": {

--- a/src/components/phase-banner/beta.njk
+++ b/src/components/phase-banner/beta.njk
@@ -7,5 +7,5 @@ layout: layout-example.njk
   "tag": {
     "text": "beta"
   },
-  "html": 'This is a new service – your <a href="#">feedback</a> will help us to improve it.'
+  "html": 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
 }) }}

--- a/src/components/phase-banner/default.njk
+++ b/src/components/phase-banner/default.njk
@@ -7,5 +7,5 @@ layout: layout-example.njk
   "tag": {
     "text": "alpha"
   },
-  "html": 'This is a new service – your <a href="#">feedback</a> will help us to improve it.'
+  "html": 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
 }) }}

--- a/src/get-in-touch.njk
+++ b/src/get-in-touch.njk
@@ -7,10 +7,10 @@
 
          <h2 class="govuk-heading-l">Private beta Slack channel</h2>
 
-         <p class="govuk-body">Use <a href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>)</a></p>
+         <p class="govuk-body">Use <a class="govuk-link" class="govuk-link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a class="govuk-link" class="govuk-link" href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>)</a></p>
 
          <h2 class="govuk-heading-l">Email</h2>
-         <p class="govuk-body">Email the Design System team on <a href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">govuk-design-system-support@digital.cabinet-office.gov.uk</a></p>
+         <p class="govuk-body">Email the Design System team on <a class="govuk-link" class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">govuk-design-system-support@digital.cabinet-office.gov.uk</a></p>
       </div>
     </div>
 </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -3,32 +3,32 @@
     <div class="govuk-o-grid govuk-o-main-wrapper">
       <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r4 govuk-!-mb-r6">
         <h2 class="govuk-heading-l">Styles</h2>
-        <p class="govuk-body">The core styles that will make your service look and feel like GOV.UK, including <a href="/styles/colour/">Colour</a>, <a href="/styles/typography/">Typography</a> and <a href="/styles/layout/">Layout</a>.</p>
-        <p class="govuk-body govuk-!-mb-r0"><a href="/styles/">See all styles</a></p>
+        <p class="govuk-body">The core styles that will make your service look and feel like GOV.UK, including <a class="govuk-link" href="/styles/colour/">Colour</a>, <a class="govuk-link" href="/styles/typography/">Typography</a> and <a class="govuk-link" href="/styles/layout/">Layout</a>.</p>
+        <p class="govuk-body govuk-!-mb-r0"><a class="govuk-link" href="/styles/">See all styles</a></p>
       </div>
       <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r4 govuk-!-mb-r6">
         <h2 class="govuk-heading-l">Components</h2>
-        <p class="govuk-body">Reusable parts of the user interface. From navigational components like <a href="/components/breadcrumbs/">Breadcrumbs</a>, to fundamental form elements like <a href="/components/radios/">Radios</a> and <a href="/components/error-message/">Error message</a>.</p>
-        <p class="govuk-body govuk-!-mb-r0"><a href="/components/">See all components</a></p>
+        <p class="govuk-body">Reusable parts of the user interface. From navigational components like <a class="govuk-link" href="/components/breadcrumbs/">Breadcrumbs</a>, to fundamental form elements like <a class="govuk-link" href="/components/radios/">Radios</a> and <a class="govuk-link" href="/components/error-message/">Error message</a>.</p>
+        <p class="govuk-body govuk-!-mb-r0"><a class="govuk-link" href="/components/">See all components</a></p>
       </div>
       <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r4 govuk-!-mb-r6">
         <h2 class="govuk-heading-l">Patterns</h2>
-        <p class="govuk-body">Best-practice design solutions for common tasks like how to <a href="/patterns/addresses/">ask users for addresses</a> or design a <a href="/patterns/question-pages/">question page</a>.</p>
-        <p class="govuk-body govuk-!-mb-r0"><a href="/patterns/">See all patterns</a></p>
+        <p class="govuk-body">Best-practice design solutions for common tasks like how to <a class="govuk-link" href="/patterns/addresses/">ask users for addresses</a> or design a <a class="govuk-link" href="/patterns/question-pages/">question page</a>.</p>
+        <p class="govuk-body govuk-!-mb-r0"><a class="govuk-link" href="/patterns/">See all patterns</a></p>
       </div>
       <div class="govuk-o-grid__item govuk-o-grid__item--full">
         {% include "../views/partials/_divider.njk" %}
       </div>
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds govuk-!-mb-r6">
         <h2 class="govuk-heading-l govuk-!-mt-r6">Using the Design System</h2>
-        <p class="govuk-body govuk-!-mb-r0">To use the code in the Design System to make prototypes, download the <a href="https://govuk-prototype-kit-beta.herokuapp.com">private beta version of the GOV.UK Prototype Kit</a>.</p>
+        <p class="govuk-body govuk-!-mb-r0">To use the code in the Design System to make prototypes, download the <a class="govuk-link" href="https://govuk-prototype-kit-beta.herokuapp.com">private beta version of the GOV.UK Prototype Kit</a>.</p>
       </div>
       <div class="govuk-o-grid__item govuk-o-grid__item--full">
         {% include "../views/partials/_divider.njk" %}
       </div>
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds govuk-!-mb-r4">
         <h2 class="govuk-heading-l govuk-!-mt-r6">Get in touch</h2>
-        <p class="govuk-body govuk-!-mb-r0">If you’ve got a question, idea or suggestion share it in <a href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>) or <a href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">email the Design System team</a></p>
+        <p class="govuk-body govuk-!-mb-r0">If you’ve got a question, idea or suggestion share it in <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a class="govuk-link" href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>) or <a class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">email the Design System team</a></p>
       </div>
     </div>
 </div>

--- a/src/javascripts/components/copy.js
+++ b/src/javascripts/components/copy.js
@@ -6,7 +6,7 @@
   // This module is dependent on /vendor/clipboard.js
   GOVUK.copy = {
     init: function (selector) {
-      $(selector).parent().prepend('<a class="govuk-c-link app-c-link--copy" href="#copy">Copy</a>')
+      $(selector).parent().prepend('<a class="govuk-link app-c-link--copy" href="#copy">Copy</a>')
       // Copy to clipboard
       try {
         new Clipboard('.app-c-link--copy', {

--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -79,7 +79,7 @@
           $(obj).find('.js-tabs__container').hide()
 
           // Add close button to each container
-          $(obj).find('.js-tabs__container').append('<a class="app-c-link--close js-link--close app-o-chevron--top" href="#close">Close</a>')
+          $(obj).find('.js-tabs__container').append('<a class="govuk-link app-c-link--close js-link--close app-o-chevron--top" href="#close">Close</a>')
           $(obj).find('.js-tabs__container').addClass('app-c-tabs__container--with-close-button')
         }
       })

--- a/src/patterns/task-list-pages/index.md.njk
+++ b/src/patterns/task-list-pages/index.md.njk
@@ -7,7 +7,7 @@ aliases:
 backlog_issue_id: 72
 layout: layout-pane.njk
 status: Experimental
-statusMessage: This pattern is currently experimental because <a href="#next-steps">more research</a> is needed to validate it.
+statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#next-steps">more research</a> is needed to validate it.
 ---
 
 Task list pages help users understand:
@@ -74,4 +74,3 @@ More research is needed to find the best way to represent:
 - partially completed tasks
 
 Research is also needed to understand whether it’s more helpful to take users back to the Task list page after each task, or to the next task in the sequence.
-

--- a/src/styles/typography/link.njk
+++ b/src/styles/typography/link.njk
@@ -2,4 +2,4 @@
 layout: layout-example.njk
 ---
 
-<a href="#" class="govuk-c-link">govuk-link</a>
+<a href="#" class="govuk-link">govuk-link</a>

--- a/src/styles/typography/list.njk
+++ b/src/styles/typography/list.njk
@@ -4,15 +4,15 @@ layout: layout-example.njk
 
 <ul class="govuk-list govuk">
   <li>
-    <a href="#">Benefits calculators</a>
+    <a class="govuk-link" href="#">Benefits calculators</a>
   </li>
   <li>
-    <a href="#">Benefit overpayments</a>
+    <a class="govuk-link" href="#">Benefit overpayments</a>
   </li>
   <li>
-    <a href="#">Benefit fraud</a>
+    <a class="govuk-link" href="#">Benefit fraud</a>
   </li>
   <li>
-    <a href="#">More</a>
+    <a class="govuk-link" href="#">More</a>
   </li>
 </ul>

--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -29,6 +29,7 @@
     font-size: 19px; // We don't have a font mixin that produces 19px on mobile
 
     & > a {
+      @include govuk-typography-weight-bold; // Override .govuk-link weight
       display: block;
       padding: 16px $govuk-spacing-scale-4 17px $govuk-spacing-scale-4;
       text-decoration: none;

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -35,6 +35,7 @@
       }
 
       a {
+        @include govuk-typography-weight-bold; // Override .govuk-link weight
         display: block;
         padding: 0 20px;
         color: $govuk-link-colour;

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -32,6 +32,10 @@
     background: inherit;
     font-weight: bold;
     text-decoration: none;
+
+    .govuk-prose-scope &:focus { // A specific selector to reset .govuk-prose-scope a:focus
+      background: inherit;
+    }
   }
 
   .govuk-prose-scope & { // A specific selector to reset .govuk-prose-scope ul li

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -158,6 +158,7 @@ $mq-breakpoint-widescreen: 1200px;
   &:active,
   &:visited,
   &:hover {
+    @include govuk-font-regular-16;
     position: absolute;
     z-index: 1;
     top: $govuk-spacing-scale-3;

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -168,6 +168,11 @@ $mq-breakpoint-widescreen: 1200px;
     background-color: $govuk-white;
     text-decoration: none;
     text-transform: uppercase;
+
+    .govuk-prose-scope & {
+      color: $govuk-button-colour; // A specific selector to override .govuk-prose-scope a:link
+      background-color: $govuk-white; // A specific selector to override .govuk-prose-scope a:focus
+    }
   }
 }
 

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -34,7 +34,7 @@
         {% include "_contact-panel.njk" %}
       {% endif %}
       {% if backlog_issue_id %}
-        <p class="govuk-body govuk-!-mb-r0"><a href="https://github.com/alphagov/govuk-design-system-backlog/issues/{{backlog_issue_id}}">Discuss ‘{{title}}’ on GitHub</a></p>
+        <p class="govuk-body govuk-!-mb-r0"><a class="govuk-link" href="https://github.com/alphagov/govuk-design-system-backlog/issues/{{backlog_issue_id}}">Discuss ‘{{title}}’ on GitHub</a></p>
       {% endif %}
     </main>
     {# No JS fallback to show overview #}

--- a/views/partials/_banner.njk
+++ b/views/partials/_banner.njk
@@ -9,7 +9,7 @@
       "classes": "app-c-tag--review"
     },
     "classes": "govuk-!-pl-r3 govuk-!-pr-r3",
-    "html": "This is a preview of a <a href=\"" + pr_url  + "\">proposed change</a> to the <a href=\"https://govuk-design-system-production.cloudapps.digital\">Design System</a>."
+    "html": "This is a preview of a <a class=\"govuk-link\" href=\"" + pr_url  + "\">proposed change</a> to the <a href=\"https://govuk-design-system-production.cloudapps.digital\">Design System</a>."
   }) }}
 {% else %}
   {{ govukPhaseBanner({
@@ -17,6 +17,6 @@
       "text": "beta"
     },
     "classes": "govuk-!-pl-r3 govuk-!-pr-r3",
-    "html": "This is a new service – your <a href=\"/get-in-touch\">feedback</a> will help us to improve it."
+    "html": "This is a new service – your <a class=\"govuk-link\" href=\"/get-in-touch\">feedback</a> will help us to improve it."
   }) }}
 {% endif %}

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -1,4 +1,4 @@
 <div class="app-c-contact-panel">
   <h2 class="app-c-contact-panel__heading">Get in touch</h2>
-  <p class="app-c-contact-panel__body">If you’ve got a question, idea or suggestion share it in <a class="app-c-contact-panel__link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a> on cross-government Slack (<a class="app-c-contact-panel__link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6">open in app</a>) or <a class="app-c-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">email the Design System team</a></p>
+  <p class="app-c-contact-panel__body">If you’ve got a question, idea or suggestion share it in <a class="govuk-link app-c-contact-panel__link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a> on cross-government Slack (<a class="govuk-link app-c-contact-panel__link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6">open in app</a>) or <a class="govuk-link app-c-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">email the Design System team</a></p>
 </div>

--- a/views/partials/_footer.njk
+++ b/views/partials/_footer.njk
@@ -3,17 +3,17 @@
     <div class="govuk-o-grid__item govuk-o-grid__item--one-quarter">
       <h2 class="app-c-footer__heading govuk-heading-m">Related resources</h2>
       <ul class="app-c-footer__list govuk-list">
-        <li class="app-c-footer__list-item"><a href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a></li>
-        <li class="app-c-footer__list-item"><a href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a></li>
+        <li class="app-c-footer__list-item"><a class="govuk-link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a></li>
+        <li class="app-c-footer__list-item"><a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a></li>
       </ul>
     </div>
   </div>
   <div class="app-c-footer__meta">
     <div class="app-c-footer__licence">
-      <a class="app-c-footer__licence-logo" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a>
-      <p class="app-c-footer__licence-description">All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+      <a class="govuk-link app-c-footer__licence-logo" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a>
+      <p class="app-c-footer__licence-description">All content is available under the <a class="govuk-link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
     </div><div class="app-c-footer__copyright">
-      <a class="app-c-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
+      <a class="govuk-link app-c-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
     </div>
   </div>
 </footer>

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -1,5 +1,5 @@
 <header class="app-c-header" role="banner">
-  <a href="/" class="app-c-header__link">
+  <a href="/" class="govuk-link app-c-header__link">
     <span class="app-c-header__logotype">
 {#
       We use an inline SVG for the crown so that we can cascade the

--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -2,11 +2,11 @@
   <ul class="app-c-mobile-nav__list">
     {% for item in navigation %}
     <li>
-      <a class="js-mobile-nav-subnav-toggler" href="/{{ item.url }}">{{ item.label }}</a>
+      <a class="govuk-link js-mobile-nav-subnav-toggler" href="/{{ item.url }}">{{ item.label }}</a>
       {% if item.items %}
       <ul class="app-c-mobile-nav__subnav js-app-mobile-nav-subnav app-c-mobile-nav__subnav--hidden">
         <li{% if path == item.url %} class="current-page"{% endif %}>
-          <a href="/{{ item.url }}">{{ item.label }} overview</a>
+          <a class="govuk-link" href="/{{ item.url }}">{{ item.label }} overview</a>
         </li>
 
         {% for theme, items in item.items | groupby("theme") %}
@@ -16,7 +16,7 @@
           <ul class="app-c-mobile-nav__theme-nav">
           {% for subitem in items %}
             <li{% if path == subitem.url %} class="current-page"{% endif %}>
-              <a href="/{{ subitem.url }}">{{ subitem.label }}</a>
+              <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
             </li>
           {% endfor %}
           </ul>

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -2,7 +2,7 @@
   <ul class="app-c-navigation__list">
     {% for item in navigation %}
     <li{% if path == item.url or item.url and item.url in path %} class="app-c-navigation--current-page"{% endif %}>
-      <a href="/{{ item.url }}">{{ item.label }}</a>
+      <a class="govuk-link" href="/{{ item.url }}">{{ item.label }}</a>
     </li>
     {% endfor %}
   </ul>

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -9,7 +9,7 @@
           <ul class="app-c-subnav__section">
           {% for subitem in items %}
             <li class="app-c-subnav__section-item{% if subitem.url == path %} app-c-subnav__section-item--current{% endif %}">
-              <a href="/{{ subitem.url }}">{{ subitem.label }}</a>
+              <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
             </li>
           {% endfor %}
           </ul>

--- a/views/partials/_toc-styles.njk
+++ b/views/partials/_toc-styles.njk
@@ -1,7 +1,7 @@
 <nav class="app-c-toc">
   <ul class="app-c-toc__section">
     <li class="app-c-toc__section-item{% if path == 'styles/typography' %} app-c-toc__section-item--current{% endif %}">
-      <a href="/styles/typography/">Typography</a>
+      <a class="govuk-link" href="/styles/typography/">Typography</a>
     </li>
   </ul>
 </nav>


### PR DESCRIPTION
This updates the DS to use the new version of FE 0.0.22-alpha with the following:

- Update `package.json` to use FE 0.0.22-alpha
- Update app markup to use the new `govuk-link` class
- Update tasklist fe-matter to use new `govuk-link`
- Update phase-banner HTML args to use `govuk-link`
- Update link and list examples to use `govuk-link`
- Update copy & close links in JS to new `govuk-link`
- Override `prose-scope` link styles for `app-c-link--copy` and `app-c-tabs__item`
- Set font styles in `app-c-link--copy`
- Reset font weight for nav & mobile nav links

Each of the above is a commit with some comments.

For "Reset font weight for nav & mobile nav links", I left a note in the commit about how the two components don't set their font styles consistently. We should probably review this but not as part of this PR.

Note: `package-lock.json` has a new entry `metalsmith-env`. I wonder if this was meant to be included in another PR? Would you know about this @alex-ju? 

As per https://trello.com/c/AaQFXAfJ/616-update-ds-to-use-frontend-022