### PR TITLE
Temporary disable grid layout until the #130 is fixed

### DIFF
--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -11,7 +11,8 @@
     }
 
     @supports (display: grid) {
-      display: grid;
+      // Temporary disable CSS Grid until #130 is fixed
+      // display: grid;
       grid-template-columns: minmax(100%, 1fr);
       grid-template-rows: repeat(3, auto);
 


### PR DESCRIPTION
This will prevent us from going out to our private beta users with a bug that we know will be fixed by a new Google Chrome release.

Note: the layout will fallback on `flex`.