### PR TITLE
Change home page content and add "Get started" page

### DIFF
--- a/src/get-in-touch.njk
+++ b/src/get-in-touch.njk
@@ -1,5 +1,9 @@
+---
+layout: layout-single-page.njk
+---
+
 <div class="govuk-o-width-container app-c-site-width-container">
-    <div class="govuk-o-grid govuk-o-main-wrapper">
+    <div class="govuk-o-grid">
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
          <h1 class="govuk-heading-xl">Get in touch</h1>
 

--- a/src/get-in-touch.njk
+++ b/src/get-in-touch.njk
@@ -2,19 +2,18 @@
 layout: layout-single-page.njk
 ---
 
-<div class="govuk-o-width-container app-c-site-width-container">
-    <div class="govuk-o-grid">
-      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-         <h1 class="govuk-heading-xl">Get in touch</h1>
+<div class="govuk-o-grid">
+  <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+     <h1 class="govuk-heading-xl">Get in touch</h1>
 
-         <p class="govuk-body-l">If you’ve got a question, idea or suggestion get in touch with the Design System team.</p>
+     <p class="govuk-body-l">If you’ve got a question, idea or suggestion get in touch with the Design System team.</p>
 
-         <h2 class="govuk-heading-l">Private beta Slack channel</h2>
+     <h2 class="govuk-heading-l">Private beta Slack channel</h2>
 
-         <p class="govuk-body">Use <a class="govuk-link" class="govuk-link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a class="govuk-link" class="govuk-link" href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>)</a></p>
+     <p class="govuk-body">Use <a class="govuk-link" class="govuk-link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a class="govuk-link" class="govuk-link" href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>)</a></p>
 
-         <h2 class="govuk-heading-l">Email</h2>
-         <p class="govuk-body">Email the Design System team on <a class="govuk-link" class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">govuk-design-system-support@digital.cabinet-office.gov.uk</a></p>
-      </div>
-    </div>
+     <h2 class="govuk-heading-l">Email</h2>
+     <p class="govuk-body">Email the Design System team on <a class="govuk-link" class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">govuk-design-system-support@digital.cabinet-office.gov.uk</a></p>
+  </div>
 </div>
+

--- a/src/get-started.md.njk
+++ b/src/get-started.md.njk
@@ -1,0 +1,96 @@
+---
+layout: layout-single-page-prose.njk
+---
+
+# Get started
+
+{% from "_example.njk" import example %}
+
+This guide explains how to create prototypes using the GOV.UK Design System and GOV.UK Prototype Kit.
+
+## Before you start
+
+To make prototypes you will need to download and install a new version of the GOV.UK Prototype Kit which has been built to work with the Design System while it’s in private beta.
+
+The installation process is the same as for the current version. You should:
+
+* [download the new version of the GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com/)
+* [follow these installation instructions](https://govuk-prototype-kit-beta.herokuapp.com/docs/install/introduction)
+
+The rest of the guide assumes that you are familar with the GOV.UK Prototype Kit.
+
+## Using the new Prototype Kit
+
+The new version of the Prototype Kit is identical to the one you may have used before except that it uses a new frontend framework called GOV.UK Frontend.
+
+This means that any code that you copy across from old prototypes will not display correctly. Instead, you should use the code provided in the Design System.
+
+## Styling content
+
+The Design System provides lots of new CSS classes for styling content, meaning you shouldn’t need to write as much of your own Sass or CSS.
+
+The class names follow the [BEM naming convention](https://en.bem.info/methodology/quick-start/). This can look a bit daunting at first, but it makes for more robust code that’s easier to maintain.
+
+There are 2 ways to apply styles to content. You can use either the prose scope wrapper or style individual elements.
+
+
+### Using the prose scope wrapper
+
+You can use the `govuk-prose-scope` class to apply GOV.UK styles to a block of text. This means you don’t need to apply classes to the individual elements.
+
+<pre class="govuk-!-mb-r6"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"govuk-prose-scope"</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">h1</span>&gt;</span>A H1 heading<span class="hljs-tag">&lt;/<span class="hljs-name">h1</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>A paragraph.<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>An unordered list:<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">ul</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">li</span>&gt;</span>apples<span class="hljs-tag">&lt;/<span class="hljs-name">li</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">li</span>&gt;</span>oranges<span class="hljs-tag">&lt;/<span class="hljs-name">li</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">li</span>&gt;</span>pears<span class="hljs-tag">&lt;/<span class="hljs-name">li</span>&gt;</span>
+  <span class="hljs-tag">&lt;/<span class="hljs-name">ul</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span></code></pre>
+
+Prose scope is designed to be used with text content only. Don’t use it to style a section containing other elements, for example form inputs.
+
+### Styling individual elements
+
+If you need more control you can add classes to the individual elements instead of using the prose scope wrapper. Avoid styling individual elements within a prose scope wrapper.
+
+<pre class="govuk-!-mb-r6"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">h1</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"govuk-heading-xl"</span>&gt;</span>A H1 heading<span class="hljs-tag">&lt;/<span class="hljs-name">h1</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">p</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"govuk-body"</span>&gt;</span>A paragraph.<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">p</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"govuk-body"</span>&gt;</span>An unordered list:<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">ul</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"govuk-list govuk-list--bullet"</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">li</span>&gt;</span>apples<span class="hljs-tag">&lt;/<span class="hljs-name">li</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">li</span>&gt;</span>oranges<span class="hljs-tag">&lt;/<span class="hljs-name">li</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">li</span>&gt;</span>pears<span class="hljs-tag">&lt;/<span class="hljs-name">li</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">ul</span>&gt;</span>
+</code></pre>
+
+
+Explore the [Styles section of the Design System](/styles/) to see what classes are available.
+
+
+## Using components
+
+Components are reusable user interface elements. The components in the Design System are designed to be accessible and responsive.
+
+There are 2 ways to use components in the Design System. You can either use HTML or a Nunjucks Macro.
+
+You can get the code from the HTML or Nunjucks tabs below any examples:
+
+{{ example({group: 'components', item: 'button', example: 'default', html: true, nunjucks: true, open: false}) }}
+
+Copy the code into your prototype where you want the component to appear.
+
+
+### Using Nunjucks macros
+
+A Nunjucks macro is a simple template that generates more complex HTML.
+
+Nunjucks macros save you time by managing repetitive or error-prone tasks, like linking form labels to their controls.
+
+Nunjucks macros also make it easier to keep your prototypes up to date. You can run a command to update component code instead of having to manually update your HTML.
+
+When using Nunjucks macros in the Prototype Kit:
+
+* omit the first line that starts with "{% raw %}{% from {% endraw %}...".
+* save and preview regularly to check that the macro is working

--- a/src/get-started.md.njk
+++ b/src/get-started.md.njk
@@ -38,7 +38,7 @@ There are 2 ways to apply styles to content. You can use either the prose scope 
 
 You can use the `govuk-prose-scope` class to apply GOV.UK styles to a block of text. This means you don’t need to apply classes to the individual elements.
 
-<pre class="govuk-!-mb-r6"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"govuk-prose-scope"</span>&gt;</span>
+<pre class="govuk-!-f-19 govuk-!-mb-r6"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"govuk-prose-scope"</span>&gt;</span>
   <span class="hljs-tag">&lt;<span class="hljs-name">h1</span>&gt;</span>A H1 heading<span class="hljs-tag">&lt;/<span class="hljs-name">h1</span>&gt;</span>
   <span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>A paragraph.<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
   <span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>An unordered list:<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
@@ -55,7 +55,7 @@ Prose scope is designed to be used with text content only. Don’t use it to sty
 
 If you need more control you can add classes to the individual elements instead of using the prose scope wrapper. Avoid styling individual elements within a prose scope wrapper.
 
-<pre class="govuk-!-mb-r6"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">h1</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"govuk-heading-xl"</span>&gt;</span>A H1 heading<span class="hljs-tag">&lt;/<span class="hljs-name">h1</span>&gt;</span>
+<pre class="govuk-!-f-19 govuk-!-mb-r6"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">h1</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"govuk-heading-xl"</span>&gt;</span>A H1 heading<span class="hljs-tag">&lt;/<span class="hljs-name">h1</span>&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">p</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"govuk-body"</span>&gt;</span>A paragraph.<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">p</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"govuk-body"</span>&gt;</span>An unordered list:<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">ul</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"govuk-list govuk-list--bullet"</span>&gt;</span>

--- a/src/index.njk
+++ b/src/index.njk
@@ -1,34 +1,81 @@
 {% include "../views/partials/_masthead.njk" %}
 <div class="govuk-o-width-container app-c-site-width-container">
     <div class="govuk-o-grid govuk-o-main-wrapper">
-      <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r4 govuk-!-mb-r6">
-        <h2 class="govuk-heading-l">Styles</h2>
-        <p class="govuk-body">The core styles that will make your service look and feel like GOV.UK, including <a class="govuk-link" href="/styles/colour/">Colour</a>, <a class="govuk-link" href="/styles/typography/">Typography</a> and <a class="govuk-link" href="/styles/layout/">Layout</a>.</p>
-        <p class="govuk-body govuk-!-mb-r0"><a class="govuk-link" href="/styles/">See all styles</a></p>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r2 govuk-!-mb-r6">
+        <h2 class="govuk-heading-l govuk-!-w-bold">Styles</h2>
+        <p class="govuk-body">Make your service look like GOV.UK with guides for applying layout, typography, colour and&nbsp;images.</p>
+        <p class="govuk-body govuk-!-mb-r0"><a href="/styles/" class="govuk-link govuk-!-w-bold">Browse styles</a></p>
       </div>
-      <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r4 govuk-!-mb-r6">
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r2 govuk-!-mb-r6">
         <h2 class="govuk-heading-l">Components</h2>
-        <p class="govuk-body">Reusable parts of the user interface. From navigational components like <a class="govuk-link" href="/components/breadcrumbs/">Breadcrumbs</a>, to fundamental form elements like <a class="govuk-link" href="/components/radios/">Radios</a> and <a class="govuk-link" href="/components/error-message/">Error message</a>.</p>
-        <p class="govuk-body govuk-!-mb-r0"><a class="govuk-link" href="/components/">See all components</a></p>
+        <p class="govuk-body">Save time with reusable, accessible components for forms, navigation, panels, tables and&nbsp;more.</p>
+        <p class="govuk-body govuk-!-mb-r0"><a href="/components/" class="govuk-link govuk-!-w-bold">Browse components</a></p>
       </div>
-      <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r4 govuk-!-mb-r6">
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r2 govuk-!-mb-r6">
         <h2 class="govuk-heading-l">Patterns</h2>
-        <p class="govuk-body">Best-practice design solutions for common tasks like how to <a class="govuk-link" href="/patterns/addresses/">ask users for addresses</a> or design a <a class="govuk-link" href="/patterns/question-pages/">question page</a>.</p>
-        <p class="govuk-body govuk-!-mb-r0"><a class="govuk-link" href="/patterns/">See all patterns</a></p>
+        <p class="govuk-body">Help users complete common tasks like entering names and addresses, filling in forms and creating accounts.</p>
+        <p class="govuk-body govuk-!-mb-r0"><a href="/patterns/" class="govuk-link govuk-!-w-bold">Browse patterns</a></p>
       </div>
       <div class="govuk-o-grid__item govuk-o-grid__item--full">
         {% include "../views/partials/_divider.njk" %}
       </div>
-      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds govuk-!-mb-r6">
-        <h2 class="govuk-heading-l govuk-!-mt-r6">Using the Design System</h2>
-        <p class="govuk-body govuk-!-mb-r0">To use the code in the Design System to make prototypes, download the <a class="govuk-link" href="https://govuk-prototype-kit-beta.herokuapp.com">private beta version of the GOV.UK Prototype Kit</a>.</p>
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds govuk-!-mt-r6 govuk-!-mb-r6">
+        <h2 class="govuk-heading-l">Get started</h2>
+        <p class="govuk-body govuk-!-mb-r0">
+          Quickly build prototypes using the styles, components and patterns in this design&nbsp;system. Read a guide on <a href="/get-started/" class="govuk-link">how to get started</a>.
+        </p>
+
       </div>
       <div class="govuk-o-grid__item govuk-o-grid__item--full">
         {% include "../views/partials/_divider.njk" %}
       </div>
-      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds govuk-!-mb-r4">
-        <h2 class="govuk-heading-l govuk-!-mt-r6">Get in touch</h2>
-        <p class="govuk-body govuk-!-mb-r0">If you’ve got a question, idea or suggestion share it in <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a class="govuk-link" href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>) or <a class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">email the Design System team</a></p>
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds govuk-!-mt-r6 govuk-!-mb-r6">
+        <h2 id="get-in-touch" class="govuk-heading-l">Support</h2>
+        <p class="govuk-body">
+          The GOV.UK Design System is maintained by the Government Digital Service.
+          If you’ve got a question, idea or suggestion you can:
+        </p>
+        <ul class="govuk-list govuk-list--bullet govuk-!-mb-r0">
+        <li>
+          <a href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" class="govuk-link">
+            email the Design System team
+          </a>
+        </li>
+        <li>
+          <a href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system" class="govuk-link">
+            get in touch on Slack</a> (<a class="govuk-link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6">open in app</a>)
+        </li>
+        </ul>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--full">
+        {% include "../views/partials/_divider.njk" %}
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds govuk-!-mt-r6 govuk-!-mb-r6">
+        <h2 class="govuk-heading-l">Contribute</h2>
+
+
+        <p class="govuk-body">
+          To propose a new style, component or pattern for the GOV.UK Design System <a href="https://github.com/alphagov/govuk-design-system-backlog/blob/master/docs/CONTRIBUTING.md" class="govuk-link">read the contribution guidelines on GitHub</a>.
+        </p>
+
+        <p class="govuk-body govuk-!-mb-r0">
+          You can see what’s currently being worked on in the <a href="https://github.com/alphagov/govuk-design-system-backlog" class="govuk-link">GOV.UK Design System Backlog</a>.
+        </p>
+
+        <!-- <p class="govuk-body">
+          We welcome contributions from the government design community. To find out what we're working on and how to get involved you can:
+        </p>
+        <ul class="govuk-list govuk-list--bullet govuk-!-mb-r0">
+        <li>
+          <a href="https://github.com/alphagov/govuk-design-system-backlog">
+            view the GOV.UK Design System Backlog</a>
+        </li>
+        <li>
+          <a href="https://github.com/alphagov/govuk-design-system-backlog/blob/master/docs/CONTRIBUTING.md">
+            read our contribution guidelines on GitHub
+          </a>
+        </li>
+        </ul> -->
       </div>
     </div>
 </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -52,8 +52,6 @@
       </div>
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds govuk-!-mt-r6 govuk-!-mb-r6">
         <h2 class="govuk-heading-l">Contribute</h2>
-
-
         <p class="govuk-body">
           To propose a new style, component or pattern for the GOV.UK Design System <a href="https://github.com/alphagov/govuk-design-system-backlog/blob/master/docs/CONTRIBUTING.md" class="govuk-link">read the contribution guidelines on GitHub</a>.
         </p>
@@ -61,21 +59,6 @@
         <p class="govuk-body govuk-!-mb-r0">
           You can see what’s currently being worked on in the <a href="https://github.com/alphagov/govuk-design-system-backlog" class="govuk-link">GOV.UK Design System Backlog</a>.
         </p>
-
-        <!-- <p class="govuk-body">
-          We welcome contributions from the government design community. To find out what we're working on and how to get involved you can:
-        </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-mb-r0">
-        <li>
-          <a href="https://github.com/alphagov/govuk-design-system-backlog">
-            view the GOV.UK Design System Backlog</a>
-        </li>
-        <li>
-          <a href="https://github.com/alphagov/govuk-design-system-backlog/blob/master/docs/CONTRIBUTING.md">
-            read our contribution guidelines on GitHub
-          </a>
-        </li>
-        </ul> -->
       </div>
     </div>
 </div>

--- a/src/stylesheets/components/_divider.scss
+++ b/src/stylesheets/components/_divider.scss
@@ -2,4 +2,5 @@
   height: 1px;
   border: 0;
   background-color: $govuk-grey-2;
+  margin: $govuk-spacing-scale-2 0;
 }

--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -2,6 +2,7 @@
 .app-c-example-wrapper {
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+  @include govuk-font-regular-19;
 }
 
 .app-c-example {

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -72,7 +72,6 @@ $mq-breakpoint-widescreen: 1200px;
 }
 
 .app-c-content {
-  @include govuk-font-regular-19;
 
   @include govuk-responsive-padding($govuk-spacing-responsive-6);
 

--- a/views/layouts/layout-single-page-prose.njk
+++ b/views/layouts/layout-single-page-prose.njk
@@ -1,0 +1,9 @@
+{% extends "layout-single-page.njk" %}
+
+{% set contents %}
+<div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+  <div class="govuk-prose-scope">
+    {{ contents | safe }}
+  </div>
+</div>
+{% endset %}

--- a/views/layouts/layout-single-page-prose.njk
+++ b/views/layouts/layout-single-page-prose.njk
@@ -1,9 +1,11 @@
 {% extends "layout-single-page.njk" %}
 
 {% set contents %}
-<div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-  <div class="govuk-prose-scope">
-    {{ contents | safe }}
+<div class="govuk-o-grid">
+  <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+    <div class="govuk-prose-scope">
+      {{ contents | safe }}
+    </div>
   </div>
 </div>
 {% endset %}

--- a/views/layouts/layout-single-page.njk
+++ b/views/layouts/layout-single-page.njk
@@ -2,11 +2,9 @@
 
 {% block body %}
 <div class="app-o-pane__content">
-  <main id="content" class="app-c-content" role="main">
+  <main id="content" class="govuk-o-main-wrapper" role="main">
     <div class="govuk-o-width-container app-c-site-width-container">
-      <div class="govuk-o-grid">
-        {{ contents | safe }}
-      </div>
+      {{ contents | safe }}
     </div>
   </main>
 

--- a/views/layouts/layout-single-page.njk
+++ b/views/layouts/layout-single-page.njk
@@ -1,0 +1,16 @@
+{% extends "_generic.njk" %}
+
+{% block body %}
+<div class="app-o-pane__content">
+  <main id="content" class="app-c-content" role="main">
+    <div class="govuk-o-width-container app-c-site-width-container">
+      <div class="govuk-o-grid">
+        {{ contents | safe }}
+      </div>
+    </div>
+  </main>
+
+  {% include "_footer.njk" %}
+</div>
+
+{% endblock %}

--- a/views/layouts/layout.njk
+++ b/views/layouts/layout.njk
@@ -10,3 +10,4 @@
 </div>
 
 {% endblock %}
+

--- a/views/partials/_masthead.njk
+++ b/views/partials/_masthead.njk
@@ -2,7 +2,7 @@
   <div class="govuk-o-width-container app-c-site-width-container">
       <div class="govuk-o-grid">
         <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-            <h1 class="govuk-heading-xl app-c-masthead__title">Design your service using GOV.UK styles, components and patterns</h1>
+            <h1 class="govuk-heading-xl app-c-masthead__title">Design your service using GOV.UK styles, components and&nbsp;patterns</h1>
             <p class="app-c-masthead__description">Use this design system to make your service consistent with GOV.UK. Learn from the research and experience of other service teams and avoid repeating work that’s already been done.</p>
         </div>
     </div>


### PR DESCRIPTION
- Update home page content
- Add "Get started page"
- Create layout for pages that don't have sub-nav
- Create layout for pages that don't have sub-nav and written in markdown
- Move `@include govuk-font-regular-19;` to example component

As part of https://trello.com/c/0HJSd2q8/635-add-get-in-touch-page-and-update-home-page-content