### PR TITLE
Add start page pattern

### DIFF
--- a/src/patterns/start-pages/default.njk
+++ b/src/patterns/start-pages/default.njk
@@ -1,0 +1,92 @@
+---
+layout: layout-example.njk
+stylesheets:
+- related-items.css
+---
+
+{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "button/macro.njk" import govukButton %}
+
+<div class="govuk-o-width-container">
+
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Home",
+        "href": "#"
+      },
+      {
+        "text": "Section",
+        "href": "#"
+      },
+      {
+        "text": "Subsection"
+      }
+    ]
+  }) }}
+
+  <div class="govuk-o-main-wrapper">
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+
+        <h1 class="govuk-heading-xl">Service name goes here</h1>
+        
+        <p class="govuk-body">Use this service to:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>do something</li>
+          <li>update your name, address or other details</li>
+          <li>do something else</li>
+        </ul>
+
+        <p class="govuk-body">Registering takes around 5 minutes.</p>
+
+        {{ govukButton({
+          "text": "Start now",
+          "href": "#",
+          "classes": "govuk-c-button--start govuk-!-mt-r2 govuk-!-mb-r8"
+        }) }}
+
+        <h2 class="govuk-heading-m">Before you start</h2>
+
+        <p class="govuk-body">You can also <a class="govuk-link" href="#">register by post</a>.</p>
+
+        <p class="govuk-body">The online service is also available in <a class="govuk-link" href="#">Welsh (Cymraeg)</a>.</p>
+
+        <p class="govuk-body">You can’t register for this service if you’re in the UK illegally.</p>
+
+      </div>
+
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+
+        <!-- The Related items component is not part of GOV.UK Frontend but will be styled if used in the Prototype Kit -->
+
+        <aside class="app-c-related-items" role="complementary">
+          <h2 class="govuk-heading-m" id="subsection-title">
+            Subsection
+          </h2>
+          <nav role="navigation" aria-labelledby="subsection-title">
+            <ul class="govuk-list govuk-!-f-16">
+              <li>
+                <a href="#">
+                  Related link
+                </a>
+              </li>
+              <li>
+                <a href="#">
+                  Related link
+                </a>
+              </li>
+              <li>
+                <a href="#" class="govuk-!-w-bold">
+                  More <span class="govuk-h-visually-hidden">in Subsection</span>
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </aside>
+
+        </div>
+    </div>
+  </div>
+</div>

--- a/src/patterns/start-pages/index.md.njk
+++ b/src/patterns/start-pages/index.md.njk
@@ -1,0 +1,51 @@
+---
+title: Start pages
+description:
+section: Patterns
+theme: Pages
+aliases:
+backlog_issue_id: 111
+layout: layout-pane.njk
+---
+
+{% from "_example.njk" import example %}
+
+If you’re building a digital service, you’ll need a starting point for users on GOV.UK.
+
+{{ example({group: 'patterns', item: 'start-pages', example: 'default', html: true, nunjucks: true, open: false}) }}
+
+## When to use this pattern
+
+If your service is in public beta or live, you must have a starting point hosted on GOV.UK. This will link your service to the rest of GOV.UK.
+
+## How it works
+
+Start pages include 4 main elements:
+
+1. The service name: this should help people understand what your service does and whether they need to use it - [learn more about naming your service](https://www.gov.uk/service-manual/design/naming-your-service).
+
+2. A short introduction to list things that most users will need to know, for example, what your service will let them do or how much it’ll cost.
+
+3. The ‘Start now’ call-to-action button.
+
+4. A list of other ways to access your service.
+
+This is a set pattern, so you won’t be able to customise it. 
+
+{{ example({group: 'patterns', item: 'start-pages', example: 'default', html: true, nunjucks: true, open: true}) }}
+
+### Testing start pages in discovery and alpha
+
+If you want to prototype designs so you can test them with users, you can use the [start page template](https://govuk-prototype-kit-beta.herokuapp.com/docs/examples/start-page) in the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com/).
+
+### Get a start page for your public beta or live service
+
+[Contact the GDS content team](https://www.gov.uk/service-manual/service-assessments/get-your-service-on-govuk) before your alpha assessment to discuss start points for your service. 
+
+The GDS content team will create a start page for you in most cases. If this isn’t the best way to meet the user need, they’ll recommend another way of joining up with the rest of GOV.UK.
+
+GDS will only publish your start page when your service passes its beta assessment or self-certification and goes into public beta.
+
+## Research on this pattern
+
+If you’ve used this pattern, get in touch to share your user research findings. 

--- a/src/patterns/start-pages/related-items.scss
+++ b/src/patterns/start-pages/related-items.scss
@@ -1,0 +1,13 @@
+@import "@govuk-frontend/globals/common";
+
+// This is a GOV.UK Publishing specific component that
+// can be seen at http://govuk-static.herokuapp.com/component-guide/related_items
+
+.app-c-related-items {
+  border-top: 10px solid $govuk-blue;
+  padding-top: $govuk-spacing-scale-2;
+}
+
+.app-c-related-items li {
+  margin-bottom: $govuk-spacing-scale-2;
+}


### PR DESCRIPTION
This pull request adds:

- Start pages pattern guidance
- Start pages examples
- Related items SCSS from the Prototype Kit (beta)

SCSS for Related items styling isn't available in GOV.UK Frontend so is styled on the example only. 

It will still be styled for a user copying and pasting into the Prototype Kit (beta). 