### PR TITLE
Add tracking code only for production

### DIFF
--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -10,10 +10,14 @@
       <script src="/javascripts/ie.js"></script>
     <![endif]-->
     <script src="/javascripts/vendor/modernizr.js"></script>
+    {% if CF_SPACE == "production" %}
     {% include "_tracking-head.njk" %}
+    {% endif %}
   </head>
   <body>
+    {% if CF_SPACE == "production" %}
     {% include "_tracking-body.njk" %}
+    {% endif %}
     <a href="#content" class="govuk-c-skip-link">Skip to main content</a>
     <div class="app-o-pane">
       <div class="app-o-pane__header">


### PR DESCRIPTION
This PR is supposed to add the tracking code only when deploying to production.

It uses the `CF_SPACE` global variable defined as `"production"` in [.travis.yml](https://github.com/alphagov/govuk-design-system/blob/master/.travis.yml#L13).

⚠️ This need to be tested, but unless someone has experience with global variables in Cloud Foundry, the only way I see is to merge the PR, test and rollback if not doing the right thing 😞 .

[Trello card](https://trello.com/c/F2uJPNSS)