### PR TITLE
Add width override class example to text input component page

### DIFF
--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -33,9 +33,11 @@ Labels should be aligned above the text input they refer to. They should be shor
 
 ### Use appropriately-sized text inputs
 
-Make text inputs the right size for the content they’re intended for. Postcode inputs should be postode-sized, telephone number inputs should be telephone number-sized.
+Make text inputs the right size for the content they’re intended for. Postcode inputs should be postcode-sized, telephone number inputs should be telephone number-sized.
 
 Ensure that users can still easily enter the information they need on smaller screens by snapping text inputs to 100% width at smaller screen sizes.
+
+{{ example({group: 'components', item: 'text-input', example: 'input-width', html: true, nunjucks: true, open: true}) }}
 
 ### Don’t disable copy and paste
 

--- a/src/components/text-input/input-width.njk
+++ b/src/components/text-input/input-width.njk
@@ -1,0 +1,65 @@
+---
+layout: layout-example.njk
+---
+
+{% from "input/macro.njk" import govukInput %}
+
+<h3 class="govuk-heading-m">Three-quarters</h3>
+
+{{ govukInput({
+  "label": {
+    "text": "Full name",
+    "classes": "govuk-!-width-three-quarters"
+  },
+  classes: "govuk-!-width-three-quarters",
+  id: "full-name",
+  name: "full-name"
+}) }}
+
+<h3 class="govuk-heading-m">Two-thirds</h3>
+
+{{ govukInput({
+  "label": {
+    "text": "Full name",
+    "classes": "govuk-!-width-two-thirds"
+  },
+  classes: "govuk-!-width-two-thirds",
+  id: "full-name",
+  name: "full-name"
+}) }}
+
+<h3 class="govuk-heading-m">One-half</h3>
+
+{{ govukInput({
+  "label": {
+    "text": "Full name",
+    "classes": "govuk-!-width-one-half"
+  },
+  classes: "govuk-!-width-one-half",
+  id: "full-name",
+  name: "full-name"
+}) }}
+
+<h3 class="govuk-heading-m">One-third</h3>
+
+{{ govukInput({
+  "label": {
+    "text": "Full name",
+    "classes": "govuk-!-width-one-third"
+  },
+  classes: "govuk-!-width-one-third",
+  id: "full-name",
+  name: "full-name"
+}) }}
+
+<h3 class="govuk-heading-m">One-quarter</h3>
+
+{{ govukInput({
+  "label": {
+    "text": "Full name",
+    "classes": "govuk-!-width-one-quarter"
+  },
+  classes: "govuk-!-width-one-quarter",
+  id: "full-name",
+  name: "full-name"
+}) }}


### PR DESCRIPTION
Raised by @joelanman - https://github.com/alphagov/govuk-design-system/issues/155

The Text input component has a section for "Use appropriately-sized text inputs" but has no connection to the width override classes.

In similar scenarios in the Design System we've re-use examples from other sections to explain something in that particular context.