### PR TITLE
Update page examples to include the `govuk-o-width-container` class

### DIFF
--- a/src/patterns/confirmation-pages/default.njk
+++ b/src/patterns/confirmation-pages/default.njk
@@ -4,24 +4,28 @@ layout: layout-example.njk
 
 {% from "panel/macro.njk" import govukPanel %}
 
-<div class="govuk-o-main-wrapper">
-  <div class="govuk-o-grid">
-    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-      {{ govukPanel({
-        "titleText": "Application complete",
-        "html": "Your reference number<br><strong>HDJ2123F</strong>"
-      })
-      }}
+<div class="govuk-o-width-container">
 
-      <p class="govuk-body">We have sent you a confirmation email.</p>
+  <div class="govuk-o-main-wrapper">
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+        {{ govukPanel({
+          "titleText": "Application complete",
+          "html": "Your reference number<br><strong>HDJ2123F</strong>"
+        })
+        }}
 
-      <h3 class="govuk-heading-m">What happens next</h3>
+        <p class="govuk-body">We have sent you a confirmation email.</p>
 
-      <p class="govuk-body">We've sent your application to Hackney Electoral Register Office.</p>
+        <h3 class="govuk-heading-m">What happens next</h3>
 
-      <p class="govuk-body">They will contact you either to confirm your registration, or to ask for more information.</p>
+        <p class="govuk-body">We've sent your application to Hackney Electoral Register Office.</p>
 
-      <p class="govuk-body"><a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)</p>
+        <p class="govuk-body">They will contact you either to confirm your registration, or to ask for more information.</p>
+
+        <p class="govuk-body"><a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)</p>
+      </div>
     </div>
   </div>
+
 </div>

--- a/src/patterns/question-pages/default.njk
+++ b/src/patterns/question-pages/default.njk
@@ -6,37 +6,41 @@ layout: layout-example.njk
 {% from "date-input/macro.njk" import govukDateInput %}
 {% from "button/macro.njk" import govukButton %}
 
-{{ govukBackLink({
-  "text": "Back"
-}) }}
+<div class="govuk-o-width-container">
 
-<div class="govuk-o-main-wrapper">
-  <div class="govuk-o-grid">
-    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-      {{ govukDateInput({
-        fieldset: {
-          legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',
-          legendHintText: 'For example, 31 3 1980'
-        },
-        id: 'dob',
-        name: 'dob',
-        items:[
-          {
-            name: 'day'
-          },
-          {
-            name: 'month'
-          },
-          {
-            name: 'year'
-          }
-        ]
-        })
-      }}
+  {{ govukBackLink({
+    "text": "Back"
+  }) }}
 
-      {{ govukButton({
-        "text": "Continue"
-      }) }}
+  <div class="govuk-o-main-wrapper">
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+        {{ govukDateInput({
+          fieldset: {
+            legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',
+            legendHintText: 'For example, 31 3 1980'
+          },
+          id: 'dob',
+          name: 'dob',
+          items:[
+            {
+              name: 'day'
+            },
+            {
+              name: 'month'
+            },
+            {
+              name: 'year'
+            }
+          ]
+          })
+        }}
+
+        {{ govukButton({
+          "text": "Continue"
+        }) }}
+      </div>
     </div>
   </div>
+
 </div>

--- a/src/patterns/question-pages/passport.njk
+++ b/src/patterns/question-pages/passport.njk
@@ -7,47 +7,51 @@ layout: layout-example.njk
 {% from "date-input/macro.njk" import govukDateInput %}
 {% from "button/macro.njk" import govukButton %}
 
-{{ govukBackLink({
-  "text": "Back"
-}) }}
+<div class="govuk-o-width-container">
 
-<div class="govuk-o-main-wrapper">
-  <div class="govuk-o-grid">
-    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-      <h1 class="govuk-heading-xl">Passport details</h1>
+  {{ govukBackLink({
+    "text": "Back"
+  }) }}
 
-      {{ govukInput({
-        label: {
-          "html": '<h3 class="govuk-heading-m govuk-!-mb-r1">Passport number</h3>',
-          "hintText": "For example, 502135326"
-        },
-        id: "passport-number",
-        name: "passport-number"
-      }) }}
+  <div class="govuk-o-main-wrapper">
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+        <h1 class="govuk-heading-xl">Passport details</h1>
 
-
-      {{ govukDateInput({
-        fieldset: {
-          legendHtml: '<h3 class="govuk-heading-m">Expiry date</h3>',
-          legendHintText: 'For example, 08 2014'
-        },
-        id: 'expiry',
-        name: 'expiry',
-        items:[
-          {
-            name: 'month'
+        {{ govukInput({
+          label: {
+            "html": '<h3 class="govuk-heading-m govuk-!-mb-r1">Passport number</h3>',
+            "hintText": "For example, 502135326"
           },
-          {
-            name: 'year'
-          }
-        ]
-        })
-      }}
+          id: "passport-number",
+          name: "passport-number"
+        }) }}
 
-      {{ govukButton({
-        "text": "Continue"
-      }) }}
 
+        {{ govukDateInput({
+          fieldset: {
+            legendHtml: '<h3 class="govuk-heading-m">Expiry date</h3>',
+            legendHintText: 'For example, 08 2014'
+          },
+          id: 'expiry',
+          name: 'expiry',
+          items:[
+            {
+              name: 'month'
+            },
+            {
+              name: 'year'
+            }
+          ]
+          })
+        }}
+
+        {{ govukButton({
+          "text": "Continue"
+        }) }}
+
+      </div>
     </div>
   </div>
+
 </div>

--- a/src/patterns/question-pages/postcode.njk
+++ b/src/patterns/question-pages/postcode.njk
@@ -6,24 +6,28 @@ layout: layout-example.njk
 {% from "input/macro.njk" import govukInput %}
 {% from "button/macro.njk" import govukButton %}
 
-{{ govukBackLink({
-  "text": "Back"
-}) }}
+<div class="govuk-o-width-container">
 
-<div class="govuk-o-main-wrapper">
-  <div class="govuk-o-grid">
-    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-      {{ govukInput({
-        "label": {
-          "html": '<h1 class="govuk-heading-xl govuk-!-mb-r4">What is your home postcode?</h1>'
-        },
-        "id": "postcode",
-        "name": "postcode"
-      }) }}
+  {{ govukBackLink({
+    "text": "Back"
+  }) }}
 
-      {{ govukButton({
-        "text": "Continue"
-      }) }}
+  <div class="govuk-o-main-wrapper">
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+        {{ govukInput({
+          "label": {
+            "html": '<h1 class="govuk-heading-xl govuk-!-mb-r4">What is your home postcode?</h1>'
+          },
+          "id": "postcode",
+          "name": "postcode"
+        }) }}
+
+        {{ govukButton({
+          "text": "Continue"
+        }) }}
+      </div>
     </div>
   </div>
+
 </div>


### PR DESCRIPTION
Realised during the research sessions that the page examples were inconsistent at including the wrapper classes.

This adds the width container to the examples, so page examples contain everything that you'd need to paste into your content block.