### PR TITLE
Update apostrophe in example

### DIFF
--- a/src/components/textarea/default.njk
+++ b/src/components/textarea/default.njk
@@ -8,6 +8,6 @@ layout: layout-example.njk
   "id": "more-detail",
   "label": {
     "text": "Can you provide more detail?",
-    "hintText": "Don't include personal or financial information, eg your National Insurance number or credit card details."
+    "hintText": "Don’t include personal or financial information, eg your National Insurance number or credit card details."
   }
 }) }}


### PR DESCRIPTION
Swap apostrophe so it doesn't render as `&#39;` in HTML example