### PR TITLE
Add <form> to question page examples

### DIFF
--- a/src/patterns/question-pages/default.njk
+++ b/src/patterns/question-pages/default.njk
@@ -8,13 +8,16 @@ layout: layout-example.njk
 
 <div class="govuk-o-width-container">
 
-  {{ govukBackLink({
-    "text": "Back"
-  }) }}
+{{ govukBackLink({
+  "text": "Back"
+}) }}
 
-  <div class="govuk-o-main-wrapper">
-    <div class="govuk-o-grid">
-      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+<div class="govuk-o-main-wrapper">
+  <div class="govuk-o-grid">
+    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+
+      <form class="form" action="/url/of/next/page" method="post">
+
         {{ govukDateInput({
           fieldset: {
             legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',
@@ -39,8 +42,8 @@ layout: layout-example.njk
         {{ govukButton({
           "text": "Continue"
         }) }}
-      </div>
+      </form>
+
     </div>
   </div>
-
 </div>

--- a/src/patterns/question-pages/passport.njk
+++ b/src/patterns/question-pages/passport.njk
@@ -18,37 +18,41 @@ layout: layout-example.njk
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
         <h1 class="govuk-heading-xl">Passport details</h1>
 
-        {{ govukInput({
-          label: {
-            "html": '<h3 class="govuk-heading-m govuk-!-mb-r1">Passport number</h3>',
-            "hintText": "For example, 502135326"
-          },
-          id: "passport-number",
-          name: "passport-number"
-        }) }}
+        <form class="form" action="/url/of/next/page" method="post">
 
-
-        {{ govukDateInput({
-          fieldset: {
-            legendHtml: '<h3 class="govuk-heading-m">Expiry date</h3>',
-            legendHintText: 'For example, 08 2014'
-          },
-          id: 'expiry',
-          name: 'expiry',
-          items:[
-            {
-              name: 'month'
+          {{ govukInput({
+            label: {
+              "html": '<h3 class="govuk-heading-m govuk-!-mb-r1">Passport number</h3>',
+              "hintText": "For example, 502135326"
             },
-            {
-              name: 'year'
-            }
-          ]
-          })
-        }}
+            id: "passport-number",
+            name: "passport-number"
+          }) }}
 
-        {{ govukButton({
-          "text": "Continue"
-        }) }}
+
+          {{ govukDateInput({
+            fieldset: {
+              legendHtml: '<h3 class="govuk-heading-m">Expiry date</h3>',
+              legendHintText: 'For example, 08 2014'
+            },
+            id: 'expiry',
+            name: 'expiry',
+            items:[
+              {
+                name: 'month'
+              },
+              {
+                name: 'year'
+              }
+            ]
+            })
+          }}
+
+          {{ govukButton({
+            "text": "Continue"
+          }) }}
+
+        </form>
 
       </div>
     </div>

--- a/src/patterns/question-pages/postcode.njk
+++ b/src/patterns/question-pages/postcode.njk
@@ -8,13 +8,15 @@ layout: layout-example.njk
 
 <div class="govuk-o-width-container">
 
-  {{ govukBackLink({
-    "text": "Back"
-  }) }}
+{{ govukBackLink({
+  "text": "Back"
+}) }}
 
-  <div class="govuk-o-main-wrapper">
-    <div class="govuk-o-grid">
-      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+<div class="govuk-o-main-wrapper">
+  <div class="govuk-o-grid">
+    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+
+      <form class="form" action="/url/of/next/page" method="post">
         {{ govukInput({
           "label": {
             "html": '<h1 class="govuk-heading-xl govuk-!-mb-r4">What is your home postcode?</h1>'
@@ -26,8 +28,8 @@ layout: layout-example.njk
         {{ govukButton({
           "text": "Continue"
         }) }}
-      </div>
+      </form>
+
     </div>
   </div>
-
 </div>


### PR DESCRIPTION
`<form>` was left of from question page example.

This aligns the functionality of the question page in the DS and Prototype kit.