### PR TITLE
Autoload the GOV.UK Frontend macros

### DIFF
--- a/config/nunjucks.js
+++ b/config/nunjucks.js
@@ -1,0 +1,8 @@
+// This is a Javascript file because you can't comment JSON :(
+
+module.exports = {
+  autoescape: true, // escape all output by default
+  noCache: true, // never use a cache and recompile templates each time
+  trimBlocks: true, // automatically remove trailing newlines from a block/tag
+  lstripBlocks: true, // automatically remove leading whitespace from a block/tag
+}

--- a/lib/frontend-macro-autoloader.js
+++ b/lib/frontend-macro-autoloader.js
@@ -1,0 +1,39 @@
+// Frontend Macro Auto-loader
+//
+// This looks for any macro.njk files inside the govuk-frontend folder and
+// grabs anything exported from within them, so that we can make them globally
+// available without having to maintain a list of imports somewhere.
+
+// path definitions
+const paths = require('../config/paths.json')
+
+// nunjucks engine options
+const nunjucksConfig = require('../config/nunjucks.js')
+
+const globby = require('globby')
+const nunjucks = require('nunjucks')
+
+// Create a nunjucks environment that we can use to parse the nunjucks files and
+// grab exported macros
+const nunjucks_env = new nunjucks.Environment(
+  new nunjucks.FileSystemLoader(paths.govukfrontend),
+  nunjucksConfig
+)
+
+// Glob the filesystem to find all macros within the GOV.UK Frontend directory
+const macro_files = globby.sync([`${paths.govukfrontend}**/macro.njk`])
+
+// Create an object in which we can store the macros we find
+let frontend_macros = {}
+
+// Iterate over each macro.njk in the GOV.UK Frontend directory, parsing the
+// template and grabbing anything it exports
+macro_files.forEach((filename) => {
+  nunjucks_env
+    .getTemplate(filename.replace(paths.govukfrontend, ''))
+    .getExported((error, macros_exported_by_template) => {
+      Object.assign(frontend_macros, macros_exported_by_template)
+    })
+})
+
+module.exports = frontend_macros

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -15,6 +15,8 @@ const env = require('metalsmith-env')               // environment vars plugin
 
 const paths = require('../config/paths.json')       // specify paths to main working directories
 const colours = require('../lib/colours.js')        // get colours data
+const nunjucksConfig = require('../config/nunjucks.js') // nunjucks engine options
+const frontendMacros = require('../lib/frontend-macro-autoloader.js') // auto-load frontend macros from installed npm packages
 const fileHelper = require('../lib/file-helper.js') // helper function to operate on files
 
 // store views paths for rendering nunjucks syntax
@@ -93,14 +95,12 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     pattern: '**/*.njk',
     engineOptions: {
       path: views,
-      autoescape: true, // escape all output by default
-      noCache: true, // never use a cache and recompile templates each time
-      trimBlocks: true, // automatically remove trailing newlines from a block/tag
-      lstripBlocks: true, // automatically remove leading whitespace from a block/tag
       globals: {
         getNunjucksCode: fileHelper.getNunjucksCode,
-        getHTMLCode: fileHelper.getHTMLCode
-      }
+        getHTMLCode: fileHelper.getHTMLCode,
+        ...frontendMacros
+      },
+      ...nunjucksConfig
     }
   }))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "@govuk-frontend/all": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.22-alpha.tgz",
-      "integrity": "sha512-Y1x8n7JkFPV92RioI9gOMlAAY/d+NI2Q1/w6DNtTKWicmjrqMddk+jeIHKSF+UlSQ49TbnWU/rXvhPBrJWx2yg==",
+      "integrity": "sha1-dJT1VDJyP4pqnJ6RiHsg7wD670U=",
       "requires": {
         "@govuk-frontend/back-link": "0.0.22-alpha",
         "@govuk-frontend/breadcrumbs": "0.0.22-alpha",
@@ -37,7 +37,7 @@
     "@govuk-frontend/back-link": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.22-alpha.tgz",
-      "integrity": "sha512-h/G1djG7Ugc6G6dAeWukQnj5OaXdx9YHcrsTjH4Jn0dl+7pEMQlwEf7AdyEg502Vs2EURE9E0+UGwISSkepIfQ==",
+      "integrity": "sha1-kGuPCgFAM6f3aDeig0aVK7b+ljc=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -45,7 +45,7 @@
     "@govuk-frontend/breadcrumbs": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.22-alpha.tgz",
-      "integrity": "sha512-yaz2PfsisqlGIXqgKtORDKvsmv7Tiyk5l8kzaglc2Vbnda+HLyvpjDdX++zp/18hlTS6g9xVxIG/ZxFsk78Kbg==",
+      "integrity": "sha1-yDhCUGDtSvtpUdfWRijT3BNPXEM=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha",
         "@govuk-frontend/icons": "0.0.22-alpha"
@@ -54,7 +54,7 @@
     "@govuk-frontend/button": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.22-alpha.tgz",
-      "integrity": "sha512-G9tK3H4GShkSA5Q0rBx6yXhg/T2oNlKjlXS0OAs9BH9KE311Ri0aZ2iWVSBTPRMDOgPJd3QkzTZjwzze3u4Cyw==",
+      "integrity": "sha1-8rYVpfDKb2c59QljHTrSVeKLVJE=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha",
         "@govuk-frontend/icons": "0.0.22-alpha"
@@ -63,7 +63,7 @@
     "@govuk-frontend/checkboxes": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.22-alpha.tgz",
-      "integrity": "sha512-qRX2GgoWkKKMoOojezm2k15SqEhVkVOwiDRGNl3xQlCZAa2YoMms6F+p/oAC3iheZXwg+SXMq9FRnQyNHdWxBA==",
+      "integrity": "sha1-Vtws+6eGAtA/cbqsS0abQbLtDIw=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha",
         "@govuk-frontend/label": "0.0.22-alpha"
@@ -72,7 +72,7 @@
     "@govuk-frontend/cookie-banner": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/cookie-banner/-/cookie-banner-0.0.22-alpha.tgz",
-      "integrity": "sha512-rPI8sWQp3nwTqjzBLmuUwYWBKi7pv3Ki2D3I9O7+2oeIRxc21ycGrLeXV4RtMoAFzEJQLveHMpmPmAAISAPGcg==",
+      "integrity": "sha1-yaLm61t40lPH7WKhrYvBqzHGv4g=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -80,7 +80,7 @@
     "@govuk-frontend/date-input": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.22-alpha.tgz",
-      "integrity": "sha512-NtpQxZ+KsSPYgHHWnFVNyHZ9s8pZ389di8XUQsMbFXvD14vG8gJT6esfxjWSEL2lk71IlQvAC4TdPFpHrvCfdw==",
+      "integrity": "sha1-5ZHEdjA6lESqKEFKFwsg6R9cqTs=",
       "requires": {
         "@govuk-frontend/error-message": "0.0.22-alpha",
         "@govuk-frontend/globals": "0.0.22-alpha",
@@ -90,7 +90,7 @@
     "@govuk-frontend/details": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.22-alpha.tgz",
-      "integrity": "sha512-q7/6L8/ZzHrIgMz9vD88JRPl1ZfDEQFFm5v0eRN0Te7Bw7L5APorhjdMeJ1Vz1G3eR81mBub7VkEmv0ueYG1Zw==",
+      "integrity": "sha1-lFcRkD8QpX8TWAKCv6/EyPs7ujc=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -98,7 +98,7 @@
     "@govuk-frontend/error-message": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.22-alpha.tgz",
-      "integrity": "sha512-XVCoTTtHs23EcD8+5rraTLxqZ2IiYUrwIIAGn9OoYtPtN4AUb5b7iwEF3Y5MDRboBQLrKG95//bAW0e7KiJzhw==",
+      "integrity": "sha1-mGj/ICJSe1tBIuLw1dziKXsXXOM=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -106,7 +106,7 @@
     "@govuk-frontend/error-summary": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.22-alpha.tgz",
-      "integrity": "sha512-qRj/D7vh6izKtbS/+mLGNtFELHB2VlsBJqENlS9M+A2GhB99+zPrRG0P+1bviFcSr4c2p1Y9XxGhlwJ9f4FA9A==",
+      "integrity": "sha1-gJ+WRjxLs1v3agf366HF+BWMsUw=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -114,7 +114,7 @@
     "@govuk-frontend/fieldset": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.22-alpha.tgz",
-      "integrity": "sha512-FXyZjADSYTs5bDH2Ajd38PEKe7qOV6a+HCrrxcEm3nwZcpm6xLLVOaftY+edZbaKpNo4Z0cbAU7TgFPys9z4pA==",
+      "integrity": "sha1-gfcnroH5w3z/BjSL8oN3Heth4Tc=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -122,7 +122,7 @@
     "@govuk-frontend/file-upload": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.22-alpha.tgz",
-      "integrity": "sha512-V+kZIoXEweq4sIlQSL+Ja9xXBk7Uh0nPlpSlymKCE1Zlbyb0j+dcJuFkd7DM1qa7Si4UTlqgdPnf+gVbvIaDwQ==",
+      "integrity": "sha1-xI6Gj/vDIlZGgwRirMLqtzh/Kxw=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -130,7 +130,7 @@
     "@govuk-frontend/globals": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.22-alpha.tgz",
-      "integrity": "sha512-ixC9uOVXCWgSdHa3zQSDzHi1/E8swsNYszMYK2m7QGioJi2b9yU3OhUCcDEvG/IU6zb8my3WYcdTmtod3Y+rEA==",
+      "integrity": "sha1-vcWLirPLr4PJQUw/VszESku4xwQ=",
       "requires": {
         "sass-mq": "3.3.2"
       }
@@ -138,12 +138,12 @@
     "@govuk-frontend/icons": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.22-alpha.tgz",
-      "integrity": "sha512-q0KrKkoAV/d/QOHR7BQDwYwL5KrDhBgCdoljbZAjWgzdLz15EeWKeBtyvSmug3hUIFMr0Pvle1V8q7B1DiyLNQ=="
+      "integrity": "sha1-CdrykkarS/MZVcVeM0QnESe6Ogw="
     },
     "@govuk-frontend/input": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.22-alpha.tgz",
-      "integrity": "sha512-W2sfC3Ag9JqLDFD60anL5WpwdXt4X+WmxHywMn7ri5jPVkoU4/MjY/0wPmybA9qzRyY20Ldd7C97yUfSKLvElg==",
+      "integrity": "sha1-GcgR5hZcP7o/VZm2rd17ythFD7c=",
       "requires": {
         "@govuk-frontend/error-message": "0.0.22-alpha",
         "@govuk-frontend/globals": "0.0.22-alpha",
@@ -153,7 +153,7 @@
     "@govuk-frontend/label": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.22-alpha.tgz",
-      "integrity": "sha512-CqXVIjRPLpr7tfgSfq5rjU0fOU9RvVaTjI9LtUYjkaPVJI+UBYe4/CwsRujEVK95NURqhBBbKzIgHV5Sx0i5UQ==",
+      "integrity": "sha1-nX0uaEEdwg7NrsdvttnRlRUhHUU=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -161,7 +161,7 @@
     "@govuk-frontend/panel": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.22-alpha.tgz",
-      "integrity": "sha512-pD22TGsVLMXjcHAkQhwo4rgL1SKLFjm3Es6jFDqUrL8Vjp7texkagbLe4R/HBDlfcc/67ZqmTEkROT9cFZvtFA==",
+      "integrity": "sha1-CQJEKDSwKWVGw0WApEmraIOIlN4=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -169,7 +169,7 @@
     "@govuk-frontend/phase-banner": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.22-alpha.tgz",
-      "integrity": "sha512-GTL1lQhgBmPBqeP/gdWagKGIYZ+f/lYuc+HrEXBwKV4q1GxUUrY5JWUJOFnT/tO+MvdVN8Bp10OdtXAjKW3X0Q==",
+      "integrity": "sha1-3sj1lgCRixEIMuMUOyOSwvfn/3Q=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha",
         "@govuk-frontend/tag": "0.0.22-alpha"
@@ -178,7 +178,7 @@
     "@govuk-frontend/previous-next": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/previous-next/-/previous-next-0.0.22-alpha.tgz",
-      "integrity": "sha512-LMN8/cdrPzNP84a4OikyJkthnE6Cp4/0vXXBn2I6fiVs7IZJioJXUqftZz2LlHmZaCYzcRzHhyVTwS3LZzvuqg==",
+      "integrity": "sha1-uvpNSB7998Jd+P5JeEOuVbSx3lo=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -186,7 +186,7 @@
     "@govuk-frontend/radios": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.22-alpha.tgz",
-      "integrity": "sha512-35o+tQNTuFyvERA9XoCCahCGtxXtrP+RnAuEfASl/fSGUop5lHTx9yoXAnVrt2CwSAzxr9+cPN4zFmbDfG1GKQ==",
+      "integrity": "sha1-lICOA8t37bw+l7jcAQ1gacJwaLI=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha",
         "@govuk-frontend/label": "0.0.22-alpha"
@@ -195,7 +195,7 @@
     "@govuk-frontend/select": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.22-alpha.tgz",
-      "integrity": "sha512-V7+tpAkcAE3glotvtstA+G+R8c5mpHO+BGkMB911ukkxu8sgSD3HAPRSiihVzfgp/liDjD6sLgc+ctWvp0VzPQ==",
+      "integrity": "sha1-rfNJEz2ZW2T8OcqKpyQrqb8pLm4=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha",
         "@govuk-frontend/label": "0.0.22-alpha"
@@ -204,7 +204,7 @@
     "@govuk-frontend/skip-link": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.22-alpha.tgz",
-      "integrity": "sha512-3G0VAPe7bFv+3uj3gZGpoSeJemXtzy7ncvmeh0q7xbb2jqb96u1eYE6WDKact2MqZiJVB9wPIegjjz1C9v3VJw==",
+      "integrity": "sha1-t0kBS/50o3IBFj+B3PtiHBeQ1tE=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -212,7 +212,7 @@
     "@govuk-frontend/table": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.22-alpha.tgz",
-      "integrity": "sha512-SwAZqy2zC5tHXIu/yQgGw2jRPDmWTOG8Ln9I6l06Vpv1alS2JPQPjBbUUPa9yc9bZvlm/nLuRkWkaHAC3WM34g==",
+      "integrity": "sha1-5aSK6ur12kTs2vAJG3rwKLiOy/4=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -220,7 +220,7 @@
     "@govuk-frontend/tag": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.22-alpha.tgz",
-      "integrity": "sha512-VFpSwjkrP2yn9pCJX++uXhe1w/2ugEqJAf4tvttOKeTLtcKAkw7HAnnmFweibG6bZ5Jz5VQNz/ih/hqaYwFECQ==",
+      "integrity": "sha1-qBAODhYZYAzvQ/lIDdgGmyb8ti0=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -228,7 +228,7 @@
     "@govuk-frontend/textarea": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.22-alpha.tgz",
-      "integrity": "sha512-aiTwWtohD+8rHKeWOhK+yMhGHQQIJZ8K929MZodVBk1LDLmrPCqjteOYNbv0hXZ19YwzKAjRDSSfsm4rPpiL4A==",
+      "integrity": "sha1-L9omxeeCQmsmjWbcfDk/ozNIh7Y=",
       "requires": {
         "@govuk-frontend/error-message": "0.0.22-alpha",
         "@govuk-frontend/globals": "0.0.22-alpha",
@@ -238,7 +238,7 @@
     "@govuk-frontend/warning-text": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/warning-text/-/warning-text-0.0.22-alpha.tgz",
-      "integrity": "sha512-CTuOIJVXm3kTI8g1RcfAVC/nxHFFEHaou+WvprlaULjNilpvjJeryGbbERxjErMJlqgUCP4DxVVluZtVqkXCFg==",
+      "integrity": "sha1-5eHW193uPKfdP1FFWExCbwVHMQQ=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -461,7 +461,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
       "requires": {
         "array-uniq": "1.0.3"
       }
@@ -469,8 +468,7 @@
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
       "version": "0.2.1",
@@ -487,8 +485,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asap": {
       "version": "2.0.6",
@@ -1919,6 +1916,20 @@
         "rimraf": "2.6.2"
       },
       "dependencies": {
+        "globby": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1978,6 +1989,30 @@
       "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
       "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
       "dev": true
+    },
+    "dir-glob": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+      "requires": {
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "requires": {
+            "pify": "3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
+      }
     },
     "doctrine": {
       "version": "1.5.0",
@@ -3943,24 +3978,22 @@
       "dev": true
     },
     "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+      "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
       "requires": {
         "array-union": "1.0.2",
-        "arrify": "1.0.1",
+        "dir-glob": "2.0.0",
         "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "ignore": "3.3.7",
+        "pify": "3.0.0",
+        "slash": "1.0.0"
       },
       "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
@@ -4231,8 +4264,7 @@
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
-      "dev": true
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
     },
     "immutable": {
       "version": "3.8.1",
@@ -5499,6 +5531,12 @@
           }
         }
       }
+    },
+    "metalsmith-tagcleaner": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/metalsmith-tagcleaner/-/metalsmith-tagcleaner-0.0.2.tgz",
+      "integrity": "sha1-YO0FpppO+zl9VdB53DDlCrO/cYs=",
+      "dev": true
     },
     "micromatch": {
       "version": "2.3.11",
@@ -6836,8 +6874,7 @@
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@govuk-frontend/all": "0.0.22-alpha",
+    "globby": "^7.1.1",
     "scss-to-json": "^2.0.0"
   },
   "devDependencies": {

--- a/src/components/back-link/default.njk
+++ b/src/components/back-link/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukBackLink({
   "text": "Back",
   "href": "#"

--- a/src/components/back-link/default.njk
+++ b/src/components/back-link/default.njk
@@ -1,8 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-{% from "back-link/macro.njk" import govukBackLink %}
-
 {{ govukBackLink({
   "text": "Back",
   "href": "#"

--- a/src/components/breadcrumbs/default.njk
+++ b/src/components/breadcrumbs/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukBreadcrumbs({
   "items": [
     {

--- a/src/components/breadcrumbs/default.njk
+++ b/src/components/breadcrumbs/default.njk
@@ -1,8 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-
 {{ govukBreadcrumbs({
   "items": [
     {

--- a/src/components/button/default.njk
+++ b/src/components/button/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukButton({
   "text": "Save and continue"
 }) }}

--- a/src/components/button/default.njk
+++ b/src/components/button/default.njk
@@ -1,8 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-{% from "button/macro.njk" import govukButton %}
-
 {{ govukButton({
   "text": "Save and continue"
 }) }}

--- a/src/components/button/disabled.njk
+++ b/src/components/button/disabled.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 <h3 class="govuk-heading-m">Input button</h3>
 
 {{ govukButton({

--- a/src/components/button/disabled.njk
+++ b/src/components/button/disabled.njk
@@ -1,8 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-{% from "button/macro.njk" import govukButton %}
-
 <h3 class="govuk-heading-m">Input button</h3>
 
 {{ govukButton({

--- a/src/components/button/primary.njk
+++ b/src/components/button/primary.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 <h3 class="govuk-heading-m">Input button</h3>
 
 {{ govukButton({

--- a/src/components/button/primary.njk
+++ b/src/components/button/primary.njk
@@ -1,8 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-{% from "button/macro.njk" import govukButton %}
-
 <h3 class="govuk-heading-m">Input button</h3>
 
 {{ govukButton({

--- a/src/components/button/start.njk
+++ b/src/components/button/start.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 <h3 class="govuk-heading-m">Input Start button</h3>
 
 {{ govukButton({

--- a/src/components/button/start.njk
+++ b/src/components/button/start.njk
@@ -1,8 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-{% from "button/macro.njk" import govukButton %}
-
 <h3 class="govuk-heading-m">Input Start button</h3>
 
 {{ govukButton({

--- a/src/components/checkboxes/default.njk
+++ b/src/components/checkboxes/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from 'checkboxes/macro.njk' import govukCheckboxes %}
-
 {{ govukCheckboxes({
   "idPrefix": "nationality",
   "name": "nationality",

--- a/src/components/checkboxes/default.njk
+++ b/src/components/checkboxes/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukCheckboxes({
   "idPrefix": "nationality",
   "name": "nationality",

--- a/src/components/date-input/default.njk
+++ b/src/components/date-input/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukDateInput({
   fieldset: {
     legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',

--- a/src/components/date-input/default.njk
+++ b/src/components/date-input/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "date-input/macro.njk" import govukDateInput %}
-
 {{ govukDateInput({
   fieldset: {
     legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',

--- a/src/components/date-input/error.njk
+++ b/src/components/date-input/error.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukDateInput({
   fieldset: {
     legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',

--- a/src/components/date-input/error.njk
+++ b/src/components/date-input/error.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "date-input/macro.njk" import govukDateInput %}
-
 {{ govukDateInput({
   fieldset: {
     legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',

--- a/src/components/details/default.njk
+++ b/src/components/details/default.njk
@@ -1,8 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-{% from "details/macro.njk" import govukDetails %}
-
 {{ govukDetails({
   "summaryText": "Help with nationality",
   "text": "We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post."

--- a/src/components/details/default.njk
+++ b/src/components/details/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukDetails({
   "summaryText": "Help with nationality",
   "text": "We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post."

--- a/src/components/error-message/default.njk
+++ b/src/components/error-message/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukErrorMessage({
   "text": "Error message goes here"
 }) }}

--- a/src/components/error-message/default.njk
+++ b/src/components/error-message/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "error-message/macro.njk" import govukErrorMessage %}
-
 {{ govukErrorMessage({
   "text": "Error message goes here"
 }) }}

--- a/src/components/error-message/label.njk
+++ b/src/components/error-message/label.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukInput({
   "label": {
     "text": "National Insurance number",

--- a/src/components/error-message/label.njk
+++ b/src/components/error-message/label.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "input/macro.njk" import govukInput %}
-
 {{ govukInput({
   "label": {
     "text": "National Insurance number",

--- a/src/components/error-message/legend.njk
+++ b/src/components/error-message/legend.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukDateInput({
   fieldset: {
     legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',

--- a/src/components/error-message/legend.njk
+++ b/src/components/error-message/legend.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "date-input/macro.njk" import govukDateInput %}
-
 {{ govukDateInput({
   fieldset: {
     legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',

--- a/src/components/error-summary/default.njk
+++ b/src/components/error-summary/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-
 {{ govukErrorSummary({
   "titleText": "Message to alert the user to a problem goes here",
   "descriptionText": "Optional description of the errors and how to correct them",

--- a/src/components/error-summary/default.njk
+++ b/src/components/error-summary/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukErrorSummary({
   "titleText": "Message to alert the user to a problem goes here",
   "descriptionText": "Optional description of the errors and how to correct them",

--- a/src/components/fieldset/default.njk
+++ b/src/components/fieldset/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukFieldset({
   "legendHtml": '<h1 class="govuk-heading-xl">Legend text goes here</h1>',
   "legendHintText": "Legend hint text goes here"

--- a/src/components/fieldset/default.njk
+++ b/src/components/fieldset/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "fieldset/macro.njk" import govukFieldset %}
-
 {{ govukFieldset({
   "legendHtml": '<h1 class="govuk-heading-xl">Legend text goes here</h1>',
   "legendHintText": "Legend hint text goes here"

--- a/src/components/file-upload/default.njk
+++ b/src/components/file-upload/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukFileUpload({
   id: 'file-upload-1',
   name: 'file-upload-1',

--- a/src/components/file-upload/default.njk
+++ b/src/components/file-upload/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "file-upload/macro.njk" import govukFileUpload %}
-
 {{ govukFileUpload({
   id: 'file-upload-1',
   name: 'file-upload-1',

--- a/src/components/panel/default.njk
+++ b/src/components/panel/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukPanel({
   "titleText": "Application complete",
   "html": "Your reference number<br><strong>HDJ2123F</strong>"

--- a/src/components/panel/default.njk
+++ b/src/components/panel/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "panel/macro.njk" import govukPanel %}
-
 {{ govukPanel({
   "titleText": "Application complete",
   "html": "Your reference number<br><strong>HDJ2123F</strong>"

--- a/src/components/phase-banner/beta.njk
+++ b/src/components/phase-banner/beta.njk
@@ -1,8 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "phase-banner/macro.njk" import govukPhaseBanner %}
 {{ govukPhaseBanner({
   "tag": {
     "text": "beta"

--- a/src/components/phase-banner/beta.njk
+++ b/src/components/phase-banner/beta.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukPhaseBanner({
   "tag": {
     "text": "beta"

--- a/src/components/phase-banner/default.njk
+++ b/src/components/phase-banner/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukPhaseBanner({
   "tag": {
     "text": "alpha"

--- a/src/components/phase-banner/default.njk
+++ b/src/components/phase-banner/default.njk
@@ -1,8 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "phase-banner/macro.njk" import govukPhaseBanner %}
 {{ govukPhaseBanner({
   "tag": {
     "text": "alpha"

--- a/src/components/radios/default.njk
+++ b/src/components/radios/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukRadios({
   "idPrefix": "changed-name",
   "name": "changed-name",

--- a/src/components/radios/default.njk
+++ b/src/components/radios/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from 'radios/macro.njk' import govukRadios %}
-
 {{ govukRadios({
   "idPrefix": "changed-name",
   "name": "changed-name",

--- a/src/components/select/default.njk
+++ b/src/components/select/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "select/macro.njk" import govukSelect %}
-
 {{ govukSelect({
   "id": "select-1",
   "name": "select-1",

--- a/src/components/select/default.njk
+++ b/src/components/select/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukSelect({
   "id": "select-1",
   "name": "select-1",

--- a/src/components/skip-link/default.njk
+++ b/src/components/skip-link/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 <p class="govuk-body">To view the Skip link component click inside this example and press tab.</p>
 {{ govukSkipLink({
   "text": "Skip to main content",

--- a/src/components/skip-link/default.njk
+++ b/src/components/skip-link/default.njk
@@ -2,9 +2,6 @@
 layout: layout-example.njk
 ---
 <p class="govuk-body">To view the Skip link component click inside this example and press tab.</p>
-
-{% from "skip-link/macro.njk" import govukSkipLink %}
-
 {{ govukSkipLink({
   "text": "Skip to main content",
   "href": "#content"

--- a/src/components/table/default.njk
+++ b/src/components/table/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukTable({
   "caption": "Dates and amounts",
   "firstCellIsHeader": true,

--- a/src/components/table/default.njk
+++ b/src/components/table/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "table/macro.njk" import govukTable %}
-
 {{ govukTable({
   "caption": "Dates and amounts",
   "firstCellIsHeader": true,

--- a/src/components/table/numbers.njk
+++ b/src/components/table/numbers.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukTable({
   "caption": "Months and rates",
   "firstCellIsHeader": true,

--- a/src/components/table/numbers.njk
+++ b/src/components/table/numbers.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "table/macro.njk" import govukTable %}
-
 {{ govukTable({
   "caption": "Months and rates",
   "firstCellIsHeader": true,

--- a/src/components/tag/default.njk
+++ b/src/components/tag/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukTag(
   {
     "text": "alpha"

--- a/src/components/tag/default.njk
+++ b/src/components/tag/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{%- from "tag/macro.njk" import govukTag -%}
-
 {{ govukTag(
   {
     "text": "alpha"

--- a/src/components/text-input/default.njk
+++ b/src/components/text-input/default.njk
@@ -1,8 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-{% from "input/macro.njk" import govukInput %}
-
 {{ govukInput({
   "label": {
     "text": "National insurance number",

--- a/src/components/text-input/default.njk
+++ b/src/components/text-input/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukInput({
   "label": {
     "text": "National insurance number",

--- a/src/components/text-input/input-width.njk
+++ b/src/components/text-input/input-width.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "input/macro.njk" import govukInput %}
-
 <h3 class="govuk-heading-m">Three-quarters</h3>
 
 {{ govukInput({

--- a/src/components/text-input/input-width.njk
+++ b/src/components/text-input/input-width.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 <h3 class="govuk-heading-m">Three-quarters</h3>
 
 {{ govukInput({

--- a/src/components/textarea/default.njk
+++ b/src/components/textarea/default.njk
@@ -1,8 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-{% from "textarea/macro.njk" import govukTextarea %}
-
 {{ govukTextarea({
   "name": "more-detail",
   "id": "more-detail",

--- a/src/components/textarea/default.njk
+++ b/src/components/textarea/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukTextarea({
   "name": "more-detail",
   "id": "more-detail",

--- a/src/components/warning-text/default.njk
+++ b/src/components/warning-text/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "warning-text/macro.njk" import govukWarningText %}
-
 {{ govukWarningText(
   {
     "text": "You can be fined up to £5,000 if you don’t register.",

--- a/src/components/warning-text/default.njk
+++ b/src/components/warning-text/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukWarningText(
   {
     "text": "You can be fined up to £5,000 if you don’t register.",

--- a/src/patterns/addresses/textarea.njk
+++ b/src/patterns/addresses/textarea.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukTextarea({
   "name": "address",
   "id": "address",

--- a/src/patterns/addresses/textarea.njk
+++ b/src/patterns/addresses/textarea.njk
@@ -1,10 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-
-{% from "textarea/macro.njk" import govukTextarea %}
-
 {{ govukTextarea({
   "name": "address",
   "id": "address",

--- a/src/patterns/confirmation-pages/default.njk
+++ b/src/patterns/confirmation-pages/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "panel/macro.njk" import govukPanel %}
-
 <div class="govuk-o-width-container">
 
   <div class="govuk-o-main-wrapper">

--- a/src/patterns/confirmation-pages/default.njk
+++ b/src/patterns/confirmation-pages/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 <div class="govuk-o-width-container">
 
   <div class="govuk-o-main-wrapper">

--- a/src/patterns/dates/default.njk
+++ b/src/patterns/dates/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukDateInput({
   fieldset: {
     legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',

--- a/src/patterns/dates/default.njk
+++ b/src/patterns/dates/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "date-input/macro.njk" import govukDateInput %}
-
 {{ govukDateInput({
   fieldset: {
     legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',

--- a/src/patterns/email-addresses/default.njk
+++ b/src/patterns/email-addresses/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukInput({
   label: {
     "text": "Email address",

--- a/src/patterns/email-addresses/default.njk
+++ b/src/patterns/email-addresses/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "input/macro.njk" import govukInput %}
-
 {{ govukInput({
   label: {
     "text": "Email address",

--- a/src/patterns/fill-in-a-form/details.njk
+++ b/src/patterns/fill-in-a-form/details.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "details/macro.njk" import govukDetails %}
-
 {{ govukDetails({
   "summaryText": "Help with nationality",
   "text": "If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card."

--- a/src/patterns/fill-in-a-form/details.njk
+++ b/src/patterns/fill-in-a-form/details.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukDetails({
   "summaryText": "Help with nationality",
   "text": "If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card."

--- a/src/patterns/fill-in-a-form/hint.njk
+++ b/src/patterns/fill-in-a-form/hint.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "input/macro.njk" import govukInput %}
-
 {{ govukInput({
   label: {
     "text": "National Insurance Number",

--- a/src/patterns/fill-in-a-form/hint.njk
+++ b/src/patterns/fill-in-a-form/hint.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukInput({
   label: {
     "text": "National Insurance Number",

--- a/src/patterns/gender-and-sex/default.njk
+++ b/src/patterns/gender-and-sex/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukRadios({
   "name": "gender",
   "fieldset": {

--- a/src/patterns/gender-and-sex/default.njk
+++ b/src/patterns/gender-and-sex/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from 'radios/macro.njk' import govukRadios %}
-
 {{ govukRadios({
   "name": "gender",
   "fieldset": {

--- a/src/patterns/names/default.njk
+++ b/src/patterns/names/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukInput({
   label: {
     "text": "Full name"

--- a/src/patterns/names/default.njk
+++ b/src/patterns/names/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "input/macro.njk" import govukInput %}
-
 {{ govukInput({
   label: {
     "text": "Full name"

--- a/src/patterns/national-insurance-numbers/default.njk
+++ b/src/patterns/national-insurance-numbers/default.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "input/macro.njk" import govukInput %}
-
 {{ govukInput({
   label: {
     "text": "National Insurance Number",

--- a/src/patterns/national-insurance-numbers/default.njk
+++ b/src/patterns/national-insurance-numbers/default.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 {{ govukInput({
   label: {
     "text": "National Insurance Number",

--- a/src/patterns/question-pages/default.njk
+++ b/src/patterns/question-pages/default.njk
@@ -2,9 +2,6 @@
 layout: layout-example.njk
 ---
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "date-input/macro.njk" import govukDateInput %}
-{% from "button/macro.njk" import govukButton %}
 
 <div class="govuk-o-width-container">
 

--- a/src/patterns/question-pages/default.njk
+++ b/src/patterns/question-pages/default.njk
@@ -2,7 +2,6 @@
 layout: layout-example.njk
 ---
 
-
 <div class="govuk-o-width-container">
 
 {{ govukBackLink({

--- a/src/patterns/question-pages/passport.njk
+++ b/src/patterns/question-pages/passport.njk
@@ -2,10 +2,7 @@
 layout: layout-example.njk
 ---
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "input/macro.njk" import govukInput %}
-{% from "date-input/macro.njk" import govukDateInput %}
-{% from "button/macro.njk" import govukButton %}
+
 
 <div class="govuk-o-width-container">
 

--- a/src/patterns/question-pages/passport.njk
+++ b/src/patterns/question-pages/passport.njk
@@ -2,8 +2,6 @@
 layout: layout-example.njk
 ---
 
-
-
 <div class="govuk-o-width-container">
 
   {{ govukBackLink({

--- a/src/patterns/question-pages/postcode.njk
+++ b/src/patterns/question-pages/postcode.njk
@@ -2,9 +2,6 @@
 layout: layout-example.njk
 ---
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "input/macro.njk" import govukInput %}
-{% from "button/macro.njk" import govukButton %}
 
 <div class="govuk-o-width-container">
 

--- a/src/patterns/question-pages/postcode.njk
+++ b/src/patterns/question-pages/postcode.njk
@@ -2,7 +2,6 @@
 layout: layout-example.njk
 ---
 
-
 <div class="govuk-o-width-container">
 
 {{ govukBackLink({

--- a/src/patterns/start-pages/default.njk
+++ b/src/patterns/start-pages/default.njk
@@ -4,9 +4,6 @@ stylesheets:
 - related-items.css
 ---
 
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "button/macro.njk" import govukButton %}
-
 <div class="govuk-o-width-container">
 
   {{ govukBreadcrumbs({

--- a/src/styles/images/default.njk
+++ b/src/styles/images/default.njk
@@ -4,5 +4,4 @@ stylesheets:
 - images.css
 ---
 
-
 <img src="3by2.jpg" alt="An image of cyclists overlayed with a 3 by 2 grid to explain the aspect ratio of the photograph">

--- a/src/styles/layout/input-width.njk
+++ b/src/styles/layout/input-width.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-
-{% from "input/macro.njk" import govukInput %}
-
 <h3 class="govuk-heading-m">Three-quarters</h3>
 
 {{ govukInput({

--- a/src/styles/layout/input-width.njk
+++ b/src/styles/layout/input-width.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 ---
+
 <h3 class="govuk-heading-m">Three-quarters</h3>
 
 {{ govukInput({

--- a/src/styles/layout/layout-wrappers.njk
+++ b/src/styles/layout/layout-wrappers.njk
@@ -3,9 +3,6 @@ layout: layout-example.njk
 stylesheets:
 - layout-wrappers-annotate.css
 ---
-
-{% from "back-link/macro.njk" import govukBackLink %}
-
 <div class="govuk-o-width-container">
   {{ govukBackLink({href: '#', text: 'Back'}) }}
   <main class="govuk-o-main-wrapper">

--- a/src/styles/layout/layout-wrappers.njk
+++ b/src/styles/layout/layout-wrappers.njk
@@ -3,6 +3,7 @@ layout: layout-example.njk
 stylesheets:
 - layout-wrappers-annotate.css
 ---
+
 <div class="govuk-o-width-container">
   {{ govukBackLink({href: '#', text: 'Back'}) }}
   <main class="govuk-o-main-wrapper">

--- a/src/styles/typography/default.njk
+++ b/src/styles/typography/default.njk
@@ -1,3 +1,4 @@
 ---
 layout: layout-example.njk
 ---
+


### PR DESCRIPTION
Glob the file system for macro file within the @govuk-frontend node modules folder, parse each file and grab any macros they export, and then make them available as globals.

This allows us to remove the `{% from “component/macro.njk" import govukComponent %}` lines from the examples we create, which means that Prototype Kit users will not have to worry about what to do with that line.

Because we need a Nunjucks environment we can use to parse the templates, the config for the nunjucks engine has been moved into the config folder and required in both places.

We should be able to adopt this in the Prototype Kit as well (though we’ll probably need to swap the spread operators out for something that works in older versions of Node as well).

https://trello.com/c/lUJckE4D/614-spike-find-a-way-to-exclude-the-from-import-lines-from-the-macro-examples-in-the-design-system-1-hour