### PR TITLE
Enable grid layout

### DIFF
--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -11,8 +11,7 @@
     }
 
     @supports (display: grid) {
-      // Temporary disable CSS Grid until #130 is fixed
-      // display: grid;
+      display: grid;
       grid-template-columns: minmax(100%, 1fr);
       grid-template-rows: repeat(3, auto);
 


### PR DESCRIPTION
#130 was fixed after Google Chrome 64 release.

This was disabled in [PR146](https://github.com/alphagov/govuk-design-system/pull/146) to prevent private beta users running into this issue.

_Note: we might want to leave this PR pending for a few days so people will have time to update to the latest version of Chrome._