### PR TITLE
Add link to the components' table of arguments

### DIFF
--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -35,6 +35,9 @@
     ```js
     {{ getNunjucksCode(examplePath) | safe }}
     ```
+    <p class="govuk-!-mt-r4 govuk-!-ml-r4">
+      <a href="https://github.com/alphagov/govuk-frontend/tree/master/src/components/{{params.item}}/README.md#component-arguments" class="govuk-link"  target="_blank">Table of available arguments</a>
+    </p>
   </div>
   {% endif %}
 </div>


### PR DESCRIPTION
Adds a link to the table of arguments section for each component in the GOV.UK Frontend README file on Github.
Trello ticket: https://trello.com/c/peF3UoZd/718-add-links-from-the-component-examples-to-the-table-of-arguments-in-the-github-readme