### PR TITLE
Fix examples on question page pattern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "@govuk-frontend/all": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.22-alpha.tgz",
-      "integrity": "sha512-Y1x8n7JkFPV92RioI9gOMlAAY/d+NI2Q1/w6DNtTKWicmjrqMddk+jeIHKSF+UlSQ49TbnWU/rXvhPBrJWx2yg==",
+      "integrity": "sha1-dJT1VDJyP4pqnJ6RiHsg7wD670U=",
       "requires": {
         "@govuk-frontend/back-link": "0.0.22-alpha",
         "@govuk-frontend/breadcrumbs": "0.0.22-alpha",
@@ -37,7 +37,7 @@
     "@govuk-frontend/back-link": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.22-alpha.tgz",
-      "integrity": "sha512-h/G1djG7Ugc6G6dAeWukQnj5OaXdx9YHcrsTjH4Jn0dl+7pEMQlwEf7AdyEg502Vs2EURE9E0+UGwISSkepIfQ==",
+      "integrity": "sha1-kGuPCgFAM6f3aDeig0aVK7b+ljc=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -45,7 +45,7 @@
     "@govuk-frontend/breadcrumbs": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.22-alpha.tgz",
-      "integrity": "sha512-yaz2PfsisqlGIXqgKtORDKvsmv7Tiyk5l8kzaglc2Vbnda+HLyvpjDdX++zp/18hlTS6g9xVxIG/ZxFsk78Kbg==",
+      "integrity": "sha1-yDhCUGDtSvtpUdfWRijT3BNPXEM=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha",
         "@govuk-frontend/icons": "0.0.22-alpha"
@@ -54,7 +54,7 @@
     "@govuk-frontend/button": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.22-alpha.tgz",
-      "integrity": "sha512-G9tK3H4GShkSA5Q0rBx6yXhg/T2oNlKjlXS0OAs9BH9KE311Ri0aZ2iWVSBTPRMDOgPJd3QkzTZjwzze3u4Cyw==",
+      "integrity": "sha1-8rYVpfDKb2c59QljHTrSVeKLVJE=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha",
         "@govuk-frontend/icons": "0.0.22-alpha"
@@ -63,7 +63,7 @@
     "@govuk-frontend/checkboxes": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.22-alpha.tgz",
-      "integrity": "sha512-qRX2GgoWkKKMoOojezm2k15SqEhVkVOwiDRGNl3xQlCZAa2YoMms6F+p/oAC3iheZXwg+SXMq9FRnQyNHdWxBA==",
+      "integrity": "sha1-Vtws+6eGAtA/cbqsS0abQbLtDIw=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha",
         "@govuk-frontend/label": "0.0.22-alpha"
@@ -72,7 +72,7 @@
     "@govuk-frontend/cookie-banner": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/cookie-banner/-/cookie-banner-0.0.22-alpha.tgz",
-      "integrity": "sha512-rPI8sWQp3nwTqjzBLmuUwYWBKi7pv3Ki2D3I9O7+2oeIRxc21ycGrLeXV4RtMoAFzEJQLveHMpmPmAAISAPGcg==",
+      "integrity": "sha1-yaLm61t40lPH7WKhrYvBqzHGv4g=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -80,7 +80,7 @@
     "@govuk-frontend/date-input": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.22-alpha.tgz",
-      "integrity": "sha512-NtpQxZ+KsSPYgHHWnFVNyHZ9s8pZ389di8XUQsMbFXvD14vG8gJT6esfxjWSEL2lk71IlQvAC4TdPFpHrvCfdw==",
+      "integrity": "sha1-5ZHEdjA6lESqKEFKFwsg6R9cqTs=",
       "requires": {
         "@govuk-frontend/error-message": "0.0.22-alpha",
         "@govuk-frontend/globals": "0.0.22-alpha",
@@ -90,7 +90,7 @@
     "@govuk-frontend/details": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.22-alpha.tgz",
-      "integrity": "sha512-q7/6L8/ZzHrIgMz9vD88JRPl1ZfDEQFFm5v0eRN0Te7Bw7L5APorhjdMeJ1Vz1G3eR81mBub7VkEmv0ueYG1Zw==",
+      "integrity": "sha1-lFcRkD8QpX8TWAKCv6/EyPs7ujc=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -98,7 +98,7 @@
     "@govuk-frontend/error-message": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.22-alpha.tgz",
-      "integrity": "sha512-XVCoTTtHs23EcD8+5rraTLxqZ2IiYUrwIIAGn9OoYtPtN4AUb5b7iwEF3Y5MDRboBQLrKG95//bAW0e7KiJzhw==",
+      "integrity": "sha1-mGj/ICJSe1tBIuLw1dziKXsXXOM=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -106,7 +106,7 @@
     "@govuk-frontend/error-summary": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.22-alpha.tgz",
-      "integrity": "sha512-qRj/D7vh6izKtbS/+mLGNtFELHB2VlsBJqENlS9M+A2GhB99+zPrRG0P+1bviFcSr4c2p1Y9XxGhlwJ9f4FA9A==",
+      "integrity": "sha1-gJ+WRjxLs1v3agf366HF+BWMsUw=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -114,7 +114,7 @@
     "@govuk-frontend/fieldset": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.22-alpha.tgz",
-      "integrity": "sha512-FXyZjADSYTs5bDH2Ajd38PEKe7qOV6a+HCrrxcEm3nwZcpm6xLLVOaftY+edZbaKpNo4Z0cbAU7TgFPys9z4pA==",
+      "integrity": "sha1-gfcnroH5w3z/BjSL8oN3Heth4Tc=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -122,7 +122,7 @@
     "@govuk-frontend/file-upload": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.22-alpha.tgz",
-      "integrity": "sha512-V+kZIoXEweq4sIlQSL+Ja9xXBk7Uh0nPlpSlymKCE1Zlbyb0j+dcJuFkd7DM1qa7Si4UTlqgdPnf+gVbvIaDwQ==",
+      "integrity": "sha1-xI6Gj/vDIlZGgwRirMLqtzh/Kxw=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -130,7 +130,7 @@
     "@govuk-frontend/globals": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.22-alpha.tgz",
-      "integrity": "sha512-ixC9uOVXCWgSdHa3zQSDzHi1/E8swsNYszMYK2m7QGioJi2b9yU3OhUCcDEvG/IU6zb8my3WYcdTmtod3Y+rEA==",
+      "integrity": "sha1-vcWLirPLr4PJQUw/VszESku4xwQ=",
       "requires": {
         "sass-mq": "3.3.2"
       }
@@ -138,12 +138,12 @@
     "@govuk-frontend/icons": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.22-alpha.tgz",
-      "integrity": "sha512-q0KrKkoAV/d/QOHR7BQDwYwL5KrDhBgCdoljbZAjWgzdLz15EeWKeBtyvSmug3hUIFMr0Pvle1V8q7B1DiyLNQ=="
+      "integrity": "sha1-CdrykkarS/MZVcVeM0QnESe6Ogw="
     },
     "@govuk-frontend/input": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.22-alpha.tgz",
-      "integrity": "sha512-W2sfC3Ag9JqLDFD60anL5WpwdXt4X+WmxHywMn7ri5jPVkoU4/MjY/0wPmybA9qzRyY20Ldd7C97yUfSKLvElg==",
+      "integrity": "sha1-GcgR5hZcP7o/VZm2rd17ythFD7c=",
       "requires": {
         "@govuk-frontend/error-message": "0.0.22-alpha",
         "@govuk-frontend/globals": "0.0.22-alpha",
@@ -153,7 +153,7 @@
     "@govuk-frontend/label": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.22-alpha.tgz",
-      "integrity": "sha512-CqXVIjRPLpr7tfgSfq5rjU0fOU9RvVaTjI9LtUYjkaPVJI+UBYe4/CwsRujEVK95NURqhBBbKzIgHV5Sx0i5UQ==",
+      "integrity": "sha1-nX0uaEEdwg7NrsdvttnRlRUhHUU=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -161,7 +161,7 @@
     "@govuk-frontend/panel": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.22-alpha.tgz",
-      "integrity": "sha512-pD22TGsVLMXjcHAkQhwo4rgL1SKLFjm3Es6jFDqUrL8Vjp7texkagbLe4R/HBDlfcc/67ZqmTEkROT9cFZvtFA==",
+      "integrity": "sha1-CQJEKDSwKWVGw0WApEmraIOIlN4=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -169,7 +169,7 @@
     "@govuk-frontend/phase-banner": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.22-alpha.tgz",
-      "integrity": "sha512-GTL1lQhgBmPBqeP/gdWagKGIYZ+f/lYuc+HrEXBwKV4q1GxUUrY5JWUJOFnT/tO+MvdVN8Bp10OdtXAjKW3X0Q==",
+      "integrity": "sha1-3sj1lgCRixEIMuMUOyOSwvfn/3Q=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha",
         "@govuk-frontend/tag": "0.0.22-alpha"
@@ -178,7 +178,7 @@
     "@govuk-frontend/previous-next": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/previous-next/-/previous-next-0.0.22-alpha.tgz",
-      "integrity": "sha512-LMN8/cdrPzNP84a4OikyJkthnE6Cp4/0vXXBn2I6fiVs7IZJioJXUqftZz2LlHmZaCYzcRzHhyVTwS3LZzvuqg==",
+      "integrity": "sha1-uvpNSB7998Jd+P5JeEOuVbSx3lo=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -186,7 +186,7 @@
     "@govuk-frontend/radios": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.22-alpha.tgz",
-      "integrity": "sha512-35o+tQNTuFyvERA9XoCCahCGtxXtrP+RnAuEfASl/fSGUop5lHTx9yoXAnVrt2CwSAzxr9+cPN4zFmbDfG1GKQ==",
+      "integrity": "sha1-lICOA8t37bw+l7jcAQ1gacJwaLI=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha",
         "@govuk-frontend/label": "0.0.22-alpha"
@@ -195,7 +195,7 @@
     "@govuk-frontend/select": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.22-alpha.tgz",
-      "integrity": "sha512-V7+tpAkcAE3glotvtstA+G+R8c5mpHO+BGkMB911ukkxu8sgSD3HAPRSiihVzfgp/liDjD6sLgc+ctWvp0VzPQ==",
+      "integrity": "sha1-rfNJEz2ZW2T8OcqKpyQrqb8pLm4=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha",
         "@govuk-frontend/label": "0.0.22-alpha"
@@ -204,7 +204,7 @@
     "@govuk-frontend/skip-link": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.22-alpha.tgz",
-      "integrity": "sha512-3G0VAPe7bFv+3uj3gZGpoSeJemXtzy7ncvmeh0q7xbb2jqb96u1eYE6WDKact2MqZiJVB9wPIegjjz1C9v3VJw==",
+      "integrity": "sha1-t0kBS/50o3IBFj+B3PtiHBeQ1tE=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -212,7 +212,7 @@
     "@govuk-frontend/table": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.22-alpha.tgz",
-      "integrity": "sha512-SwAZqy2zC5tHXIu/yQgGw2jRPDmWTOG8Ln9I6l06Vpv1alS2JPQPjBbUUPa9yc9bZvlm/nLuRkWkaHAC3WM34g==",
+      "integrity": "sha1-5aSK6ur12kTs2vAJG3rwKLiOy/4=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -220,7 +220,7 @@
     "@govuk-frontend/tag": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.22-alpha.tgz",
-      "integrity": "sha512-VFpSwjkrP2yn9pCJX++uXhe1w/2ugEqJAf4tvttOKeTLtcKAkw7HAnnmFweibG6bZ5Jz5VQNz/ih/hqaYwFECQ==",
+      "integrity": "sha1-qBAODhYZYAzvQ/lIDdgGmyb8ti0=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -228,7 +228,7 @@
     "@govuk-frontend/textarea": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.22-alpha.tgz",
-      "integrity": "sha512-aiTwWtohD+8rHKeWOhK+yMhGHQQIJZ8K929MZodVBk1LDLmrPCqjteOYNbv0hXZ19YwzKAjRDSSfsm4rPpiL4A==",
+      "integrity": "sha1-L9omxeeCQmsmjWbcfDk/ozNIh7Y=",
       "requires": {
         "@govuk-frontend/error-message": "0.0.22-alpha",
         "@govuk-frontend/globals": "0.0.22-alpha",
@@ -238,7 +238,7 @@
     "@govuk-frontend/warning-text": {
       "version": "0.0.22-alpha",
       "resolved": "https://registry.npmjs.org/@govuk-frontend/warning-text/-/warning-text-0.0.22-alpha.tgz",
-      "integrity": "sha512-CTuOIJVXm3kTI8g1RcfAVC/nxHFFEHaou+WvprlaULjNilpvjJeryGbbERxjErMJlqgUCP4DxVVluZtVqkXCFg==",
+      "integrity": "sha1-5eHW193uPKfdP1FFWExCbwVHMQQ=",
       "requires": {
         "@govuk-frontend/globals": "0.0.22-alpha"
       }
@@ -7246,7 +7246,7 @@
     "scss-to-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/scss-to-json/-/scss-to-json-2.0.0.tgz",
-      "integrity": "sha512-XIh0Va7RiozUtUBznXiaxlqam6FQiEvJQs7HnnNZ5o7qn3KwswF1sLd8Rn9ezVufSK7VnCEKkbwkVNZ+JXNnfA==",
+      "integrity": "sha1-3Y90hp2j2Z+0TI9SNfU067Ew6kc=",
       "requires": {
         "cssmin": "0.4.3",
         "minimist": "1.2.0",

--- a/src/patterns/question-pages/default.njk
+++ b/src/patterns/question-pages/default.njk
@@ -8,42 +8,43 @@ layout: layout-example.njk
 
 <div class="govuk-o-width-container">
 
-{{ govukBackLink({
-  "text": "Back"
-}) }}
+  {{ govukBackLink({
+    "text": "Back"
+  }) }}
 
-<div class="govuk-o-main-wrapper">
-  <div class="govuk-o-grid">
-    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+  <div class="govuk-o-main-wrapper">
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
 
-      <form class="form" action="/url/of/next/page" method="post">
+        <form class="form" action="/url/of/next/page" method="post">
 
-        {{ govukDateInput({
-          fieldset: {
-            legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',
-            legendHintText: 'For example, 31 3 1980'
-          },
-          id: 'dob',
-          name: 'dob',
-          items:[
-            {
-              name: 'day'
+          {{ govukDateInput({
+            fieldset: {
+              legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',
+              legendHintText: 'For example, 31 3 1980'
             },
-            {
-              name: 'month'
-            },
-            {
-              name: 'year'
-            }
-          ]
-          })
-        }}
+            id: 'dob',
+            name: 'dob',
+            items:[
+              {
+                name: 'day'
+              },
+              {
+                name: 'month'
+              },
+              {
+                name: 'year'
+              }
+            ]
+            })
+          }}
 
-        {{ govukButton({
-          "text": "Continue"
-        }) }}
-      </form>
+          {{ govukButton({
+            "text": "Continue"
+          }) }}
+        </form>
 
+      </div>
     </div>
   </div>
 </div>

--- a/src/patterns/question-pages/postcode.njk
+++ b/src/patterns/question-pages/postcode.njk
@@ -8,28 +8,29 @@ layout: layout-example.njk
 
 <div class="govuk-o-width-container">
 
-{{ govukBackLink({
-  "text": "Back"
-}) }}
+  {{ govukBackLink({
+    "text": "Back"
+  }) }}
 
-<div class="govuk-o-main-wrapper">
-  <div class="govuk-o-grid">
-    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+  <div class="govuk-o-main-wrapper">
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
 
-      <form class="form" action="/url/of/next/page" method="post">
-        {{ govukInput({
-          "label": {
-            "html": '<h1 class="govuk-heading-xl govuk-!-mb-r4">What is your home postcode?</h1>'
-          },
-          "id": "postcode",
-          "name": "postcode"
-        }) }}
+        <form class="form" action="/url/of/next/page" method="post">
+          {{ govukInput({
+            "label": {
+              "html": '<h1 class="govuk-heading-xl govuk-!-mb-r4">What is your home postcode?</h1>'
+            },
+            "id": "postcode",
+            "name": "postcode"
+          }) }}
 
-        {{ govukButton({
-          "text": "Continue"
-        }) }}
-      </form>
+          {{ govukButton({
+            "text": "Continue"
+          }) }}
+        </form>
 
+      </div>
     </div>
   </div>
 </div>

--- a/src/patterns/question-pages/postcode.njk
+++ b/src/patterns/question-pages/postcode.njk
@@ -5,6 +5,7 @@ layout: layout-example.njk
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "input/macro.njk" import govukInput %}
 {% from "button/macro.njk" import govukButton %}
+{% from "fieldset/macro.njk" import govukFieldset %}
 
 <div class="govuk-o-width-container">
 
@@ -17,17 +18,26 @@ layout: layout-example.njk
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
 
         <form class="form" action="/url/of/next/page" method="post">
-          {{ govukInput({
-            "label": {
-              "html": '<h1 class="govuk-heading-xl govuk-!-mb-r4">What is your home postcode?</h1>'
-            },
-            "id": "postcode",
-            "name": "postcode"
-          }) }}
+
+          {% call govukFieldset({
+            "legendHtml": '<h1 class="govuk-heading-xl govuk-!-mb-r4">What is your home postcode?</h1>'
+          }) %}
+
+            {{ govukInput({
+              "label": {
+                "text": 'What is your home postcode?',
+                "classes": 'govuk-h-visually-hidden'
+              },
+              "id": "postcode",
+              "name": "postcode"
+            }) }}
+
+          {% endcall %}
 
           {{ govukButton({
             "text": "Continue"
           }) }}
+
         </form>
 
       </div>


### PR DESCRIPTION
This adds:

- closing `<div>`'s for  `<div class="govuk-o-width-container">` on two examples
- corrects indent of example code
- Swaps a `<label>` with an `<h1>` for a `<legend>` with an `<h1>` (and hidden `<label>`) on postcode example (this is probably what it should have been from the start)