### PR TITLE
Update fieldset examples to use macros

### DIFF
--- a/src/components/fieldset/address-group.njk
+++ b/src/components/fieldset/address-group.njk
@@ -4,33 +4,54 @@ stylesheets:
 - address-wrapper.css
 ---
 
-<fieldset class="govuk-c-fieldset">
-  <legend class="govuk-c-fieldset__legend">
-    <h1 class="govuk-heading-xl">What is your address?</h1>
-  </legend>
+{% from "input/macro.njk" import govukInput %}
+{% from "fieldset/macro.njk" import govukFieldset %}
 
-  <label class="govuk-c-label" for="address-line-1">
-    Building and street <span class="govuk-h-visually-hidden">line 1 of 2</span>
-  </label>
-  <input class="govuk-c-input" id="address-line-1" name="address-line-1" type="text">
+{% call govukFieldset({
+  "legendHtml": '<h1 class="govuk-heading-xl govuk-!-mb-r4">What is your address?</h1>'
+}) %}
 
-  <label class="govuk-c-label govuk-h-visually-hidden" for="address-street">
-    Building and street line 2 of 2
-  </label>
-  <input class="govuk-c-input" id="address-line-2" name="address-line-2" type="text">
+  {{ govukInput({
+    "label": {
+      "html": 'Building and street <span class="govuk-h-visually-hidden">line 1 of 2</span>'
+    },
+    "id": "address-line-1",
+    "name": "address-line-1"
+  }) }}
 
-  <label class="govuk-c-label" for="address-town">
-    Town or city
-  </label>
-  <input class="govuk-c-input govuk-!-width-two-thirds" id="address-town" name="address-town" type="text">
+  {{ govukInput({
+    "label": {
+      "html": '<span class="govuk-h-visually-hidden">Building and street line 2 of 2</span>'
+    },
+    "id": "address-line-2",
+    "name": "address-line-2"
+  }) }}
 
-  <label class="govuk-c-label" for="address-county">
-    County
-  </label>
-  <input class="govuk-c-input govuk-!-width-two-thirds" id="address-county" name="address-county" type="text">
+  {{ govukInput({
+    "label": {
+      "html": 'Town or city'
+    },
+    "classes": 'govuk-!-width-two-thirds',
+    "id": "address-town",
+    "name": "address-town"
+  }) }}
 
-  <label class="govuk-c-label" for="address-postcode">
-    Postcode
-  </label>
-  <input class="govuk-c-input govuk-!-width-one-third" id="address-postcode" name="address-postcode" type="text">
-</fieldset>
+  {{ govukInput({
+    "label": {
+      "html": 'County'
+    },
+    "classes": 'govuk-!-width-two-thirds',
+    "id": "address-county",
+    "name": "address-county"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "html": 'Postcode'
+    },
+    "classes": 'govuk-!-width-one-third',
+    "id": "address-postcode",
+    "name": "address-postcode"
+  }) }}
+
+{% endcall %}

--- a/src/components/fieldset/index.md.njk
+++ b/src/components/fieldset/index.md.njk
@@ -17,7 +17,7 @@ Use the Fieldset component to group related form inputs.
 
 Use the Fieldset component when you need to show a relationship between multiple form inputs. For example, you may need to group a set of text inputs into a single fieldset when [asking for an address](../../patterns/addresses).
 
-{{ example({group: 'components', item: 'fieldset', example: 'address-group', html: true, open: true}) }}
+{{ example({group: 'components', item: 'fieldset', example: 'address-group', html: true, nunjucks: true, open: true}) }}
 
 If you’re using the examples or macros for [Radios](../radios), [Checkboxes](../checkboxes) or [Date input](../date-input), the fieldset will already be included.
 

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -40,7 +40,7 @@ When using an address lookup, you should:
 
 ## Multiple text inputs
 
-{{ example({group: 'patterns', item: 'addresses', example: 'multiple', html: true, nunjucks: false, open: true}) }}
+{{ example({group: 'patterns', item: 'addresses', example: 'multiple', html: true, nunjucks: true, open: true}) }}
 
 ### When to use multiple text inputs
 

--- a/src/patterns/addresses/multiple.njk
+++ b/src/patterns/addresses/multiple.njk
@@ -4,33 +4,54 @@ stylesheets:
 - address-wrapper.css
 ---
 
-<fieldset class="govuk-c-fieldset">
-  <legend class="govuk-c-fieldset__legend">
-    <h1 class="govuk-heading-xl">What is your address?</h1>
-  </legend>
+{% from "input/macro.njk" import govukInput %}
+{% from "fieldset/macro.njk" import govukFieldset %}
 
-  <label class="govuk-c-label" for="address-line-1">
-    Building and street <span class="govuk-h-visually-hidden">line 1 of 2</span>
-  </label>
-  <input class="govuk-c-input" id="address-line-1" name="address-line-1" type="text">
+{% call govukFieldset({
+  "legendHtml": '<h1 class="govuk-heading-xl govuk-!-mb-r4">What is your address?</h1>'
+}) %}
 
-  <label class="govuk-c-label govuk-h-visually-hidden" for="address-street">
-    Building and street line 2 of 2
-  </label>
-  <input class="govuk-c-input" id="address-line-2" name="address-line-2" type="text">
+  {{ govukInput({
+    "label": {
+      "html": 'Building and street <span class="govuk-h-visually-hidden">line 1 of 2</span>'
+    },
+    "id": "address-line-1",
+    "name": "address-line-1"
+  }) }}
 
-  <label class="govuk-c-label" for="address-town">
-    Town or city
-  </label>
-  <input class="govuk-c-input govuk-!-width-two-thirds" id="address-town" name="address-town" type="text">
+  {{ govukInput({
+    "label": {
+      "html": '<span class="govuk-h-visually-hidden">Building and street line 2 of 2</span>'
+    },
+    "id": "address-line-2",
+    "name": "address-line-2"
+  }) }}
 
-  <label class="govuk-c-label" for="address-county">
-    County
-  </label>
-  <input class="govuk-c-input govuk-!-width-two-thirds" id="address-county" name="address-county" type="text">
+  {{ govukInput({
+    "label": {
+      "html": 'Town or city'
+    },
+    "classes": 'govuk-!-width-two-thirds',
+    "id": "address-town",
+    "name": "address-town"
+  }) }}
 
-  <label class="govuk-c-label" for="address-postcode">
-    Postcode
-  </label>
-  <input class="govuk-c-input govuk-!-width-one-third" id="address-postcode" name="address-postcode" type="text">
-</fieldset>
+  {{ govukInput({
+    "label": {
+      "html": 'County'
+    },
+    "classes": 'govuk-!-width-two-thirds',
+    "id": "address-county",
+    "name": "address-county"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "html": 'Postcode'
+    },
+    "classes": 'govuk-!-width-one-third',
+    "id": "address-postcode",
+    "name": "address-postcode"
+  }) }}
+
+{% endcall %}

--- a/src/patterns/question-pages/passport.njk
+++ b/src/patterns/question-pages/passport.njk
@@ -6,6 +6,7 @@ layout: layout-example.njk
 {% from "input/macro.njk" import govukInput %}
 {% from "date-input/macro.njk" import govukDateInput %}
 {% from "button/macro.njk" import govukButton %}
+{% from "fieldset/macro.njk" import govukFieldset %}
 
 <div class="govuk-o-width-container">
 
@@ -20,14 +21,22 @@ layout: layout-example.njk
 
         <form class="form" action="/url/of/next/page" method="post">
 
-          {{ govukInput({
-            label: {
-              "html": '<h3 class="govuk-heading-m govuk-!-mb-r1">Passport number</h3>',
-              "hintText": "For example, 502135326"
-            },
-            id: "passport-number",
-            name: "passport-number"
-          }) }}
+          {% call govukFieldset({
+            "legendHtml": '<h3 class="govuk-heading-m govuk-!-mb-r1">Passport number</h3>',
+            "legendHintText": 'For example, 502135326'
+          }) %}
+
+            {{ govukInput({
+              label: {
+                "html": 'Passport number',
+                "hintText": 'For example, 502135326',
+                "classes": 'govuk-h-visually-hidden'
+              },
+              id: "passport-number",
+              name: "passport-number"
+            }) }}
+
+          {% endcall %}
 
 
           {{ govukDateInput({


### PR DESCRIPTION
Currently all examples using the fieldset (when not using a component that has it integrated) use HTML only.

This updates all examples to use macros (thanks for teaching me how to do this @alex-ju)