### PR TITLE
Add tracking to table of arguments link

### DIFF
--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -36,7 +36,7 @@
     {{ getNunjucksCode(examplePath) | safe }}
     ```
     <p class="govuk-!-mt-r4 govuk-!-ml-r4">
-      <a href="https://github.com/alphagov/govuk-frontend/tree/master/src/components/{{params.item}}/README.md#component-arguments" class="govuk-link"  target="_blank">Table of available arguments</a>
+      <a href="https://github.com/alphagov/govuk-frontend/tree/master/src/components/{{params.item}}/README.md#component-arguments" class="govuk-link"  target="_blank" data-track="link to table of arguments in Frontend readme">Table of available arguments</a>
     </p>
   </div>
   {% endif %}


### PR DESCRIPTION
Adds `data-track` attribute to the table of arguments link in Nunjucks code examples

Trello ticket: https://trello.com/c/QyN449SZ/719-track-clicks-from-the-component-examples-to-the-table-of-arguments