### PR TITLE
Add condition to show link to Frontend README only on components

### DIFF
--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -35,9 +35,11 @@
     ```js
     {{ getNunjucksCode(examplePath) | safe }}
     ```
+  {%- if (params.group == 'components') %}
     <p class="govuk-!-mt-r4 govuk-!-ml-r4">
       <a href="https://github.com/alphagov/govuk-frontend/tree/master/src/components/{{params.item}}/README.md#component-arguments" class="govuk-link"  target="_blank">Table of available arguments</a>
     </p>
+  {% endif %}
   </div>
   {% endif %}
 </div>


### PR DESCRIPTION
We don't want to show the link everywhere we have the Nunjucks tab, only in components.
Forgot to add condition in #177
