### PR TITLE
PR FOR DISCUSSION: Update style of related links to follow GOV.UK rollout

### DIFF
--- a/src/patterns/start-pages/default.njk
+++ b/src/patterns/start-pages/default.njk
@@ -30,7 +30,11 @@ stylesheets:
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
 
         <h1 class="govuk-heading-xl">Service name goes here</h1>
-        
+
+      </div>
+    </div>
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
         <p class="govuk-body">Use this service to:</p>
 
         <ul class="govuk-list govuk-list--bullet">
@@ -62,11 +66,11 @@ stylesheets:
         <!-- The Related items component is not part of GOV.UK Frontend but will be styled if used in the Prototype Kit -->
 
         <aside class="app-c-related-items" role="complementary">
-          <h2 class="govuk-heading-m" id="subsection-title">
+          <h3 class="govuk-heading-s" id="subsection-title">
             Subsection
           </h2>
           <nav role="navigation" aria-labelledby="subsection-title">
-            <ul class="govuk-list govuk-!-f-16">
+            <ul class="govuk-list">
               <li>
                 <a href="#">
                   Related link

--- a/src/patterns/start-pages/related-items.scss
+++ b/src/patterns/start-pages/related-items.scss
@@ -4,10 +4,24 @@
 // can be seen at http://govuk-static.herokuapp.com/component-guide/related_items
 
 .app-c-related-items {
-  border-top: 10px solid $govuk-blue;
+  @include govuk-responsive-margin($govuk-spacing-responsive-9, "top");
   padding-top: $govuk-spacing-scale-2;
+  border-top: 2px solid $govuk-blue;
+
+  @include mq($from: tablet) {
+    margin-top: 0;
+  }
+}
+
+.app-c-related-items h3 {
+  @include govuk-responsive-margin($govuk-spacing-responsive-2, "bottom");
 }
 
 .app-c-related-items li {
   margin-bottom: $govuk-spacing-scale-2;
+}
+
+.app-c-related-items li a {
+  font-size: 16px;
+  text-decoration: none;
 }


### PR DESCRIPTION
I've updated the related links styling on the Start Page to represent what will shortly be rolled out on GOV.UK (live on many other page formats already).

**Changes that we may need to consider for GOV.UK Frontend**
- Navigational links (or links outside of main content) are not underlined
- Font-size within list is a hard 16px (doesn't change to 14px on mobile)

**Changes to this page (That didn't need any modification to styles)**
- The h1 is wrapped in it's own grid, the related items sit on the same line as the first line of content

**Other changes**
- Removed the overrides from the HTML and added specific styles to the example .scss file

This change would also need to be released in the GOV.UK Prototype Kit before merge
