### PR TITLE
Remove panel, highlight and page colours

### DIFF
--- a/data/colours.json
+++ b/data/colours.json
@@ -19,18 +19,9 @@
         "name": "$govuk-link-visited-colour"
       }
     ],
-    "Backgrounds": [
+    "Border": [
       {
         "name": "$govuk-border-colour"
-      },
-      {
-        "name": "$govuk-panel-colour"
-      },
-      {
-        "name": "$govuk-highlight-colour"
-      },
-      {
-        "name": "$govuk-page-colour"
       }
     ],
     "Buttons": [


### PR DESCRIPTION
These colours are not actually used in Frontend and their definitions are being removed in the next version. As the only colour left in this section is in fact a border, not a background, rename the section.

https://github.com/alphagov/govuk-frontend/pull/525