### PR TITLE
Document setting height of a textarea using rows

### DIFF
--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -33,7 +33,9 @@ Labels must be aligned above the textarea they refer to. They should be short, d
 
 ### Use appropriately-sized textareas
 
-Make the height of a textarea proportional to the amount of text you expect users to&nbsp;enter.
+Make the height of a textarea proportional to the amount of text you expect users to enter. You can set the height of a textarea by by specifying the `rows` attribute.
+
+{{ example({group: 'components', item: 'textarea', example: 'specifying-rows', html: true, nunjucks: true, open: true}) }}
 
 ### Don’t disable copy and paste
 

--- a/src/components/textarea/specifying-rows.njk
+++ b/src/components/textarea/specifying-rows.njk
@@ -1,0 +1,14 @@
+---
+layout: layout-example.njk
+---
+{% from "textarea/macro.njk" import govukTextarea %}
+
+{{ govukTextarea({
+  "name": "more-detail",
+  "id": "more-detail",
+  "rows": "8",
+  "label": {
+    "text": "Can you provide more detail?",
+    "hintText": "Don’t include personal or financial information, eg your National Insurance number or credit card details."
+  }
+}) }}


### PR DESCRIPTION
In user research we've seen participants wanting to know how to set the height of a textarea.

We have existing documentation that tells users they should set the height proportional to the expected content, but don't tell them they can use the rows attribute to do this.

This has not yet been reviewed by a content designer.