### PR TITLE
Remove checked state from radio example

### DIFF
--- a/src/components/radios/default.njk
+++ b/src/components/radios/default.njk
@@ -18,8 +18,7 @@ layout: layout-example.njk
     },
     {
       "value": "no",
-      "text": "No",
-      "checked": true
+      "text": "No"
     }
   ]
 }) }}


### PR DESCRIPTION
This fixes #189 

We tell people to copy and paste our examples, but in this case they would get a pre-checked radio, which we don't actually recommend people do.

This PR removes the checked state.