### PR TITLE
Add link to the table of arguments in GOV.UK Frontend readme

### DIFF
--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -29,7 +29,7 @@ Back links must always go at the top of a page.
 
 Make sure the link takes users to the previous page and that it works even when JavaScript isn’t available.
 
-There are 2 ways to use the Back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Back link macro.
+There are 2 ways to use the Back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'back-link', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/breadcrumbs/index.md.njk
+++ b/src/components/breadcrumbs/index.md.njk
@@ -27,7 +27,7 @@ If you’re using other navigational elements on the page, such as a sidebar, co
 
 The Breadcrumbs component should include the user’s current page, which should be visually different from the other links in the breadcrumb.
 
-There are 2 ways to use the Breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Breadcrumbs macro.
+There are 2 ways to use the Breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'breadcrumbs', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -21,7 +21,7 @@ Write button text in sentence case, describing the action it performs. For examp
 
 Align the primary action button to the left edge of your form.
 
-There are 2 ways to use the Button component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Button macro.
+There are 2 ways to use the Button component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'button', example: 'primary', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -26,7 +26,7 @@ Don’t use the Checkboxes component if users can only choose one option from a 
 
 ## How it works
 
-There are 2 ways to use the Checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Checkboxes macro.
+There are 2 ways to use the Checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'checkboxes', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -27,7 +27,7 @@ Read more about how to [ask users for dates](../../patterns/dates/).
 
 The Date input component consists of 3 fields to let users enter a day, month and year.
 
-There are 2 ways to use the Date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Date input macro.
+There are 2 ways to use the Date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'date-input', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/details/index.md.njk
+++ b/src/components/details/index.md.njk
@@ -25,7 +25,7 @@ Don’t use the Details component to hide information that the majority of your 
 
 The Details component is a short link that expands into more detailed help text when a user clicks on it.
 
-There are 2 ways to use the Details component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Details macro.
+There are 2 ways to use the Details component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'details', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -26,7 +26,7 @@ For each error:
 
 You must also summarise all errors at the top of the page the user is on using an [Error summary](../error-summary).
 
-There are 2 ways to use the Error message component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Error message macro.
+There are 2 ways to use the Error message component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 ### Legend
 

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -27,7 +27,7 @@ Additionally, you should reflect that there has been an error in the `<title>` b
 
 You must also show an [error message](../error-message) alongside the specific input or inputs which have errors.
 
-There are 2 ways to use the Error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Error summary macro.
+There are 2 ways to use the Error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'error-summary', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/file-upload/index.md.njk
+++ b/src/components/file-upload/index.md.njk
@@ -19,7 +19,7 @@ You should only ask users to upload something if it’s critical to the delivery
 
 ## How it works
 
-There are 2 ways to use the File upload component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the File upload macro.
+There are 2 ways to use the File upload component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'file-upload', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -25,7 +25,7 @@ Don’t use the Panel component to highlight important information within body c
 
 ## How it works
 
-There are 2 ways to use the Panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Panel macro.
+There are 2 ways to use the Panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'panel', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -21,7 +21,7 @@ Use an alpha banner when your service is in alpha, and a beta banner if your ser
 ## How it works
 Your banner must be directly under the black GOV.UK header and colour bar.
 
-There are 2 ways to use the Phase banner component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Phase banner macro.
+There are 2 ways to use the Phase banner component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'phase-banner', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -21,7 +21,7 @@ Don’t use the Radios component if users might need to select more than one opt
 
 ## How it works
 
-There are 2 ways to use the Radios component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Radios macro.
+There are 2 ways to use the Radios component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'radios', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/select/index.md.njk
+++ b/src/components/select/index.md.njk
@@ -21,7 +21,7 @@ The Select component allows users to choose an option from a long list. Before u
 
 Asking questions means you’re less likely to need to use the Select component, and can consider using a different solution, such as [Radios](../radios/).
 
-There are 2 ways to use the Select component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com),  you can use the Select macro.
+There are 2 ways to use the Select component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com),  you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'select', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/skip-link/index.md.njk
+++ b/src/components/skip-link/index.md.njk
@@ -25,7 +25,7 @@ Including the Skip link component gives users the option to bypass the top-level
 
 The Skip link component is visually hidden until a keyboard press activates it.
 
-There are 2 ways to use the Skip link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Skip link macro.
+There are 2 ways to use the Skip link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'skip-link', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -31,7 +31,7 @@ Use the `<caption>` element to describe a table in the same way you would use a 
 
 Use table headers to tell users what the rows and columns represent. Use the `scope` attribute to help users of assistive technology distinguish between row and column headers.
 
-There are 2 ways to use the Table component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Table macro.
+There are 2 ways to use the Table component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'table', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -17,7 +17,7 @@ Use the Tag component to indicate the status of something, such as an item on a 
 
 ## How it works
 
-There are 2 ways to use the Tag component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Tag macro.
+There are 2 ways to use the Tag component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'tag', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -21,7 +21,7 @@ Don’t use the Text input component if you need to let users enter longer answe
 
 ## How it works
 
-There are 2 ways to use the Text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Text input macro.
+There are 2 ways to use the Text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'text-input', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'text-input', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: 'components', item: 'text-input', frontendComponentName: 'input', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -23,7 +23,7 @@ Don’t use the Text input component if you need to let users enter longer answe
 
 There are 2 ways to use the Text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'text-input', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'components', item: 'text-input', frontendComponentName: 'input', example: 'default', html: true, nunjucks: true, open: true}) }}
 
 ### Label text inputs
 
@@ -37,7 +37,7 @@ Make text inputs the right size for the content they’re intended for. Postcode
 
 Ensure that users can still easily enter the information they need on smaller screens by snapping text inputs to 100% width at smaller screen sizes.
 
-{{ example({group: 'components', item: 'text-input', example: 'input-width', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'components', item: 'text-input', frontendComponentName: 'input', example: 'input-width', html: true, nunjucks: true, open: true}) }}
 
 ### Don’t disable copy and paste
 

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -21,7 +21,7 @@ Don’t use the Textarea component if you need to let users enter shorter answer
 
 ## How it works
 
-There are 2 ways to use the Textarea component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Textarea macro.
+There are 2 ways to use the Textarea component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'textarea', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/components/warning-text/index.md.njk
+++ b/src/components/warning-text/index.md.njk
@@ -17,7 +17,7 @@ Use the Warning text component when you need to warn users about something impor
 
 ## How it works
 
-There are 2 ways to use the Warning text component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Warning text macro.
+There are 2 ways to use the Warning text component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'warning-text', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -118,6 +118,6 @@
   text-decoration: none;
 
   @include mq($from: 1080px) {
-    bottom: $govuk-spacing-scale-3 + 2; // ont baseline adjustment
+    bottom: $govuk-spacing-scale-3 + 2; // font baseline adjustment
   }
 }

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -98,10 +98,26 @@
   padding-bottom: $govuk-spacing-scale-6;
 }
 
+.app-c-tabs__text {
+  padding: $govuk-spacing-scale-4 $govuk-spacing-scale-4 $govuk-spacing-scale-4 $govuk-spacing-scale-4;
+
+  // magical number 1080px below as the content is inside a narrow panel
+  // and can't rely on predefined media queries
+  // sassmq converts pixels to ems
+
+  @include mq($from: 1080px) {
+    padding-bottom: 0;
+  }
+}
+
 // Close container button
 .app-c-link--close {
   position: absolute;
   right: $govuk-spacing-scale-3;
   bottom: $govuk-spacing-scale-3 / 2;
   text-decoration: none;
+
+  @include mq($from: 1080px) {
+    bottom: $govuk-spacing-scale-3 + 2; // ont baseline adjustment
+  }
 }

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -35,6 +35,9 @@
     ```js
     {{ getNunjucksCode(examplePath) | safe }}
     ```
+  {%- if (params.group == 'components') %}
+    <p class="app-c-tabs__copy">You can configure this component using the <a href="https://github.com/alphagov/govuk-frontend/tree/master/packages/{{params.item}}/README.md#component-arguments" class="govuk-link"  target="_blank" data-track="link to table of arguments in Frontend readme">Nunjucks macro arguments</a>.</p>
+  {% endif %}
   </div>
   {% endif %}
 </div>

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -1,8 +1,9 @@
 {% macro example(params) %}
-
 {% set examplePath = "src/" + params.group + "/" + params.item + "/" + params.example + ".njk" %}
 {% set exampleURL = "/" + params.group + "/" + params.item + "/" + params.example + "/index.html" %}
 {% set exampleId = "example-" + params.example %}
+{% set frontendComponentName = params.frontendComponentName | default(params.item) %}
+
 {% if params.open %}
   {% set exampleId = exampleId + '-open' %}
 {% endif %}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -36,7 +36,7 @@
     {{ getNunjucksCode(examplePath) | safe }}
     ```
   {%- if (params.group == 'components') %}
-    <p class="app-c-tabs__copy">You can configure this component using the <a href="https://github.com/alphagov/govuk-frontend/tree/master/packages/{{params.item}}/README.md#component-arguments" class="govuk-link"  target="_blank" data-track="link to table of arguments in Frontend readme">Nunjucks macro arguments</a>.</p>
+    <p class="app-c-tabs__text">You can configure this component using the <a href="https://github.com/alphagov/govuk-frontend/tree/master/packages/{{frontendComponentName}}/README.md#component-arguments" class="govuk-link"  target="_blank" data-components="github-component-arguments" rel="noopener">Nunjucks macro arguments</a>.</p>
   {% endif %}
   </div>
   {% endif %}


### PR DESCRIPTION
- Adds link with tracking data- attribute to the table inside of each Nunjucks macro tab.
- Updates wording on each component page.

Trello ticket: https://trello.com/c/peF3UoZd/718-add-links-from-the-component-examples-to-the-table-of-arguments-in-the-github-readme