### PR TITLE
Update example forms to remove form class, avoid 404s

### DIFF
--- a/src/patterns/question-pages/default.njk
+++ b/src/patterns/question-pages/default.njk
@@ -15,7 +15,14 @@ layout: layout-example.njk
   <div class="govuk-o-main-wrapper">
     <div class="govuk-o-grid">
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+      <!--
+        This example omits the 'action' and uses the 'get' method so that
+        submitting the form just reloads the example. In most cases, your form tag
+        will probably need to look something like this:
+
         <form action="/url/of/next/page" method="post">
+      -->
+        <form method="get">
 
           {{ govukDateInput({
             fieldset: {

--- a/src/patterns/question-pages/default.njk
+++ b/src/patterns/question-pages/default.njk
@@ -15,8 +15,7 @@ layout: layout-example.njk
   <div class="govuk-o-main-wrapper">
     <div class="govuk-o-grid">
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-
-        <form class="form" action="/url/of/next/page" method="post">
+        <form action="/url/of/next/page" method="post">
 
           {{ govukDateInput({
             fieldset: {

--- a/src/patterns/question-pages/passport.njk
+++ b/src/patterns/question-pages/passport.njk
@@ -17,8 +17,14 @@ layout: layout-example.njk
     <div class="govuk-o-grid">
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
         <h1 class="govuk-heading-xl">Passport details</h1>
+      <!--
+        This example omits the 'action' and uses the 'get' method so that
+        submitting the form just reloads the example. In most cases, your form
+        tag will probably need to look something like this:
 
         <form action="/url/of/next/page" method="post">
+      -->
+        <form method="get">
 
           {{ govukInput({
             label: {

--- a/src/patterns/question-pages/passport.njk
+++ b/src/patterns/question-pages/passport.njk
@@ -18,7 +18,7 @@ layout: layout-example.njk
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
         <h1 class="govuk-heading-xl">Passport details</h1>
 
-        <form class="form" action="/url/of/next/page" method="post">
+        <form action="/url/of/next/page" method="post">
 
           {{ govukInput({
             label: {

--- a/src/patterns/question-pages/postcode.njk
+++ b/src/patterns/question-pages/postcode.njk
@@ -15,8 +15,14 @@ layout: layout-example.njk
   <div class="govuk-o-main-wrapper">
     <div class="govuk-o-grid">
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+      <!--
+        This example omits the 'action' and uses the 'get' method so that
+        submitting the form just reloads the example. In most cases, your form
+        tag will probably need to look something like this:
 
         <form action="/url/of/next/page" method="post">
+      -->
+        <form method="get">
           {{ govukInput({
             "label": {
               "html": '<h1 class="govuk-heading-xl govuk-!-mb-r4">What is your home postcode?</h1>'

--- a/src/patterns/question-pages/postcode.njk
+++ b/src/patterns/question-pages/postcode.njk
@@ -16,7 +16,7 @@ layout: layout-example.njk
     <div class="govuk-o-grid">
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
 
-        <form class="form" action="/url/of/next/page" method="post">
+        <form action="/url/of/next/page" method="post">
           {{ govukInput({
             "label": {
               "html": '<h1 class="govuk-heading-xl govuk-!-mb-r4">What is your home postcode?</h1>'


### PR DESCRIPTION
Remove non-existent form class from forms.

Update form tags to GET the same example – the forms currently POST to a non-existent URL which results in the example iframe 404’ing:

<img width="1392" alt="screen shot 2018-03-01 at 11 27 17gmt" src="https://user-images.githubusercontent.com/121939/36842446-9d8769fe-1d43-11e8-9e92-b0f96f4deed8.png">