### PR TITLE
Update to frontend 0.0.24 alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,225 +4,225 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@govuk-frontend/all": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.23-alpha.tgz",
-      "integrity": "sha512-obc/wmk0TKj4rsxkVQUtNGvhgunebR/+XCpoFq4bqbMLp/xA8q9HovT6fZFHERH4AvrJk3uXJ/P4gxVJw56yug==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.24-alpha.tgz",
+      "integrity": "sha512-aP9CJ8abGw2nBrndq3jpSoBNFuU51p/Cuhsmwrp1r11sfcO3i9OLpl4L+lVHQ7+HPAnOEL8rnW5jmhnOAtkWtg==",
       "requires": {
-        "@govuk-frontend/back-link": "0.0.23-alpha",
-        "@govuk-frontend/breadcrumbs": "0.0.23-alpha",
-        "@govuk-frontend/button": "0.0.23-alpha",
-        "@govuk-frontend/checkboxes": "0.0.23-alpha",
-        "@govuk-frontend/date-input": "0.0.23-alpha",
-        "@govuk-frontend/details": "0.0.23-alpha",
-        "@govuk-frontend/error-message": "0.0.23-alpha",
-        "@govuk-frontend/error-summary": "0.0.23-alpha",
-        "@govuk-frontend/fieldset": "0.0.23-alpha",
-        "@govuk-frontend/file-upload": "0.0.23-alpha",
-        "@govuk-frontend/icons": "0.0.23-alpha",
-        "@govuk-frontend/input": "0.0.23-alpha",
-        "@govuk-frontend/label": "0.0.23-alpha",
-        "@govuk-frontend/panel": "0.0.23-alpha",
-        "@govuk-frontend/phase-banner": "0.0.23-alpha",
-        "@govuk-frontend/radios": "0.0.23-alpha",
-        "@govuk-frontend/select": "0.0.23-alpha",
-        "@govuk-frontend/skip-link": "0.0.23-alpha",
-        "@govuk-frontend/table": "0.0.23-alpha",
-        "@govuk-frontend/tag": "0.0.23-alpha",
-        "@govuk-frontend/textarea": "0.0.23-alpha",
-        "@govuk-frontend/warning-text": "0.0.23-alpha"
+        "@govuk-frontend/back-link": "0.0.24-alpha",
+        "@govuk-frontend/breadcrumbs": "0.0.24-alpha",
+        "@govuk-frontend/button": "0.0.24-alpha",
+        "@govuk-frontend/checkboxes": "0.0.24-alpha",
+        "@govuk-frontend/date-input": "0.0.24-alpha",
+        "@govuk-frontend/details": "0.0.24-alpha",
+        "@govuk-frontend/error-message": "0.0.24-alpha",
+        "@govuk-frontend/error-summary": "0.0.24-alpha",
+        "@govuk-frontend/fieldset": "0.0.24-alpha",
+        "@govuk-frontend/file-upload": "0.0.24-alpha",
+        "@govuk-frontend/icons": "0.0.24-alpha",
+        "@govuk-frontend/input": "0.0.24-alpha",
+        "@govuk-frontend/label": "0.0.24-alpha",
+        "@govuk-frontend/panel": "0.0.24-alpha",
+        "@govuk-frontend/phase-banner": "0.0.24-alpha",
+        "@govuk-frontend/radios": "0.0.24-alpha",
+        "@govuk-frontend/select": "0.0.24-alpha",
+        "@govuk-frontend/skip-link": "0.0.24-alpha",
+        "@govuk-frontend/table": "0.0.24-alpha",
+        "@govuk-frontend/tag": "0.0.24-alpha",
+        "@govuk-frontend/textarea": "0.0.24-alpha",
+        "@govuk-frontend/warning-text": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/back-link": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.23-alpha.tgz",
-      "integrity": "sha512-uaZXlQgf2p5LCBVi/9W8eyAbxylgZSWhcNNKmMY7yhJMoDpD7oBHJQuu5SeG4SoPJpZGICvNknf79fI/6O1Chw==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.24-alpha.tgz",
+      "integrity": "sha512-rDOJgqfABOxfuZkQrcVcqS7vvm8d8zd/cfGRFdw2y4B/+Pchk3OeCV4++ampnREaEkLsVNAMysEBcbkn3ixCYQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/breadcrumbs": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.23-alpha.tgz",
-      "integrity": "sha512-EuAknpqKL4mophrhBqG4/h4W3FaCq4SnYvDWAbsBW1LuTzLyQcEZ2LchAeSkp8QMsJcwarkBYjF9tnZ8PQ09CA==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.24-alpha.tgz",
+      "integrity": "sha512-9gRaQEf69uHMxfyLo3RReAfwlovjLw9Q1ZflEdEQWPkiPZhMZt0IAkps+ryU8up4bY/c1GIS0qPmzpubAFPsng==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha",
-        "@govuk-frontend/icons": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha",
+        "@govuk-frontend/icons": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/button": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.23-alpha.tgz",
-      "integrity": "sha512-H3ECeVR3J+RhEitbhpm4gk0YBmZjRzeOmKJH78+io2OvmUTz9ZYDINmgkHq6YdG520Fi2xaIJayHj9mMlmma0Q==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.24-alpha.tgz",
+      "integrity": "sha512-9w2vDlLoz6FubEw6RqDL2eDLlTGVqWikW7u/DQa47g21vjVoBBRgOSsKxHdZsVyqFvRnz3yyO1wY3J+wMuQj7Q==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha",
-        "@govuk-frontend/icons": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha",
+        "@govuk-frontend/icons": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/checkboxes": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.23-alpha.tgz",
-      "integrity": "sha512-Hyd7cBzFEiE/qJca9+YnpWCiMK+78wfPK5HZaVB0YO/41FPmUy/t8Ee6suYfF4307sRf3ZDaOYsM64D2qA3wfg==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.24-alpha.tgz",
+      "integrity": "sha512-54v2Uo5bsaJe2ZhpalKppjY1hcGLPd8557DVlt+loeZk6sI0lu9PkrKzBInfnKhat9/evS5ARCAslAYV9L5MRw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha",
-        "@govuk-frontend/label": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha",
+        "@govuk-frontend/label": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/date-input": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.23-alpha.tgz",
-      "integrity": "sha512-HhsCPx4kUAEJCBplLLAjKykzXy/NMU2BqwBxOZ0rsXeIJq1gi9GK5EaSY/A2dRRcSEnUfFrQhzFP0GwoXkNL4A==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.24-alpha.tgz",
+      "integrity": "sha512-Amkx9Uyf2yB73BjfeAgUXT/isihefOLT0Om59SPJ0Xk+gFg7dkBNGE8rWCZud2ns9XUagB6tJBUc3axviV5Snw==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.23-alpha",
-        "@govuk-frontend/globals": "0.0.23-alpha",
-        "@govuk-frontend/label": "0.0.23-alpha"
+        "@govuk-frontend/error-message": "0.0.24-alpha",
+        "@govuk-frontend/globals": "0.0.24-alpha",
+        "@govuk-frontend/label": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/details": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.23-alpha.tgz",
-      "integrity": "sha512-6y2ZxxmcqFIXuZXuV06kHnXOvYuvTY1KflUGjSnnx6JNJPKaOFyAxsPLwCJRac8rc/85BVKy24BrJkY+4J+HrQ==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.24-alpha.tgz",
+      "integrity": "sha512-BtsIu/YlmVsavWsZdtnjNIjUjkvjPUf3gBVbEqPhx9muPRN2Y3TYf0OSQ+jkWckIGARWZ5kAalZTWEk2x3ZcKA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/error-message": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.23-alpha.tgz",
-      "integrity": "sha512-cMbEkGut5aGhAiCCLkSOIIqeVhLqgRK9qJmWyfxmZKRCnz1H3oXDivJbpnzYkkXgNAPGovSQyjPxNA6iILOJ3w==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.24-alpha.tgz",
+      "integrity": "sha512-zjzcHXVzthvHHviT7Uak16UIuWVkeBA16J5JVt5OWt48qb5weQ/0wFvlcLN4p7OcdRL7tB1i2XTibRZMWYz5Ag==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/error-summary": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.23-alpha.tgz",
-      "integrity": "sha512-yAH/zbdheAf9A2oMgvSQAwx3o1G17G70RxSk4ZSBNLUCuZfntIdTZnCKgUZnEsb0u46XjIAdV4pS0wC4B7D1dA==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.24-alpha.tgz",
+      "integrity": "sha512-SP3mV4Esa5PrC3+LVU8pMWntl/nJASr3LAJ+ekyPlmP2AUbn7rJwZAl4K6JdNj6Ltct0sifqYKmmJgoq/NzQ6w==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/fieldset": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.23-alpha.tgz",
-      "integrity": "sha512-1koVrdAutMvDS2dUs6W6+xaDCNODnVVIPqo4TbkvSNLIqLOmWlF5b7JbrbkiOh+nynDcNJJ5RFDmh+/sZo2upQ==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.24-alpha.tgz",
+      "integrity": "sha512-7qAJQPK93PAqBSf0oZ2G+Yhw2AsUfuIZFMBh/nKeScYCrq0h8lmEOmQz34lPXLm1ItvOZ/jMbanVt29xk1n9Eg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/file-upload": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.23-alpha.tgz",
-      "integrity": "sha512-7Syv0JEximHi9LHRlxY8xNVNUthWlF38NI+2Np3fcpbrCoAGmX4+Al1WObfRzCcWU/rZrkMbADDdik/lzstCkA==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.24-alpha.tgz",
+      "integrity": "sha512-bpcWONtV5lB4jsZLthPfpUvnX/XJ0PuzQc2jMP6pRBXpKlTIfT5gDOFlwTfyvkgx5gsDFGxCXmgwb6uUspYsBg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/globals": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.23-alpha.tgz",
-      "integrity": "sha512-hMh+c5KKVsSppKduZH2BaB/x2n5W0fM+vpjYm3MlaE6o8reKRGsK8Lway06n5MQxBDyQIg4/Uk99rD+IaWC7pg==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.24-alpha.tgz",
+      "integrity": "sha512-wal3cUGYVBLteQ47DqlYIVAbcvaWyjd/v3aFjpnTvi21PkWZKAEL0Ak42Odf/Kz0inKrfL/r5EEzR2qdLPFwrg==",
       "requires": {
         "sass-mq": "3.3.2"
       }
     },
     "@govuk-frontend/icons": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.23-alpha.tgz",
-      "integrity": "sha512-kNqe1Efjdycq8Hlx0QQ8ZJszKyrStAUUY5Ke4TTVTVww1QPCHnH1fEUxR966C2sHvvHhLlyXhy03BXyqb1iF/Q=="
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.24-alpha.tgz",
+      "integrity": "sha512-5ZJAe8DETS1XPbTW3WqXAabkteMm4n5v16SzyIa8d7V/TIsoY3JFojRFPjvFx9pEXo4sm0sLM+kohPhrUS/LoA=="
     },
     "@govuk-frontend/input": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.23-alpha.tgz",
-      "integrity": "sha512-ghtJ0TvLSh9Wp4Za+5Az5HnKcOHxbQnP5zc82X8ZzgO9z30Jo3hdlibITPTPCOp5UWxFfl1sB4Rxi2PaxAzenw==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.24-alpha.tgz",
+      "integrity": "sha512-uc6xlRur4lg2sqje4vfWzMSg294/402xrVSxIomfCddTYOoIlTvuKA6JzNESeBkVoXltTRtjh/jFKp0bTjZvKA==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.23-alpha",
-        "@govuk-frontend/globals": "0.0.23-alpha",
-        "@govuk-frontend/label": "0.0.23-alpha"
+        "@govuk-frontend/error-message": "0.0.24-alpha",
+        "@govuk-frontend/globals": "0.0.24-alpha",
+        "@govuk-frontend/label": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/label": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.23-alpha.tgz",
-      "integrity": "sha512-HRhXJpx/i3MG/PEX1XsmmWOOAvRoSI8wgnm+VgMnAXy0GqoQ706WBZgnZki7pRTizWKlSGVAvN30a/VBxOCbgg==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.24-alpha.tgz",
+      "integrity": "sha512-2yzdpgMJuaD9WHBcoteMc2j5X+qtg0cQNHyOOe9KphOMtRCw8SMonv6lNpb9UtG7/g1G3HEbjOuXmSirEaUpow==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/panel": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.23-alpha.tgz",
-      "integrity": "sha512-zGMJKnG6ddJLgpNNlgsjCWImsw2UJjaJ8JDkbNMKAwFb/ls1Rs989LbUXhpTDjY0Rcg6lTFF52IjGGWt5l/OyQ==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.24-alpha.tgz",
+      "integrity": "sha512-dtkoQKxR0uNiVRt0m1qXqoLSLgt+sIZG/HF7BI8T7TTCfFCUwuXNwqY/y8sC2Xe8pQY/FtRPJ+Wqx6j7LlD6rw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/phase-banner": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.23-alpha.tgz",
-      "integrity": "sha512-4lMvVAEf/RSV+LDBZmiEn3YCFXZ81GXUWdf+Hbx6lC6MM0JZjhQR0oinU9seGI3PkpeGmpDxVfd3KbL1HGQSPg==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.24-alpha.tgz",
+      "integrity": "sha512-KU6v08fdBxzIM7TcJXhUrEgQpn3375F+Favqo+Wr7OoSt2Qlew1V3BKFRM8xRMtcnqqhjRyYJwPNMTA7JP08qA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha",
-        "@govuk-frontend/tag": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha",
+        "@govuk-frontend/tag": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/radios": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.23-alpha.tgz",
-      "integrity": "sha512-PePAy7+7eEnp6JYQDZSZbf4NnI7AZPy5ols6JR5jpgiWjPdc36hoFIVkfW+Odw3dGdaZ+BKiJTSnYEFe4yCrsA==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.24-alpha.tgz",
+      "integrity": "sha512-lfdhn+ZwsALbM2FxSJ2qomcnP5UJpalO3iTo15IEzvRqkWmvtGaoAe2Z1hHt3IoURAPB6Rk0lPMWNDOwXdRxRA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha",
-        "@govuk-frontend/label": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha",
+        "@govuk-frontend/label": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/select": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.23-alpha.tgz",
-      "integrity": "sha512-X5guj7a9tKEVXw0qpK5Nz+W8YujyZXFDxs4QRqVCDpNiLQ3T/XJVHuWUpVPPXdGmIyfL0Q103WbgJ1OLI/qsVQ==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.24-alpha.tgz",
+      "integrity": "sha512-S5AcA1psNnk4lM3+bKYi48NMSiWmCcCaTcmoTj5apNzcwHdkFyzZjBGyhWbHDhBU/zY3e8YTSoEcxcvbQvemLg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha",
-        "@govuk-frontend/label": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha",
+        "@govuk-frontend/label": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/skip-link": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.23-alpha.tgz",
-      "integrity": "sha512-Q7Wn/foLfyUmWcKUdxumrBVe6pX3DQz7UqFd2huO2SmfjXv3/MA+myOeym8+DOyT55fRSirdqVYZ2WBW7LjN0w==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.24-alpha.tgz",
+      "integrity": "sha512-St1pjVJ0HPFbgJJmTyl0b3ncQzzYnA7MabmoGW/qNE1o1OQY0WwOICse/q7TbsREIEc1MxFGHd7p4vAWrOoNHA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/table": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.23-alpha.tgz",
-      "integrity": "sha512-JFNBMmjZNzSZQaDcRyFJu3YWJN5QHynmVN7F79+gseA4dmxxRCnCNps4fBmht4H5M5x1pc90Yv4EAu/ipGxHfQ==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.24-alpha.tgz",
+      "integrity": "sha512-Fr6ZXUoWJWKS6nC+FPrxn2SrhiPYrTprbSeVIIvA351O6404a5NvGU+ugJ2E6OA+ygZm+iDh2casf1Cw3+LrfQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/tag": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.23-alpha.tgz",
-      "integrity": "sha512-LWPM6uzMBIzgz/MzEKaar5mOBBJwSKOQHcMMvhyhkEy/7IIQDTUSr6Tme/IeeiwNNEvEg1X9n1BA4E4H6ufgEA==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.24-alpha.tgz",
+      "integrity": "sha512-rsNeaByIEd0ph2JVybRzaSu8qvbf4mxAgPLZ979LaRTp/eze7gJ9dcQnWgXe74aY4V5WIRCn5xpbWZ6wUh6bWA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/textarea": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.23-alpha.tgz",
-      "integrity": "sha512-ZZwWCnjXT2nv+WSlouvb15VDxl22AKTV0lR06jQ2nTdvBb9MUFnhAgpcjkBwOlbsFD0zDzKhso49JrWLSPxDVw==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.24-alpha.tgz",
+      "integrity": "sha512-yjlNHnNU9iPwyKZb+RLrpBqXjQiX7Ui+pMLw4Ky/1MjOcA5Zszg9G0rUkw8F7OL8+IthtB7e+rUX6Dl5gDOmcg==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.23-alpha",
-        "@govuk-frontend/globals": "0.0.23-alpha",
-        "@govuk-frontend/label": "0.0.23-alpha"
+        "@govuk-frontend/error-message": "0.0.24-alpha",
+        "@govuk-frontend/globals": "0.0.24-alpha",
+        "@govuk-frontend/label": "0.0.24-alpha"
       }
     },
     "@govuk-frontend/warning-text": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/warning-text/-/warning-text-0.0.23-alpha.tgz",
-      "integrity": "sha512-miHiVDnqzvm/NlNIcxt3NECHUtw+EzyqxmC6yCC8WVNI6kWiib5r+MHVOfSltVV83gHyrKh2s81MeAyX5qjAIw==",
+      "version": "0.0.24-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/warning-text/-/warning-text-0.0.24-alpha.tgz",
+      "integrity": "sha512-zfLRZFb+F0tK8wookRhzZpppnWnkGklo99q4/vfuptoOZSsJRRnQ4W3dUXCDVBiGWrrUOsJDyzj/QUCmDC5iSA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.23-alpha"
+        "@govuk-frontend/globals": "0.0.24-alpha"
       }
     },
     "a-sync-waterfall": {
@@ -7909,7 +7909,7 @@
     },
     "substitute": {
       "version": "https://github.com/segmentio/substitute/archive/0.0.1.tar.gz",
-      "integrity": "sha1-QyhmmFsDw7DT9xrGPRrhoY369H0=",
+      "integrity": "sha512-EnlQz7Yu+hwB9lqjP4MfEJaDDARyba6zXvFPYhDHj93LR8jtivHJEouukvaMm9ykXAxVf5TSGrkfMlutax+pGA==",
       "dev": true
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-frontend/all": "0.0.23-alpha",
+    "@govuk-frontend/all": "0.0.24-alpha",
     "clipboard": "^1.7.1",
     "html5shiv": "^3.7.3",
     "jquery": "^1.12.4",

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -3,7 +3,7 @@
 //
 // Based on the existing GOV.UK footer in GOV.UK Template
 
-@include exports("footer") {
+@include govuk-exports("footer") {
   $app-footer-background: $govuk-grey-3;
   $app-footer-border-top: #a1acb2;
   $app-footer-link: #454a4c;

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -8,7 +8,7 @@
 // removing this affects the positioning of the underline and causes other
 // issues with the display of the focus style in IE8-11.
 
-@include exports("header") {
+@include govuk-exports("header") {
 
   .app-c-header {
     padding: $govuk-spacing-scale-2 $govuk-spacing-scale-3;

--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -1,4 +1,4 @@
-@include exports("pane") {
+@include govuk-exports("pane") {
   $toc-width: 300px;
 
   .app-o-pane {

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -1,4 +1,4 @@
-@include exports("subnav") {
+@include govuk-exports("subnav") {
 
   .app-c-subnav {
     padding: $govuk-spacing-scale-3;


### PR DESCRIPTION
- Update package.json to install latest GOV.UK Frontend
- Rename `exports` mixin to match naming in GOV.UK Frontend