### PR TITLE
Remove non-existent form class from forms

### DIFF
--- a/src/patterns/question-pages/default.njk
+++ b/src/patterns/question-pages/default.njk
@@ -15,8 +15,7 @@ layout: layout-example.njk
   <div class="govuk-o-main-wrapper">
     <div class="govuk-o-grid">
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-
-        <form class="form" action="/url/of/next/page" method="post">
+        <form action="/url/of/next/page" method="post">
 
           {{ govukDateInput({
             fieldset: {

--- a/src/patterns/question-pages/passport.njk
+++ b/src/patterns/question-pages/passport.njk
@@ -18,7 +18,7 @@ layout: layout-example.njk
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
         <h1 class="govuk-heading-xl">Passport details</h1>
 
-        <form class="form" action="/url/of/next/page" method="post">
+        <form action="/url/of/next/page" method="post">
 
           {{ govukInput({
             label: {

--- a/src/patterns/question-pages/postcode.njk
+++ b/src/patterns/question-pages/postcode.njk
@@ -16,7 +16,7 @@ layout: layout-example.njk
     <div class="govuk-o-grid">
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
 
-        <form class="form" action="/url/of/next/page" method="post">
+        <form action="/url/of/next/page" method="post">
           {{ govukInput({
             "label": {
               "html": '<h1 class="govuk-heading-xl govuk-!-mb-r4">What is your home postcode?</h1>'


### PR DESCRIPTION
This is the non-contentious (I hope!) change from #199 – removing the `form` classes from the forms in the examples.

https://trello.com/c/BVm3eKnt/805-remove-non-existent-form-classes-from-forms-in-question-page-examples