### PR TITLE
Only include GTM if GTM_TAG is set

### DIFF
--- a/views/partials/_tracking-body.njk
+++ b/views/partials/_tracking-body.njk
@@ -1,5 +1,6 @@
-
+{% if GTM_TAG %}
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ GTM_TAG }}"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
+{% endif %}

--- a/views/partials/_tracking-head.njk
+++ b/views/partials/_tracking-head.njk
@@ -1,3 +1,4 @@
+{% if GTM_TAG %}
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -5,3 +6,4 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer', '{{ GTM_TAG }}');</script>
 <!-- End Google Tag Manager -->
+{% endif %}


### PR DESCRIPTION
This prevents making invalid requests to GTM when running the Design System locally.

This has been tested locally by running `GTM_ID="GTM-WVLM6KW" npm start` and verifying that both tracking scripts are present.