### PR TITLE
Update with frontend 0.0.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,225 +4,235 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@govuk-frontend/all": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.25-alpha.tgz",
-      "integrity": "sha512-sGyZ5hAG/EG5irN82hZvH0Emx0X7ETNEGT4SuQSQ9RGiEzvLBzEqYeNxfPT1NZ27+fao1uts2Nlv4+rohP8yAg==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.26-alpha.tgz",
+      "integrity": "sha512-UMwm2D40xf9NDao0mU8wu3JEXhGEFMMEfwKrd6NflRuJE5VvYQZtq9I1Gz5ZCgM2VE/RRPImCLWJtMYH0csr0w==",
       "requires": {
-        "@govuk-frontend/back-link": "0.0.25-alpha",
-        "@govuk-frontend/breadcrumbs": "0.0.25-alpha",
-        "@govuk-frontend/button": "0.0.25-alpha",
-        "@govuk-frontend/checkboxes": "0.0.25-alpha",
-        "@govuk-frontend/date-input": "0.0.25-alpha",
-        "@govuk-frontend/details": "0.0.25-alpha",
-        "@govuk-frontend/error-message": "0.0.25-alpha",
-        "@govuk-frontend/error-summary": "0.0.25-alpha",
-        "@govuk-frontend/fieldset": "0.0.25-alpha",
-        "@govuk-frontend/file-upload": "0.0.25-alpha",
-        "@govuk-frontend/icons": "0.0.25-alpha",
-        "@govuk-frontend/input": "0.0.25-alpha",
-        "@govuk-frontend/label": "0.0.25-alpha",
-        "@govuk-frontend/panel": "0.0.25-alpha",
-        "@govuk-frontend/phase-banner": "0.0.25-alpha",
-        "@govuk-frontend/radios": "0.0.25-alpha",
-        "@govuk-frontend/select": "0.0.25-alpha",
-        "@govuk-frontend/skip-link": "0.0.25-alpha",
-        "@govuk-frontend/table": "0.0.25-alpha",
-        "@govuk-frontend/tag": "0.0.25-alpha",
-        "@govuk-frontend/textarea": "0.0.25-alpha",
-        "@govuk-frontend/warning-text": "0.0.25-alpha"
+        "@govuk-frontend/back-link": "0.0.26-alpha",
+        "@govuk-frontend/breadcrumbs": "0.0.26-alpha",
+        "@govuk-frontend/button": "0.0.26-alpha",
+        "@govuk-frontend/checkboxes": "0.0.26-alpha",
+        "@govuk-frontend/date-input": "0.0.26-alpha",
+        "@govuk-frontend/details": "0.0.26-alpha",
+        "@govuk-frontend/error-message": "0.0.26-alpha",
+        "@govuk-frontend/error-summary": "0.0.26-alpha",
+        "@govuk-frontend/fieldset": "0.0.26-alpha",
+        "@govuk-frontend/file-upload": "0.0.26-alpha",
+        "@govuk-frontend/footer": "0.0.26-alpha",
+        "@govuk-frontend/icons": "0.0.26-alpha",
+        "@govuk-frontend/input": "0.0.26-alpha",
+        "@govuk-frontend/label": "0.0.26-alpha",
+        "@govuk-frontend/panel": "0.0.26-alpha",
+        "@govuk-frontend/phase-banner": "0.0.26-alpha",
+        "@govuk-frontend/radios": "0.0.26-alpha",
+        "@govuk-frontend/select": "0.0.26-alpha",
+        "@govuk-frontend/skip-link": "0.0.26-alpha",
+        "@govuk-frontend/table": "0.0.26-alpha",
+        "@govuk-frontend/tag": "0.0.26-alpha",
+        "@govuk-frontend/textarea": "0.0.26-alpha",
+        "@govuk-frontend/warning-text": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/back-link": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.25-alpha.tgz",
-      "integrity": "sha512-YhKUqzAQacqCXtLed1rz/A3r68JkMWMv8Pj9IBHDgVlt8TSH970MKMEEXB8+Cbvp8FsfvH2qCNcAk7DI+45lqg==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.26-alpha.tgz",
+      "integrity": "sha512-eDop5ju0520ThWbzZN661JcPSXl+J7I70/tOoR7gHgeYIz8uFTAGsJ+OvQOAOeZndPQ3TtGKT7Fy0B51wSlUxA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/breadcrumbs": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.25-alpha.tgz",
-      "integrity": "sha512-qM1zoBZuP9uRRSUG8ID3Sv21QKAdDS6xiephxKTdiKs86VyTrW4ob7wEgH3i1itmubqh4pA2NvhcKnbRNET/DQ==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.26-alpha.tgz",
+      "integrity": "sha512-o/zvPr6d/7MwuXfneLieYZLm5/wuGZzHZstjsxNdH/HCWeQs/CEaf78JUt9TH0+t/YNKia86WLzzuNOGAxxh/g==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha",
-        "@govuk-frontend/icons": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha",
+        "@govuk-frontend/icons": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/button": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.25-alpha.tgz",
-      "integrity": "sha512-Nc9q5iHQySUtl+YbByk9n/EnAPQRc6KxFjebCzwY90k99dMgJpm3TGyclzo1sBJvkI7FNelqtoV4QQ6qrlA1Bg==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.26-alpha.tgz",
+      "integrity": "sha512-MQ1EcrcXea7NkUiLS+uroX5XwvyeyiWdGYTuANcqEAm0Zx8hCCJhiK9Hi2Uj2Yu/wPilQ/JcRxDlsoxdX4+UVg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha",
-        "@govuk-frontend/icons": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha",
+        "@govuk-frontend/icons": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/checkboxes": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.25-alpha.tgz",
-      "integrity": "sha512-CdEfLhADIepleL4qRoGjiR/xJFvlJzsRUq/I3hNiIdEaPFNh6lYnIkzxmt1GbMXsFjsGV0NUQY6psxk2ib9JUA==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.26-alpha.tgz",
+      "integrity": "sha512-aeLN5rgL+OGUZP4ZSqpCqhg4DojBHj1TOItAR+Nznwxk4Ees9kn9LuWQSt7s+19mvTx34SdmsEmvAS/OG/mcPA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha",
-        "@govuk-frontend/label": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha",
+        "@govuk-frontend/label": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/date-input": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.25-alpha.tgz",
-      "integrity": "sha512-BZDXv7LuYhMMi3t30nStMNRFrQdpXaO7Q0GCbsTrEJUNFZh2r2jMTFFc8UYeC8VccG4ceeSDRenUXdm/jOTk0w==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.26-alpha.tgz",
+      "integrity": "sha512-OTTFqd7EdyZeQmztDd297MQHfTh0Q9za2tvnEtKfqKbtyvteDITLUXrmu4cUVrQeppftfhfLBspVnZq08V5tHw==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.25-alpha",
-        "@govuk-frontend/globals": "0.0.25-alpha",
-        "@govuk-frontend/label": "0.0.25-alpha"
+        "@govuk-frontend/error-message": "0.0.26-alpha",
+        "@govuk-frontend/globals": "0.0.26-alpha",
+        "@govuk-frontend/label": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/details": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.25-alpha.tgz",
-      "integrity": "sha512-ZdBVBa2QWUczPh4R2I9NO1YDTmGyDf3zBvCFEc1AUsE4mqMCYejtTljCK2YHlIvM8BgcNc/vfBDVHu0oTHMYjg==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.26-alpha.tgz",
+      "integrity": "sha512-4x5+SOE4NGsuY0spOiAAjxWCIVIU6bW5+im1TWQEFghkrj1gYWOj8ubf4CzaaO64SRdz7RJg7nCHh765Ye07Ag==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/error-message": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.25-alpha.tgz",
-      "integrity": "sha512-Q6wzOuynww3yLQR15DBacQ/V/OMPcgkjrCjtcHvpR6vt7C6vfipCSKV6uxf8SxhW7SoX8PJWNDXtRMczpm56zw==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.26-alpha.tgz",
+      "integrity": "sha512-4fm9y4SXSSqgNAElb/mG3u41rN2N8Fc5JKYH+XCPCl+T0Ez57/LeHvDopImEZ00rsZCGzuW45hEDhi4tozICoQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/error-summary": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.25-alpha.tgz",
-      "integrity": "sha512-ffRmED5rN2KiCJsKn6u7Yj3uqthR5YUFtH8KQR++uALyBbYrkqTq0EL9aRx7iozhg/683WlY1XCWSNg2XYXyoA==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.26-alpha.tgz",
+      "integrity": "sha512-r+hkrRYsIOYUpcgcbOUV1R3DTO3FYOpWtnsLS4eWHR8MlmHAAZZKIxD6CbTP+biVfQ69dPoq7uBdUYy/XL7M4Q==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/fieldset": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.25-alpha.tgz",
-      "integrity": "sha512-ptmqJvstRSkswhf9j0kRxXwjO20VTpioED8rexuega3nT0Izx1RACIxDicF7KROJKfLJy4ySA8pDGPTwsiMkQA==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.26-alpha.tgz",
+      "integrity": "sha512-J7b11PxpDiZdyy0pn0Cf/k96raj8YNMGWFmKVedoPBZSiTZgudNrg3INzDQLwsNkQN+uOWjwMurltDdfJpuE9Q==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/file-upload": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.25-alpha.tgz",
-      "integrity": "sha512-dMqU1er1LVPwdenKqTJEY1a/7eZs4nFTb6iOuwi9PsXbsSgfoyHcqJglLTvXFVJPZABnTV55Td5ur/6eVQ+n5A==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.26-alpha.tgz",
+      "integrity": "sha512-8ZJs/cdYpLSk0+QbPxGrZ/VtuflU22Kbk1kNROy3sf6knMkajp4pMMFeyZ/dpKx6TPkHFl3SDhdOddezAfYHRQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha"
+      }
+    },
+    "@govuk-frontend/footer": {
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/footer/-/footer-0.0.26-alpha.tgz",
+      "integrity": "sha512-cO5K8DZ9ewrcN/htThnWeEKt5M3uXJ3LBcaOoCTFWvXsbIf9kIU0+JVrjphS8tN245ajW7AREgkm4VzOvYp6/Q==",
+      "requires": {
+        "@govuk-frontend/globals": "0.0.26-alpha",
+        "@govuk-frontend/icons": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/globals": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.25-alpha.tgz",
-      "integrity": "sha512-NY//ZF4Y1/QDTCGPESnrwjZpxLDTizRuENdzdlaTksrWwFKZp0RVdbqB0H+85PAkbMiMkmWzkWdW3GDiAmOmsQ==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.26-alpha.tgz",
+      "integrity": "sha512-ZqocVmgs/ubl0EeyQv1/n0nUJv9rCWWLWVpIPyPqriBtQAYWzlpg+mEwZ27+K0xl+E5PEWxZW/vKyErMMfrpsA==",
       "requires": {
         "sass-mq": "3.3.2"
       }
     },
     "@govuk-frontend/icons": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.25-alpha.tgz",
-      "integrity": "sha512-JsnEX4s7iB1Cl5ecs06pgErMILNLduPvSJACxn6wnc19/HqipshJ/UFoyJ7STDJ1K1mgBaTmbxzCHzo1tnFoHg=="
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.26-alpha.tgz",
+      "integrity": "sha512-XtFR4J4w5VeWRQjzbUKC7b3wMC7vwI7mSQKbMo+5Ey0v98Gq9RdRPdVbfAlEnZyFaHTi8OTmt+qWcHjiKwMY2w=="
     },
     "@govuk-frontend/input": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.25-alpha.tgz",
-      "integrity": "sha512-jVxQ2XRIgn4kvGiiW7Zi5WIRCgpA/bbZYh1XF1ClxBmx0fNalc69fpFOMqOAuhindyPS4ugFZzQMniWDSKrvQg==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.26-alpha.tgz",
+      "integrity": "sha512-3tK3UTmS8YDNAG9u9bWUDoDeoLTHjdoKdlABV730srnnm0xREoUWLkR23TE9W4DtQsl4qHWrwYg+taydhCUy4Q==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.25-alpha",
-        "@govuk-frontend/globals": "0.0.25-alpha",
-        "@govuk-frontend/label": "0.0.25-alpha"
+        "@govuk-frontend/error-message": "0.0.26-alpha",
+        "@govuk-frontend/globals": "0.0.26-alpha",
+        "@govuk-frontend/label": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/label": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.25-alpha.tgz",
-      "integrity": "sha512-Q0NVLwQx/kve3X6yDTjA2vVXKUrgbQsQPdjgPCPh9hy26B+WxTJj0RaAbPiAIaNoZnACgvWyvoqjlQI0RZrPGg==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.26-alpha.tgz",
+      "integrity": "sha512-DV4fYIzub6Zxh3j6myB6wBbR6I4T4i+fa2O5EM2c3d6h/VwZgDWYUXe2VhAc+0Pyqd3MevS2dAFc5NEJ4uycUQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/panel": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.25-alpha.tgz",
-      "integrity": "sha512-Oo6OsRQ71UfKh8UrUSPXu3neHmWMID+KRDPYRP/M8qEfPOVBW1xjY3oJk2EAT/XTIfL95pSsEP75OB3mhRzdLw==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.26-alpha.tgz",
+      "integrity": "sha512-slYnmUNzkYt6dCjE+ENkrieNHGnfIA0pWGRVJNy8sjXzsderoyWTxZTv64sq2XUyJHkjSTgpekTdsVodIFMtIg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/phase-banner": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.25-alpha.tgz",
-      "integrity": "sha512-+4WmGK4h2wMYmOgUiHSTMfVn9kYG17jUKNGhj/VtYI4mp6E1hI0/Q0EKscj3lh1Vo3Zaiy/InQSAgF0dlTq7xw==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.26-alpha.tgz",
+      "integrity": "sha512-4OM4lrR/Cr39Fb/i4zutG22xVr6L3FIWaPh4ePvo0x2LsuW45aPajOWooHZtzeWdrDW40ABl/ILzro8S6qZGJw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha",
-        "@govuk-frontend/tag": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha",
+        "@govuk-frontend/tag": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/radios": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.25-alpha.tgz",
-      "integrity": "sha512-mERKJZJ7oA/Jfp/3r2YJF9ZGzjcQO17oX3uih4N9rpCUvlCOHP5YcskxHIAmXjvFqPDx8LgR1zgTfVBP0brvyg==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.26-alpha.tgz",
+      "integrity": "sha512-uC/oM4G6Vw1CL88OO4XxHzx7lRKxp8YChe5iILaF+z4utJMFzQsrIeYxNdMEsTyxfIXZdbaTA6nGtD9qkxjlSw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha",
-        "@govuk-frontend/label": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha",
+        "@govuk-frontend/label": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/select": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.25-alpha.tgz",
-      "integrity": "sha512-XMgZVX7R99XpQhiCiC3+/kJaDL3/9n8fyTfGT1OKlaGdVPmnzWPsPdGdzB0roOti1hngpHnFLzvBKOU92qauJQ==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.26-alpha.tgz",
+      "integrity": "sha512-TA7/0RordPcAKH/C5GtmJCO4pcqvDYBh+elFNTUeTIObCrfeKd70C/Tv4uvJbzW+NtWJOvf8zocg/xsvDSDMgQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha",
-        "@govuk-frontend/label": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha",
+        "@govuk-frontend/label": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/skip-link": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.25-alpha.tgz",
-      "integrity": "sha512-78Zzg60XYK0ZlS5QoxWWckVCE2T06OAxNFUufr6VTxSiz9TCoR1hfFtwB/uZAIiQohfJsoWY1Wr7yAzlN/Pw7g==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.26-alpha.tgz",
+      "integrity": "sha512-V4kSsRrkd6dy5p4Szg8i8OSWYO6uVgIylp1lN5VrsX3v3ou6hYZ+UMC0w0SY1BHPsi4enDRXeJVNoAMotJtXVQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/table": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.25-alpha.tgz",
-      "integrity": "sha512-XjTbIFHi7FutgWnnZL22c0MV60O1tRb2XtQSGroskYkjdK6sF7ZcuXOlM9UDRKp3pmytTDxRdbo3CT1wL3hzSg==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.26-alpha.tgz",
+      "integrity": "sha512-gXEQ34rCzaxF0GXr03z/TgtRgk75YWnxbY+hYhDzEVzimlwYDoHxo8+xOUl/BJEfdMTO5WTdb3ieIxvWKRrqlg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/tag": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.25-alpha.tgz",
-      "integrity": "sha512-86vdNkBqv78L7aK/RT1HGv6xToRy5NnnnxixH7e2Fo9rY/UhBzCBuPu4USxN6Hqp//Kr6Zlun60iqph2acrmuw==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.26-alpha.tgz",
+      "integrity": "sha512-AzdmY6HAYbo+KkG0KO0BCaau4d919PFrZC3KXkojYJn4AFjbIyhyQwI3bKIfEDTqXdWA7D8moK/ek8zlrPK7pg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/textarea": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.25-alpha.tgz",
-      "integrity": "sha512-Y0XgU4CRW8qXxYh0bVio4k03inJ02Z2/i5/3BfoYvFVDP0kM2gcO4SsGstGWgJ4ZQuBBDmBl+6C48CjUeTY3lg==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.26-alpha.tgz",
+      "integrity": "sha512-GG+8PfDJHw6EYHsY2BY8SWJnkPac2WfpIV6u7VgxUYFOVf+6q1SWX1MUQ+6AAuxQOuYB7HzXiSwFKeTDrUmNuA==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.25-alpha",
-        "@govuk-frontend/globals": "0.0.25-alpha",
-        "@govuk-frontend/label": "0.0.25-alpha"
+        "@govuk-frontend/error-message": "0.0.26-alpha",
+        "@govuk-frontend/globals": "0.0.26-alpha",
+        "@govuk-frontend/label": "0.0.26-alpha"
       }
     },
     "@govuk-frontend/warning-text": {
-      "version": "0.0.25-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/warning-text/-/warning-text-0.0.25-alpha.tgz",
-      "integrity": "sha512-KdtCwqjDXcqQN8OGSnIo8Xt5tzaTINtjfLZ+UAeDvqRftJ76o3ctC7v+rIdGODnFhgrGzK28aD1Xoadkr+BNAA==",
+      "version": "0.0.26-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/warning-text/-/warning-text-0.0.26-alpha.tgz",
+      "integrity": "sha512-UkKA9EDk9U/iYboGg2wISjZcp2nIRIAGqqhHi2tBu6CyK2aag8w+Mjwtz1rYF2Ken1hQUumbSedXemDu6YFK+w==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.25-alpha"
+        "@govuk-frontend/globals": "0.0.26-alpha"
       }
     },
     "a-sync-waterfall": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-frontend/all": "0.0.25-alpha",
+    "@govuk-frontend/all": "0.0.26-alpha",
     "clipboard": "^2.0.0",
     "html5shiv": "^3.7.3",
     "jquery": "^1.12.4",

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -3,7 +3,7 @@
 //
 // Based on the existing GOV.UK footer in GOV.UK Template
 
-@include govuk-exports("footer") {
+@include govuk-exports("app-footer") {
   $app-footer-background: $govuk-grey-3;
   $app-footer-border-top: #a1acb2;
   $app-footer-link: #454a4c;


### PR DESCRIPTION
- Update package.json and package-lock.json to install latest GOV.UK Frontend
- Rename app footer `exports()` to avoid clashing with footer `exports()` from Frontend 

https://trello.com/c/gNYQwaAM/813-update-govuk-design-system-to-use-the-latest-release

Before exports renaming:
![screen shot 2018-03-14 at 16 25 19](https://user-images.githubusercontent.com/3758555/37416151-f7e92c46-27a4-11e8-82e4-337df2c3e48e.png)
