### PR TITLE
Broken build notifications; improve Travis docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 
+# Override the default Travis behaviour so that rather than trying to run tests
+# we instead lint the codebase and try to build the design system
+#
+# The lint and build tasks are defined in package.json
 script:
   - npm run lint
   - npm run build
@@ -8,25 +12,35 @@ sudo: false
 
 env:
   global:
+  # CloudFoundry credentials for deployment
   - CF_API="https://api.cloud.service.gov.uk"
   - CF_ORG="govuk-design-system"
   - CF_SPACE="production"
   - CF_USERNAME="design-system-deploy-production@digital.cabinet-office.gov.uk"
   # CF_PASSWORD
   - secure: UYvRRq3/WSAF5udIroJRoN0i4ha04K9tWf5ozXAidP9oF1o3kAdz7dMlb/UWE10KCki8WwYSKufsJknSC7yygg6BgkajpUFWZc36XWUgyIlXEti3kxjq8GhHUtVQpdH/Mp702DgzJCgA4Bwj9TlfkyP+PIYW4PfljRllJtPzqgxSur++23Q+kMmvA8T/GOEyab72ZjEMQmonl0Vxf6UWx/y7/4+XLj34OTzoYQ18utWfH9o9i1KUA8dYFCT3oCauGXF8Ra6iOPmNhBjvKrT9+foyYvfbwtL+o+tcbyBQM+p2toWUC2E5e+gIyed+woNnUMFGjGzkwzRe5evhH7RbssGMnkAHn19EGht+Ycdo5Wqh06kmb6sGVFa5EfvuX8AUHaOJrjBjS4ojHA9rmrkCrLvXpKECJi/NK2if5mk39ULtmtUzBBAjgPY3ZY34wweKrRgKz1Q2+Z59nJuX4/UM/KP3lrG0IWKIqdcrnoRaXsWADmf512zFw699+3rre6Bv7h08cyJZWAPWFhZiFibFOQXpT7uVeGyF2VcNrDjVzOiUFOWb7+5IRLi3Volp9o5OHuH1aOw3vNb2KqbIvJAFcQJF4l7c8Jopp6obeyBtXsupAVOTKZQnc9rokwDvyLbCNfseXXWNPekRD9+Ey8asSM+NauWLASFIWxNrRj6M5m0=
-  # NPM_TOKEN
+
+  # An NPM_TOKEN belonging to the govuk-frontend-test user, who has access to
+  # the private govuk-frontend packages.
   - secure: pzsV8YKYzvIgJCr69XmVb78gsEvvAsIB0A7JIq5gu0KtdCRsv9S/u3zrdkRK7XpLMsQG5PRjwl4HL822fGfYK/We8hsjbGXf/dlD6xSD6ssX+rCGqUm0jr5QZcBXK3gL3Fcmk+xc0H8zrQH5bqnSktQzMA9U77wUaqjy/rRy2+QlSJesLuIPBGJpyysvAxDREH6IXz9QR8dX9wO6fB+1lIkDtJvemH06komM9pcPEXQaoAUNP5jrMONMATQru+2gv3RzD/CN9nZJL6F+VRTn41L2+GRYIH6s/uROEYskq0MOShtJMzRrHJgUMZSTKL7rR/vGVQptNFzGbKzALM/dQFZ31t5adaTb9UWxkVcXf7yV/YzzLQuCuK+eRsTzuDux84Fvgzl8LFvGiGuYWGkSCvsmRreijgmtEQRZmXedadhWtPzF7oDjO/DlZP2nbF12r4YsS14iBgmhdiqrjJCTpeU+XKABhX/WA9OPcmUcSFsMEJrmZ6vqRImY+L50KVL24BUac6xFMBexdsiL0i7GdiGNa3WX3LC3Nml1n7vplhuWcIQomNLrb6tyzk9WLG8Q+8REIpo09qsmq/XEyGZWAehlmNxswV4HwiDxZD2/sGDj16Uc/LJeu4ydg/Ct3s6lbGmzVtnYbzChe+dtNkuabMUsQS3qQzsnYvb41XyIJls=
+
   # Google Tag Manager ID – different for production and preview builds
   - GTM_TAG="GTM-53XG2JT"
 
 before_install:
   - if [[ `npm -v | cut -d. -f1` -lt 5 ]]; then npm i -g npm@latest; fi
+  # Configure NPM to use the NPM_TOKEN
   - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
 
 install:
   - npm install --no-optional
 
+# Set up dependencies for deployment:
+#
+# - The CloudFoundry command line tools
+# - The autopilot plugin for zero downtime push
 before_deploy:
+  # Add the home directory (where we install CloudFoundry) to our $PATH
   - export PATH=$HOME:$PATH
   # Install CloudFoundry
   - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&source=github"
@@ -34,12 +48,22 @@ before_deploy:
   # Install Autopilot plugin for zero-downtime-push
   - travis_retry cf install-plugin autopilot -f -r CF-Community
 
+# Deploy the Design System to production when the master branch is changed (1)
+#
+# Travis is not involved in deploying PR or branch previews – these are handled
+# by Netlify.
+#
+# We use a script rather than using Travis' built in CloudFoundry provider
+# because it does not support zero downtime deploys
+# (https://github.com/travis-ci/dpl/pull/610)
 deploy:
   provider: script
   script: "./bin/deploy-travis"
+  # We build the site as part of the build, so we want to keep it so it can be
+  # deployed!
   skip_cleanup: true
   on:
-    branch: master
+    branch: master # 1
 
 # Notify the developers on the team when:
 # - a build was just broken or still is broken (1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,17 @@ env:
   # CF_PASSWORD
   - secure: UYvRRq3/WSAF5udIroJRoN0i4ha04K9tWf5ozXAidP9oF1o3kAdz7dMlb/UWE10KCki8WwYSKufsJknSC7yygg6BgkajpUFWZc36XWUgyIlXEti3kxjq8GhHUtVQpdH/Mp702DgzJCgA4Bwj9TlfkyP+PIYW4PfljRllJtPzqgxSur++23Q+kMmvA8T/GOEyab72ZjEMQmonl0Vxf6UWx/y7/4+XLj34OTzoYQ18utWfH9o9i1KUA8dYFCT3oCauGXF8Ra6iOPmNhBjvKrT9+foyYvfbwtL+o+tcbyBQM+p2toWUC2E5e+gIyed+woNnUMFGjGzkwzRe5evhH7RbssGMnkAHn19EGht+Ycdo5Wqh06kmb6sGVFa5EfvuX8AUHaOJrjBjS4ojHA9rmrkCrLvXpKECJi/NK2if5mk39ULtmtUzBBAjgPY3ZY34wweKrRgKz1Q2+Z59nJuX4/UM/KP3lrG0IWKIqdcrnoRaXsWADmf512zFw699+3rre6Bv7h08cyJZWAPWFhZiFibFOQXpT7uVeGyF2VcNrDjVzOiUFOWb7+5IRLi3Volp9o5OHuH1aOw3vNb2KqbIvJAFcQJF4l7c8Jopp6obeyBtXsupAVOTKZQnc9rokwDvyLbCNfseXXWNPekRD9+Ey8asSM+NauWLASFIWxNrRj6M5m0=
 
-  # An NPM_TOKEN belonging to the govuk-frontend-test user, who has access to
-  # the private govuk-frontend packages.
+  # NPM_TOKEN - An npm token belonging to the govuk-frontend-test user, who has
+  # access to the private govuk-frontend packages.
+  #
+  # https://docs.npmjs.com/getting-started/working_with_tokens
   - secure: pzsV8YKYzvIgJCr69XmVb78gsEvvAsIB0A7JIq5gu0KtdCRsv9S/u3zrdkRK7XpLMsQG5PRjwl4HL822fGfYK/We8hsjbGXf/dlD6xSD6ssX+rCGqUm0jr5QZcBXK3gL3Fcmk+xc0H8zrQH5bqnSktQzMA9U77wUaqjy/rRy2+QlSJesLuIPBGJpyysvAxDREH6IXz9QR8dX9wO6fB+1lIkDtJvemH06komM9pcPEXQaoAUNP5jrMONMATQru+2gv3RzD/CN9nZJL6F+VRTn41L2+GRYIH6s/uROEYskq0MOShtJMzRrHJgUMZSTKL7rR/vGVQptNFzGbKzALM/dQFZ31t5adaTb9UWxkVcXf7yV/YzzLQuCuK+eRsTzuDux84Fvgzl8LFvGiGuYWGkSCvsmRreijgmtEQRZmXedadhWtPzF7oDjO/DlZP2nbF12r4YsS14iBgmhdiqrjJCTpeU+XKABhX/WA9OPcmUcSFsMEJrmZ6vqRImY+L50KVL24BUac6xFMBexdsiL0i7GdiGNa3WX3LC3Nml1n7vplhuWcIQomNLrb6tyzk9WLG8Q+8REIpo09qsmq/XEyGZWAehlmNxswV4HwiDxZD2/sGDj16Uc/LJeu4ydg/Ct3s6lbGmzVtnYbzChe+dtNkuabMUsQS3qQzsnYvb41XyIJls=
 
   # Google Tag Manager ID – different for production and preview builds
   - GTM_TAG="GTM-53XG2JT"
 
 before_install:
-  # Configure NPM to use the NPM_TOKEN
+  # Configure npm to use the NPM_TOKEN
   - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,18 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
+
+# Notify the developers on the team when:
+# - a build was just broken or still is broken (1)
+# - a previously broken build is fixed (2)
+#
+# Unfortunately there is currently no way to filter branches, so we get these
+# notifications for any branch (but not for the pull requests themselves)
+notifications:
+  email:
+    recipients:
+      - design-system-developers@digital.cabinet-office.gov.uk
+    # This is the default behaviour for email notifications, this just makes
+    # it explicit
+    on_success: change # 1
+    on_failure: always # 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
   - GTM_TAG="GTM-53XG2JT"
 
 before_install:
-  - if [[ `npm -v | cut -d. -f1` -lt 5 ]]; then npm i -g npm@latest; fi
   # Configure NPM to use the NPM_TOKEN
   - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
 


### PR DESCRIPTION
Configure Travis to notify us by email when a build fails.

Improve the other documentation in the Travis config.