### PR TITLE
Fix iframe auto-resize and resize label position

### DIFF
--- a/src/javascripts/components/example.js
+++ b/src/javascripts/components/example.js
@@ -7,7 +7,7 @@
     init: function (selector) {
       try {
         // Example iframe; set the height equal to the body height
-        $(selector).iFrameResize({scrolling: 'auto'})
+        $(selector).iFrameResize({scrolling: 'auto', autoResize: false})
       } catch (err) {
         if (err) {
           console.error(err.message)

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -121,11 +121,12 @@ $mq-breakpoint-widescreen: 1200px;
 
   &:before {
     content: "Resize";
-    position: absolute;
+    position: fixed;
     z-index: 2;
     right: $govuk-spacing-scale-3;
     bottom: 0;
     color: $govuk-secondary-text-colour;
+    background: $govuk-white;
     @include govuk-font-regular-16;
   }
 }


### PR DESCRIPTION
This PR is fixing two bugs found by @ignaciaorellana while presenting the product on Friday.
- The position of the Resize label is `absolute` instead of `fixed`
![example-resize-position](https://user-images.githubusercontent.com/788096/37652571-deaaca9e-2c33-11e8-8efb-94f623e3edf8.gif)

- When clicking the `body` of the `iframe`d document the frame automatically resizes to fit height.
![example-resize-autoresize](https://user-images.githubusercontent.com/788096/37652576-e0d97a9a-2c33-11e8-8185-a55823ad9cdd.gif)

