### PR TITLE
Fix fuchsia colour name

### DIFF
--- a/data/colours.json
+++ b/data/colours.json
@@ -104,7 +104,7 @@
       "name": "$govuk-purple"
     },
     {
-      "name": "$govuk-fuschia"
+      "name": "$govuk-fuchsia"
     },
     {
       "name": "$govuk-pink"

--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -28,6 +28,7 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
     <th scope="col">Notes</th>
   </thead>
 
+  {# colours is an object built by ./lib/colours.js based on data defined in ./data/colours.json #}
   {% for groupName, group in colours.main %}
 
     <tr>


### PR DESCRIPTION
Accidentally missed from #208.

Before
<img width="739" alt="missing-fuchsia" src="https://user-images.githubusercontent.com/788096/37668115-93316c08-2c5b-11e8-8870-30da098a85fc.png">

After (no difference in size or spacing, it's just the screen capture size being fit to the container)
<img width="709" alt="not-missing-fuchsia" src="https://user-images.githubusercontent.com/788096/37668182-c22e654c-2c5b-11e8-9223-e24fb68568b6.png">
