### PR TITLE
Add common layouts to the top of the layout section

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -1,22 +1,23 @@
-const metalsmith = require('metalsmith')              // static site generator
-const assets = require('metalsmith-assets')           // copy static assets
-const concat = require('metalsmith-concat')           // concatenate files
-const env = require('metalsmith-env')                  // environment vars plugin
-const inplace = require('metalsmith-in-place')        // render templating syntax in your source files
-const layouts = require('metalsmith-layouts')         // apply layouts to source files
-const markdown = require('metalsmith-markdown')       // convert markdown files to html
-const metallic = require('metalsmith-metallic')       // highlight code in markdown files
-const tagcleaner = require('metalsmith-tagcleaner')    // Use tag cleaner to remove <p> tags around images
-const permalinks = require('metalsmith-permalinks')    // apply a permalink pattern to files
-const sass = require('metalsmith-sass')                // convert Sass files to CSS using LibSass
+const metalsmith = require('metalsmith')                     // static site generator
+const assets = require('metalsmith-assets')                  // copy static assets
+const concat = require('metalsmith-concat')                  // concatenate files
+const env = require('metalsmith-env')                        // environment vars plugin
+const inplace = require('metalsmith-in-place')               // render templating syntax in your source files
+const layouts = require('metalsmith-layouts')                // apply layouts to source files
+const markdown = require('metalsmith-markdown')              // convert markdown files to html
+const metallic = require('metalsmith-metallic')              // highlight code in markdown files
+const tagcleaner = require('metalsmith-tagcleaner')          // Use tag cleaner to remove <p> tags around images
+const permalinks = require('metalsmith-permalinks')          // apply a permalink pattern to files
+const sass = require('metalsmith-sass')                      // convert Sass files to CSS using LibSass
+const hashAssets = require('metalsmith-fingerprint-ignore')  // add hash to specified files and ignores files that match a pattern
 
-// const debug = require('./debug')                    // debug plugin
-const navigation = require('./navigation.js')          // navigation plugin
-const modernizrBuild = require('./modernizr-build.js') // modernizr build plugin
+// const debug = require('./debug')                          // debug plugin
+const navigation = require('./navigation.js')                // navigation plugin
+const modernizrBuild = require('./modernizr-build.js')       // modernizr build plugin
 
-const colours = require('../lib/colours.js')           // get colours data
-const fileHelper = require('../lib/file-helper.js')    // helper function to operate on files
-const paths = require('../config/paths.json')          // specify paths to main working directories
+const colours = require('../lib/colours.js')                 // get colours data
+const fileHelper = require('../lib/file-helper.js')          // helper function to operate on files
+const paths = require('../config/paths.json')                // specify paths to main working directories
 
 // store views paths for rendering nunjucks syntax
 const views = [
@@ -97,6 +98,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     ],
     output: 'javascripts/application.js'
   }))
+
   // concatenate IE only javascript files
   .use(concat({
     files: [
@@ -112,6 +114,15 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     config: '../config/modernizr.json',
     destination: 'javascripts/vendor/',
     filename: 'modernizr.js'
+  }))
+
+  // add hash to files
+  .use(hashAssets({
+    pattern: [
+      'stylesheets/main.css',
+      'javascripts/application.js',
+      'javascripts/ie.js'
+    ]
   }))
 
   // render templating syntax in source files

--- a/package-lock.json
+++ b/package-lock.json
@@ -6333,6 +6333,16 @@
         }
       }
     },
+    "metalsmith-fingerprint-ignore": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/metalsmith-fingerprint-ignore/-/metalsmith-fingerprint-ignore-2.0.0.tgz",
+      "integrity": "sha512-WzNu17SChB+dXdmhxXiCtTziA3D6rx1l2tohkU+c9KWpUFpt9uAWGdWDqkYop8K2aQXgfgiFQW4LWMRzAcUTbA==",
+      "dev": true,
+      "requires": {
+        "multimatch": "2.1.0",
+        "slash": "1.0.0"
+      }
+    },
     "metalsmith-in-place": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/metalsmith-in-place/-/metalsmith-in-place-3.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,235 +4,235 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@govuk-frontend/all": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.26-alpha.tgz",
-      "integrity": "sha512-UMwm2D40xf9NDao0mU8wu3JEXhGEFMMEfwKrd6NflRuJE5VvYQZtq9I1Gz5ZCgM2VE/RRPImCLWJtMYH0csr0w==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.27-alpha.tgz",
+      "integrity": "sha512-4Ol/sYgdEoiLUE3ug4xdr5Xq+c/ptkWcflv/7185UUY84jnAYOPDloXlKMvyJ3jOAaOCc4k0JLnT8gg60UFDBg==",
       "requires": {
-        "@govuk-frontend/back-link": "0.0.26-alpha",
-        "@govuk-frontend/breadcrumbs": "0.0.26-alpha",
-        "@govuk-frontend/button": "0.0.26-alpha",
-        "@govuk-frontend/checkboxes": "0.0.26-alpha",
-        "@govuk-frontend/date-input": "0.0.26-alpha",
-        "@govuk-frontend/details": "0.0.26-alpha",
-        "@govuk-frontend/error-message": "0.0.26-alpha",
-        "@govuk-frontend/error-summary": "0.0.26-alpha",
-        "@govuk-frontend/fieldset": "0.0.26-alpha",
-        "@govuk-frontend/file-upload": "0.0.26-alpha",
-        "@govuk-frontend/footer": "0.0.26-alpha",
-        "@govuk-frontend/icons": "0.0.26-alpha",
-        "@govuk-frontend/input": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha",
-        "@govuk-frontend/panel": "0.0.26-alpha",
-        "@govuk-frontend/phase-banner": "0.0.26-alpha",
-        "@govuk-frontend/radios": "0.0.26-alpha",
-        "@govuk-frontend/select": "0.0.26-alpha",
-        "@govuk-frontend/skip-link": "0.0.26-alpha",
-        "@govuk-frontend/table": "0.0.26-alpha",
-        "@govuk-frontend/tag": "0.0.26-alpha",
-        "@govuk-frontend/textarea": "0.0.26-alpha",
-        "@govuk-frontend/warning-text": "0.0.26-alpha"
+        "@govuk-frontend/back-link": "0.0.27-alpha",
+        "@govuk-frontend/breadcrumbs": "0.0.27-alpha",
+        "@govuk-frontend/button": "0.0.27-alpha",
+        "@govuk-frontend/checkboxes": "0.0.27-alpha",
+        "@govuk-frontend/date-input": "0.0.27-alpha",
+        "@govuk-frontend/details": "0.0.27-alpha",
+        "@govuk-frontend/error-message": "0.0.27-alpha",
+        "@govuk-frontend/error-summary": "0.0.27-alpha",
+        "@govuk-frontend/fieldset": "0.0.27-alpha",
+        "@govuk-frontend/file-upload": "0.0.27-alpha",
+        "@govuk-frontend/footer": "0.0.27-alpha",
+        "@govuk-frontend/icons": "0.0.27-alpha",
+        "@govuk-frontend/input": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha",
+        "@govuk-frontend/panel": "0.0.27-alpha",
+        "@govuk-frontend/phase-banner": "0.0.27-alpha",
+        "@govuk-frontend/radios": "0.0.27-alpha",
+        "@govuk-frontend/select": "0.0.27-alpha",
+        "@govuk-frontend/skip-link": "0.0.27-alpha",
+        "@govuk-frontend/table": "0.0.27-alpha",
+        "@govuk-frontend/tag": "0.0.27-alpha",
+        "@govuk-frontend/textarea": "0.0.27-alpha",
+        "@govuk-frontend/warning-text": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/back-link": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.26-alpha.tgz",
-      "integrity": "sha512-eDop5ju0520ThWbzZN661JcPSXl+J7I70/tOoR7gHgeYIz8uFTAGsJ+OvQOAOeZndPQ3TtGKT7Fy0B51wSlUxA==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.27-alpha.tgz",
+      "integrity": "sha512-qyhWEHqu2SjQde9L20tKTddRNauMvSpGeaPK56rRzi4Gne1HH8ale2rkn8G7YMPksdW6qwmF6/vNAKCPyOuoKg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/breadcrumbs": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.26-alpha.tgz",
-      "integrity": "sha512-o/zvPr6d/7MwuXfneLieYZLm5/wuGZzHZstjsxNdH/HCWeQs/CEaf78JUt9TH0+t/YNKia86WLzzuNOGAxxh/g==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.27-alpha.tgz",
+      "integrity": "sha512-I8NAVerlhwiX+zXdIVYVihRMNYsOAJdmGvRd9mauHTQ414CYu+nxhmwVCPyNX/CRu7vC2P4ckUZpRhcSrbtlMg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/icons": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/icons": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/button": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.26-alpha.tgz",
-      "integrity": "sha512-MQ1EcrcXea7NkUiLS+uroX5XwvyeyiWdGYTuANcqEAm0Zx8hCCJhiK9Hi2Uj2Yu/wPilQ/JcRxDlsoxdX4+UVg==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.27-alpha.tgz",
+      "integrity": "sha512-VO6Nf4apv47Sb9/2CLv8GE9w4DaUgAzoepWLHLBAItK1Ihrws0jeFykwEqTFVZK54Dji7C0+Ra1cEfLJ6rqi6w==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/icons": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/icons": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/checkboxes": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.26-alpha.tgz",
-      "integrity": "sha512-aeLN5rgL+OGUZP4ZSqpCqhg4DojBHj1TOItAR+Nznwxk4Ees9kn9LuWQSt7s+19mvTx34SdmsEmvAS/OG/mcPA==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.27-alpha.tgz",
+      "integrity": "sha512-wLRHyveppUVq+2LX7ikXPH/1WgWUthjQ+ZutjeOTDeB/IVqqMPXN+KA9j36SwlVCiT1NaqD7XGj5xosYTPvvsw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/date-input": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.26-alpha.tgz",
-      "integrity": "sha512-OTTFqd7EdyZeQmztDd297MQHfTh0Q9za2tvnEtKfqKbtyvteDITLUXrmu4cUVrQeppftfhfLBspVnZq08V5tHw==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.27-alpha.tgz",
+      "integrity": "sha512-i3Rl1Q2nIG7tGGufGg78Gb4O73eBIYhe0amWiNxZeWZa2PFBt+i+jbC7G5KiNHxRL9eCkMtajex2yFhWbppXlg==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.26-alpha",
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha"
+        "@govuk-frontend/error-message": "0.0.27-alpha",
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/details": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.26-alpha.tgz",
-      "integrity": "sha512-4x5+SOE4NGsuY0spOiAAjxWCIVIU6bW5+im1TWQEFghkrj1gYWOj8ubf4CzaaO64SRdz7RJg7nCHh765Ye07Ag==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.27-alpha.tgz",
+      "integrity": "sha512-fG6XqZKydP2yVn0njqTysPrdFZBQj98irxkF80rnXLu9opE3P2KK89Ix4HTv1187lXxpKCjMOtPs1y2uOMy5CA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/error-message": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.26-alpha.tgz",
-      "integrity": "sha512-4fm9y4SXSSqgNAElb/mG3u41rN2N8Fc5JKYH+XCPCl+T0Ez57/LeHvDopImEZ00rsZCGzuW45hEDhi4tozICoQ==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.27-alpha.tgz",
+      "integrity": "sha512-e0D/LzeGOYjnAZfhTM5th9KtcJOH9wLx3zTBWGopnTz9k6ZWQuxkVP11g7C9h07sQU0CD7AmVaHmpNseLboB6Q==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/error-summary": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.26-alpha.tgz",
-      "integrity": "sha512-r+hkrRYsIOYUpcgcbOUV1R3DTO3FYOpWtnsLS4eWHR8MlmHAAZZKIxD6CbTP+biVfQ69dPoq7uBdUYy/XL7M4Q==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.27-alpha.tgz",
+      "integrity": "sha512-PfACItaL8fLncmpwxCmeH9s7xoDghYczcUuQX3LypbitkfyVchyDzoM/oNbqeQQALuqexbsk8DaatroocAwNMA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/fieldset": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.26-alpha.tgz",
-      "integrity": "sha512-J7b11PxpDiZdyy0pn0Cf/k96raj8YNMGWFmKVedoPBZSiTZgudNrg3INzDQLwsNkQN+uOWjwMurltDdfJpuE9Q==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.27-alpha.tgz",
+      "integrity": "sha512-FyiB7jLzL5ddTpgR9x9QRQEnok86gzggeF7dVhzEI1GmRondKEHiGlPPbzMVSANE/klYzAvuJvX4pn0mlMEQqQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/file-upload": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.26-alpha.tgz",
-      "integrity": "sha512-8ZJs/cdYpLSk0+QbPxGrZ/VtuflU22Kbk1kNROy3sf6knMkajp4pMMFeyZ/dpKx6TPkHFl3SDhdOddezAfYHRQ==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.27-alpha.tgz",
+      "integrity": "sha512-2KTqmPAa+60znH768IWs4M1sIa7CWZBIQDpky5d4yBuclKTu4zwcq/RfM+hn3+AHel4dXWpPaR8RyT2c2EYReA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/footer": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/footer/-/footer-0.0.26-alpha.tgz",
-      "integrity": "sha512-cO5K8DZ9ewrcN/htThnWeEKt5M3uXJ3LBcaOoCTFWvXsbIf9kIU0+JVrjphS8tN245ajW7AREgkm4VzOvYp6/Q==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/footer/-/footer-0.0.27-alpha.tgz",
+      "integrity": "sha512-s3oEUSaOBRMiLp89SQfQnX6T3t185awguWMgYdd1fCVTrT7cmqspWnDRZTrUk/oQr0U94I0zDBlWDVj/5hNk8A==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/icons": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/icons": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/globals": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.26-alpha.tgz",
-      "integrity": "sha512-ZqocVmgs/ubl0EeyQv1/n0nUJv9rCWWLWVpIPyPqriBtQAYWzlpg+mEwZ27+K0xl+E5PEWxZW/vKyErMMfrpsA==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.27-alpha.tgz",
+      "integrity": "sha512-y2YDYyv5rQRrSNcpHjoREjMeXlinkJ8JjNp+Lg4MvelGL34HfBAXMvnImVb7VQM6WkRsQY7dgcrkJoWSqjzAjg==",
       "requires": {
         "sass-mq": "3.3.2"
       }
     },
     "@govuk-frontend/icons": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.26-alpha.tgz",
-      "integrity": "sha512-XtFR4J4w5VeWRQjzbUKC7b3wMC7vwI7mSQKbMo+5Ey0v98Gq9RdRPdVbfAlEnZyFaHTi8OTmt+qWcHjiKwMY2w=="
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.27-alpha.tgz",
+      "integrity": "sha512-Ct/OgSqJVA1hz60sDIqSoN4vtJKNskfyOIkdI342fBKf9ZQVw8shswZ0D+kYYzr9YoPLSc/dKHjbDUIiMpgDdw=="
     },
     "@govuk-frontend/input": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.26-alpha.tgz",
-      "integrity": "sha512-3tK3UTmS8YDNAG9u9bWUDoDeoLTHjdoKdlABV730srnnm0xREoUWLkR23TE9W4DtQsl4qHWrwYg+taydhCUy4Q==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.27-alpha.tgz",
+      "integrity": "sha512-n+8I1+zu52nHb82WcajblcAhCq0l/ygFJrGDZDrmf6hiK+vvHZDwqGTT0+zWcn7aKriPT+bSeqWYFV4GchCKbg==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.26-alpha",
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha"
+        "@govuk-frontend/error-message": "0.0.27-alpha",
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/label": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.26-alpha.tgz",
-      "integrity": "sha512-DV4fYIzub6Zxh3j6myB6wBbR6I4T4i+fa2O5EM2c3d6h/VwZgDWYUXe2VhAc+0Pyqd3MevS2dAFc5NEJ4uycUQ==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.27-alpha.tgz",
+      "integrity": "sha512-IWNqf7W+4/c3haMFm9ZDk73CJ9GHymNwyQb64ZZzYZ+n7Scov9K5CzYiYTqk2gMX9Elw3lvQtyRJQxB64AVnfw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/panel": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.26-alpha.tgz",
-      "integrity": "sha512-slYnmUNzkYt6dCjE+ENkrieNHGnfIA0pWGRVJNy8sjXzsderoyWTxZTv64sq2XUyJHkjSTgpekTdsVodIFMtIg==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.27-alpha.tgz",
+      "integrity": "sha512-WNQez91KYGghYyLFhIE2ltYRDGnETsuP95WuDZWwGiGa51HWDO1KmXiQqyHwyt9vG3dbL8sA+B5dnjtYNHDhiQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/phase-banner": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.26-alpha.tgz",
-      "integrity": "sha512-4OM4lrR/Cr39Fb/i4zutG22xVr6L3FIWaPh4ePvo0x2LsuW45aPajOWooHZtzeWdrDW40ABl/ILzro8S6qZGJw==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.27-alpha.tgz",
+      "integrity": "sha512-cAHZQ2F9Zph2mjvCD7VYMt6XJly0KR18bmy3HpOK3YZhLsB6oBBA/Qc5dK8gfyFOyNxUdFxx5fIFengDLjC1xA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/tag": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/tag": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/radios": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.26-alpha.tgz",
-      "integrity": "sha512-uC/oM4G6Vw1CL88OO4XxHzx7lRKxp8YChe5iILaF+z4utJMFzQsrIeYxNdMEsTyxfIXZdbaTA6nGtD9qkxjlSw==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.27-alpha.tgz",
+      "integrity": "sha512-9j3WJ+9UTNdh9vr57snsNF34NIZTJcputRLVTlJWbbOw4+iaat6tMC+lufl6DVjQP8UdmmVpDG42UU9F3Xexkg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/select": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.26-alpha.tgz",
-      "integrity": "sha512-TA7/0RordPcAKH/C5GtmJCO4pcqvDYBh+elFNTUeTIObCrfeKd70C/Tv4uvJbzW+NtWJOvf8zocg/xsvDSDMgQ==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.27-alpha.tgz",
+      "integrity": "sha512-kzSkiyBlxH4oafUC29b61CL7HbpB5aZzTyikgZkvj9mTJFsMOXPXMsvQujkZJKsayloBg66KpkszoFRpBTKNBw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/skip-link": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.26-alpha.tgz",
-      "integrity": "sha512-V4kSsRrkd6dy5p4Szg8i8OSWYO6uVgIylp1lN5VrsX3v3ou6hYZ+UMC0w0SY1BHPsi4enDRXeJVNoAMotJtXVQ==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.27-alpha.tgz",
+      "integrity": "sha512-I5zfqNNdcY2kGkz/2ItRoF7L8MKDYKt9hrcw+6gyKpVbcrJErc7nCgCP/ws+hnJNIEz57kNFYeTPHunfNpIAzA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/table": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.26-alpha.tgz",
-      "integrity": "sha512-gXEQ34rCzaxF0GXr03z/TgtRgk75YWnxbY+hYhDzEVzimlwYDoHxo8+xOUl/BJEfdMTO5WTdb3ieIxvWKRrqlg==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.27-alpha.tgz",
+      "integrity": "sha512-zNqrXnEf1bLUtOPfLo7DZl/u1VneyeuMBG/Qc+MTXEOw2Z+r6npx6tEedRgQAvFxGXSDYInHp9VowQ5VTE/qAg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/tag": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.26-alpha.tgz",
-      "integrity": "sha512-AzdmY6HAYbo+KkG0KO0BCaau4d919PFrZC3KXkojYJn4AFjbIyhyQwI3bKIfEDTqXdWA7D8moK/ek8zlrPK7pg==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.27-alpha.tgz",
+      "integrity": "sha512-Tdc4JiR7RYDdGNniByz/98BogQd5PG6jOXn7xyT7NHKV9IPJaQcKw8e+NzWlxdTu37qt1piEZRszNY2QK0ZHiA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/textarea": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.26-alpha.tgz",
-      "integrity": "sha512-GG+8PfDJHw6EYHsY2BY8SWJnkPac2WfpIV6u7VgxUYFOVf+6q1SWX1MUQ+6AAuxQOuYB7HzXiSwFKeTDrUmNuA==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.27-alpha.tgz",
+      "integrity": "sha512-gfb72PYrHBDPQrZWQphqTIqh927q9+pcr1auBhxtzuUB74mBGKLNLTHtMRZQo90Tqf5XGn/mQywOUyuvt/HpNA==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.26-alpha",
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha"
+        "@govuk-frontend/error-message": "0.0.27-alpha",
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/warning-text": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/warning-text/-/warning-text-0.0.26-alpha.tgz",
-      "integrity": "sha512-UkKA9EDk9U/iYboGg2wISjZcp2nIRIAGqqhHi2tBu6CyK2aag8w+Mjwtz1rYF2Ken1hQUumbSedXemDu6YFK+w==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/warning-text/-/warning-text-0.0.27-alpha.tgz",
+      "integrity": "sha512-9U53nKLbWWlY/T1+TIpLXMZlVLdeIEsqApeO+XY/zEHlz8IvU7w8Gq5v25UtV+PffOM7XmhTRRFMZbEPnnPjrA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "a-sync-waterfall": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-frontend/all": "0.0.26-alpha",
+    "@govuk-frontend/all": "0.0.27-alpha",
     "clipboard": "^2.0.0",
     "html5shiv": "^3.7.3",
     "jquery": "^1.12.4",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "metalsmith-browser-sync": "^1.1.1",
     "metalsmith-concat": "^6.0.0",
     "metalsmith-env": "^2.1.1",
+    "metalsmith-fingerprint-ignore": "^2.0.0",
     "metalsmith-in-place": "^3.0.1",
     "metalsmith-layouts": "^1.8.1",
     "metalsmith-markdown": "^0.2.2",

--- a/src/errors/404.html
+++ b/src/errors/404.html
@@ -1,5 +1,5 @@
-<main id="content" class="app-c-content" role="main">
-  <div class="govuk-o-width-container app-c-site-width-container--constraint">
+<main id="content" class="app-content" role="main">
+  <div class="govuk-o-width-container app-site-width-container--constraint">
     <h1 class="govuk-heading-xl">Page not found</h1>
     <p>If you entered a web address please check it was correct.</p>
   </div>

--- a/src/errors/generic.html
+++ b/src/errors/generic.html
@@ -1,5 +1,5 @@
-<main id="content" class="app-c-content" role="main">
-  <div class="govuk-o-width-container app-c-site-width-container--constraint">
+<main id="content" class="app-content" role="main">
+  <div class="govuk-o-width-container app-site-width-container--constraint">
     <h1 class="govuk-heading-xl">Something went wrong</h1>
   </div>
 </main>

--- a/src/index.njk
+++ b/src/index.njk
@@ -1,5 +1,5 @@
 {% include "../views/partials/_masthead.njk" %}
-<div class="govuk-o-width-container app-c-site-width-container">
+<div class="govuk-o-width-container app-site-width-container">
     <div class="govuk-o-grid govuk-o-main-wrapper">
       <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r2 govuk-!-mb-r6">
         <h2 class="govuk-heading-l govuk-!-w-bold">Styles</h2>

--- a/src/javascripts/components/copy.js
+++ b/src/javascripts/components/copy.js
@@ -7,10 +7,10 @@
   // This module is dependent on /vendor/clipboard.js
   GOVUK.copy = {
     init: function (selector) {
-      $(selector).parent().prepend('<a class="govuk-link app-c-link--copy" href="#copy" aria-live="assertive">Copy</a>')
+      $(selector).parent().prepend('<a class="govuk-link app-link--copy" href="#copy" aria-live="assertive">Copy</a>')
       // Copy to clipboard
       try {
-        new ClipboardJS('.app-c-link--copy', {
+        new ClipboardJS('.app-link--copy', {
           target: function (trigger) {
             return trigger.nextElementSibling
           }

--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -7,12 +7,12 @@
   GOVUK.mobileNav = {
     $mobileNav: $('.js-app-mobile-nav'),
     $mobileNavToggler: $('.js-app-mobile-nav-toggler'),
-    mobileNavActiveClass: 'app-c-mobile-nav--active',
-    mobileNavTogglerActiveClass: 'app-c-header-mobile-nav-toggler--active',
+    mobileNavActiveClass: 'app-mobile-nav--active',
+    mobileNavTogglerActiveClass: 'app-header-mobile-nav-toggler--active',
     $subNav: $('.js-app-mobile-nav-subnav'),
     $subNavToggler: $('.js-mobile-nav-subnav-toggler'),
-    subNavActiveClass: 'app-c-mobile-nav__subnav--active',
-    subNavTogglerActiveClass: 'app-c-mobile-nav__subnav-toggler--active',
+    subNavActiveClass: 'app-mobile-nav__subnav--active',
+    subNavTogglerActiveClass: 'app-mobile-nav__subnav-toggler--active',
 
     bindUIEvents: function () {
       GOVUK.mobileNav.$mobileNavToggler.on('click', function (e) {
@@ -58,11 +58,11 @@
 
     includeAria: function () {
       GOVUK.mobileNav.$mobileNav.attr('aria-hidden', 'true')
-      GOVUK.mobileNav.$mobileNav.attr('aria-labelledby', 'app-c-header-mobile-nav-toggler')
+      GOVUK.mobileNav.$mobileNav.attr('aria-labelledby', 'app-header-mobile-nav-toggler')
 
       GOVUK.mobileNav.$mobileNavToggler.attr('aria-label', 'Toggle mobile menu')
       GOVUK.mobileNav.$mobileNavToggler.attr('aria-expanded', 'false')
-      GOVUK.mobileNav.$mobileNavToggler.attr('aria-controls', 'app-c-mobile-nav')
+      GOVUK.mobileNav.$mobileNavToggler.attr('aria-controls', 'app-mobile-nav')
 
       GOVUK.mobileNav.$subNavToggler.each(function (index) {
         var $toggler = $(this)

--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -16,8 +16,8 @@
       var $example = $(id).parent()
 
       // Reset state
-      $example.find('.js-tabs__item').removeClass('app-c-tabs__item--current')
-      $example.find('.js-tabs__heading').removeClass('app-c-tabs__heading--current')
+      $example.find('.js-tabs__item').removeClass('app-tabs__item--current')
+      $example.find('.js-tabs__heading').removeClass('app-tabs__heading--current')
       $example.find('.js-tabs__item a').removeAttr('aria-selected')
       $example.find('.js-tabs__container').hide().attr('aria-hidden', 'true')
     },
@@ -37,10 +37,10 @@
       $('[href="' + id + '"]').attr('aria-selected', 'true')
       var $parents = $('[href="' + id + '"]').parent()
       $.each($parents, function (key, obj) {
-        if ($(obj).hasClass('app-c-tabs__item')) {
-          $(obj).addClass('app-c-tabs__item--current')
-        } else if ($(obj).hasClass('app-c-tabs__heading')) {
-          $(obj).addClass('app-c-tabs__heading--current')
+        if ($(obj).hasClass('app-tabs__item')) {
+          $(obj).addClass('app-tabs__item--current')
+        } else if ($(obj).hasClass('app-tabs__heading')) {
+          $(obj).addClass('app-tabs__heading--current')
         }
       })
 
@@ -79,8 +79,8 @@
           $(obj).find('.js-tabs__container').hide()
 
           // Add close button to each container
-          $(obj).find('.js-tabs__container').append('<a class="govuk-link app-c-link--close js-link--close app-o-chevron--top" href="#close">Close</a>')
-          $(obj).find('.js-tabs__container').addClass('app-c-tabs__container--with-close-button')
+          $(obj).find('.js-tabs__container').append('<a class="govuk-link app-link--close js-link--close app-chevron--top" href="#close">Close</a>')
+          $(obj).find('.js-tabs__container').addClass('app-tabs__container--with-close-button')
         }
       })
 

--- a/src/javascripts/main.js
+++ b/src/javascripts/main.js
@@ -9,7 +9,7 @@ $(document).ready(function () {
   GOVUK.tabs.init('.js-example')
 
   // Add copy to clipboard to code blocks inside tab containers
-  GOVUK.copy.init('.app-c-tabs__container pre')
+  GOVUK.copy.init('.app-tabs__container pre')
 
   // Initialise mobile navigation
   GOVUK.mobileNav.init()

--- a/src/patterns/start-pages/default.njk
+++ b/src/patterns/start-pages/default.njk
@@ -61,7 +61,7 @@ stylesheets:
 
         <!-- The Related items component is not part of GOV.UK Frontend but will be styled if used in the Prototype Kit -->
 
-        <aside class="app-c-related-items" role="complementary">
+        <aside class="app-related-items" role="complementary">
           <h2 class="govuk-heading-m" id="subsection-title">
             Subsection
           </h2>

--- a/src/patterns/start-pages/related-items.scss
+++ b/src/patterns/start-pages/related-items.scss
@@ -3,11 +3,11 @@
 // This is a GOV.UK Publishing specific component that
 // can be seen at http://govuk-static.herokuapp.com/component-guide/related_items
 
-.app-c-related-items {
+.app-related-items {
   border-top: 10px solid $govuk-blue;
   padding-top: $govuk-spacing-scale-2;
 }
 
-.app-c-related-items li {
+.app-related-items li {
   margin-bottom: $govuk-spacing-scale-2;
 }

--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -20,7 +20,7 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
 
 ## Main colours
 
-<table class="govuk-body app-c-colour-list">
+<table class="govuk-body app-colour-list">
 
   <thead class="govuk-h-visually-hidden">
     <th scope="col">Sass name</th>
@@ -42,16 +42,16 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
 
     {% for colour in group %}
 
-      <tr class="app-c-colour-list-row">
+      <tr class="app-colour-list-row">
 
-        <th class="app-c-colour-list-column app-c-colour-list-column--name">
-          <span class="app-c-swatch {% if colour.colour == "#fff" %}app-c-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
+        <th class="app-colour-list-column app-colour-list-column--name">
+          <span class="app-swatch {% if colour.colour == "#fff" %}app-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
           {{colour.name}}
         </th>
-        <td class="app-c-colour-list-column app-c-colour-list-column--colour">
+        <td class="app-colour-list-column app-colour-list-column--colour">
           {{colour.colour}}
         </td>
-        <td class="app-c-colour-list-column app-c-colour-list-column--notes">
+        <td class="app-colour-list-column app-colour-list-column--notes">
           {{colour.notes}}
         </td>
 
@@ -65,7 +65,7 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
 
 ## Greyscale
 
-<table class="govuk-body app-c-colour-list">
+<table class="govuk-body app-colour-list">
 
   <thead class="govuk-h-visually-hidden">
     <th scope="col">Sass name</th>
@@ -75,17 +75,17 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
 
   {% for colour in colours.greyscale %}
 
-    <tr class="app-c-colour-list-row">
+    <tr class="app-colour-list-row">
 
-      <th class="app-c-colour-list-column app-c-colour-list-column--name">
-        <span class="app-c-swatch {% if colour.colour == "#fff" %}app-c-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
+      <th class="app-colour-list-column app-colour-list-column--name">
+        <span class="app-swatch {% if colour.colour == "#fff" %}app-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
         {{colour.name}}
       </th>
 
-      <td class="app-c-colour-list-column app-c-colour-list-column--colour">
+      <td class="app-colour-list-column app-colour-list-column--colour">
         {{colour.colour}}
       </td>
-      <td class="app-c-colour-list-column app-c-colour-list-column--notes">
+      <td class="app-colour-list-column app-colour-list-column--notes">
         {{colour.notes}}
       </td>
 
@@ -103,7 +103,7 @@ If you need to use tints of the extended palette, use either 25% or 50%.
 
 You can find departmental colours in the GOV.UK Frontend [_colours-organisations](https://github.com/alphagov/govuk-frontend/blob/master/src/globals/scss/settings/_colours-organisations.scss) file.
 
-<table class="govuk-body app-c-colour-list">
+<table class="govuk-body app-colour-list">
 
   <thead class="govuk-h-visually-hidden">
     <th scope="col">Sass name</th>
@@ -113,16 +113,16 @@ You can find departmental colours in the GOV.UK Frontend [_colours-organisations
 
   {% for colour in colours.extended %}
 
-    <tr class="app-c-colour-list-row">
+    <tr class="app-colour-list-row">
 
-      <th class="app-c-colour-list-column app-c-colour-list-column--name">
-        <span class="app-c-swatch {% if colour.colour == "#fff" %}app-c-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
+      <th class="app-colour-list-column app-colour-list-column--name">
+        <span class="app-swatch {% if colour.colour == "#fff" %}app-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
         {{colour.name}}
       </th>
-      <td class="app-c-colour-list-column app-c-colour-list-column--colour">
+      <td class="app-colour-list-column app-colour-list-column--colour">
         {{colour.colour}}
       </td>
-      <td class="app-c-colour-list-column app-c-colour-list-column--notes">
+      <td class="app-colour-list-column app-colour-list-column--notes">
         {{colour.notes}}
       </td>
 

--- a/src/styles/layout/common-two-thirds-one-third.njk
+++ b/src/styles/layout/common-two-thirds-one-third.njk
@@ -10,12 +10,12 @@ layout: layout-example.njk
 
     <div class="govuk-o-grid">
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-        <h1 class="govuk-heading-xl">Two thirds column</h1>
+        <h1 class="govuk-heading-xl">Two-thirds column</h1>
         <p class="govuk-body">This is a paragraph inside a two thirds wide column</p>
       </div>
 
       <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
-        <h3 class="govuk-heading-m">One third column</h3>
+        <h3 class="govuk-heading-m">One-third column</h3>
         <p class="govuk-body">This is a paragraph inside a one third wide column</p>
 
       </div>

--- a/src/styles/layout/common-two-thirds-one-third.njk
+++ b/src/styles/layout/common-two-thirds-one-third.njk
@@ -1,0 +1,25 @@
+---
+layout: layout-example.njk
+---
+
+{% from "back-link/macro.njk" import govukBackLink %}
+
+<div class="govuk-o-width-container">
+  {{ govukBackLink({href: '#', text: 'Back'}) }}
+  <main class="govuk-o-main-wrapper">
+
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+        <h1 class="govuk-heading-xl">Two thirds column</h1>
+        <p class="govuk-body">This is a paragraph inside a two thirds wide column</p>
+      </div>
+
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+        <h3 class="govuk-heading-m">One third column</h3>
+        <p class="govuk-body">This is a paragraph inside a one third wide column</p>
+
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/src/styles/layout/common-two-thirds-one-third.njk
+++ b/src/styles/layout/common-two-thirds-one-third.njk
@@ -17,7 +17,6 @@ layout: layout-example.njk
       <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
         <h3 class="govuk-heading-m">One-third column</h3>
         <p class="govuk-body">This is a paragraph inside a one third wide column</p>
-
       </div>
     </div>
 

--- a/src/styles/layout/common-two-thirds-two-thirds-one-third.njk
+++ b/src/styles/layout/common-two-thirds-two-thirds-one-third.njk
@@ -10,19 +10,19 @@ layout: layout-example.njk
 
     <div class="govuk-o-grid">
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-        <h1 class="govuk-heading-xl">Two thirds column</h1>
+        <h1 class="govuk-heading-xl">Two-thirds column</h1>
       </div>
     </div>
 
     <div class="govuk-o-grid">
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-        <h2 class="govuk-heading-l">Two thirds column</h2>
+        <h2 class="govuk-heading-l">Two-thirds column</h2>
         <p class="govuk-body-l">This is a lead paragraph inside a two thirds wide column</p>
         <p class="govuk-body">This is a paragraph inside a two thirds wide column</p>
       </div>
 
       <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
-        <h3 class="govuk-heading-m">One third column</h3>
+        <h3 class="govuk-heading-m">One-third column</h3>
         <p class="govuk-body">This is a paragraph inside a one third wide column</p>
 
       </div>

--- a/src/styles/layout/common-two-thirds-two-thirds-one-third.njk
+++ b/src/styles/layout/common-two-thirds-two-thirds-one-third.njk
@@ -1,0 +1,32 @@
+---
+layout: layout-example.njk
+---
+
+{% from "back-link/macro.njk" import govukBackLink %}
+
+<div class="govuk-o-width-container">
+  {{ govukBackLink({href: '#', text: 'Back'}) }}
+  <main class="govuk-o-main-wrapper">
+
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+        <h1 class="govuk-heading-xl">Two thirds column</h1>
+      </div>
+    </div>
+
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+        <h2 class="govuk-heading-l">Two thirds column</h2>
+        <p class="govuk-body-l">This is a lead paragraph inside a two thirds wide column</p>
+        <p class="govuk-body">This is a paragraph inside a two thirds wide column</p>
+      </div>
+
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+        <h3 class="govuk-heading-m">One third column</h3>
+        <p class="govuk-body">This is a paragraph inside a one third wide column</p>
+
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/src/styles/layout/common-two-thirds.njk
+++ b/src/styles/layout/common-two-thirds.njk
@@ -10,7 +10,7 @@ layout: layout-example.njk
 
     <div class="govuk-o-grid">
       <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-        <h1 class="govuk-heading-xl">Two thirds column</h1>
+        <h1 class="govuk-heading-xl">Two-thirds column</h1>
         <p class="govuk-body">This is a paragraph inside a two thirds wide column</p>
       </div>
 

--- a/src/styles/layout/common-two-thirds.njk
+++ b/src/styles/layout/common-two-thirds.njk
@@ -1,0 +1,21 @@
+---
+layout: layout-example.njk
+---
+
+{% from "back-link/macro.njk" import govukBackLink %}
+
+<div class="govuk-o-width-container">
+  {{ govukBackLink({href: '#', text: 'Back'}) }}
+  <main class="govuk-o-main-wrapper">
+
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+        <h1 class="govuk-heading-xl">Two thirds column</h1>
+        <p class="govuk-body">This is a paragraph inside a two thirds wide column</p>
+      </div>
+
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -32,7 +32,9 @@ The default maximum page width is 1020px, but you can make it wider if your cont
 {{ example({group: 'styles', item: 'layout', example: 'common-two-thirds-two-thirds-one-third', html: true, open: true}) }}
 
 
-If you want to build your layout from scratch, here’s an explaination of how the page wrappers and grid system works.
+## Building your own layout
+
+If you want to build your layout from scratch, or understand what each of the parts are responsible for, here’s an explanation of how the page wrappers and grid system works.
 
 ## Page wrappers
 

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -17,6 +17,23 @@ Don’t make assumptions about what devices people are using. Design for differe
 
 The default maximum page width is 1020px, but you can make it wider if your content requires it.
 
+## Common layouts
+
+### Row 1: Two-thirds
+
+{{ example({group: 'styles', item: 'layout', example: 'common-two-thirds', html: true, open: true}) }}
+
+### Two-thirds / One-third
+
+{{ example({group: 'styles', item: 'layout', example: 'common-two-thirds-one-third', html: true, open: true}) }}
+
+### Row 1: Two thirds <br>Row 2: Two-thirds / One-third
+
+{{ example({group: 'styles', item: 'layout', example: 'common-two-thirds-two-thirds-one-third', html: true, open: true}) }}
+
+
+If you want to build your layout from scratch, here’s an explaination of how the page wrappers and grid system works.
+
 ## Page wrappers
 
 To set up your layout you will need to create 2 wrappers. The first should have the class  `govuk-o-width-container`, which sets the maximum width of the content but doesn’t add any vertical margin or padding.
@@ -39,7 +56,7 @@ Most GOV.UK pages follow a two-thirds to one-third layout but the grid system al
 
 Your main content should always be in a two-thirds column even if you’re not using a corresponding one-third column for secondary content.
 
-## Understanding the grid system
+### Understanding the grid system
 
 The grid is structured with a `govuk-o-grid` wrapper which acts as a row to contain your grid columns.
 

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -19,6 +19,7 @@ The default maximum page width is 1020px, but you can make it wider if your cont
 
 ## Common layouts
 
+
 ### Two-thirds
 
 {{ example({group: 'styles', item: 'layout', example: 'common-two-thirds', html: true, open: true}) }}
@@ -26,6 +27,7 @@ The default maximum page width is 1020px, but you can make it wider if your cont
 ### Two-thirds / One-third
 
 {{ example({group: 'styles', item: 'layout', example: 'common-two-thirds-one-third', html: true, open: true}) }}
+
 
 ### Row 1: Two-thirds <br>Row 2: Two-thirds / One-third
 

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -19,7 +19,7 @@ The default maximum page width is 1020px, but you can make it wider if your cont
 
 ## Common layouts
 
-### Row 1: Two-thirds
+### Two-thirds
 
 {{ example({group: 'styles', item: 'layout', example: 'common-two-thirds', html: true, open: true}) }}
 
@@ -27,7 +27,7 @@ The default maximum page width is 1020px, but you can make it wider if your cont
 
 {{ example({group: 'styles', item: 'layout', example: 'common-two-thirds-one-third', html: true, open: true}) }}
 
-### Row 1: Two thirds <br>Row 2: Two-thirds / One-third
+### Row 1: Two-thirds <br>Row 2: Two-thirds / One-third
 
 {{ example({group: 'styles', item: 'layout', example: 'common-two-thirds-two-thirds-one-third', html: true, open: true}) }}
 

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -13,7 +13,7 @@ layout: layout-pane.njk
 
 The Design System uses a responsive spacing scale which adapts based on screen size. For example, if you apply spacing unit 9 to a margin, it will be 60px on large screens and 40px on small screens.
 
-<table class="govuk-c-table app-c-table--constrained">
+<table class="govuk-c-table app-table--constrained">
   <caption class="govuk-c-table__caption small govuk-h-visually-hidden">GOV.UK Frontend spacing scale</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">

--- a/src/stylesheets/components/_contact-panel.scss
+++ b/src/stylesheets/components/_contact-panel.scss
@@ -1,30 +1,30 @@
 
-.app-c-contact-panel {
+.app-contact-panel {
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
   @include govuk-responsive-padding($govuk-spacing-responsive-3);
   background-color: $govuk-blue;
 
-  .app-c-contact-panel__heading,
-  .app-c-contact-panel__body,
-  .app-c-contact-panel__link {
+  .app-contact-panel__heading,
+  .app-contact-panel__body,
+  .app-contact-panel__link {
     color: $govuk-white;
   }
 
-  .app-c-contact-panel__link:hover {
+  .app-contact-panel__link:hover {
     color: lighten($govuk-light-blue, 45%);
   }
 
-  .app-c-contact-panel__link:focus {
+  .app-contact-panel__link:focus {
     color: $govuk-blue;
   }
 }
 
-.app-c-contact-panel__heading {
+.app-contact-panel__heading {
   @extend .govuk-heading-m;
 }
 
-.app-c-contact-panel__body {
+.app-contact-panel__body {
   @include govuk-font-regular-19
   margin: 0;
 }

--- a/src/stylesheets/components/_divider.scss
+++ b/src/stylesheets/components/_divider.scss
@@ -1,4 +1,4 @@
-.app-c-divider {
+.app-divider {
   height: 1px;
   margin: $govuk-spacing-scale-2 0;
   border: 0;

--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -26,6 +26,7 @@
   padding: 5px $govuk-spacing-scale-6 / 2;
   @include govuk-font-regular-14;
   background: $govuk-grey-3;
+  z-index: 1;
 
   a {
     color: $govuk-link-colour;
@@ -53,4 +54,5 @@
   min-height: $govuk-spacing-scale-6 * 2;
   overflow: auto;
   resize: both;
+  transform: translate3d(0, 0, 0);
 }

--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -1,17 +1,17 @@
 // Example styles
-.app-c-example-wrapper {
+.app-example-wrapper {
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
   @include govuk-font-regular-19;
 }
 
-.app-c-example {
+.app-example {
   position: relative;
   border: 1px solid $govuk-border-colour;
   background: $govuk-grey-3;
 }
 
-.app-c-example--tabs {
+.app-example--tabs {
   @include govuk-responsive-margin($govuk-spacing-responsive-0, "bottom");
 
   @include mq($from: desktop) {
@@ -19,7 +19,7 @@
   }
 }
 
-.app-c-example__new-window {
+.app-example__new-window {
   position: absolute;
   top: 0;
   left: 0;
@@ -40,7 +40,7 @@
   }
 }
 
-.app-c-example__frame {
+.app-example__frame {
   display: block;
   width: 100%;
   max-width: 100%;
@@ -49,7 +49,7 @@
   background: $govuk-white;
 }
 
-.app-c-example__frame--resizable {
+.app-example__frame--resizable {
   min-width: 230px;
   min-height: $govuk-spacing-scale-6 * 2;
   overflow: auto;

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -1,130 +1,20 @@
 //
 // Footer Component
 //
-// Based on the existing GOV.UK footer in GOV.UK Template
+// GOV.UK Frontend footer adapted for full width
 
 @include govuk-exports("app-footer") {
-  $app-footer-background: $govuk-grey-3;
-  $app-footer-border-top: #a1acb2;
-  $app-footer-link: #454a4c;
-  $app-footer-text: $app-footer-link;
-  $app-footer-link-hover: #171819;
-
-  .app-c-footer {
-    display: block;
-    padding: $govuk-gutter $govuk-spacing-scale-3 ($govuk-gutter * 2);
-    border-top: 1px solid $app-footer-border-top;
-    color: $app-footer-text;
-    background: $app-footer-background;
+  .app-o-width-container--full {
+    max-width: 100%;
+    padding: 0;
     @include mq($from: desktop) {
-      padding: $govuk-spacing-scale-6;
-    }
-
-    a:link,
-    a:visited {
-      color: $app-footer-link;
-    }
-
-    a:hover,
-    a:active {
-      color: $app-footer-link-hover;
+      margin: 0 auto;
+      padding: 0 $govuk-spacing-scale-6;
     }
   }
 
-  .app-c-footer__navigation {
-
-    @include mq($until: desktop) {
-      margin-bottom: $govuk-spacing-scale-6;
-    }
-  }
-
-  .app-c-footer__heading {
+  .app-c-footer .govuk-c-footer__section-break {
     margin-bottom: 0;
-    color: $govuk-text-colour;
-  }
-
-  .app-c-footer__heading:nth-of-type(1) {
-    margin-top: 0;
-  }
-
-  .app-c-footer__list {
-    margin: 0;
-  }
-
-  .app-c-footer__list-item {
-    margin-bottom: 0;
-
-    a {
-      display: inline-block;
-      margin-top: $govuk-spacing-scale-2;
-      @include govuk-font-regular-16;
-    }
-  }
-
-  .app-c-footer__licence {
-    line-height: 1;
-    @include mq ($from: desktop) {
-      display: inline-block;
-      width: 75%;
-      vertical-align: bottom;
-    }
-  }
-
-  .app-c-footer__licence-logo {
-    display: block;
-    width: 41px; // Based on the open-government-licence_2x.png image width: 81px/2
-    height: 17px; // Based on the open-government-licence_2x.png image height: 33px/2
-    overflow: hidden;
-    background-image: url("/images/open-government-licence.png");
-    @include govuk-h-device-pixel-ratio {
-      background-image: url("/images/open-government-licence_2x.png");
-    }
-    background-repeat: no-repeat;
-    background-size: 41px 17px; // Based on the open-government-licence_2x.png image size: 81x17px/2
-    text-indent: -999em;
-    @include mq($until: desktop) {
-      margin-bottom: $govuk-spacing-scale-3;
-    }
-    @include mq($from: desktop) {
-      display: inline-block;
-      margin-right: $govuk-spacing-scale-2;
-      vertical-align: top;
-    }
-  }
-
-  .app-c-footer__licence-description {
-    display: inline-block;
-    @include govuk-font-regular-16;
-    margin: 0;
-  }
-
-  .app-c-footer__copyright {
-    @include govuk-font-regular-16;
-    margin-top: $govuk-spacing-scale-5;
-    @include mq ($from: desktop) {
-      display: inline-block;
-      width: 25%;
-      margin-top: 0;
-    }
-  }
-
-  .app-c-footer__copyright-logo {
-    display: block;
-    min-width: 125px; // Based on the govuk-crest-2x.png image width: 250px/2
-    padding: (102px + $govuk-spacing-scale-2) 0 0 0; // Based on the govuk-crest-2x.png image height + spacing: 204px/2 + $govuk-spacing-scale-2
-    background-image: url("/images/govuk-crest.png");
-    @include govuk-h-device-pixel-ratio {
-      background-image: url("/images/govuk-crest-2x.png");
-    }
-    background-repeat: no-repeat;
-    background-position: 50% 0%;
-    background-size: 125px 102px; // Based on the govuk-crest-2x.png image size: 250x204px/2
-    text-align: center;
-    text-decoration: none;
-    white-space: nowrap;
-    @include mq ($from: desktop) {
-      background-position: 100% 0%;
-      text-align: right;
-    }
+    border-bottom: 0;
   }
 }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -4,7 +4,7 @@
 // GOV.UK Frontend footer adapted for full width
 
 @include govuk-exports("app-footer") {
-  .app-o-width-container--full {
+  .app-width-container--full {
     max-width: 100%;
     padding: 0;
     @include mq($from: desktop) {
@@ -13,7 +13,7 @@
     }
   }
 
-  .app-c-footer .govuk-c-footer__section-break {
+  .app-footer .govuk-c-footer__section-break {
     margin-bottom: 0;
     border-bottom: 0;
   }

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -10,35 +10,35 @@
 
 @include govuk-exports("header") {
 
-  .app-c-header {
+  .app-header {
     padding: $govuk-spacing-scale-2 $govuk-spacing-scale-3;
     border-bottom: 10px solid $govuk-blue;
     color: $govuk-white;
     background: $govuk-black;
   }
 
-  .app-c-header__logotype {
+  .app-header__logotype {
     margin-right: $govuk-spacing-scale-1;
   }
 
-  .app-c-header__logotype-crown {
+  .app-header__logotype-crown {
     margin-right: 1px;
     fill: currentColor;
     vertical-align: middle;
   }
 
-  .app-c-header__logotype-crown-fallback-image {
+  .app-header__logotype-crown-fallback-image {
     width: 36px;
     height: 32px;
     border: 0;
     vertical-align: middle;
   }
 
-  .app-c-header__title {
+  .app-header__title {
     @include govuk-font-regular-24;
   }
 
-  .app-c-header__link {
+  .app-header__link {
     // Font size needs to be set on the link so that the box sizing is correct
     // in Firefox
     @include govuk-typography-common;
@@ -67,18 +67,18 @@
   }
 
   @include mq($media-type: print) {
-    .app-c-header {
+    .app-header {
       border-bottom-width: 0;
       color: $govuk-black;
       background: transparent;
     }
 
     // Hide the inverted crown when printing in browsers that don't support SVG.
-    .app-c-header__logotype-crown-fallback-image {
+    .app-header__logotype-crown-fallback-image {
       display: none;
     }
 
-    .app-c-header__link {
+    .app-header__link {
       &:link,
       &:visited {
         color: $govuk-black;
@@ -91,12 +91,12 @@
     }
   }
 
-  .app-c-header-mobile-nav-toggler-wrapper {
+  .app-header-mobile-nav-toggler-wrapper {
     display: block;
     text-align: right;
   }
 
-  .app-c-header-mobile-nav-toggler {
+  .app-header-mobile-nav-toggler {
     width: 100px;
     margin-top: $govuk-spacing-scale-2;
     margin-bottom: $govuk-spacing-scale-2;
@@ -111,7 +111,7 @@
       box-shadow: 0 0 0 $govuk-black; // Override the button default green
     }
 
-    &--active.app-c-header-mobile-nav-toggler {
+    &--active.app-header-mobile-nav-toggler {
       background-color: $govuk-blue;
       box-shadow: 0 0 0 $govuk-blue;
     }
@@ -123,13 +123,13 @@
 
   // Begin adjustments for font baseline offset
   // These should be removed when the font is updated with the correct baseline
-  .app-c-header__logotype-crown,
-  .app-c-header__logotype-crown-fallback-image {
+  .app-header__logotype-crown,
+  .app-header__logotype-crown-fallback-image {
     position: relative;
     top: -4px;
   }
 
-  .app-c-header {
+  .app-header {
     $offset: 3px;
     padding-top: $govuk-spacing-scale-2 + $offset;
     padding-bottom: $govuk-spacing-scale-2 - $offset;

--- a/src/stylesheets/components/_masthead.scss
+++ b/src/stylesheets/components/_masthead.scss
@@ -1,16 +1,16 @@
-.app-c-masthead {
+.app-masthead {
   @include govuk-responsive-padding($govuk-spacing-responsive-6, "top");
   @include govuk-responsive-padding($govuk-spacing-responsive-6, "bottom");
   color: $govuk-white;
   background-color: $govuk-blue;
 }
 
-.app-c-masthead__title {
+.app-masthead__title {
   color: $govuk-white;
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
 }
 
-.app-c-masthead__description {
+.app-masthead__description {
   @include govuk-font-regular-24;
   margin-bottom: 0;
 }

--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -1,4 +1,4 @@
-.app-c-mobile-nav {
+.app-mobile-nav {
   display: none;
 
   &--active {
@@ -10,13 +10,13 @@
   }
 }
 
-.no-js .app-c-mobile-nav {
+.no-js .app-mobile-nav {
   @include mq($until: desktop) {
     display: block;
   }
 }
 
-.app-c-mobile-nav__list {
+.app-mobile-nav__list {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -44,7 +44,7 @@
   }
 }
 
-.app-c-mobile-nav__subnav {
+.app-mobile-nav__subnav {
   display: none;
   margin: 0;
   padding: $govuk-spacing-scale-2 0 0 0;
@@ -72,11 +72,11 @@
   }
 }
 
-.app-c-mobile-nav__current-page {
+.app-mobile-nav__current-page {
   border-left: 4px solid $govuk-blue;
 }
 
-.app-c-mobile-nav__theme {
+.app-mobile-nav__theme {
   margin: 0;
   padding: $govuk-spacing-scale-4 $govuk-spacing-scale-4 $govuk-spacing-scale-1 $govuk-spacing-scale-4;
   color: $govuk-grey-1;
@@ -84,7 +84,7 @@
   text-transform: uppercase;
 }
 
-.app-c-mobile-nav__theme-nav {
+.app-mobile-nav__theme-nav {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -110,6 +110,6 @@
   }
 }
 
-.app-c-mobile-nav__subnav-toggler--active {
+.app-mobile-nav__subnav-toggler--active {
   border-top: 1px solid $govuk-white;
 }

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -1,4 +1,4 @@
-.app-c-navigation {
+.app-navigation {
   $navigation-height: 53px;
   padding-right: $govuk-spacing-scale-3;
   padding-left: $govuk-spacing-scale-3;
@@ -26,7 +26,7 @@
         border-bottom: 4px solid $govuk-light-blue;
       }
 
-      &.app-c-navigation--current-page {
+      &.app-navigation--current-page {
         border-bottom: 4px solid $govuk-blue !important;
 
         a:hover {

--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -1,7 +1,7 @@
 @include govuk-exports("pane") {
   $toc-width: 300px;
 
-  .app-o-pane {
+  .app-pane {
     $pane-height: 100vh;
 
     @include mq($from: tablet) {
@@ -23,7 +23,7 @@
     }
   }
 
-  .app-o-pane__header {
+  .app-pane__header {
     @include mq($from: tablet) {
       display: flex;
       flex-direction: column;
@@ -39,7 +39,7 @@
     }
   }
 
-  .app-o-pane__body {
+  .app-pane__body {
     @include mq($from: tablet) {
       display: flex;
       position: relative;
@@ -66,7 +66,7 @@
     }
   }
 
-  .app-o-pane__subnav {
+  .app-pane__subnav {
     border-right: 1px solid $govuk-border-colour;
     @include mq($from: tablet) {
       width: $toc-width;
@@ -82,11 +82,11 @@
     }
   }
 
-  .app-o-pane__subnav-mobile-overview {
+  .app-pane__subnav-mobile-overview {
     display: none; // No JS fallback for overview links
   }
 
-  .app-o-pane__content {
+  .app-pane__content {
     @include mq($from: tablet) {
       display: flex;
       margin-left: auto;
@@ -111,23 +111,23 @@
 
   .no-js {
 
-    .app-o-pane__subnav-mobile-overview {
+    .app-pane__subnav-mobile-overview {
       display: block; // No JS fallback for overview links
     }
   }
 
   .no-flexbox {
-    .app-o-pane__body {
+    .app-pane__body {
       display: block;
     }
 
-    .app-o-pane__subnav {
+    .app-pane__subnav {
       width: $toc-width;
       float: left;
       overflow-x: hidden;
     }
 
-    .app-o-pane__content {
+    .app-pane__content {
       overflow-x: hidden;
     }
   }

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -1,11 +1,11 @@
 @include govuk-exports("subnav") {
 
-  .app-c-subnav {
+  .app-subnav {
     padding: $govuk-spacing-scale-3;
     @include govuk-font-regular-16;
   }
 
-  .app-c-subnav__section {
+  .app-subnav__section {
     margin: 0 0 $govuk-spacing-scale-4;
     padding: 0;
     list-style-type: none;
@@ -26,7 +26,7 @@
     }
   }
 
-  .app-c-subnav__section-item--current {
+  .app-subnav__section-item--current {
     a,
     a:link,
     a:visited {
@@ -36,7 +36,7 @@
     }
   }
 
-  .app-c-subnav__theme {
+  .app-subnav__theme {
     margin: 0;
     padding: $govuk-spacing-scale-2 $govuk-spacing-scale-3;
     color: $govuk-grey-1;

--- a/src/stylesheets/components/_table.scss
+++ b/src/stylesheets/components/_table.scss
@@ -1,3 +1,3 @@
-.app-c-table--fixed {
+.app-table--fixed {
   table-layout: fixed;
 }

--- a/src/stylesheets/components/_table.scss
+++ b/src/stylesheets/components/_table.scss
@@ -1,0 +1,3 @@
+.app-c-table--fixed {
+  table-layout: fixed;
+}

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -1,5 +1,5 @@
 // Tabs styles
-.app-c-tabs {
+.app-tabs {
   margin: -1px auto;
   padding: 0;
   overflow: visible;
@@ -16,7 +16,7 @@
   }
 }
 
-.app-c-tabs__item {
+.app-tabs__item {
   display: inline-block;
   position: relative;
   z-index: 2;
@@ -43,7 +43,7 @@
   }
 }
 
-.app-c-tabs__item--current {
+.app-tabs__item--current {
   a {
     border-top-color: $govuk-blue;
     border-bottom-color: $govuk-blue;
@@ -52,7 +52,7 @@
 }
 
 // Tab drawer heading for accordion look on mobile
-.app-c-tabs__heading {
+.app-tabs__heading {
   a {
     display: none;
     position: relative;
@@ -75,12 +75,12 @@
   }
 }
 
-.app-c-tabs__heading--current {
+.app-tabs__heading--current {
   background-color: darken($govuk-grey-4, 3%);
 }
 
 // Tab containers
-.app-c-tabs__container {
+.app-tabs__container {
   position: relative;
   margin-top: -2px;
   border: 1px solid $govuk-border-colour;
@@ -90,15 +90,15 @@
   }
 }
 
-.app-c-tabs__container pre {
+.app-tabs__container pre {
   border: 0;
 }
 
-.app-c-tabs__container--with-close-button pre {
+.app-tabs__container--with-close-button pre {
   padding-bottom: $govuk-spacing-scale-6;
 }
 
-.app-c-tabs__text {
+.app-tabs__text {
   padding: $govuk-spacing-scale-4 $govuk-spacing-scale-4 $govuk-spacing-scale-4 $govuk-spacing-scale-4;
 
   // magical number 1080px below as the content is inside a narrow panel
@@ -111,7 +111,7 @@
 }
 
 // Close container button
-.app-c-link--close {
+.app-link--close {
   position: absolute;
   right: $govuk-spacing-scale-3;
   bottom: $govuk-spacing-scale-3 / 2;

--- a/src/stylesheets/components/_tag.scss
+++ b/src/stylesheets/components/_tag.scss
@@ -1,3 +1,3 @@
-.app-c-tag--review {
+.app-tag--review {
   background-color: $govuk-red;
 }

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -17,6 +17,7 @@ $app-code-color: #dd1144;
 @import "components/pane";
 @import "components/subnav";
 @import "components/tabs";
+@import "components/table";
 @import "components/tag";
 
 body {

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -24,19 +24,19 @@ body {
   margin: 0;
 }
 
-.app-u-hide-mobile {
+.app-hide-mobile {
   @include mq($until: tablet) {
     display: none;
   }
 }
 
-.app-u-hide-tablet {
+.app-hide-tablet {
   @include mq($from: tablet) {
     display: none;
   }
 }
 
-.app-u-hide-desktop {
+.app-hide-desktop {
   @include mq($from: desktop) {
     display: none;
   }
@@ -46,14 +46,14 @@ body {
 $mq-breakpoint-widescreen: 1200px;
 
 // This will be coming to FE later but making it app specific for now
-.app-c-site-width-container {
+.app-site-width-container {
   @media (min-width: $mq-breakpoint-widescreen) {
     max-width: 1100px;
   }
 }
 
 // This layout is currently used on error pages like 404
-.app-c-site-width-container--constraint {
+.app-site-width-container--constraint {
   max-width: 960px;
 }
 
@@ -73,7 +73,7 @@ $mq-breakpoint-widescreen: 1200px;
   }
 }
 
-.app-c-content {
+.app-content {
 
   @include govuk-responsive-padding($govuk-spacing-responsive-6);
 
@@ -84,10 +84,10 @@ $mq-breakpoint-widescreen: 1200px;
   h5,
   h6,
   p,
-  ul:not(.app-c-tabs),
+  ul:not(.app-tabs),
   ol,
   img,
-  .app-c-table--constrained {
+  .app-table--constrained {
     max-width: 38em;
   }
 
@@ -102,22 +102,22 @@ $mq-breakpoint-widescreen: 1200px;
   }
 }
 
-.app-c-content__header {
+.app-content__header {
   @include govuk-font-regular-24;
 }
 
-.app-c-content__heading {
+.app-content__heading {
   margin-top: 0;
   margin-bottom: $govuk-spacing-scale-6;
 }
 
-.app-c-content__section-heading {
+.app-content__section-heading {
   margin-top: 0;
   margin-bottom: 0;
   color: $govuk-secondary-text-colour;
 }
 
-.app-o-example-page {
+.app-example-page {
   padding: $govuk-spacing-scale-6 * 2 $govuk-spacing-scale-6 $govuk-spacing-scale-6;
 
   &:before {
@@ -132,13 +132,13 @@ $mq-breakpoint-widescreen: 1200px;
   }
 }
 
-.app-o-example-page--full-page {
+.app-example-page--full-page {
   padding: 0;
 }
 
 // Generic chevron
 // can be rotated for --right --bottom --left versions
-.app-o-chevron--top::before {
+.app-chevron--top::before {
   content: "";
   display: inline-block;
   position: relative;
@@ -155,7 +155,7 @@ $mq-breakpoint-widescreen: 1200px;
 }
 
 // Copy button
-.app-c-link--copy {
+.app-link--copy {
   &:link,
   &:active,
   &:visited,
@@ -183,12 +183,12 @@ $mq-breakpoint-widescreen: 1200px;
 
 $colour-list-breakpoint: 980px;
 
-.app-c-colour-list {
+.app-colour-list {
   width: 100%;
   border-collapse: collapse;
 }
 
-.app-c-colour-list-row {
+.app-colour-list-row {
   display: block;
   position: relative;
   margin-bottom: $govuk-spacing-scale-2;
@@ -198,7 +198,7 @@ $colour-list-breakpoint: 980px;
   }
 }
 
-.app-c-colour-list-column {
+.app-colour-list-column {
   display: block;
   padding-left: 50px;
   @include mq($from: $colour-list-breakpoint) {
@@ -208,7 +208,7 @@ $colour-list-breakpoint: 980px;
   }
 }
 
-.app-c-swatch {
+.app-swatch {
   display: block;
   position: absolute;
   top: 0;
@@ -227,11 +227,11 @@ $colour-list-breakpoint: 980px;
   }
 }
 
-.app-c-swatch-border {
+.app-swatch-border {
   border-color: $govuk-grey-2;
 }
 
-.app-c-colour-list-column--name {
+.app-colour-list-column--name {
   font-weight: normal;
   text-align: left;
   @include mq($from: $colour-list-breakpoint) {
@@ -239,13 +239,13 @@ $colour-list-breakpoint: 980px;
   }
 }
 
-.app-c-colour-list-column--colour {
+.app-colour-list-column--colour {
   @include mq($from: $colour-list-breakpoint) {
     width: 15%;
   }
 }
 
-.app-c-colour-list-column--notes {
+.app-colour-list-column--notes {
   @include mq($from: $colour-list-breakpoint) {
     width: 35%;
   }
@@ -261,8 +261,8 @@ pre {
 }
 
 .no-js {
-  // Adjustments in app-o-pane layout as it has toc below
-  .app-o-pane__content .app-c-content {
+  // Adjustments in app-pane layout as it has toc below
+  .app-pane__content .app-content {
 
     @include mq($until: tablet) {
       padding-bottom: 10px;

--- a/src/whats-changed.md.njk
+++ b/src/whats-changed.md.njk
@@ -14,7 +14,7 @@ The tables below show the old and new names for components, classes and mixins, 
 
 ## Component names
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Component names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -105,7 +105,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Typography class names
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Typography class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -155,7 +155,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Lists
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Lists</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -182,7 +182,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Layout and grid system class names
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Grid system class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -230,7 +230,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Form related class names
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -278,7 +278,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Helper class names
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -297,7 +297,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Override class names
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Override class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -365,7 +365,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 
 ### Typography
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -470,7 +470,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 </table>
 
 ### Layout
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -507,7 +507,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 </table>
 
 ### Media queries
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -532,7 +532,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 </table>
 
 ### Images
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -550,7 +550,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Shims
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -571,7 +571,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 </table>
 
 ### Internet Explorer
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">

--- a/src/whats-changed.md.njk
+++ b/src/whats-changed.md.njk
@@ -1,0 +1,592 @@
+---
+layout: layout-single-page-prose.njk
+---
+
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl">Get started</span>
+  Switching to GOV.UK&nbsp;Frontend
+</h1>
+
+[GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) is the frontend codebase that replaces GOV.UK Elements, Frontend&nbsp;Toolkit and parts of GOV.UK Template.
+
+The tables below show the old and new names for components, classes and mixins, to help you find what you need.
+
+## Component names
+
+<table class="govuk-c-table app-c-table--fixed">
+  <caption class="govuk-c-table__caption govuk-h-visually-hidden">Component names</caption>
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="col">GOV.UK Elements</th>
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">link-back</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/back-link">Back link component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">Button</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/button">Button component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">Checkboxes</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/checkboxes">Checkboxes component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">Date pattern</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/date-input">Date input component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">Hidden text (Progressive disclousure)</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/details">Details component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">Errors and validation</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/error-message">Error message component</a><br><a class="govuk-link" href="../components/error-summary">Error summary component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">&lt;fieldset&gt;</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/fieldset">Fieldset component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">File upload</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/file-upload">File upload component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">Alpha and beta banners</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/phase-banner">Phase banner component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">Radio buttons</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/radios">Radios component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">Select boxes</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/select">Select component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">Phase tag</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/tag">Tag component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">Form fields</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/text-input">Text input component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">&lt;textarea&gt;</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/textarea">Textarea component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">Warning text (previously Legal text)</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/text-input">Warning text component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">govuk-box-highlight</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../components/panel">Panel component</a></td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">Inset text</td>
+      <td class="govuk-c-table__cell ">Deprecated: this component is not included in GOV.UK Frontend</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">panel (object)<br>
+        panel-border-wide<br>panel-border-narrow</td>
+      <td class="govuk-c-table__cell ">Deprecated: this style is now contained within each component that needs it </td>
+    </tr>
+  </tbody>
+</table>
+
+## Class names
+
+GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativebloq.com/web-design/manage-large-scale-web-projects-new-css-architecture-itcss-41514731) to structure CSS and define class names. This means all of the existing class names have changed.
+
+### Typography class names
+
+<table class="govuk-c-table app-c-table--fixed">
+  <caption class="govuk-c-table__caption govuk-h-visually-hidden">Typography class names</caption>
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="col">GOV.UK Elements</th>
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">heading-xlarge</td>
+      <td class="govuk-c-table__cell ">govuk-heading-xl</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">heading-large</td>
+      <td class="govuk-c-table__cell ">govuk-heading-l</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">heading-medium</td>
+      <td class="govuk-c-table__cell ">govuk-heading-m</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">heading-small</td>
+      <td class="govuk-c-table__cell ">govuk-heading-s</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">lede</td>
+      <td class="govuk-c-table__cell ">govuk-body-l</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">&lt;p&gt;<br>body-text</td>
+      <td class="govuk-c-table__cell ">govuk-body</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">font-xsmall</td>
+      <td class="govuk-c-table__cell ">govuk-body-s</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">&lt;a&gt;</td>
+      <td class="govuk-c-table__cell ">govuk-link</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">&lt;hr&gt;</td>
+      <td class="govuk-c-table__cell ">govuk-section-break<br>govuk-section-break--visible<br>govuk-section-break--xl<br>govuk-section-break--l<br>govuk-section-break--m</td>
+    </tr>
+  </tbody>
+</table>
+
+### Lists
+
+<table class="govuk-c-table app-c-table--fixed">
+  <caption class="govuk-c-table__caption govuk-h-visually-hidden">Lists</caption>
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="col">GOV.UK Elements</th>
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">list</td>
+      <td class="govuk-c-table__cell ">govuk-list</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">list<br>list-bullet</td>
+      <td class="govuk-c-table__cell ">govuk-list<br>govuk-list--bullet</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">list<br>list-number</td>
+      <td class="govuk-c-table__cell ">govuk-list<br>govuk-list--number</td>
+    </tr>
+  </tbody>
+</table>
+
+
+### Layout and grid system class names
+
+<table class="govuk-c-table app-c-table--fixed">
+  <caption class="govuk-c-table__caption govuk-h-visually-hidden">Grid system class names</caption>
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="col">GOV.UK Elements</th>
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">grid-row</td>
+      <td class="govuk-c-table__cell ">govuk-o-grid</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">N/A</td>
+      <td class="govuk-c-table__cell ">govuk-o-grid__item</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">column-full</td>
+      <td class="govuk-c-table__cell ">govuk-o-grid__item<br>govuk-o-grid__item--full</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">column-one-half</td>
+      <td class="govuk-c-table__cell ">govuk-o-grid__item<br>govuk-o-grid__item--one-half</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">column-one-third</td>
+      <td class="govuk-c-table__cell ">govuk-o-grid__item<br>govuk-o-grid__item--one-third</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">column-two-thirds</td>
+      <td class="govuk-c-table__cell ">govuk-o-grid__item<br>govuk-o-grid__item--two-thirds</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">column-one-quarter</td>
+      <td class="govuk-c-table__cell ">govuk-o-grid__item<br>govuk-o-grid__item--one-quarter</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">#content</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../styles/layout#page-wrappers">Page wrappers</a></td>
+    </tr>
+
+  </tbody>
+</table>
+
+
+### Form related class names
+
+<table class="govuk-c-table app-c-table--fixed">
+  <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="col">GOV.UK Elements</th>
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">form-group</td>
+      <td class="govuk-c-table__cell ">govuk-o-form-group</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">form-hint</td>
+      <td class="govuk-c-table__cell ">Specific to component, for example<br>govuk-c-label__hint</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">form-label</td>
+      <td class="govuk-c-table__cell ">Specific to component, for example<br>govuk-c-label<br>govuk-c-radios__label</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">form-label-bold</td>
+      <td class="govuk-c-table__cell ">govuk-c-label--bold</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">form-control<br>form-control-3-4<br>form-control-2-3<br>form-control-1-2<br>form-control-1-3<br>form-control-1-4<br>form-control-1-8</td>
+      <td class="govuk-c-table__cell "><a class="govuk-link" href="../styles/spacing#width-override-classes">Width override classes</a></td>
+    </tr>
+
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">form-section</td>
+      <td class="govuk-c-table__cell ">Deprecated: not required with new spacing implementation</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">form-group-related</td>
+      <td class="govuk-c-table__cell ">Deprecated: not required with new spacing implementation</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">form-group-compound</td>
+      <td class="govuk-c-table__cell ">Deprecated: not required with new spacing implementation</td>
+    </tr>
+  </tbody>
+</table>
+
+
+### Helper class names
+
+<table class="govuk-c-table app-c-table--fixed">
+  <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="col">GOV.UK Elements</th>
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">visually-hidden, visuallyhidden</td>
+      <td class="govuk-c-table__cell ">govuk-h-visually-hidden<br>govuk-h-visually-hidden-focussable</td>
+    </tr>
+
+  </tbody>
+</table>
+
+### Override class names
+
+<table class="govuk-c-table app-c-table--fixed">
+  <caption class="govuk-c-table__caption govuk-h-visually-hidden">Override class names</caption>
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="col">GOV.UK Elements</th>
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">font-xxlarge</td>
+      <td class="govuk-c-table__cell ">govuk-!-f-80</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">font-xlarge</td>
+      <td class="govuk-c-table__cell ">govuk-!-f-48</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">font-large</td>
+      <td class="govuk-c-table__cell ">govuk-!-f-36</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">font-medium</td>
+      <td class="govuk-c-table__cell ">govuk-!-f-24</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">font-small</td>
+      <td class="govuk-c-table__cell ">govuk-!-f-19</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">font-xsmall</td>
+      <td class="govuk-c-table__cell ">govuk-!-f-16</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">bold-xxlarge</td>
+      <td class="govuk-c-table__cell ">govuk-!-f-80<br>govuk-!-w-bold</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">bold-xlarge</td>
+      <td class="govuk-c-table__cell ">govuk-!-f-48<br>govuk-!-w-bold</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">bold-large</td>
+      <td class="govuk-c-table__cell ">govuk-!-f-36<br>govuk-!-w-bold</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">bold-medium</td>
+      <td class="govuk-c-table__cell ">govuk-!-f-24<br>govuk-!-w-bold</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">bold-small</td>
+      <td class="govuk-c-table__cell ">govuk-!-f-19<br>govuk-!-w-bold</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">bold-xsmall</td>
+      <td class="govuk-c-table__cell ">govuk-!-f-16<br>govuk-!-w-bold</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">bold</td>
+      <td class="govuk-c-table__cell ">govuk-!-w-bold</td>
+    </tr>
+  </tbody>
+</table>
+
+## Mixins
+
+
+### Typography
+<table class="govuk-c-table app-c-table--fixed">
+  <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend Tooklit</th>
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include core-80</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-regular-80</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include core-48</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-regular-48</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include core-36</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-regular-36</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include core-27</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-regular-27</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include core-24</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-regular-24</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include core-19</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-regular-19</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include core-16</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-regular-16</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include core-14</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-regular-14</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include bold-80</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-bold-80</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include bold-48</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-bold-48</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include bold-36</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-bold-36</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include bold-27</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-bold-27</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include bold-24</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-bold-24</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include bold-19</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-bold-19</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include bold-16</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-bold-16</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include bold-14</td>
+      <td class="govuk-c-table__cell ">@include govuk-font-bold-14</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include heading-80</td>
+      <td class="govuk-c-table__cell ">Deprecated: 80px headings are not used, @include govuk-font-bold-80 should be used instead</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include heading-48</td>
+      <td class="govuk-c-table__cell ">@extend %govuk-heading-xl</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include heading-36</td>
+      <td class="govuk-c-table__cell ">@extend %govuk-heading-l</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include heading-27</td>
+      <td class="govuk-c-table__cell ">Deprecated: 27px hardings are not used, @include govuk-font-bold-27 should be used instead</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include heading-24</td>
+      <td class="govuk-c-table__cell ">@extend %govuk-heading-m</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include copy-19</td>
+      <td class="govuk-c-table__cell ">@extend %govuk-body</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include copy-14</td>
+      <td class="govuk-c-table__cell ">@extend %govuk-body-xs</td>
+    </tr>
+  </tbody>
+</table>
+
+### Layout
+<table class="govuk-c-table app-c-table--fixed">
+  <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend Tooklit</th>
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@extend site-width-container</td>
+      <td class="govuk-c-table__cell ">@include govuk-width-container</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include grid-column( 1/4 )</td>
+      <td class="govuk-c-table__cell ">Deprecated: you can’t apply grid properties to other elements using GOV.UK Frontend</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include grid-column( 1/2 )</td>
+      <td class="govuk-c-table__cell ">Deprecated: you can’t apply grid properties to other elements using GOV.UK Frontend</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include grid-column( 1/3 )</td>
+      <td class="govuk-c-table__cell ">Deprecated: you can’t apply grid properties to other elements using GOV.UK Frontend</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include grid-column( 2/3 )</td>
+      <td class="govuk-c-table__cell ">Deprecated: you can’t apply grid properties to other elements using GOV.UK Frontend</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell "> @include grid-column( 1/3, $full-width: desktop );</td>
+      <td class="govuk-c-table__cell ">Deprecated: you can’t apply grid properties to other elements using GOV.UK Frontend</td>
+    </tr>
+  </tbody>
+</table>
+
+### Media queries
+<table class="govuk-c-table app-c-table--fixed">
+  <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend Tooklit</th>
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include media(desktop)</td>
+      <td class="govuk-c-table__cell ">@include mq($from: desktop)<br>@include mq($to: desktop)</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include media(tablet)</td>
+      <td class="govuk-c-table__cell ">@include mq($from: tablet)<br>@include mq($to: tablet)</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include media(mobile)</td>
+      <td class="govuk-c-table__cell ">@include mq($from: mobile)<br>@include mq($to: mobile)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Images
+<table class="govuk-c-table app-c-table--fixed">
+  <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend Tooklit</th>
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include device-pixel-ratio($ratio: 2)</td>
+      <td class="govuk-c-table__cell ">@include govuk-h-device-pixel-ratio($ratio: 2)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Shims
+
+<table class="govuk-c-table app-c-table--fixed">
+  <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend Tooklit</th>
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include inline-block</td>
+      <td class="govuk-c-table__cell ">Deprecated: inline-block is now the default for any components</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@extend contain-floats</td>
+      <td class="govuk-c-table__cell ">@include govuk-h-clearfix</td>
+    </tr>
+  </tbody>
+</table>
+
+### Internet Explorer
+<table class="govuk-c-table app-c-table--fixed">
+  <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend Tooklit</th>
+      <th class="govuk-c-table__header" scope="col">GOV.UK Frontend</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include ie-lte(8)</td>
+      <td class="govuk-c-table__cell ">@include govuk-ie-lte(8)</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <td class="govuk-c-table__cell ">@include ie(6)</td>
+      <td class="govuk-c-table__cell ">@include govuk-ie(6)</td>
+    </tr>
+  </tbody>
+</table>

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -6,7 +6,11 @@ const paths = require('../config/paths.json') // specify paths to main working d
 // setup synchronised browser testing
 metalsmith.use(browsersync({
   server: paths.public, // server directory
-  files: [paths.source + '**/*', paths.views + '**/*'] // files to watch
+  files: [
+    paths.source + '**/*',
+    paths.views + '**/*',
+    'node_modules/@govuk-frontend/**/*'
+  ] // files to watch
 }))
 
 // build to destination directory

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -15,12 +15,12 @@
   <body>
     {% include "_tracking-body.njk" %}
     <a href="#content" class="govuk-c-skip-link">Skip to main content</a>
-    <div class="app-o-pane">
-      <div class="app-o-pane__header">
+    <div class="app-pane">
+      <div class="app-pane__header">
         {% include "_header.njk" %}
         {% include "_banner.njk" %}
       </div>
-      <div class="app-o-pane__nav">
+      <div class="app-pane__nav">
         {% include "_navigation.njk" %}
         {% include "_mobile-navigation.njk" %}
       </div>

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -5,9 +5,9 @@
     <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ title }}</title>
-    <link href="/stylesheets/main.css" rel="stylesheet" media="all" />
+    <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
     <!--[if lt IE 9]>
-      <script src="/javascripts/ie.js"></script>
+      <script src="/{{ fingerprint['javascripts/ie.js'] }}"></script>
     <![endif]-->
     <script src="/javascripts/vendor/modernizr.js"></script>
     {% include "_tracking-head.njk" %}
@@ -30,6 +30,6 @@
       {% endblock %}
 
     </div>
-    <script src="/javascripts/application.js"></script>
+    <script src="/{{ fingerprint['javascripts/application.js'] }}"></script>
   </body>
 </html>

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -16,7 +16,7 @@
     <![endif]-->
     <script src="/javascripts/vendor/modernizr.js"></script>
   </head>
-  <body class="app-o-example-page">
+  <body class="app-example-page">
     {% block body %}
       {{ contents | safe }}
     {% endblock %}

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -5,7 +5,7 @@
     <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ title }}</title>
-    <link href="/stylesheets/main.css" rel="stylesheet" media="all" />
+    <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
     {#- Include any additional stylesheets specified in the example frontmatter #}
     {% for stylesheet in stylesheets %}
     <link href="{{ stylesheet }}" rel="stylesheet" media="all" />

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -1,13 +1,13 @@
 {% extends "_generic.njk" %}
 
 {% block body %}
-<div class="app-o-pane__body">
-  <div class="app-o-pane__subnav app-u-hide-mobile">
+<div class="app-pane__body">
+  <div class="app-pane__subnav app-hide-mobile">
     {% include "_subnav.njk" %}
   </div>
-  <div class="app-o-pane__content">
-    <main id="content" class="app-c-content" role="main">
-      <div class="app-c-content__header">
+  <div class="app-pane__content">
+    <main id="content" class="app-content" role="main">
+      <div class="app-content__header">
         <h1 class="govuk-heading-xl">
           <span class="govuk-caption-xl">
           {% if theme %}
@@ -38,7 +38,7 @@
       {% endif %}
     </main>
     {# No JS fallback to show overview #}
-    <div class="app-o-pane__subnav-mobile-overview app-u-hide-desktop">
+    <div class="app-pane__subnav-mobile-overview app-hide-desktop">
       {% include "_subnav.njk" %}
     </div>
     {% include "_footer.njk" %}

--- a/views/layouts/layout-single-page.njk
+++ b/views/layouts/layout-single-page.njk
@@ -1,9 +1,9 @@
 {% extends "_generic.njk" %}
 
 {% block body %}
-<div class="app-o-pane__content">
+<div class="app-pane__content">
   <main id="content" class="govuk-o-main-wrapper" role="main">
-    <div class="govuk-o-width-container app-c-site-width-container">
+    <div class="govuk-o-width-container app-site-width-container">
       {{ contents | safe }}
     </div>
   </main>

--- a/views/layouts/layout.njk
+++ b/views/layouts/layout.njk
@@ -1,7 +1,7 @@
 {% extends "_generic.njk" %}
 
 {% block body %}
-<div class="app-o-pane__content">
+<div class="app-pane__content">
   <main id="content" role="main">
     {{ contents | safe }}
   </main>

--- a/views/partials/_banner.njk
+++ b/views/partials/_banner.njk
@@ -14,7 +14,7 @@
   {{ govukPhaseBanner({
     "tag": {
       "text": "preview",
-      "classes": "app-c-tag--review"
+      "classes": "app-tag--review"
     },
     "classes": "govuk-!-pl-r3 govuk-!-pr-r3",
     "html": phaseBannerText

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -1,4 +1,4 @@
-<div class="app-c-contact-panel">
-  <h2 class="app-c-contact-panel__heading">Get in touch</h2>
-  <p class="app-c-contact-panel__body">If you’ve got a question, idea or suggestion share it in <a class="govuk-link app-c-contact-panel__link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a> on cross-government Slack (<a class="govuk-link app-c-contact-panel__link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6">open in app</a>) or <a class="govuk-link app-c-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">email the Design System team</a></p>
+<div class="app-contact-panel">
+  <h2 class="app-contact-panel__heading">Get in touch</h2>
+  <p class="app-contact-panel__body">If you’ve got a question, idea or suggestion share it in <a class="govuk-link app-contact-panel__link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a> on cross-government Slack (<a class="govuk-link app-contact-panel__link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6">open in app</a>) or <a class="govuk-link app-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">email the Design System team</a></p>
 </div>

--- a/views/partials/_divider.njk
+++ b/views/partials/_divider.njk
@@ -1,1 +1,1 @@
-<hr class="app-c-divider">
+<hr class="app-divider">

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -8,22 +8,22 @@
   {% set exampleId = exampleId + '-open' %}
 {% endif %}
 
-<div class="app-c-example-wrapper js-example" id="{{ exampleId }}">
-  <div class="app-c-example {{ "app-c-example--tabs" if params.html or params.nunjucks }}">
-    <span class="app-c-example__new-window"><a href="{{ exampleURL }}" target="_blank">(open in new window)</a></span>
-    <iframe class="app-c-example__frame app-c-example__frame--resizable js-example__frame" src="{{ exampleURL }}" frameBorder="0"></iframe>
+<div class="app-example-wrapper js-example" id="{{ exampleId }}">
+  <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
+    <span class="app-example__new-window"><a href="{{ exampleURL }}" target="_blank">(open in new window)</a></span>
+    <iframe class="app-example__frame app-example__frame--resizable js-example__frame" src="{{ exampleURL }}" frameBorder="0"></iframe>
   </div>
 
   {%- if (params.html and params.nunjucks) %}
-  <ul class="app-c-tabs" role="tablist">
-    <li class="app-c-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></li>
-    <li class="app-c-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></li>
+  <ul class="app-tabs" role="tablist">
+    <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></li>
+    <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></li>
   </ul>
   {% endif %}
 
   {%- if (params.html) %}
-  <div class="app-c-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
-  <div class="app-c-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
+  <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
+  <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
     ```html
     {{ getHTMLCode(examplePath) | safe }}
     ```
@@ -31,13 +31,13 @@
   {% endif %}
 
   {%- if (params.nunjucks) %}
-  <div class="app-c-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
-  <div class="app-c-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
+  <div class="app-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
+  <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
     ```js
     {{ getNunjucksCode(examplePath) | safe }}
     ```
   {%- if (params.group == 'components') %}
-    <p class="app-c-tabs__text">You can configure this component using the <a href="https://github.com/alphagov/govuk-frontend/tree/master/packages/{{frontendComponentName}}/README.md#component-arguments" class="govuk-link"  target="_blank" data-components="github-component-arguments" rel="noopener">Nunjucks macro arguments</a>.</p>
+    <p class="app-tabs__text">You can configure this component using the <a href="https://github.com/alphagov/govuk-frontend/tree/master/packages/{{frontendComponentName}}/README.md#component-arguments" class="govuk-link"  target="_blank" data-components="github-component-arguments" rel="noopener">Nunjucks macro arguments</a>.</p>
   {% endif %}
   </div>
   {% endif %}

--- a/views/partials/_footer.njk
+++ b/views/partials/_footer.njk
@@ -1,8 +1,8 @@
 {% from "footer/macro.njk" import govukFooter %}
 
 {{ govukFooter({
-  "classes": "app-c-footer app-c-footer--full ",
-  "containerClasses" : "app-o-width-container--full",
+  "classes": "app-footer app-footer--full ",
+  "containerClasses" : "app-width-container--full",
   "navigation": [
     {
       "title": "Related resources",

--- a/views/partials/_footer.njk
+++ b/views/partials/_footer.njk
@@ -1,19 +1,22 @@
-<footer class="app-c-footer">
-  <div class="app-c-footer__navigation govuk-o-grid">
-    <div class="govuk-o-grid__item govuk-o-grid__item--one-quarter">
-      <h2 class="app-c-footer__heading govuk-heading-m">Related resources</h2>
-      <ul class="app-c-footer__list govuk-list">
-        <li class="app-c-footer__list-item"><a class="govuk-link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a></li>
-        <li class="app-c-footer__list-item"><a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a></li>
-      </ul>
-    </div>
-  </div>
-  <div class="app-c-footer__meta">
-    <div class="app-c-footer__licence">
-      <a class="govuk-link app-c-footer__licence-logo" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a>
-      <p class="app-c-footer__licence-description">All content is available under the <a class="govuk-link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
-    </div><div class="app-c-footer__copyright">
-      <a class="govuk-link app-c-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
-    </div>
-  </div>
-</footer>
+{% from "footer/macro.njk" import govukFooter %}
+
+{{ govukFooter({
+  "classes": "app-c-footer app-c-footer--full ",
+  "containerClasses" : "app-o-width-container--full",
+  "navigation": [
+    {
+      "title": "Related resources",
+      "columns": 1,
+      "items": [
+        {
+          "href": "https://www.gov.uk/guidance/government-design-principles",
+          "text": "Government Design Principles"
+        },
+        {
+          "href": "https://www.gov.uk/service-manual",
+          "text": "GOV.UK Service Manual"
+        }
+      ]
+    }
+  ]
+}) }}

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -1,6 +1,6 @@
-<header class="app-c-header" role="banner">
-  <a href="/" class="govuk-link app-c-header__link">
-    <span class="app-c-header__logotype">
+<header class="app-header" role="banner">
+  <a href="/" class="govuk-link app-header__link">
+    <span class="app-header__logotype">
 {#
       We use an inline SVG for the crown so that we can cascade the
       currentColor into the crown whilst continuing to support older browsers
@@ -10,7 +10,7 @@
       We use currentColour so that we can easily invert it when printing and
       when the focus state is applied. This also benefits users who override
       colours in their browser as they will still see the crown. #}
-      <svg xmlns="http://www.w3.org/2000/svg" class="app-c-header__logotype-crown" width="36" height="32" viewBox="0 0 132 97">
+      <svg xmlns="http://www.w3.org/2000/svg" class="app-header__logotype-crown" width="36" height="32" viewBox="0 0 132 97">
         <path d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z" fill="currentColor" fill-rule="evenodd"></path>
 {#
         Fallback PNG image for older browsers.
@@ -23,18 +23,18 @@
 
         In other browsers <image> is synonymous for the <img> tag and will be
         interpreted as such, displaying the fallback image. #}
-        <image src="/images/govuk-logotype-crown.png" xlink:href="" class="app-c-header__logotype-crown-fallback-image"></image>
+        <image src="/images/govuk-logotype-crown.png" xlink:href="" class="app-header__logotype-crown-fallback-image"></image>
       </svg>
-      <span class="app-c-header__logotype-text">
+      <span class="app-header__logotype-text">
         GOV.UK
       </span>
     </span>
-    <span class="app-c-header__title">
+    <span class="app-header__title">
       Design System
     </span>
   </a>
-  <div class="app-c-header-mobile-nav-toggler-wrapper">
-    <button id="app-c-mobile-nav-toggler" class="govuk-c-button app-c-header-mobile-nav-toggler js-app-mobile-nav-toggler">
+  <div class="app-header-mobile-nav-toggler-wrapper">
+    <button id="app-mobile-nav-toggler" class="govuk-c-button app-header-mobile-nav-toggler js-app-mobile-nav-toggler">
       Menu
     </button>
   </div>

--- a/views/partials/_masthead.njk
+++ b/views/partials/_masthead.njk
@@ -1,9 +1,9 @@
-<div class="app-c-masthead">
-  <div class="govuk-o-width-container app-c-site-width-container">
+<div class="app-masthead">
+  <div class="govuk-o-width-container app-site-width-container">
       <div class="govuk-o-grid">
         <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-            <h1 class="govuk-heading-xl app-c-masthead__title">Design your service using GOV.UK styles, components and&nbsp;patterns</h1>
-            <p class="app-c-masthead__description">Use this design system to make your service consistent with GOV.UK. Learn from the research and experience of other service teams and avoid repeating work that’s already been done.</p>
+            <h1 class="govuk-heading-xl app-masthead__title">Design your service using GOV.UK styles, components and&nbsp;patterns</h1>
+            <p class="app-masthead__description">Use this design system to make your service consistent with GOV.UK. Learn from the research and experience of other service teams and avoid repeating work that’s already been done.</p>
         </div>
     </div>
   </div>

--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -1,19 +1,19 @@
-<nav id="app-c-mobile-nav" class="app-c-mobile-nav js-app-mobile-nav" role="navigation">
-  <ul class="app-c-mobile-nav__list">
+<nav id="app-mobile-nav" class="app-mobile-nav js-app-mobile-nav" role="navigation">
+  <ul class="app-mobile-nav__list">
     {% for item in navigation %}
     <li>
       <a class="govuk-link js-mobile-nav-subnav-toggler" href="/{{ item.url }}">{{ item.label }}</a>
       {% if item.items %}
-      <ul class="app-c-mobile-nav__subnav js-app-mobile-nav-subnav app-c-mobile-nav__subnav--hidden">
+      <ul class="app-mobile-nav__subnav js-app-mobile-nav-subnav app-mobile-nav__subnav--hidden">
         <li{% if path == item.url %} class="current-page"{% endif %}>
           <a class="govuk-link" href="/{{ item.url }}">{{ item.label }} overview</a>
         </li>
 
         {% for theme, items in item.items | groupby("theme") %}
           {% if theme != 'undefined' %}
-            <h4 class="app-c-mobile-nav__theme">{{ theme }}</h4>
+            <h4 class="app-mobile-nav__theme">{{ theme }}</h4>
           {% endif %}
-          <ul class="app-c-mobile-nav__theme-nav">
+          <ul class="app-mobile-nav__theme-nav">
           {% for subitem in items %}
             <li{% if path == subitem.url %} class="current-page"{% endif %}>
               <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -1,7 +1,7 @@
-<nav class="app-c-navigation govuk-h-clearfix">
-  <ul class="app-c-navigation__list">
+<nav class="app-navigation govuk-h-clearfix">
+  <ul class="app-navigation__list">
     {% for item in navigation %}
-    <li{% if path == item.url or item.url and item.url in path %} class="app-c-navigation--current-page"{% endif %}>
+    <li{% if path == item.url or item.url and item.url in path %} class="app-navigation--current-page"{% endif %}>
       <a class="govuk-link" href="/{{ item.url }}" data-topnav="{{ item.label }}">{{ item.label }}</a>
     </li>
     {% endfor %}

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -1,14 +1,14 @@
-<nav class="app-c-subnav">
+<nav class="app-subnav">
     {% for item in navigation %}
       {% if item.url in path %}
       {% if item.items %}
         {% for theme, items in item.items | groupby("theme") %}
           {% if theme != 'undefined' %}
-            <h4 class="app-c-subnav__theme">{{ theme }}</h4>
+            <h4 class="app-subnav__theme">{{ theme }}</h4>
           {% endif %}
-          <ul class="app-c-subnav__section">
+          <ul class="app-subnav__section">
           {% for subitem in items %}
-            <li class="app-c-subnav__section-item{% if subitem.url == path %} app-c-subnav__section-item--current{% endif %}">
+            <li class="app-subnav__section-item{% if subitem.url == path %} app-subnav__section-item--current{% endif %}">
               <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
             </li>
           {% endfor %}

--- a/views/partials/_toc-styles.njk
+++ b/views/partials/_toc-styles.njk
@@ -1,6 +1,6 @@
-<nav class="app-c-toc">
-  <ul class="app-c-toc__section">
-    <li class="app-c-toc__section-item{% if path == 'styles/typography' %} app-c-toc__section-item--current{% endif %}">
+<nav class="app-toc">
+  <ul class="app-toc__section">
+    <li class="app-toc__section-item{% if path == 'styles/typography' %} app-toc__section-item--current{% endif %}">
       <a class="govuk-link" href="/styles/typography/">Typography</a>
     </li>
   </ul>


### PR DESCRIPTION
The initial content design of this page guided a user through all of the component parts to layout in order.

From research we observed users wanted to create layouts quickly and understanding how the page was constructed was a secondary use case. Especially for prototyping.

Therefore 3 examples of common layouts have been added at the top of the page.

This requires a content review by @amyhupe 