### PR TITLE
DO NOT MERGE: Add Task list page example

### DIFF
--- a/src/patterns/task-list-pages/default.njk
+++ b/src/patterns/task-list-pages/default.njk
@@ -1,0 +1,96 @@
+---
+layout: layout-example.njk
+stylesheets:
+- task-list-pages.css
+---
+
+<!--
+This pattern is experimental
+The code will only work in the GOV.UK Prototype Kit
+-->
+
+<div class="govuk-o-width-container">
+  <a href="#" class="govuk-c-back-link">Back</a>
+
+  <main class="govuk-o-main-wrapper">
+
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+        <h1 class="govuk-heading-xl">
+          Service name goes here
+        </h1>
+
+        <ol class="govuk-list govuk-list--number govuk-c-task-list">
+          <li>
+            <h2 class="govuk-c-task-list__section">
+              <span class="govuk-c-task-list__section-number">1. </span> Check before you start
+            </h2>
+            <ul class="govuk-list govuk-c-task-list__items">
+              <li class="govuk-c-task-list__item">
+                <a class="govuk-c-task-list__task-name" href="#" aria-describedby="eligibility-completed">
+                  Check eligibility
+                </a>
+                <strong class="govuk-c-tag govuk-c-task-list__task-completed" id="eligibility-completed">Completed</strong>
+              </li>
+              <li class="govuk-c-task-list__item">
+                <a class="govuk-c-task-list__task-name" href="#" aria-describedby="read-declaration-completed">
+                  Read declaration
+                </a>
+                <strong class="govuk-c-tag govuk-c-task-list__task-completed" id="read-declaration-completed">Completed</strong>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <h2 class="govuk-c-task-list__section">
+              <span class="govuk-c-task-list__section-number">2. </span> Prepare application
+            </h2>
+            <ul class="govuk-list govuk-c-task-list__items">
+              <li class="govuk-c-task-list__item">
+                <a class="govuk-c-task-list__task-name" href="#" aria-describedby="company-information-completed">
+                  Company information
+                </a>
+                <strong class="govuk-c-tag govuk-c-task-list__task-completed" id="company-information-completed">Completed</strong>
+              </li>
+              <li class="govuk-c-task-list__item">
+                <a class="govuk-c-task-list__task-name" href="#" aria-describedby="contact-details-completed">
+                  Your contact details
+                </a>
+                <strong class="govuk-c-tag govuk-c-task-list__task-completed" id="contact-details-completed">Completed</strong>
+              </li>
+              <li class="govuk-c-task-list__item">
+                <a class="govuk-c-task-list__task-name" href="#">
+                  List convictions
+                </a>
+              </li>
+              <li class="govuk-c-task-list__item">
+                <a class="govuk-c-task-list__task-name" href="#">
+                  Provide financial evidence
+                </a>
+              </li>
+              <li class="govuk-c-task-list__item">
+                <a class="govuk-c-task-list__task-name" href="#" aria-describedby="medical-information-completed">
+                  Give medical information
+                </a>
+                <strong class="govuk-c-tag govuk-c-task-list__task-completed" id="medical-information-completed">Completed</strong>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <h2 class="govuk-c-task-list__section">
+              <span class="govuk-c-task-list__section-number">3. </span> Apply
+            </h2>
+            <ul class="govuk-list govuk-c-task-list__items">
+              <li class="govuk-c-task-list__item">
+                <a class="govuk-c-task-list__task-name" href="#">
+                  Submit and pay
+                </a>
+              </li>
+            </ul>
+          </li>
+        </ol>
+
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/src/patterns/task-list-pages/index.md.njk
+++ b/src/patterns/task-list-pages/index.md.njk
@@ -10,13 +10,15 @@ status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#next-steps">more research</a> is needed to validate it.
 ---
 
+{% from "_example.njk" import example %}
+
 Task list pages help users understand:
 
 - the tasks involved in completing a transaction
 - the order they should complete tasks in
 - when they have completed tasks
 
-![A screenshot showing an example of the task list as used in a fictional service](task-list-whole.png)
+{{ example({group: 'patterns', item: 'task-list-pages', example: 'default', html: true, nunjucks: false, open: false}) }}
 
 ## When to use this pattern
 

--- a/src/patterns/task-list-pages/task-list-pages.scss
+++ b/src/patterns/task-list-pages/task-list-pages.scss
@@ -1,0 +1,60 @@
+@import "@govuk-frontend/globals/common";
+
+.govuk-c-task-list {
+  list-style-type: none;
+  padding-left: 0;
+  @include mq($from: tablet) {
+    min-width: 550px;
+  }
+}
+
+.govuk-c-task-list__section {
+  display: table;
+  @include govuk-font-bold-24;
+}
+
+.govuk-c-task-list__section-number {
+  display: table-cell;
+
+  @include mq($from: tablet) {
+    min-width: $govuk-spacing-scale-6;
+    padding-right: 0;
+  }
+}
+
+.govuk-c-task-list__items {
+  @include govuk-responsive-margin($govuk-spacing-responsive-9, "bottom");
+  @include mq($from: tablet) {
+    padding-left: $govuk-spacing-scale-6;
+  }
+}
+
+.govuk-c-task-list__item {
+  border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: 0 !important;
+  padding-top: $govuk-spacing-scale-2;
+  padding-bottom: $govuk-spacing-scale-2;
+  @include govuk-h-clearfix;
+}
+
+.govuk-c-task-list__item:first-child {
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.govuk-c-task-list__task-name {
+  display: block;
+  @include mq($from: 450px) {
+    float: left;
+  }
+}
+
+.govuk-c-task-list__task-completed {
+  margin-top: $govuk-spacing-scale-2;
+  margin-bottom: $govuk-spacing-scale-1;
+
+  @include mq($from: 450px) {
+    float: right;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
This PR adds a coded version of the Task list page to the Design System.

The task list specific CSS **IS NOT** in GOV.UK Frontend, however I have remade it using GOV.UK Frontend component conventions (ish) and is defined in the example folder. 

The idea is that, as this pattern is "experimental" we could supply code that would work in the Prototype Kit, even if not in GOV.UK Frontend. (This code would also need to be copied into the Prototype Kit and released at the same time)

**This highlights a really interesting problem in GOV.UK Frontend.**

The Task list is a "Page" pattern. I have written the CSS as if it was a component. Where would CSS that was specific to a Pattern live in our frontend architecture?