### PR TITLE
Ensure when npm-linking govuk-frontend browsersync picks up changes.

### DIFF
--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -6,7 +6,11 @@ const paths = require('../config/paths.json') // specify paths to main working d
 // setup synchronised browser testing
 metalsmith.use(browsersync({
   server: paths.public, // server directory
-  files: [paths.source + '**/*', paths.views + '**/*'] // files to watch
+  files: [
+    paths.source + '**/*',
+    paths.views + '**/*',
+    'node_modules/@govuk-frontend/**/*'
+  ] // files to watch
 }))
 
 // build to destination directory


### PR DESCRIPTION
Enables you to make changes in the GOV.UK Frontend project and see it update
in the design system quickly.

As part of https://github.com/alphagov/govuk-frontend/pull/624