### PR TITLE
Remove app-c, app-h and app-o prefixes

### DIFF
--- a/src/errors/404.html
+++ b/src/errors/404.html
@@ -1,5 +1,5 @@
-<main id="content" class="app-c-content" role="main">
-  <div class="govuk-o-width-container app-c-site-width-container--constraint">
+<main id="content" class="app-content" role="main">
+  <div class="govuk-o-width-container app-site-width-container--constraint">
     <h1 class="govuk-heading-xl">Page not found</h1>
     <p>If you entered a web address please check it was correct.</p>
   </div>

--- a/src/errors/generic.html
+++ b/src/errors/generic.html
@@ -1,5 +1,5 @@
-<main id="content" class="app-c-content" role="main">
-  <div class="govuk-o-width-container app-c-site-width-container--constraint">
+<main id="content" class="app-content" role="main">
+  <div class="govuk-o-width-container app-site-width-container--constraint">
     <h1 class="govuk-heading-xl">Something went wrong</h1>
   </div>
 </main>

--- a/src/index.njk
+++ b/src/index.njk
@@ -1,5 +1,5 @@
 {% include "../views/partials/_masthead.njk" %}
-<div class="govuk-o-width-container app-c-site-width-container">
+<div class="govuk-o-width-container app-site-width-container">
     <div class="govuk-o-grid govuk-o-main-wrapper">
       <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-!-mt-r2 govuk-!-mb-r6">
         <h2 class="govuk-heading-l govuk-!-w-bold">Styles</h2>

--- a/src/javascripts/components/copy.js
+++ b/src/javascripts/components/copy.js
@@ -7,10 +7,10 @@
   // This module is dependent on /vendor/clipboard.js
   GOVUK.copy = {
     init: function (selector) {
-      $(selector).parent().prepend('<a class="govuk-link app-c-link--copy" href="#copy" aria-live="assertive">Copy</a>')
+      $(selector).parent().prepend('<a class="govuk-link app-link--copy" href="#copy" aria-live="assertive">Copy</a>')
       // Copy to clipboard
       try {
-        new ClipboardJS('.app-c-link--copy', {
+        new ClipboardJS('.app-link--copy', {
           target: function (trigger) {
             return trigger.nextElementSibling
           }

--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -7,12 +7,12 @@
   GOVUK.mobileNav = {
     $mobileNav: $('.js-app-mobile-nav'),
     $mobileNavToggler: $('.js-app-mobile-nav-toggler'),
-    mobileNavActiveClass: 'app-c-mobile-nav--active',
-    mobileNavTogglerActiveClass: 'app-c-header-mobile-nav-toggler--active',
+    mobileNavActiveClass: 'app-mobile-nav--active',
+    mobileNavTogglerActiveClass: 'app-header-mobile-nav-toggler--active',
     $subNav: $('.js-app-mobile-nav-subnav'),
     $subNavToggler: $('.js-mobile-nav-subnav-toggler'),
-    subNavActiveClass: 'app-c-mobile-nav__subnav--active',
-    subNavTogglerActiveClass: 'app-c-mobile-nav__subnav-toggler--active',
+    subNavActiveClass: 'app-mobile-nav__subnav--active',
+    subNavTogglerActiveClass: 'app-mobile-nav__subnav-toggler--active',
 
     bindUIEvents: function () {
       GOVUK.mobileNav.$mobileNavToggler.on('click', function (e) {
@@ -58,11 +58,11 @@
 
     includeAria: function () {
       GOVUK.mobileNav.$mobileNav.attr('aria-hidden', 'true')
-      GOVUK.mobileNav.$mobileNav.attr('aria-labelledby', 'app-c-header-mobile-nav-toggler')
+      GOVUK.mobileNav.$mobileNav.attr('aria-labelledby', 'app-header-mobile-nav-toggler')
 
       GOVUK.mobileNav.$mobileNavToggler.attr('aria-label', 'Toggle mobile menu')
       GOVUK.mobileNav.$mobileNavToggler.attr('aria-expanded', 'false')
-      GOVUK.mobileNav.$mobileNavToggler.attr('aria-controls', 'app-c-mobile-nav')
+      GOVUK.mobileNav.$mobileNavToggler.attr('aria-controls', 'app-mobile-nav')
 
       GOVUK.mobileNav.$subNavToggler.each(function (index) {
         var $toggler = $(this)

--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -16,8 +16,8 @@
       var $example = $(id).parent()
 
       // Reset state
-      $example.find('.js-tabs__item').removeClass('app-c-tabs__item--current')
-      $example.find('.js-tabs__heading').removeClass('app-c-tabs__heading--current')
+      $example.find('.js-tabs__item').removeClass('app-tabs__item--current')
+      $example.find('.js-tabs__heading').removeClass('app-tabs__heading--current')
       $example.find('.js-tabs__item a').removeAttr('aria-selected')
       $example.find('.js-tabs__container').hide().attr('aria-hidden', 'true')
     },
@@ -37,10 +37,10 @@
       $('[href="' + id + '"]').attr('aria-selected', 'true')
       var $parents = $('[href="' + id + '"]').parent()
       $.each($parents, function (key, obj) {
-        if ($(obj).hasClass('app-c-tabs__item')) {
-          $(obj).addClass('app-c-tabs__item--current')
-        } else if ($(obj).hasClass('app-c-tabs__heading')) {
-          $(obj).addClass('app-c-tabs__heading--current')
+        if ($(obj).hasClass('app-tabs__item')) {
+          $(obj).addClass('app-tabs__item--current')
+        } else if ($(obj).hasClass('app-tabs__heading')) {
+          $(obj).addClass('app-tabs__heading--current')
         }
       })
 
@@ -79,8 +79,8 @@
           $(obj).find('.js-tabs__container').hide()
 
           // Add close button to each container
-          $(obj).find('.js-tabs__container').append('<a class="govuk-link app-c-link--close js-link--close app-o-chevron--top" href="#close">Close</a>')
-          $(obj).find('.js-tabs__container').addClass('app-c-tabs__container--with-close-button')
+          $(obj).find('.js-tabs__container').append('<a class="govuk-link app-link--close js-link--close app-chevron--top" href="#close">Close</a>')
+          $(obj).find('.js-tabs__container').addClass('app-tabs__container--with-close-button')
         }
       })
 

--- a/src/javascripts/main.js
+++ b/src/javascripts/main.js
@@ -9,7 +9,7 @@ $(document).ready(function () {
   GOVUK.tabs.init('.js-example')
 
   // Add copy to clipboard to code blocks inside tab containers
-  GOVUK.copy.init('.app-c-tabs__container pre')
+  GOVUK.copy.init('.app-tabs__container pre')
 
   // Initialise mobile navigation
   GOVUK.mobileNav.init()

--- a/src/patterns/start-pages/default.njk
+++ b/src/patterns/start-pages/default.njk
@@ -61,7 +61,7 @@ stylesheets:
 
         <!-- The Related items component is not part of GOV.UK Frontend but will be styled if used in the Prototype Kit -->
 
-        <aside class="app-c-related-items" role="complementary">
+        <aside class="app-related-items" role="complementary">
           <h2 class="govuk-heading-m" id="subsection-title">
             Subsection
           </h2>

--- a/src/patterns/start-pages/related-items.scss
+++ b/src/patterns/start-pages/related-items.scss
@@ -3,11 +3,11 @@
 // This is a GOV.UK Publishing specific component that
 // can be seen at http://govuk-static.herokuapp.com/component-guide/related_items
 
-.app-c-related-items {
+.app-related-items {
   border-top: 10px solid $govuk-blue;
   padding-top: $govuk-spacing-scale-2;
 }
 
-.app-c-related-items li {
+.app-related-items li {
   margin-bottom: $govuk-spacing-scale-2;
 }

--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -20,7 +20,7 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
 
 ## Main colours
 
-<table class="govuk-body app-c-colour-list">
+<table class="govuk-body app-colour-list">
 
   <thead class="govuk-h-visually-hidden">
     <th scope="col">Sass name</th>
@@ -42,16 +42,16 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
 
     {% for colour in group %}
 
-      <tr class="app-c-colour-list-row">
+      <tr class="app-colour-list-row">
 
-        <th class="app-c-colour-list-column app-c-colour-list-column--name">
-          <span class="app-c-swatch {% if colour.colour == "#fff" %}app-c-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
+        <th class="app-colour-list-column app-colour-list-column--name">
+          <span class="app-swatch {% if colour.colour == "#fff" %}app-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
           {{colour.name}}
         </th>
-        <td class="app-c-colour-list-column app-c-colour-list-column--colour">
+        <td class="app-colour-list-column app-colour-list-column--colour">
           {{colour.colour}}
         </td>
-        <td class="app-c-colour-list-column app-c-colour-list-column--notes">
+        <td class="app-colour-list-column app-colour-list-column--notes">
           {{colour.notes}}
         </td>
 
@@ -65,7 +65,7 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
 
 ## Greyscale
 
-<table class="govuk-body app-c-colour-list">
+<table class="govuk-body app-colour-list">
 
   <thead class="govuk-h-visually-hidden">
     <th scope="col">Sass name</th>
@@ -75,17 +75,17 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
 
   {% for colour in colours.greyscale %}
 
-    <tr class="app-c-colour-list-row">
+    <tr class="app-colour-list-row">
 
-      <th class="app-c-colour-list-column app-c-colour-list-column--name">
-        <span class="app-c-swatch {% if colour.colour == "#fff" %}app-c-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
+      <th class="app-colour-list-column app-colour-list-column--name">
+        <span class="app-swatch {% if colour.colour == "#fff" %}app-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
         {{colour.name}}
       </th>
 
-      <td class="app-c-colour-list-column app-c-colour-list-column--colour">
+      <td class="app-colour-list-column app-colour-list-column--colour">
         {{colour.colour}}
       </td>
-      <td class="app-c-colour-list-column app-c-colour-list-column--notes">
+      <td class="app-colour-list-column app-colour-list-column--notes">
         {{colour.notes}}
       </td>
 
@@ -103,7 +103,7 @@ If you need to use tints of the extended palette, use either 25% or 50%.
 
 You can find departmental colours in the GOV.UK Frontend [_colours-organisations](https://github.com/alphagov/govuk-frontend/blob/master/src/globals/scss/settings/_colours-organisations.scss) file.
 
-<table class="govuk-body app-c-colour-list">
+<table class="govuk-body app-colour-list">
 
   <thead class="govuk-h-visually-hidden">
     <th scope="col">Sass name</th>
@@ -113,16 +113,16 @@ You can find departmental colours in the GOV.UK Frontend [_colours-organisations
 
   {% for colour in colours.extended %}
 
-    <tr class="app-c-colour-list-row">
+    <tr class="app-colour-list-row">
 
-      <th class="app-c-colour-list-column app-c-colour-list-column--name">
-        <span class="app-c-swatch {% if colour.colour == "#fff" %}app-c-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
+      <th class="app-colour-list-column app-colour-list-column--name">
+        <span class="app-swatch {% if colour.colour == "#fff" %}app-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
         {{colour.name}}
       </th>
-      <td class="app-c-colour-list-column app-c-colour-list-column--colour">
+      <td class="app-colour-list-column app-colour-list-column--colour">
         {{colour.colour}}
       </td>
-      <td class="app-c-colour-list-column app-c-colour-list-column--notes">
+      <td class="app-colour-list-column app-colour-list-column--notes">
         {{colour.notes}}
       </td>
 

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -13,7 +13,7 @@ layout: layout-pane.njk
 
 The Design System uses a responsive spacing scale which adapts based on screen size. For example, if you apply spacing unit 9 to a margin, it will be 60px on large screens and 40px on small screens.
 
-<table class="govuk-c-table app-c-table--constrained">
+<table class="govuk-c-table app-table--constrained">
   <caption class="govuk-c-table__caption small govuk-h-visually-hidden">GOV.UK Frontend spacing scale</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">

--- a/src/stylesheets/components/_contact-panel.scss
+++ b/src/stylesheets/components/_contact-panel.scss
@@ -1,30 +1,30 @@
 
-.app-c-contact-panel {
+.app-contact-panel {
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
   @include govuk-responsive-padding($govuk-spacing-responsive-3);
   background-color: $govuk-blue;
 
-  .app-c-contact-panel__heading,
-  .app-c-contact-panel__body,
-  .app-c-contact-panel__link {
+  .app-contact-panel__heading,
+  .app-contact-panel__body,
+  .app-contact-panel__link {
     color: $govuk-white;
   }
 
-  .app-c-contact-panel__link:hover {
+  .app-contact-panel__link:hover {
     color: lighten($govuk-light-blue, 45%);
   }
 
-  .app-c-contact-panel__link:focus {
+  .app-contact-panel__link:focus {
     color: $govuk-blue;
   }
 }
 
-.app-c-contact-panel__heading {
+.app-contact-panel__heading {
   @extend .govuk-heading-m;
 }
 
-.app-c-contact-panel__body {
+.app-contact-panel__body {
   @include govuk-font-regular-19
   margin: 0;
 }

--- a/src/stylesheets/components/_divider.scss
+++ b/src/stylesheets/components/_divider.scss
@@ -1,4 +1,4 @@
-.app-c-divider {
+.app-divider {
   height: 1px;
   margin: $govuk-spacing-scale-2 0;
   border: 0;

--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -1,17 +1,17 @@
 // Example styles
-.app-c-example-wrapper {
+.app-example-wrapper {
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
   @include govuk-font-regular-19;
 }
 
-.app-c-example {
+.app-example {
   position: relative;
   border: 1px solid $govuk-border-colour;
   background: $govuk-grey-3;
 }
 
-.app-c-example--tabs {
+.app-example--tabs {
   @include govuk-responsive-margin($govuk-spacing-responsive-0, "bottom");
 
   @include mq($from: desktop) {
@@ -19,7 +19,7 @@
   }
 }
 
-.app-c-example__new-window {
+.app-example__new-window {
   position: absolute;
   top: 0;
   left: 0;
@@ -40,7 +40,7 @@
   }
 }
 
-.app-c-example__frame {
+.app-example__frame {
   display: block;
   width: 100%;
   max-width: 100%;
@@ -49,7 +49,7 @@
   background: $govuk-white;
 }
 
-.app-c-example__frame--resizable {
+.app-example__frame--resizable {
   min-width: 230px;
   min-height: $govuk-spacing-scale-6 * 2;
   overflow: auto;

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -4,7 +4,7 @@
 // GOV.UK Frontend footer adapted for full width
 
 @include govuk-exports("app-footer") {
-  .app-o-width-container--full {
+  .app-width-container--full {
     max-width: 100%;
     padding: 0;
     @include mq($from: desktop) {
@@ -13,7 +13,7 @@
     }
   }
 
-  .app-c-footer .govuk-c-footer__section-break {
+  .app-footer .govuk-c-footer__section-break {
     margin-bottom: 0;
     border-bottom: 0;
   }

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -10,35 +10,35 @@
 
 @include govuk-exports("header") {
 
-  .app-c-header {
+  .app-header {
     padding: $govuk-spacing-scale-2 $govuk-spacing-scale-3;
     border-bottom: 10px solid $govuk-blue;
     color: $govuk-white;
     background: $govuk-black;
   }
 
-  .app-c-header__logotype {
+  .app-header__logotype {
     margin-right: $govuk-spacing-scale-1;
   }
 
-  .app-c-header__logotype-crown {
+  .app-header__logotype-crown {
     margin-right: 1px;
     fill: currentColor;
     vertical-align: middle;
   }
 
-  .app-c-header__logotype-crown-fallback-image {
+  .app-header__logotype-crown-fallback-image {
     width: 36px;
     height: 32px;
     border: 0;
     vertical-align: middle;
   }
 
-  .app-c-header__title {
+  .app-header__title {
     @include govuk-font-regular-24;
   }
 
-  .app-c-header__link {
+  .app-header__link {
     // Font size needs to be set on the link so that the box sizing is correct
     // in Firefox
     @include govuk-typography-common;
@@ -67,18 +67,18 @@
   }
 
   @include mq($media-type: print) {
-    .app-c-header {
+    .app-header {
       border-bottom-width: 0;
       color: $govuk-black;
       background: transparent;
     }
 
     // Hide the inverted crown when printing in browsers that don't support SVG.
-    .app-c-header__logotype-crown-fallback-image {
+    .app-header__logotype-crown-fallback-image {
       display: none;
     }
 
-    .app-c-header__link {
+    .app-header__link {
       &:link,
       &:visited {
         color: $govuk-black;
@@ -91,12 +91,12 @@
     }
   }
 
-  .app-c-header-mobile-nav-toggler-wrapper {
+  .app-header-mobile-nav-toggler-wrapper {
     display: block;
     text-align: right;
   }
 
-  .app-c-header-mobile-nav-toggler {
+  .app-header-mobile-nav-toggler {
     width: 100px;
     margin-top: $govuk-spacing-scale-2;
     margin-bottom: $govuk-spacing-scale-2;
@@ -111,7 +111,7 @@
       box-shadow: 0 0 0 $govuk-black; // Override the button default green
     }
 
-    &--active.app-c-header-mobile-nav-toggler {
+    &--active.app-header-mobile-nav-toggler {
       background-color: $govuk-blue;
       box-shadow: 0 0 0 $govuk-blue;
     }
@@ -123,13 +123,13 @@
 
   // Begin adjustments for font baseline offset
   // These should be removed when the font is updated with the correct baseline
-  .app-c-header__logotype-crown,
-  .app-c-header__logotype-crown-fallback-image {
+  .app-header__logotype-crown,
+  .app-header__logotype-crown-fallback-image {
     position: relative;
     top: -4px;
   }
 
-  .app-c-header {
+  .app-header {
     $offset: 3px;
     padding-top: $govuk-spacing-scale-2 + $offset;
     padding-bottom: $govuk-spacing-scale-2 - $offset;

--- a/src/stylesheets/components/_masthead.scss
+++ b/src/stylesheets/components/_masthead.scss
@@ -1,16 +1,16 @@
-.app-c-masthead {
+.app-masthead {
   @include govuk-responsive-padding($govuk-spacing-responsive-6, "top");
   @include govuk-responsive-padding($govuk-spacing-responsive-6, "bottom");
   color: $govuk-white;
   background-color: $govuk-blue;
 }
 
-.app-c-masthead__title {
+.app-masthead__title {
   color: $govuk-white;
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
 }
 
-.app-c-masthead__description {
+.app-masthead__description {
   @include govuk-font-regular-24;
   margin-bottom: 0;
 }

--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -1,4 +1,4 @@
-.app-c-mobile-nav {
+.app-mobile-nav {
   display: none;
 
   &--active {
@@ -10,13 +10,13 @@
   }
 }
 
-.no-js .app-c-mobile-nav {
+.no-js .app-mobile-nav {
   @include mq($until: desktop) {
     display: block;
   }
 }
 
-.app-c-mobile-nav__list {
+.app-mobile-nav__list {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -44,7 +44,7 @@
   }
 }
 
-.app-c-mobile-nav__subnav {
+.app-mobile-nav__subnav {
   display: none;
   margin: 0;
   padding: $govuk-spacing-scale-2 0 0 0;
@@ -72,11 +72,11 @@
   }
 }
 
-.app-c-mobile-nav__current-page {
+.app-mobile-nav__current-page {
   border-left: 4px solid $govuk-blue;
 }
 
-.app-c-mobile-nav__theme {
+.app-mobile-nav__theme {
   margin: 0;
   padding: $govuk-spacing-scale-4 $govuk-spacing-scale-4 $govuk-spacing-scale-1 $govuk-spacing-scale-4;
   color: $govuk-grey-1;
@@ -84,7 +84,7 @@
   text-transform: uppercase;
 }
 
-.app-c-mobile-nav__theme-nav {
+.app-mobile-nav__theme-nav {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -110,6 +110,6 @@
   }
 }
 
-.app-c-mobile-nav__subnav-toggler--active {
+.app-mobile-nav__subnav-toggler--active {
   border-top: 1px solid $govuk-white;
 }

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -1,4 +1,4 @@
-.app-c-navigation {
+.app-navigation {
   $navigation-height: 53px;
   padding-right: $govuk-spacing-scale-3;
   padding-left: $govuk-spacing-scale-3;
@@ -26,7 +26,7 @@
         border-bottom: 4px solid $govuk-light-blue;
       }
 
-      &.app-c-navigation--current-page {
+      &.app-navigation--current-page {
         border-bottom: 4px solid $govuk-blue !important;
 
         a:hover {

--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -1,7 +1,7 @@
 @include govuk-exports("pane") {
   $toc-width: 300px;
 
-  .app-o-pane {
+  .app-pane {
     $pane-height: 100vh;
 
     @include mq($from: tablet) {
@@ -23,7 +23,7 @@
     }
   }
 
-  .app-o-pane__header {
+  .app-pane__header {
     @include mq($from: tablet) {
       display: flex;
       flex-direction: column;
@@ -39,7 +39,7 @@
     }
   }
 
-  .app-o-pane__body {
+  .app-pane__body {
     @include mq($from: tablet) {
       display: flex;
       position: relative;
@@ -66,7 +66,7 @@
     }
   }
 
-  .app-o-pane__subnav {
+  .app-pane__subnav {
     border-right: 1px solid $govuk-border-colour;
     @include mq($from: tablet) {
       width: $toc-width;
@@ -82,11 +82,11 @@
     }
   }
 
-  .app-o-pane__subnav-mobile-overview {
+  .app-pane__subnav-mobile-overview {
     display: none; // No JS fallback for overview links
   }
 
-  .app-o-pane__content {
+  .app-pane__content {
     @include mq($from: tablet) {
       display: flex;
       margin-left: auto;
@@ -111,23 +111,23 @@
 
   .no-js {
 
-    .app-o-pane__subnav-mobile-overview {
+    .app-pane__subnav-mobile-overview {
       display: block; // No JS fallback for overview links
     }
   }
 
   .no-flexbox {
-    .app-o-pane__body {
+    .app-pane__body {
       display: block;
     }
 
-    .app-o-pane__subnav {
+    .app-pane__subnav {
       width: $toc-width;
       float: left;
       overflow-x: hidden;
     }
 
-    .app-o-pane__content {
+    .app-pane__content {
       overflow-x: hidden;
     }
   }

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -1,11 +1,11 @@
 @include govuk-exports("subnav") {
 
-  .app-c-subnav {
+  .app-subnav {
     padding: $govuk-spacing-scale-3;
     @include govuk-font-regular-16;
   }
 
-  .app-c-subnav__section {
+  .app-subnav__section {
     margin: 0 0 $govuk-spacing-scale-4;
     padding: 0;
     list-style-type: none;
@@ -26,7 +26,7 @@
     }
   }
 
-  .app-c-subnav__section-item--current {
+  .app-subnav__section-item--current {
     a,
     a:link,
     a:visited {
@@ -36,7 +36,7 @@
     }
   }
 
-  .app-c-subnav__theme {
+  .app-subnav__theme {
     margin: 0;
     padding: $govuk-spacing-scale-2 $govuk-spacing-scale-3;
     color: $govuk-grey-1;

--- a/src/stylesheets/components/_table.scss
+++ b/src/stylesheets/components/_table.scss
@@ -1,3 +1,3 @@
-.app-c-table--fixed {
+.app-table--fixed {
   table-layout: fixed;
 }

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -1,5 +1,5 @@
 // Tabs styles
-.app-c-tabs {
+.app-tabs {
   margin: -1px auto;
   padding: 0;
   overflow: visible;
@@ -16,7 +16,7 @@
   }
 }
 
-.app-c-tabs__item {
+.app-tabs__item {
   display: inline-block;
   position: relative;
   z-index: 2;
@@ -43,7 +43,7 @@
   }
 }
 
-.app-c-tabs__item--current {
+.app-tabs__item--current {
   a {
     border-top-color: $govuk-blue;
     border-bottom-color: $govuk-blue;
@@ -52,7 +52,7 @@
 }
 
 // Tab drawer heading for accordion look on mobile
-.app-c-tabs__heading {
+.app-tabs__heading {
   a {
     display: none;
     position: relative;
@@ -75,12 +75,12 @@
   }
 }
 
-.app-c-tabs__heading--current {
+.app-tabs__heading--current {
   background-color: darken($govuk-grey-4, 3%);
 }
 
 // Tab containers
-.app-c-tabs__container {
+.app-tabs__container {
   position: relative;
   margin-top: -2px;
   border: 1px solid $govuk-border-colour;
@@ -90,15 +90,15 @@
   }
 }
 
-.app-c-tabs__container pre {
+.app-tabs__container pre {
   border: 0;
 }
 
-.app-c-tabs__container--with-close-button pre {
+.app-tabs__container--with-close-button pre {
   padding-bottom: $govuk-spacing-scale-6;
 }
 
-.app-c-tabs__text {
+.app-tabs__text {
   padding: $govuk-spacing-scale-4 $govuk-spacing-scale-4 $govuk-spacing-scale-4 $govuk-spacing-scale-4;
 
   // magical number 1080px below as the content is inside a narrow panel
@@ -111,7 +111,7 @@
 }
 
 // Close container button
-.app-c-link--close {
+.app-link--close {
   position: absolute;
   right: $govuk-spacing-scale-3;
   bottom: $govuk-spacing-scale-3 / 2;

--- a/src/stylesheets/components/_tag.scss
+++ b/src/stylesheets/components/_tag.scss
@@ -1,3 +1,3 @@
-.app-c-tag--review {
+.app-tag--review {
   background-color: $govuk-red;
 }

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -46,14 +46,14 @@ body {
 $mq-breakpoint-widescreen: 1200px;
 
 // This will be coming to FE later but making it app specific for now
-.app-c-site-width-container {
+.app-site-width-container {
   @media (min-width: $mq-breakpoint-widescreen) {
     max-width: 1100px;
   }
 }
 
 // This layout is currently used on error pages like 404
-.app-c-site-width-container--constraint {
+.app-site-width-container--constraint {
   max-width: 960px;
 }
 
@@ -73,7 +73,7 @@ $mq-breakpoint-widescreen: 1200px;
   }
 }
 
-.app-c-content {
+.app-content {
 
   @include govuk-responsive-padding($govuk-spacing-responsive-6);
 
@@ -84,10 +84,10 @@ $mq-breakpoint-widescreen: 1200px;
   h5,
   h6,
   p,
-  ul:not(.app-c-tabs),
+  ul:not(.app-tabs),
   ol,
   img,
-  .app-c-table--constrained {
+  .app-table--constrained {
     max-width: 38em;
   }
 
@@ -102,22 +102,22 @@ $mq-breakpoint-widescreen: 1200px;
   }
 }
 
-.app-c-content__header {
+.app-content__header {
   @include govuk-font-regular-24;
 }
 
-.app-c-content__heading {
+.app-content__heading {
   margin-top: 0;
   margin-bottom: $govuk-spacing-scale-6;
 }
 
-.app-c-content__section-heading {
+.app-content__section-heading {
   margin-top: 0;
   margin-bottom: 0;
   color: $govuk-secondary-text-colour;
 }
 
-.app-o-example-page {
+.app-example-page {
   padding: $govuk-spacing-scale-6 * 2 $govuk-spacing-scale-6 $govuk-spacing-scale-6;
 
   &:before {
@@ -132,13 +132,13 @@ $mq-breakpoint-widescreen: 1200px;
   }
 }
 
-.app-o-example-page--full-page {
+.app-example-page--full-page {
   padding: 0;
 }
 
 // Generic chevron
 // can be rotated for --right --bottom --left versions
-.app-o-chevron--top::before {
+.app-chevron--top::before {
   content: "";
   display: inline-block;
   position: relative;
@@ -155,7 +155,7 @@ $mq-breakpoint-widescreen: 1200px;
 }
 
 // Copy button
-.app-c-link--copy {
+.app-link--copy {
   &:link,
   &:active,
   &:visited,
@@ -183,12 +183,12 @@ $mq-breakpoint-widescreen: 1200px;
 
 $colour-list-breakpoint: 980px;
 
-.app-c-colour-list {
+.app-colour-list {
   width: 100%;
   border-collapse: collapse;
 }
 
-.app-c-colour-list-row {
+.app-colour-list-row {
   display: block;
   position: relative;
   margin-bottom: $govuk-spacing-scale-2;
@@ -198,7 +198,7 @@ $colour-list-breakpoint: 980px;
   }
 }
 
-.app-c-colour-list-column {
+.app-colour-list-column {
   display: block;
   padding-left: 50px;
   @include mq($from: $colour-list-breakpoint) {
@@ -208,7 +208,7 @@ $colour-list-breakpoint: 980px;
   }
 }
 
-.app-c-swatch {
+.app-swatch {
   display: block;
   position: absolute;
   top: 0;
@@ -227,11 +227,11 @@ $colour-list-breakpoint: 980px;
   }
 }
 
-.app-c-swatch-border {
+.app-swatch-border {
   border-color: $govuk-grey-2;
 }
 
-.app-c-colour-list-column--name {
+.app-colour-list-column--name {
   font-weight: normal;
   text-align: left;
   @include mq($from: $colour-list-breakpoint) {
@@ -239,13 +239,13 @@ $colour-list-breakpoint: 980px;
   }
 }
 
-.app-c-colour-list-column--colour {
+.app-colour-list-column--colour {
   @include mq($from: $colour-list-breakpoint) {
     width: 15%;
   }
 }
 
-.app-c-colour-list-column--notes {
+.app-colour-list-column--notes {
   @include mq($from: $colour-list-breakpoint) {
     width: 35%;
   }
@@ -261,8 +261,8 @@ pre {
 }
 
 .no-js {
-  // Adjustments in app-o-pane layout as it has toc below
-  .app-o-pane__content .app-c-content {
+  // Adjustments in app-pane layout as it has toc below
+  .app-pane__content .app-content {
 
     @include mq($until: tablet) {
       padding-bottom: 10px;

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -24,19 +24,19 @@ body {
   margin: 0;
 }
 
-.app-u-hide-mobile {
+.app-hide-mobile {
   @include mq($until: tablet) {
     display: none;
   }
 }
 
-.app-u-hide-tablet {
+.app-hide-tablet {
   @include mq($from: tablet) {
     display: none;
   }
 }
 
-.app-u-hide-desktop {
+.app-hide-desktop {
   @include mq($from: desktop) {
     display: none;
   }

--- a/src/whats-changed.md.njk
+++ b/src/whats-changed.md.njk
@@ -14,7 +14,7 @@ The tables below show the old and new names for components, classes and mixins, 
 
 ## Component names
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Component names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -105,7 +105,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Typography class names
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Typography class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -155,7 +155,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Lists
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Lists</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -182,7 +182,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Layout and grid system class names
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Grid system class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -230,7 +230,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Form related class names
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -278,7 +278,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Helper class names
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -297,7 +297,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Override class names
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Override class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -365,7 +365,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 
 ### Typography
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -470,7 +470,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 </table>
 
 ### Layout
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -507,7 +507,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 </table>
 
 ### Media queries
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -532,7 +532,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 </table>
 
 ### Images
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -550,7 +550,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 
 ### Shims
 
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
@@ -571,7 +571,7 @@ GOV.UK Frontend uses [BEM](http://getbem.com/) and [ITCSS](https://www.creativeb
 </table>
 
 ### Internet Explorer
-<table class="govuk-c-table app-c-table--fixed">
+<table class="govuk-c-table app-table--fixed">
   <caption class="govuk-c-table__caption govuk-h-visually-hidden">Helper class names</caption>
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -15,12 +15,12 @@
   <body>
     {% include "_tracking-body.njk" %}
     <a href="#content" class="govuk-c-skip-link">Skip to main content</a>
-    <div class="app-o-pane">
-      <div class="app-o-pane__header">
+    <div class="app-pane">
+      <div class="app-pane__header">
         {% include "_header.njk" %}
         {% include "_banner.njk" %}
       </div>
-      <div class="app-o-pane__nav">
+      <div class="app-pane__nav">
         {% include "_navigation.njk" %}
         {% include "_mobile-navigation.njk" %}
       </div>

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -16,7 +16,7 @@
     <![endif]-->
     <script src="/javascripts/vendor/modernizr.js"></script>
   </head>
-  <body class="app-o-example-page">
+  <body class="app-example-page">
     {% block body %}
       {{ contents | safe }}
     {% endblock %}

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -1,13 +1,13 @@
 {% extends "_generic.njk" %}
 
 {% block body %}
-<div class="app-o-pane__body">
-  <div class="app-o-pane__subnav app-u-hide-mobile">
+<div class="app-pane__body">
+  <div class="app-pane__subnav app-u-hide-mobile">
     {% include "_subnav.njk" %}
   </div>
-  <div class="app-o-pane__content">
-    <main id="content" class="app-c-content" role="main">
-      <div class="app-c-content__header">
+  <div class="app-pane__content">
+    <main id="content" class="app-content" role="main">
+      <div class="app-content__header">
         <h1 class="govuk-heading-xl">
           <span class="govuk-caption-xl">
           {% if theme %}
@@ -38,7 +38,7 @@
       {% endif %}
     </main>
     {# No JS fallback to show overview #}
-    <div class="app-o-pane__subnav-mobile-overview app-u-hide-desktop">
+    <div class="app-pane__subnav-mobile-overview app-u-hide-desktop">
       {% include "_subnav.njk" %}
     </div>
     {% include "_footer.njk" %}

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -2,7 +2,7 @@
 
 {% block body %}
 <div class="app-pane__body">
-  <div class="app-pane__subnav app-u-hide-mobile">
+  <div class="app-pane__subnav app-hide-mobile">
     {% include "_subnav.njk" %}
   </div>
   <div class="app-pane__content">
@@ -38,7 +38,7 @@
       {% endif %}
     </main>
     {# No JS fallback to show overview #}
-    <div class="app-pane__subnav-mobile-overview app-u-hide-desktop">
+    <div class="app-pane__subnav-mobile-overview app-hide-desktop">
       {% include "_subnav.njk" %}
     </div>
     {% include "_footer.njk" %}

--- a/views/layouts/layout-single-page.njk
+++ b/views/layouts/layout-single-page.njk
@@ -1,9 +1,9 @@
 {% extends "_generic.njk" %}
 
 {% block body %}
-<div class="app-o-pane__content">
+<div class="app-pane__content">
   <main id="content" class="govuk-o-main-wrapper" role="main">
-    <div class="govuk-o-width-container app-c-site-width-container">
+    <div class="govuk-o-width-container app-site-width-container">
       {{ contents | safe }}
     </div>
   </main>

--- a/views/layouts/layout.njk
+++ b/views/layouts/layout.njk
@@ -1,7 +1,7 @@
 {% extends "_generic.njk" %}
 
 {% block body %}
-<div class="app-o-pane__content">
+<div class="app-pane__content">
   <main id="content" role="main">
     {{ contents | safe }}
   </main>

--- a/views/partials/_banner.njk
+++ b/views/partials/_banner.njk
@@ -14,7 +14,7 @@
   {{ govukPhaseBanner({
     "tag": {
       "text": "preview",
-      "classes": "app-c-tag--review"
+      "classes": "app-tag--review"
     },
     "classes": "govuk-!-pl-r3 govuk-!-pr-r3",
     "html": phaseBannerText

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -1,4 +1,4 @@
-<div class="app-c-contact-panel">
-  <h2 class="app-c-contact-panel__heading">Get in touch</h2>
-  <p class="app-c-contact-panel__body">If you’ve got a question, idea or suggestion share it in <a class="govuk-link app-c-contact-panel__link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a> on cross-government Slack (<a class="govuk-link app-c-contact-panel__link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6">open in app</a>) or <a class="govuk-link app-c-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">email the Design System team</a></p>
+<div class="app-contact-panel">
+  <h2 class="app-contact-panel__heading">Get in touch</h2>
+  <p class="app-contact-panel__body">If you’ve got a question, idea or suggestion share it in <a class="govuk-link app-contact-panel__link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a> on cross-government Slack (<a class="govuk-link app-contact-panel__link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6">open in app</a>) or <a class="govuk-link app-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">email the Design System team</a></p>
 </div>

--- a/views/partials/_divider.njk
+++ b/views/partials/_divider.njk
@@ -1,1 +1,1 @@
-<hr class="app-c-divider">
+<hr class="app-divider">

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -8,22 +8,22 @@
   {% set exampleId = exampleId + '-open' %}
 {% endif %}
 
-<div class="app-c-example-wrapper js-example" id="{{ exampleId }}">
-  <div class="app-c-example {{ "app-c-example--tabs" if params.html or params.nunjucks }}">
-    <span class="app-c-example__new-window"><a href="{{ exampleURL }}" target="_blank">(open in new window)</a></span>
-    <iframe class="app-c-example__frame app-c-example__frame--resizable js-example__frame" src="{{ exampleURL }}" frameBorder="0"></iframe>
+<div class="app-example-wrapper js-example" id="{{ exampleId }}">
+  <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
+    <span class="app-example__new-window"><a href="{{ exampleURL }}" target="_blank">(open in new window)</a></span>
+    <iframe class="app-example__frame app-example__frame--resizable js-example__frame" src="{{ exampleURL }}" frameBorder="0"></iframe>
   </div>
 
   {%- if (params.html and params.nunjucks) %}
-  <ul class="app-c-tabs" role="tablist">
-    <li class="app-c-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></li>
-    <li class="app-c-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></li>
+  <ul class="app-tabs" role="tablist">
+    <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></li>
+    <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></li>
   </ul>
   {% endif %}
 
   {%- if (params.html) %}
-  <div class="app-c-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
-  <div class="app-c-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
+  <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
+  <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
     ```html
     {{ getHTMLCode(examplePath) | safe }}
     ```
@@ -31,13 +31,13 @@
   {% endif %}
 
   {%- if (params.nunjucks) %}
-  <div class="app-c-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
-  <div class="app-c-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
+  <div class="app-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
+  <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
     ```js
     {{ getNunjucksCode(examplePath) | safe }}
     ```
   {%- if (params.group == 'components') %}
-    <p class="app-c-tabs__text">You can configure this component using the <a href="https://github.com/alphagov/govuk-frontend/tree/master/packages/{{frontendComponentName}}/README.md#component-arguments" class="govuk-link"  target="_blank" data-components="github-component-arguments" rel="noopener">Nunjucks macro arguments</a>.</p>
+    <p class="app-tabs__text">You can configure this component using the <a href="https://github.com/alphagov/govuk-frontend/tree/master/packages/{{frontendComponentName}}/README.md#component-arguments" class="govuk-link"  target="_blank" data-components="github-component-arguments" rel="noopener">Nunjucks macro arguments</a>.</p>
   {% endif %}
   </div>
   {% endif %}

--- a/views/partials/_footer.njk
+++ b/views/partials/_footer.njk
@@ -1,8 +1,8 @@
 {% from "footer/macro.njk" import govukFooter %}
 
 {{ govukFooter({
-  "classes": "app-c-footer app-c-footer--full ",
-  "containerClasses" : "app-o-width-container--full",
+  "classes": "app-footer app-footer--full ",
+  "containerClasses" : "app-width-container--full",
   "navigation": [
     {
       "title": "Related resources",

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -1,6 +1,6 @@
-<header class="app-c-header" role="banner">
-  <a href="/" class="govuk-link app-c-header__link">
-    <span class="app-c-header__logotype">
+<header class="app-header" role="banner">
+  <a href="/" class="govuk-link app-header__link">
+    <span class="app-header__logotype">
 {#
       We use an inline SVG for the crown so that we can cascade the
       currentColor into the crown whilst continuing to support older browsers
@@ -10,7 +10,7 @@
       We use currentColour so that we can easily invert it when printing and
       when the focus state is applied. This also benefits users who override
       colours in their browser as they will still see the crown. #}
-      <svg xmlns="http://www.w3.org/2000/svg" class="app-c-header__logotype-crown" width="36" height="32" viewBox="0 0 132 97">
+      <svg xmlns="http://www.w3.org/2000/svg" class="app-header__logotype-crown" width="36" height="32" viewBox="0 0 132 97">
         <path d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z" fill="currentColor" fill-rule="evenodd"></path>
 {#
         Fallback PNG image for older browsers.
@@ -23,18 +23,18 @@
 
         In other browsers <image> is synonymous for the <img> tag and will be
         interpreted as such, displaying the fallback image. #}
-        <image src="/images/govuk-logotype-crown.png" xlink:href="" class="app-c-header__logotype-crown-fallback-image"></image>
+        <image src="/images/govuk-logotype-crown.png" xlink:href="" class="app-header__logotype-crown-fallback-image"></image>
       </svg>
-      <span class="app-c-header__logotype-text">
+      <span class="app-header__logotype-text">
         GOV.UK
       </span>
     </span>
-    <span class="app-c-header__title">
+    <span class="app-header__title">
       Design System
     </span>
   </a>
-  <div class="app-c-header-mobile-nav-toggler-wrapper">
-    <button id="app-c-mobile-nav-toggler" class="govuk-c-button app-c-header-mobile-nav-toggler js-app-mobile-nav-toggler">
+  <div class="app-header-mobile-nav-toggler-wrapper">
+    <button id="app-mobile-nav-toggler" class="govuk-c-button app-header-mobile-nav-toggler js-app-mobile-nav-toggler">
       Menu
     </button>
   </div>

--- a/views/partials/_masthead.njk
+++ b/views/partials/_masthead.njk
@@ -1,9 +1,9 @@
-<div class="app-c-masthead">
-  <div class="govuk-o-width-container app-c-site-width-container">
+<div class="app-masthead">
+  <div class="govuk-o-width-container app-site-width-container">
       <div class="govuk-o-grid">
         <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-            <h1 class="govuk-heading-xl app-c-masthead__title">Design your service using GOV.UK styles, components and&nbsp;patterns</h1>
-            <p class="app-c-masthead__description">Use this design system to make your service consistent with GOV.UK. Learn from the research and experience of other service teams and avoid repeating work that’s already been done.</p>
+            <h1 class="govuk-heading-xl app-masthead__title">Design your service using GOV.UK styles, components and&nbsp;patterns</h1>
+            <p class="app-masthead__description">Use this design system to make your service consistent with GOV.UK. Learn from the research and experience of other service teams and avoid repeating work that’s already been done.</p>
         </div>
     </div>
   </div>

--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -1,19 +1,19 @@
-<nav id="app-c-mobile-nav" class="app-c-mobile-nav js-app-mobile-nav" role="navigation">
-  <ul class="app-c-mobile-nav__list">
+<nav id="app-mobile-nav" class="app-mobile-nav js-app-mobile-nav" role="navigation">
+  <ul class="app-mobile-nav__list">
     {% for item in navigation %}
     <li>
       <a class="govuk-link js-mobile-nav-subnav-toggler" href="/{{ item.url }}">{{ item.label }}</a>
       {% if item.items %}
-      <ul class="app-c-mobile-nav__subnav js-app-mobile-nav-subnav app-c-mobile-nav__subnav--hidden">
+      <ul class="app-mobile-nav__subnav js-app-mobile-nav-subnav app-mobile-nav__subnav--hidden">
         <li{% if path == item.url %} class="current-page"{% endif %}>
           <a class="govuk-link" href="/{{ item.url }}">{{ item.label }} overview</a>
         </li>
 
         {% for theme, items in item.items | groupby("theme") %}
           {% if theme != 'undefined' %}
-            <h4 class="app-c-mobile-nav__theme">{{ theme }}</h4>
+            <h4 class="app-mobile-nav__theme">{{ theme }}</h4>
           {% endif %}
-          <ul class="app-c-mobile-nav__theme-nav">
+          <ul class="app-mobile-nav__theme-nav">
           {% for subitem in items %}
             <li{% if path == subitem.url %} class="current-page"{% endif %}>
               <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -1,7 +1,7 @@
-<nav class="app-c-navigation govuk-h-clearfix">
-  <ul class="app-c-navigation__list">
+<nav class="app-navigation govuk-h-clearfix">
+  <ul class="app-navigation__list">
     {% for item in navigation %}
-    <li{% if path == item.url or item.url and item.url in path %} class="app-c-navigation--current-page"{% endif %}>
+    <li{% if path == item.url or item.url and item.url in path %} class="app-navigation--current-page"{% endif %}>
       <a class="govuk-link" href="/{{ item.url }}" data-topnav="{{ item.label }}">{{ item.label }}</a>
     </li>
     {% endfor %}

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -1,14 +1,14 @@
-<nav class="app-c-subnav">
+<nav class="app-subnav">
     {% for item in navigation %}
       {% if item.url in path %}
       {% if item.items %}
         {% for theme, items in item.items | groupby("theme") %}
           {% if theme != 'undefined' %}
-            <h4 class="app-c-subnav__theme">{{ theme }}</h4>
+            <h4 class="app-subnav__theme">{{ theme }}</h4>
           {% endif %}
-          <ul class="app-c-subnav__section">
+          <ul class="app-subnav__section">
           {% for subitem in items %}
-            <li class="app-c-subnav__section-item{% if subitem.url == path %} app-c-subnav__section-item--current{% endif %}">
+            <li class="app-subnav__section-item{% if subitem.url == path %} app-subnav__section-item--current{% endif %}">
               <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
             </li>
           {% endfor %}

--- a/views/partials/_toc-styles.njk
+++ b/views/partials/_toc-styles.njk
@@ -1,6 +1,6 @@
-<nav class="app-c-toc">
-  <ul class="app-c-toc__section">
-    <li class="app-c-toc__section-item{% if path == 'styles/typography' %} app-c-toc__section-item--current{% endif %}">
+<nav class="app-toc">
+  <ul class="app-toc__section">
+    <li class="app-toc__section-item{% if path == 'styles/typography' %} app-toc__section-item--current{% endif %}">
       <a class="govuk-link" href="/styles/typography/">Typography</a>
     </li>
   </ul>


### PR DESCRIPTION
To maintain consistency with the coding conventions in Frontend, where we're removing these prefixes.
This PR removes all `app` related prefixes

Trello ticket: https://trello.com/c/WLxTUttG/871-update-design-system-styles-to-follow-new-conventions