### PR TITLE
Update to Frontend 0.0.27-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,235 +4,235 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@govuk-frontend/all": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.26-alpha.tgz",
-      "integrity": "sha512-UMwm2D40xf9NDao0mU8wu3JEXhGEFMMEfwKrd6NflRuJE5VvYQZtq9I1Gz5ZCgM2VE/RRPImCLWJtMYH0csr0w==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.27-alpha.tgz",
+      "integrity": "sha512-4Ol/sYgdEoiLUE3ug4xdr5Xq+c/ptkWcflv/7185UUY84jnAYOPDloXlKMvyJ3jOAaOCc4k0JLnT8gg60UFDBg==",
       "requires": {
-        "@govuk-frontend/back-link": "0.0.26-alpha",
-        "@govuk-frontend/breadcrumbs": "0.0.26-alpha",
-        "@govuk-frontend/button": "0.0.26-alpha",
-        "@govuk-frontend/checkboxes": "0.0.26-alpha",
-        "@govuk-frontend/date-input": "0.0.26-alpha",
-        "@govuk-frontend/details": "0.0.26-alpha",
-        "@govuk-frontend/error-message": "0.0.26-alpha",
-        "@govuk-frontend/error-summary": "0.0.26-alpha",
-        "@govuk-frontend/fieldset": "0.0.26-alpha",
-        "@govuk-frontend/file-upload": "0.0.26-alpha",
-        "@govuk-frontend/footer": "0.0.26-alpha",
-        "@govuk-frontend/icons": "0.0.26-alpha",
-        "@govuk-frontend/input": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha",
-        "@govuk-frontend/panel": "0.0.26-alpha",
-        "@govuk-frontend/phase-banner": "0.0.26-alpha",
-        "@govuk-frontend/radios": "0.0.26-alpha",
-        "@govuk-frontend/select": "0.0.26-alpha",
-        "@govuk-frontend/skip-link": "0.0.26-alpha",
-        "@govuk-frontend/table": "0.0.26-alpha",
-        "@govuk-frontend/tag": "0.0.26-alpha",
-        "@govuk-frontend/textarea": "0.0.26-alpha",
-        "@govuk-frontend/warning-text": "0.0.26-alpha"
+        "@govuk-frontend/back-link": "0.0.27-alpha",
+        "@govuk-frontend/breadcrumbs": "0.0.27-alpha",
+        "@govuk-frontend/button": "0.0.27-alpha",
+        "@govuk-frontend/checkboxes": "0.0.27-alpha",
+        "@govuk-frontend/date-input": "0.0.27-alpha",
+        "@govuk-frontend/details": "0.0.27-alpha",
+        "@govuk-frontend/error-message": "0.0.27-alpha",
+        "@govuk-frontend/error-summary": "0.0.27-alpha",
+        "@govuk-frontend/fieldset": "0.0.27-alpha",
+        "@govuk-frontend/file-upload": "0.0.27-alpha",
+        "@govuk-frontend/footer": "0.0.27-alpha",
+        "@govuk-frontend/icons": "0.0.27-alpha",
+        "@govuk-frontend/input": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha",
+        "@govuk-frontend/panel": "0.0.27-alpha",
+        "@govuk-frontend/phase-banner": "0.0.27-alpha",
+        "@govuk-frontend/radios": "0.0.27-alpha",
+        "@govuk-frontend/select": "0.0.27-alpha",
+        "@govuk-frontend/skip-link": "0.0.27-alpha",
+        "@govuk-frontend/table": "0.0.27-alpha",
+        "@govuk-frontend/tag": "0.0.27-alpha",
+        "@govuk-frontend/textarea": "0.0.27-alpha",
+        "@govuk-frontend/warning-text": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/back-link": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.26-alpha.tgz",
-      "integrity": "sha512-eDop5ju0520ThWbzZN661JcPSXl+J7I70/tOoR7gHgeYIz8uFTAGsJ+OvQOAOeZndPQ3TtGKT7Fy0B51wSlUxA==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.27-alpha.tgz",
+      "integrity": "sha512-qyhWEHqu2SjQde9L20tKTddRNauMvSpGeaPK56rRzi4Gne1HH8ale2rkn8G7YMPksdW6qwmF6/vNAKCPyOuoKg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/breadcrumbs": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.26-alpha.tgz",
-      "integrity": "sha512-o/zvPr6d/7MwuXfneLieYZLm5/wuGZzHZstjsxNdH/HCWeQs/CEaf78JUt9TH0+t/YNKia86WLzzuNOGAxxh/g==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.27-alpha.tgz",
+      "integrity": "sha512-I8NAVerlhwiX+zXdIVYVihRMNYsOAJdmGvRd9mauHTQ414CYu+nxhmwVCPyNX/CRu7vC2P4ckUZpRhcSrbtlMg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/icons": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/icons": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/button": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.26-alpha.tgz",
-      "integrity": "sha512-MQ1EcrcXea7NkUiLS+uroX5XwvyeyiWdGYTuANcqEAm0Zx8hCCJhiK9Hi2Uj2Yu/wPilQ/JcRxDlsoxdX4+UVg==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.27-alpha.tgz",
+      "integrity": "sha512-VO6Nf4apv47Sb9/2CLv8GE9w4DaUgAzoepWLHLBAItK1Ihrws0jeFykwEqTFVZK54Dji7C0+Ra1cEfLJ6rqi6w==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/icons": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/icons": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/checkboxes": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.26-alpha.tgz",
-      "integrity": "sha512-aeLN5rgL+OGUZP4ZSqpCqhg4DojBHj1TOItAR+Nznwxk4Ees9kn9LuWQSt7s+19mvTx34SdmsEmvAS/OG/mcPA==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.27-alpha.tgz",
+      "integrity": "sha512-wLRHyveppUVq+2LX7ikXPH/1WgWUthjQ+ZutjeOTDeB/IVqqMPXN+KA9j36SwlVCiT1NaqD7XGj5xosYTPvvsw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/date-input": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.26-alpha.tgz",
-      "integrity": "sha512-OTTFqd7EdyZeQmztDd297MQHfTh0Q9za2tvnEtKfqKbtyvteDITLUXrmu4cUVrQeppftfhfLBspVnZq08V5tHw==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.27-alpha.tgz",
+      "integrity": "sha512-i3Rl1Q2nIG7tGGufGg78Gb4O73eBIYhe0amWiNxZeWZa2PFBt+i+jbC7G5KiNHxRL9eCkMtajex2yFhWbppXlg==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.26-alpha",
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha"
+        "@govuk-frontend/error-message": "0.0.27-alpha",
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/details": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.26-alpha.tgz",
-      "integrity": "sha512-4x5+SOE4NGsuY0spOiAAjxWCIVIU6bW5+im1TWQEFghkrj1gYWOj8ubf4CzaaO64SRdz7RJg7nCHh765Ye07Ag==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.27-alpha.tgz",
+      "integrity": "sha512-fG6XqZKydP2yVn0njqTysPrdFZBQj98irxkF80rnXLu9opE3P2KK89Ix4HTv1187lXxpKCjMOtPs1y2uOMy5CA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/error-message": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.26-alpha.tgz",
-      "integrity": "sha512-4fm9y4SXSSqgNAElb/mG3u41rN2N8Fc5JKYH+XCPCl+T0Ez57/LeHvDopImEZ00rsZCGzuW45hEDhi4tozICoQ==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.27-alpha.tgz",
+      "integrity": "sha512-e0D/LzeGOYjnAZfhTM5th9KtcJOH9wLx3zTBWGopnTz9k6ZWQuxkVP11g7C9h07sQU0CD7AmVaHmpNseLboB6Q==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/error-summary": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.26-alpha.tgz",
-      "integrity": "sha512-r+hkrRYsIOYUpcgcbOUV1R3DTO3FYOpWtnsLS4eWHR8MlmHAAZZKIxD6CbTP+biVfQ69dPoq7uBdUYy/XL7M4Q==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.27-alpha.tgz",
+      "integrity": "sha512-PfACItaL8fLncmpwxCmeH9s7xoDghYczcUuQX3LypbitkfyVchyDzoM/oNbqeQQALuqexbsk8DaatroocAwNMA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/fieldset": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.26-alpha.tgz",
-      "integrity": "sha512-J7b11PxpDiZdyy0pn0Cf/k96raj8YNMGWFmKVedoPBZSiTZgudNrg3INzDQLwsNkQN+uOWjwMurltDdfJpuE9Q==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.27-alpha.tgz",
+      "integrity": "sha512-FyiB7jLzL5ddTpgR9x9QRQEnok86gzggeF7dVhzEI1GmRondKEHiGlPPbzMVSANE/klYzAvuJvX4pn0mlMEQqQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/file-upload": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.26-alpha.tgz",
-      "integrity": "sha512-8ZJs/cdYpLSk0+QbPxGrZ/VtuflU22Kbk1kNROy3sf6knMkajp4pMMFeyZ/dpKx6TPkHFl3SDhdOddezAfYHRQ==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.27-alpha.tgz",
+      "integrity": "sha512-2KTqmPAa+60znH768IWs4M1sIa7CWZBIQDpky5d4yBuclKTu4zwcq/RfM+hn3+AHel4dXWpPaR8RyT2c2EYReA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/footer": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/footer/-/footer-0.0.26-alpha.tgz",
-      "integrity": "sha512-cO5K8DZ9ewrcN/htThnWeEKt5M3uXJ3LBcaOoCTFWvXsbIf9kIU0+JVrjphS8tN245ajW7AREgkm4VzOvYp6/Q==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/footer/-/footer-0.0.27-alpha.tgz",
+      "integrity": "sha512-s3oEUSaOBRMiLp89SQfQnX6T3t185awguWMgYdd1fCVTrT7cmqspWnDRZTrUk/oQr0U94I0zDBlWDVj/5hNk8A==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/icons": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/icons": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/globals": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.26-alpha.tgz",
-      "integrity": "sha512-ZqocVmgs/ubl0EeyQv1/n0nUJv9rCWWLWVpIPyPqriBtQAYWzlpg+mEwZ27+K0xl+E5PEWxZW/vKyErMMfrpsA==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.27-alpha.tgz",
+      "integrity": "sha512-y2YDYyv5rQRrSNcpHjoREjMeXlinkJ8JjNp+Lg4MvelGL34HfBAXMvnImVb7VQM6WkRsQY7dgcrkJoWSqjzAjg==",
       "requires": {
         "sass-mq": "3.3.2"
       }
     },
     "@govuk-frontend/icons": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.26-alpha.tgz",
-      "integrity": "sha512-XtFR4J4w5VeWRQjzbUKC7b3wMC7vwI7mSQKbMo+5Ey0v98Gq9RdRPdVbfAlEnZyFaHTi8OTmt+qWcHjiKwMY2w=="
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.27-alpha.tgz",
+      "integrity": "sha512-Ct/OgSqJVA1hz60sDIqSoN4vtJKNskfyOIkdI342fBKf9ZQVw8shswZ0D+kYYzr9YoPLSc/dKHjbDUIiMpgDdw=="
     },
     "@govuk-frontend/input": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.26-alpha.tgz",
-      "integrity": "sha512-3tK3UTmS8YDNAG9u9bWUDoDeoLTHjdoKdlABV730srnnm0xREoUWLkR23TE9W4DtQsl4qHWrwYg+taydhCUy4Q==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.27-alpha.tgz",
+      "integrity": "sha512-n+8I1+zu52nHb82WcajblcAhCq0l/ygFJrGDZDrmf6hiK+vvHZDwqGTT0+zWcn7aKriPT+bSeqWYFV4GchCKbg==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.26-alpha",
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha"
+        "@govuk-frontend/error-message": "0.0.27-alpha",
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/label": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.26-alpha.tgz",
-      "integrity": "sha512-DV4fYIzub6Zxh3j6myB6wBbR6I4T4i+fa2O5EM2c3d6h/VwZgDWYUXe2VhAc+0Pyqd3MevS2dAFc5NEJ4uycUQ==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.27-alpha.tgz",
+      "integrity": "sha512-IWNqf7W+4/c3haMFm9ZDk73CJ9GHymNwyQb64ZZzYZ+n7Scov9K5CzYiYTqk2gMX9Elw3lvQtyRJQxB64AVnfw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/panel": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.26-alpha.tgz",
-      "integrity": "sha512-slYnmUNzkYt6dCjE+ENkrieNHGnfIA0pWGRVJNy8sjXzsderoyWTxZTv64sq2XUyJHkjSTgpekTdsVodIFMtIg==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.27-alpha.tgz",
+      "integrity": "sha512-WNQez91KYGghYyLFhIE2ltYRDGnETsuP95WuDZWwGiGa51HWDO1KmXiQqyHwyt9vG3dbL8sA+B5dnjtYNHDhiQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/phase-banner": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.26-alpha.tgz",
-      "integrity": "sha512-4OM4lrR/Cr39Fb/i4zutG22xVr6L3FIWaPh4ePvo0x2LsuW45aPajOWooHZtzeWdrDW40ABl/ILzro8S6qZGJw==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.27-alpha.tgz",
+      "integrity": "sha512-cAHZQ2F9Zph2mjvCD7VYMt6XJly0KR18bmy3HpOK3YZhLsB6oBBA/Qc5dK8gfyFOyNxUdFxx5fIFengDLjC1xA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/tag": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/tag": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/radios": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.26-alpha.tgz",
-      "integrity": "sha512-uC/oM4G6Vw1CL88OO4XxHzx7lRKxp8YChe5iILaF+z4utJMFzQsrIeYxNdMEsTyxfIXZdbaTA6nGtD9qkxjlSw==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.27-alpha.tgz",
+      "integrity": "sha512-9j3WJ+9UTNdh9vr57snsNF34NIZTJcputRLVTlJWbbOw4+iaat6tMC+lufl6DVjQP8UdmmVpDG42UU9F3Xexkg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/select": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.26-alpha.tgz",
-      "integrity": "sha512-TA7/0RordPcAKH/C5GtmJCO4pcqvDYBh+elFNTUeTIObCrfeKd70C/Tv4uvJbzW+NtWJOvf8zocg/xsvDSDMgQ==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.27-alpha.tgz",
+      "integrity": "sha512-kzSkiyBlxH4oafUC29b61CL7HbpB5aZzTyikgZkvj9mTJFsMOXPXMsvQujkZJKsayloBg66KpkszoFRpBTKNBw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/skip-link": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.26-alpha.tgz",
-      "integrity": "sha512-V4kSsRrkd6dy5p4Szg8i8OSWYO6uVgIylp1lN5VrsX3v3ou6hYZ+UMC0w0SY1BHPsi4enDRXeJVNoAMotJtXVQ==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.27-alpha.tgz",
+      "integrity": "sha512-I5zfqNNdcY2kGkz/2ItRoF7L8MKDYKt9hrcw+6gyKpVbcrJErc7nCgCP/ws+hnJNIEz57kNFYeTPHunfNpIAzA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/table": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.26-alpha.tgz",
-      "integrity": "sha512-gXEQ34rCzaxF0GXr03z/TgtRgk75YWnxbY+hYhDzEVzimlwYDoHxo8+xOUl/BJEfdMTO5WTdb3ieIxvWKRrqlg==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.27-alpha.tgz",
+      "integrity": "sha512-zNqrXnEf1bLUtOPfLo7DZl/u1VneyeuMBG/Qc+MTXEOw2Z+r6npx6tEedRgQAvFxGXSDYInHp9VowQ5VTE/qAg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/tag": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.26-alpha.tgz",
-      "integrity": "sha512-AzdmY6HAYbo+KkG0KO0BCaau4d919PFrZC3KXkojYJn4AFjbIyhyQwI3bKIfEDTqXdWA7D8moK/ek8zlrPK7pg==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.27-alpha.tgz",
+      "integrity": "sha512-Tdc4JiR7RYDdGNniByz/98BogQd5PG6jOXn7xyT7NHKV9IPJaQcKw8e+NzWlxdTu37qt1piEZRszNY2QK0ZHiA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/textarea": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.26-alpha.tgz",
-      "integrity": "sha512-GG+8PfDJHw6EYHsY2BY8SWJnkPac2WfpIV6u7VgxUYFOVf+6q1SWX1MUQ+6AAuxQOuYB7HzXiSwFKeTDrUmNuA==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.27-alpha.tgz",
+      "integrity": "sha512-gfb72PYrHBDPQrZWQphqTIqh927q9+pcr1auBhxtzuUB74mBGKLNLTHtMRZQo90Tqf5XGn/mQywOUyuvt/HpNA==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.26-alpha",
-        "@govuk-frontend/globals": "0.0.26-alpha",
-        "@govuk-frontend/label": "0.0.26-alpha"
+        "@govuk-frontend/error-message": "0.0.27-alpha",
+        "@govuk-frontend/globals": "0.0.27-alpha",
+        "@govuk-frontend/label": "0.0.27-alpha"
       }
     },
     "@govuk-frontend/warning-text": {
-      "version": "0.0.26-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/warning-text/-/warning-text-0.0.26-alpha.tgz",
-      "integrity": "sha512-UkKA9EDk9U/iYboGg2wISjZcp2nIRIAGqqhHi2tBu6CyK2aag8w+Mjwtz1rYF2Ken1hQUumbSedXemDu6YFK+w==",
+      "version": "0.0.27-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/warning-text/-/warning-text-0.0.27-alpha.tgz",
+      "integrity": "sha512-9U53nKLbWWlY/T1+TIpLXMZlVLdeIEsqApeO+XY/zEHlz8IvU7w8Gq5v25UtV+PffOM7XmhTRRFMZbEPnnPjrA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.26-alpha"
+        "@govuk-frontend/globals": "0.0.27-alpha"
       }
     },
     "a-sync-waterfall": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-frontend/all": "0.0.26-alpha",
+    "@govuk-frontend/all": "0.0.27-alpha",
     "clipboard": "^2.0.0",
     "html5shiv": "^3.7.3",
     "jquery": "^1.12.4",


### PR DESCRIPTION
Update package.json and package-lock.json to install latest GOV.UK Frontend

Created issues for documentation of new features that needs to be created for DS docs:

- https://github.com/alphagov/govuk-design-system/issues/231
- https://github.com/alphagov/govuk-design-system/issues/232
- https://github.com/alphagov/govuk-design-system/issues/234

Trello card: https://trello.com/c/vPvNOxab/896-update-design-system-with-changes-from-frontend