### PR TITLE
Update govuk-frontend to 0.0.28-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,235 +4,235 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@govuk-frontend/all": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.27-alpha.tgz",
-      "integrity": "sha512-4Ol/sYgdEoiLUE3ug4xdr5Xq+c/ptkWcflv/7185UUY84jnAYOPDloXlKMvyJ3jOAaOCc4k0JLnT8gg60UFDBg==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/all/-/all-0.0.28-alpha.tgz",
+      "integrity": "sha512-6YT+C7QGu7hiRY1o6f8hOUxgHYRmGjkIXCHFsdHqCdSRTKPXIiKjstGI5kIDDZZmSKkqF3QsskHKafPAC3/ODg==",
       "requires": {
-        "@govuk-frontend/back-link": "0.0.27-alpha",
-        "@govuk-frontend/breadcrumbs": "0.0.27-alpha",
-        "@govuk-frontend/button": "0.0.27-alpha",
-        "@govuk-frontend/checkboxes": "0.0.27-alpha",
-        "@govuk-frontend/date-input": "0.0.27-alpha",
-        "@govuk-frontend/details": "0.0.27-alpha",
-        "@govuk-frontend/error-message": "0.0.27-alpha",
-        "@govuk-frontend/error-summary": "0.0.27-alpha",
-        "@govuk-frontend/fieldset": "0.0.27-alpha",
-        "@govuk-frontend/file-upload": "0.0.27-alpha",
-        "@govuk-frontend/footer": "0.0.27-alpha",
-        "@govuk-frontend/icons": "0.0.27-alpha",
-        "@govuk-frontend/input": "0.0.27-alpha",
-        "@govuk-frontend/label": "0.0.27-alpha",
-        "@govuk-frontend/panel": "0.0.27-alpha",
-        "@govuk-frontend/phase-banner": "0.0.27-alpha",
-        "@govuk-frontend/radios": "0.0.27-alpha",
-        "@govuk-frontend/select": "0.0.27-alpha",
-        "@govuk-frontend/skip-link": "0.0.27-alpha",
-        "@govuk-frontend/table": "0.0.27-alpha",
-        "@govuk-frontend/tag": "0.0.27-alpha",
-        "@govuk-frontend/textarea": "0.0.27-alpha",
-        "@govuk-frontend/warning-text": "0.0.27-alpha"
+        "@govuk-frontend/back-link": "0.0.28-alpha",
+        "@govuk-frontend/breadcrumbs": "0.0.28-alpha",
+        "@govuk-frontend/button": "0.0.28-alpha",
+        "@govuk-frontend/checkboxes": "0.0.28-alpha",
+        "@govuk-frontend/date-input": "0.0.28-alpha",
+        "@govuk-frontend/details": "0.0.28-alpha",
+        "@govuk-frontend/error-message": "0.0.28-alpha",
+        "@govuk-frontend/error-summary": "0.0.28-alpha",
+        "@govuk-frontend/fieldset": "0.0.28-alpha",
+        "@govuk-frontend/file-upload": "0.0.28-alpha",
+        "@govuk-frontend/footer": "0.0.28-alpha",
+        "@govuk-frontend/icons": "0.0.28-alpha",
+        "@govuk-frontend/input": "0.0.28-alpha",
+        "@govuk-frontend/label": "0.0.28-alpha",
+        "@govuk-frontend/panel": "0.0.28-alpha",
+        "@govuk-frontend/phase-banner": "0.0.28-alpha",
+        "@govuk-frontend/radios": "0.0.28-alpha",
+        "@govuk-frontend/select": "0.0.28-alpha",
+        "@govuk-frontend/skip-link": "0.0.28-alpha",
+        "@govuk-frontend/table": "0.0.28-alpha",
+        "@govuk-frontend/tag": "0.0.28-alpha",
+        "@govuk-frontend/textarea": "0.0.28-alpha",
+        "@govuk-frontend/warning-text": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/back-link": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.27-alpha.tgz",
-      "integrity": "sha512-qyhWEHqu2SjQde9L20tKTddRNauMvSpGeaPK56rRzi4Gne1HH8ale2rkn8G7YMPksdW6qwmF6/vNAKCPyOuoKg==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/back-link/-/back-link-0.0.28-alpha.tgz",
+      "integrity": "sha512-DtP8qtc0FOTxDLU9Ivjy0HihzrXxN2/DT321albNJxpr2BKGXIA1TXW0PAGx+eYKnZBLsNl2kX0rYTvzJN9B9w==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/breadcrumbs": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.27-alpha.tgz",
-      "integrity": "sha512-I8NAVerlhwiX+zXdIVYVihRMNYsOAJdmGvRd9mauHTQ414CYu+nxhmwVCPyNX/CRu7vC2P4ckUZpRhcSrbtlMg==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/breadcrumbs/-/breadcrumbs-0.0.28-alpha.tgz",
+      "integrity": "sha512-7GWrepcXlWNpzBCkdXKbfJJfxpyl7wdl6jFO7vwbnfy9NxaEQiaehWvqOlBWNJeOVyPNgSO5L3SQ4cH2daxrKg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha",
-        "@govuk-frontend/icons": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha",
+        "@govuk-frontend/icons": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/button": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.27-alpha.tgz",
-      "integrity": "sha512-VO6Nf4apv47Sb9/2CLv8GE9w4DaUgAzoepWLHLBAItK1Ihrws0jeFykwEqTFVZK54Dji7C0+Ra1cEfLJ6rqi6w==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/button/-/button-0.0.28-alpha.tgz",
+      "integrity": "sha512-nmtqBDqXGmcqGYpGrVmOxFMLvEYmKncDS5YEoIqS1vM8TmM7KMhj3Ax5o1ylKO7d4LVSrfPazC+P9P6Aky056A==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha",
-        "@govuk-frontend/icons": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha",
+        "@govuk-frontend/icons": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/checkboxes": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.27-alpha.tgz",
-      "integrity": "sha512-wLRHyveppUVq+2LX7ikXPH/1WgWUthjQ+ZutjeOTDeB/IVqqMPXN+KA9j36SwlVCiT1NaqD7XGj5xosYTPvvsw==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/checkboxes/-/checkboxes-0.0.28-alpha.tgz",
+      "integrity": "sha512-yTJreWy9XimVur3APOTn8sDvZNfe/Xv5CSc36lm7ZSyJq+3QJVY3gW5jkSgyAvUo4LqnDW1Sx88fSOyVYF8w2g==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha",
-        "@govuk-frontend/label": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha",
+        "@govuk-frontend/label": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/date-input": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.27-alpha.tgz",
-      "integrity": "sha512-i3Rl1Q2nIG7tGGufGg78Gb4O73eBIYhe0amWiNxZeWZa2PFBt+i+jbC7G5KiNHxRL9eCkMtajex2yFhWbppXlg==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/date-input/-/date-input-0.0.28-alpha.tgz",
+      "integrity": "sha512-omxYBwtRn04rUsvElNa84T/aoni2Grus3OiVNi4nSL6TcYR4eynybUW42aX8ZKpHzdLh78LGzgE+K5ivsBHkwg==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.27-alpha",
-        "@govuk-frontend/globals": "0.0.27-alpha",
-        "@govuk-frontend/label": "0.0.27-alpha"
+        "@govuk-frontend/error-message": "0.0.28-alpha",
+        "@govuk-frontend/globals": "0.0.28-alpha",
+        "@govuk-frontend/label": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/details": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.27-alpha.tgz",
-      "integrity": "sha512-fG6XqZKydP2yVn0njqTysPrdFZBQj98irxkF80rnXLu9opE3P2KK89Ix4HTv1187lXxpKCjMOtPs1y2uOMy5CA==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/details/-/details-0.0.28-alpha.tgz",
+      "integrity": "sha512-24wk+m4d1HJTnEC/IoCslhiRmzMdJH36yscZKZyW9kOVuljnEU8tPCouzziI2VgnfCL7bUGx3auptTSSM6IFtA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/error-message": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.27-alpha.tgz",
-      "integrity": "sha512-e0D/LzeGOYjnAZfhTM5th9KtcJOH9wLx3zTBWGopnTz9k6ZWQuxkVP11g7C9h07sQU0CD7AmVaHmpNseLboB6Q==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-message/-/error-message-0.0.28-alpha.tgz",
+      "integrity": "sha512-7kqko7fu2g6qixIFmxXiT3UeY9a+fanX+HrVLORuN/cBUXh6X1zr6e/E2Kuky7ze1uILPl4IegqDXCbH1BOEkw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/error-summary": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.27-alpha.tgz",
-      "integrity": "sha512-PfACItaL8fLncmpwxCmeH9s7xoDghYczcUuQX3LypbitkfyVchyDzoM/oNbqeQQALuqexbsk8DaatroocAwNMA==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/error-summary/-/error-summary-0.0.28-alpha.tgz",
+      "integrity": "sha512-jQaHhxwAC7xU0ZFMEtIjGNBgWvgumnjiszQ8Q7RddhSC2orPa+fiBKpWtYXfYKsyDxDXyWPmeAgJq+zlQzG95g==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/fieldset": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.27-alpha.tgz",
-      "integrity": "sha512-FyiB7jLzL5ddTpgR9x9QRQEnok86gzggeF7dVhzEI1GmRondKEHiGlPPbzMVSANE/klYzAvuJvX4pn0mlMEQqQ==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/fieldset/-/fieldset-0.0.28-alpha.tgz",
+      "integrity": "sha512-RDFRtgQEUGHMpP3GH906Y+EtmFvGB5cVVxrWE9Z2qBr3HcBsDGcEQeIPopk9Ft10mXL/LFD030YedvZvFz9GWg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/file-upload": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.27-alpha.tgz",
-      "integrity": "sha512-2KTqmPAa+60znH768IWs4M1sIa7CWZBIQDpky5d4yBuclKTu4zwcq/RfM+hn3+AHel4dXWpPaR8RyT2c2EYReA==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/file-upload/-/file-upload-0.0.28-alpha.tgz",
+      "integrity": "sha512-5cK2ZnVjDz+5mcKMmOWyFeoZ0ZKDgAlkzUxWcjH8tdO06rrpHE4L/ltaReGrQj5qSgJp4LhSxU4kafRS6r/blA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/footer": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/footer/-/footer-0.0.27-alpha.tgz",
-      "integrity": "sha512-s3oEUSaOBRMiLp89SQfQnX6T3t185awguWMgYdd1fCVTrT7cmqspWnDRZTrUk/oQr0U94I0zDBlWDVj/5hNk8A==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/footer/-/footer-0.0.28-alpha.tgz",
+      "integrity": "sha512-zs8TywvXVsPIBNqYL2WasRjTu3GgxBRhk8GJWnlDDqR5ABYuzhmVIlT8DEQnUuJx4jyjCTe3VQAA2CbShECmUg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha",
-        "@govuk-frontend/icons": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha",
+        "@govuk-frontend/icons": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/globals": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.27-alpha.tgz",
-      "integrity": "sha512-y2YDYyv5rQRrSNcpHjoREjMeXlinkJ8JjNp+Lg4MvelGL34HfBAXMvnImVb7VQM6WkRsQY7dgcrkJoWSqjzAjg==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/globals/-/globals-0.0.28-alpha.tgz",
+      "integrity": "sha512-6NjrZzYDt4pAMPb6BAwx9JpjYiwofk63psahaIWTLm/xmsxUzzmWIcGfHxoe/RZ3GuUJw0tZm2nsPLrUH1djKg==",
       "requires": {
         "sass-mq": "3.3.2"
       }
     },
     "@govuk-frontend/icons": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.27-alpha.tgz",
-      "integrity": "sha512-Ct/OgSqJVA1hz60sDIqSoN4vtJKNskfyOIkdI342fBKf9ZQVw8shswZ0D+kYYzr9YoPLSc/dKHjbDUIiMpgDdw=="
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/icons/-/icons-0.0.28-alpha.tgz",
+      "integrity": "sha512-3lCdYEdbHlwNMwTsvNGo6599rf+28Lw7AtSKTwi7FplD71FKR0+dyrZlO+gCaCxr4o7jwMRzaf2zXcQY/ZOxkg=="
     },
     "@govuk-frontend/input": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.27-alpha.tgz",
-      "integrity": "sha512-n+8I1+zu52nHb82WcajblcAhCq0l/ygFJrGDZDrmf6hiK+vvHZDwqGTT0+zWcn7aKriPT+bSeqWYFV4GchCKbg==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/input/-/input-0.0.28-alpha.tgz",
+      "integrity": "sha512-os3Qcs6et5WShFWtqoJf6nYFcTUVhh4rhCMtNZSKUGvh156DJzB0TGAPgk5trPHeNW843tA2Xg110f1QEu84ZQ==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.27-alpha",
-        "@govuk-frontend/globals": "0.0.27-alpha",
-        "@govuk-frontend/label": "0.0.27-alpha"
+        "@govuk-frontend/error-message": "0.0.28-alpha",
+        "@govuk-frontend/globals": "0.0.28-alpha",
+        "@govuk-frontend/label": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/label": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.27-alpha.tgz",
-      "integrity": "sha512-IWNqf7W+4/c3haMFm9ZDk73CJ9GHymNwyQb64ZZzYZ+n7Scov9K5CzYiYTqk2gMX9Elw3lvQtyRJQxB64AVnfw==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/label/-/label-0.0.28-alpha.tgz",
+      "integrity": "sha512-ifsZWEyXVlY1PEQAu1n3FTmT41O2WkvpM46qinv+YWvfK3YZaHLMaDVWD4Zqwa5V3MiOXij9ZsDR/rhSoWBdMg==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/panel": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.27-alpha.tgz",
-      "integrity": "sha512-WNQez91KYGghYyLFhIE2ltYRDGnETsuP95WuDZWwGiGa51HWDO1KmXiQqyHwyt9vG3dbL8sA+B5dnjtYNHDhiQ==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/panel/-/panel-0.0.28-alpha.tgz",
+      "integrity": "sha512-4QgLgyukJgNnP0uFFF9/mB+jlqxQ3BclVPBp/NyYI8lVFc22xf1A9Oz/V2QEW0zocC1W6s/anripuPGUFyFbAw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/phase-banner": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.27-alpha.tgz",
-      "integrity": "sha512-cAHZQ2F9Zph2mjvCD7VYMt6XJly0KR18bmy3HpOK3YZhLsB6oBBA/Qc5dK8gfyFOyNxUdFxx5fIFengDLjC1xA==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/phase-banner/-/phase-banner-0.0.28-alpha.tgz",
+      "integrity": "sha512-M/4bnI9t0XBXQb4Qmnqoi4wY1TpB+duo9Ly5N1M5mLPyoLrPFBO1Mip9R+F1IFXlGo9z8LSuMG+eZWukiirbsA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha",
-        "@govuk-frontend/tag": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha",
+        "@govuk-frontend/tag": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/radios": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.27-alpha.tgz",
-      "integrity": "sha512-9j3WJ+9UTNdh9vr57snsNF34NIZTJcputRLVTlJWbbOw4+iaat6tMC+lufl6DVjQP8UdmmVpDG42UU9F3Xexkg==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/radios/-/radios-0.0.28-alpha.tgz",
+      "integrity": "sha512-LJ6qSMLTVWwVQ+sPGos77nCuzgHebtje1TvsoJxz5GLUvpUfhZOWYgHrQuMZWXTK3yGs/M/Y1Xve56cQIwU0XQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha",
-        "@govuk-frontend/label": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha",
+        "@govuk-frontend/label": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/select": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.27-alpha.tgz",
-      "integrity": "sha512-kzSkiyBlxH4oafUC29b61CL7HbpB5aZzTyikgZkvj9mTJFsMOXPXMsvQujkZJKsayloBg66KpkszoFRpBTKNBw==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/select/-/select-0.0.28-alpha.tgz",
+      "integrity": "sha512-/Zlg2ZJE87/CfLDwo1b8AvMOXQd72fIZRykE5fNfgNDwMx7Z6lFtf/1qy8QrTk1UJenALSbrYSJPAM9v7G4x+w==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha",
-        "@govuk-frontend/label": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha",
+        "@govuk-frontend/label": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/skip-link": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.27-alpha.tgz",
-      "integrity": "sha512-I5zfqNNdcY2kGkz/2ItRoF7L8MKDYKt9hrcw+6gyKpVbcrJErc7nCgCP/ws+hnJNIEz57kNFYeTPHunfNpIAzA==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/skip-link/-/skip-link-0.0.28-alpha.tgz",
+      "integrity": "sha512-2FPihfdOYCh58qBsjq+SoCQcyk1U3vL0iIOfO9GJpa5Lr+vbWKxB8lD0vNIfU1wWStTR56HcNqXY4xOIx3AT+Q==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/table": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.27-alpha.tgz",
-      "integrity": "sha512-zNqrXnEf1bLUtOPfLo7DZl/u1VneyeuMBG/Qc+MTXEOw2Z+r6npx6tEedRgQAvFxGXSDYInHp9VowQ5VTE/qAg==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/table/-/table-0.0.28-alpha.tgz",
+      "integrity": "sha512-zthOOKQ5jSI6D1mRYweEW0ZJWTcB4G89woxyRUChE2nHG6A+alo3h9IM9w+w8M0N+IT4w+LQgQYpR0yIe2jJmw==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/tag": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.27-alpha.tgz",
-      "integrity": "sha512-Tdc4JiR7RYDdGNniByz/98BogQd5PG6jOXn7xyT7NHKV9IPJaQcKw8e+NzWlxdTu37qt1piEZRszNY2QK0ZHiA==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/tag/-/tag-0.0.28-alpha.tgz",
+      "integrity": "sha512-KVLl1biMiFvAZxedyFm7iSFuaz3ONYWMy2AchoIzfCP3HsmJ46ORgyrtc1VP0dcnwM63LY2emEVhUcTYSPSAkQ==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/textarea": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.27-alpha.tgz",
-      "integrity": "sha512-gfb72PYrHBDPQrZWQphqTIqh927q9+pcr1auBhxtzuUB74mBGKLNLTHtMRZQo90Tqf5XGn/mQywOUyuvt/HpNA==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/textarea/-/textarea-0.0.28-alpha.tgz",
+      "integrity": "sha512-CWWy31HYR3kDQWlVtkUNqR9FZSNLWAqLIBPI+Rmz6w+Y3ypUiQAP8H4oLvJyJZfcNOsFOtyPlG+EA4K+97n87Q==",
       "requires": {
-        "@govuk-frontend/error-message": "0.0.27-alpha",
-        "@govuk-frontend/globals": "0.0.27-alpha",
-        "@govuk-frontend/label": "0.0.27-alpha"
+        "@govuk-frontend/error-message": "0.0.28-alpha",
+        "@govuk-frontend/globals": "0.0.28-alpha",
+        "@govuk-frontend/label": "0.0.28-alpha"
       }
     },
     "@govuk-frontend/warning-text": {
-      "version": "0.0.27-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/warning-text/-/warning-text-0.0.27-alpha.tgz",
-      "integrity": "sha512-9U53nKLbWWlY/T1+TIpLXMZlVLdeIEsqApeO+XY/zEHlz8IvU7w8Gq5v25UtV+PffOM7XmhTRRFMZbEPnnPjrA==",
+      "version": "0.0.28-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/warning-text/-/warning-text-0.0.28-alpha.tgz",
+      "integrity": "sha512-xE+dGL4dB9G2oV4B+QVUurBr/geMZj8XIxya1fn/FNZa25gxi0NBW3hSE/r7kPN5mfhbXDpJJ32wymRMC6abgA==",
       "requires": {
-        "@govuk-frontend/globals": "0.0.27-alpha"
+        "@govuk-frontend/globals": "0.0.28-alpha"
       }
     },
     "a-sync-waterfall": {
@@ -8937,7 +8937,7 @@
     },
     "substitute": {
       "version": "https://github.com/segmentio/substitute/archive/0.0.1.tar.gz",
-      "integrity": "sha512-EnlQz7Yu+hwB9lqjP4MfEJaDDARyba6zXvFPYhDHj93LR8jtivHJEouukvaMm9ykXAxVf5TSGrkfMlutax+pGA==",
+      "integrity": "sha1-QyhmmFsDw7DT9xrGPRrhoY369H0=",
       "dev": true
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-frontend/all": "0.0.27-alpha",
+    "@govuk-frontend/all": "0.0.28-alpha",
     "clipboard": "^2.0.0",
     "html5shiv": "^3.7.3",
     "jquery": "^1.12.4",


### PR DESCRIPTION
Updated govuk-frontend to 0.0.28-alpha.
No additional changes to the Design System itself.