### PR TITLE
Fix nav alignment

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -37,7 +37,7 @@
       a {
         @include govuk-typography-weight-bold; // Override .govuk-link weight
         display: block;
-        padding: 0 20px;
+        padding: 0 $govuk-spacing-scale-3;
         color: $govuk-link-colour;
         text-decoration: none;
 


### PR DESCRIPTION
Very small PR to change the padding on the nav from 20px to `govuk-spacing-scale-3`. The intent was the edge of the word "About" would line up with the secondary nav.

**Before**
<img width="186" alt="screen shot 2018-04-16 at 14 55 56" src="https://user-images.githubusercontent.com/23356842/38813291-72cce4b6-4186-11e8-86bc-4f5a38478382.png">

**After**
<img width="145" alt="screen shot 2018-04-16 at 14 55 45" src="https://user-images.githubusercontent.com/23356842/38813285-711877f2-4186-11e8-8e31-674c7c338efb.png">

