### PR TITLE
Update theme styling to use lowercase, regular weight font

### DIFF
--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -80,6 +80,8 @@
   margin: 0;
   padding: $govuk-spacing-scale-4 $govuk-spacing-scale-4 $govuk-spacing-scale-1 $govuk-spacing-scale-4;
   color: $govuk-grey-1;
+  // Font is defined as a hard 19px so
+  // it doesn't re-size on mobile viewport
   font-size: 19px;
   font-weight: 400;
 }

--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -80,8 +80,8 @@
   margin: 0;
   padding: $govuk-spacing-scale-4 $govuk-spacing-scale-4 $govuk-spacing-scale-1 $govuk-spacing-scale-4;
   color: $govuk-grey-1;
-  @include govuk-font-bold-19;
-  text-transform: uppercase;
+  font-size: 19px;
+  font-weight: 400;
 }
 
 .app-mobile-nav__theme-nav {

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -40,7 +40,6 @@
     margin: 0;
     padding: $govuk-spacing-scale-2 $govuk-spacing-scale-3;
     color: $govuk-grey-1;
-    @include govuk-font-bold-16;
-    text-transform: uppercase;
+    @include govuk-font-regular-19;
   }
 }


### PR DESCRIPTION
Requested by @timpaul 

![screen shot 2018-04-16 at 15 33 22](https://user-images.githubusercontent.com/23356842/38815330-9942f428-418b-11e8-9f6c-db4daf86ea26.png)

Note - I have used a hard 19px unit on mobile as I do not want it to change to 16px on mobile.

![screen shot 2018-04-16 at 15 33 38](https://user-images.githubusercontent.com/23356842/38815336-9c3768da-418b-11e8-9cb1-013a7821f10a.png)
