### PR TITLE
[DON'T MERGE] Service Worker added for offline documentation

### DIFF
--- a/config/workbox-cli-config.js
+++ b/config/workbox-cli-config.js
@@ -1,0 +1,36 @@
+const paths = require('./paths.json') // specify paths to main working directories
+
+module.exports = {
+  globDirectory: paths.public,
+  globPatterns: [
+    '**/*.{html,js,css,png,jpg}'
+  ],
+  swDest: paths.public + 'service-worker.js',
+  importWorkboxFrom: 'local',
+  skipWaiting: true,
+  clientsClaim: true,
+  directoryIndex: 'index.html',
+  cacheId: 'govuk-ds',
+  runtimeCaching: [{
+    urlPattern: /.*/,
+    handler: 'networkFirst'
+  },
+  {
+    urlPattern: new RegExp('https://www.google-analytics.com/analytics.js'),
+    handler: 'networkFirst',
+    options: {
+      expiration: {
+        maxAgeSeconds: 60 * 60
+      }
+    }
+  },
+  {
+    urlPattern: new RegExp('https://www.googletagmanager.com/gtm.js'),
+    handler: 'networkFirst',
+    options: {
+      expiration: {
+        maxAgeSeconds: 60 * 60
+      }
+    }
+  }]
+}

--- a/lib/build-service-worker.js
+++ b/lib/build-service-worker.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const workbox = require('workbox-build')
+
+module.exports = {
+  generate: function () {
+    return workbox.generateSW(
+      require('../config/workbox-cli-config')
+    ).then(() => {
+      console.info('Service worker generation completed.')
+    }).catch((error) => {
+      console.warn('Service worker generation failed: ' + error)
+    })
+  },
+  init: function () {
+    this.generate()
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1888,6 +1888,15 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
       "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
     },
+    "common-tags": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.2.tgz",
+      "integrity": "sha512-joj9ZlUOjCrwdbmiLqafeUSgkUM74NqhLsZtSqDmhKudaIY197zTrb8JMl31fMnCUuxwFT23eC/oWvrZzDLRJQ==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -5438,6 +5447,23 @@
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
+    "isemail": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
+      "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        }
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5464,6 +5490,25 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "joi": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
+      "integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.1",
+        "isemail": "3.1.2",
+        "topo": "2.0.2"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+          "dev": true
+        }
+      }
     },
     "jquery": {
       "version": "1.12.4",
@@ -7430,6 +7475,12 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "pretty-bytes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
+      "dev": true
+    },
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -9182,6 +9233,23 @@
       "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA==",
       "dev": true
     },
+    "topo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.1"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+          "dev": true
+        }
+      }
+    },
     "tough-cookie": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
@@ -9707,6 +9775,150 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "workbox-background-sync": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.1.0.tgz",
+      "integrity": "sha512-4R5zL/TJI+pUO29SMMCAa8A7EkfDt2p0/hqLeUPMFfxiMzZtAjQ9b7YL8ES6ieFBmWZbSF+PuXdHUveIkF29pA==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "3.1.0"
+      }
+    },
+    "workbox-broadcast-cache-update": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.1.0.tgz",
+      "integrity": "sha512-OrKUfgtEErxxVeAF6pPgy6921UrVUZsZwVNrxb1Jh30hqs1hgYUZ+CFdRrRYyfUesb/YZ54psDaBV61vEH1jbg==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "3.1.0"
+      }
+    },
+    "workbox-build": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-3.1.0.tgz",
+      "integrity": "sha512-ZRWHlXMLpD4xRBoZba8dUIDGYIlS3bGLsFEaWylieKddAxT4ff5d4H/BFRlnMR319gJzokClfbFT+i+G1bhJ4Q==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "common-tags": "1.7.2",
+        "fs-extra": "4.0.3",
+        "glob": "7.1.2",
+        "joi": "11.4.0",
+        "lodash.template": "4.4.0",
+        "pretty-bytes": "4.0.2",
+        "workbox-background-sync": "3.1.0",
+        "workbox-broadcast-cache-update": "3.1.0",
+        "workbox-cache-expiration": "3.1.0",
+        "workbox-cacheable-response": "3.1.0",
+        "workbox-core": "3.1.0",
+        "workbox-google-analytics": "3.1.0",
+        "workbox-precaching": "3.1.0",
+        "workbox-routing": "3.1.0",
+        "workbox-strategies": "3.1.0",
+        "workbox-sw": "3.1.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        },
+        "lodash.template": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+          "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+          "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "3.0.0"
+          }
+        }
+      }
+    },
+    "workbox-cache-expiration": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.1.0.tgz",
+      "integrity": "sha512-M958TkpSGNCZM09N9aACZkjsStbFlkRYJ/jCjKLU/Xn3oJKn+R/8RXpcsk6bO5IG3Xbb5wFGH4fKtn7MTwCBBg==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "3.1.0"
+      }
+    },
+    "workbox-cacheable-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.1.0.tgz",
+      "integrity": "sha512-Mv8oV0jpDFkJ0cqTcXBVClR/NE+xxlkUi4ei1nbI/H2T/rvo4HvXCgRU2STdvv+3z59Em+t4PuHPhwM4gMshoA==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "3.1.0"
+      }
+    },
+    "workbox-core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.1.0.tgz",
+      "integrity": "sha512-AR/p3fOpe9frDt/PEO2tHUNCQFG921DnCeP0dulwvyvlriYubT8L2yxIWdiiZrA+kXEzYwfC89XicIoJNInGNw==",
+      "dev": true
+    },
+    "workbox-google-analytics": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.1.0.tgz",
+      "integrity": "sha512-lD9H/hLj9VKdexw/LsdM8JZ2ZW2HM7Hf9lcVkpeSRuuh5BmpUUl3fTvQZyQqYFW4exKjtI3M4l/kEF7oMM6vWw==",
+      "dev": true,
+      "requires": {
+        "workbox-background-sync": "3.1.0",
+        "workbox-core": "3.1.0",
+        "workbox-routing": "3.1.0",
+        "workbox-strategies": "3.1.0"
+      }
+    },
+    "workbox-precaching": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.1.0.tgz",
+      "integrity": "sha512-lFhL+RN86gLOKnlQO4p5I8oH3axY1RrS3wIUyi8n6Hvn9xNc4ZmQFyjwrJNMBQBe2MImeLe90tGMTElKVBaXfg==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "3.1.0"
+      }
+    },
+    "workbox-routing": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.1.0.tgz",
+      "integrity": "sha512-OZgCZ3wbo/jNvm0sJIqFiNuQz87FFQYCXlFzL/klCn7X6BrAYM+5f2gbtSDSmpzqgfK858jSBsyEQr7ech6+FQ==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "3.1.0"
+      }
+    },
+    "workbox-strategies": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.1.0.tgz",
+      "integrity": "sha512-fJJZEKDhZE7FKMhUUxpGkoMQGuTlDhv3x1Y6/DTG1piTM2wltyMxRKJvm62cx+EJPQ7f0Cu4uYanQiFJB7aGkA==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "3.1.0"
+      }
+    },
+    "workbox-sw": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-3.1.0.tgz",
+      "integrity": "sha512-A4cPW0JFKP5NRjA1r5ZrslCaes3EggV/gSWXLw/TTj6MlAxo9XmDCRdJ8pabfz8B+Zd/v/r1d7tdQK5OhitYyg==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "metalsmith-sass": "^1.5.1",
     "metalsmith-tagcleaner": "0.0.2",
     "nunjucks": "^3.1.2",
-    "standard": "^10.0.3"
+    "standard": "^10.0.3",
+    "workbox-build": "^3.1.0"
   },
   "engines": {
     "node": "8.9.4"

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -1,6 +1,9 @@
 const metalsmith = require('../lib/metalsmith') // configured static site generator
+const generateServiceWorker = require('../lib/build-service-worker') // setup service worker generation
 
 // build to destination directory
 metalsmith.build(function (err, files) {
   if (err) { throw err }
+  // after all files are built, generate the service worker
+  generateServiceWorker.init()
 })

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -1,11 +1,13 @@
 const browsersync = require('metalsmith-browser-sync') // setup synchronised browser testing
 const metalsmith = require('../lib/metalsmith') // configured static site generator
-
 const paths = require('../config/paths.json') // specify paths to main working directories
+const generateServiceWorker = require('../lib/build-service-worker') // setup service worker generation
 
 // setup synchronised browser testing
 metalsmith.use(browsersync({
+  open: true,
   server: paths.public, // server directory
+  port: 4000, // unique port for service worker on 'localhost'
   files: [
     paths.source + '**/*',
     paths.views + '**/*',
@@ -16,4 +18,6 @@ metalsmith.use(browsersync({
 // build to destination directory
 metalsmith.build(function (err, files) {
   if (err) { throw err }
+  // after all files are built, generate the service worker
+  generateServiceWorker.init()
 })

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -31,5 +31,16 @@
 
     </div>
     <script src="/{{ fingerprint['javascripts/application.js'] }}"></script>
+    <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/service-worker.js').then(registration => {
+          console.log('Service Worker registered: ', registration);
+        }).catch(registrationError => {
+          console.log('Service Worker registration failed: ', registrationError);
+        });
+      });
+    }
+    </script>
   </body>
 </html>

--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -2,11 +2,11 @@
   <ul class="app-mobile-nav__list">
     {% for item in navigation %}
     <li>
-      <a class="govuk-link js-mobile-nav-subnav-toggler" href="/{{ item.url }}">{{ item.label }}</a>
+      <a class="govuk-link js-mobile-nav-subnav-toggler" href="/{{ item.url }}/">{{ item.label }}</a>
       {% if item.items %}
       <ul class="app-mobile-nav__subnav js-app-mobile-nav-subnav {% if item.url in path %}{% else %}app-mobile-nav__subnav--hidden{% endif %}">
         <li{% if path == item.url %} class="current-page"{% endif %}>
-          <a class="govuk-link" href="/{{ item.url }}">{{ item.label }} overview</a>
+          <a class="govuk-link" href="/{{ item.url }}/">{{ item.label }} overview</a>
         </li>
 
         {% for theme, items in item.items | groupby("theme") %}
@@ -16,7 +16,7 @@
           <ul class="app-mobile-nav__theme-nav">
           {% for subitem in items %}
             <li{% if path == subitem.url %} class="current-page"{% endif %}>
-              <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
+              <a class="govuk-link" href="/{{ subitem.url }}/">{{ subitem.label }}</a>
             </li>
           {% endfor %}
           </ul>

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -2,7 +2,7 @@
   <ul class="app-navigation__list">
     {% for item in navigation %}
     <li{% if path == item.url or item.url and item.url in path %} class="app-navigation--current-page"{% endif %}>
-      <a class="govuk-link" href="/{{ item.url }}" data-topnav="{{ item.label }}">{{ item.label }}</a>
+      <a class="govuk-link" href="/{{ item.url }}{% if item.url %}/{% endif %}" data-topnav="{{ item.label }}">{{ item.label }}</a>
     </li>
     {% endfor %}
   </ul>

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -9,7 +9,7 @@
           <ul class="app-subnav__section">
           {% for subitem in items %}
             <li class="app-subnav__section-item{% if subitem.url == path %} app-subnav__section-item--current{% endif %}">
-              <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
+              <a class="govuk-link" href="/{{ subitem.url }}/">{{ subitem.label }}</a>
             </li>
           {% endfor %}
           </ul>


### PR DESCRIPTION
In a recent document discussing the "Design System and Frontend documentation" there was a question about where the documentation should sit. One of the options was _"All documentation lives in the Design System and the main Frontend README is just a link to the Get started guide in the Design System"_. The only risk listed with this approach was _"Users who clone the repo or download the zip from GitHub won’t have access to offline documentation."_ This PR has been created to solve this issue for Design System users who require documentation while they are offline.

A service worker has been added with all the heavy lifting done using [Workbox](https://developers.google.com/web/tools/workbox/). Workbox is built into the metalsmith build pipeline. Workbox handles the file manifest and looks for changes between builds. Once a change is detected, the manifest is updated. Old cache is cleared and replaced with the newest version.

It is now possible to view all the DS docs while offline. There may be considerations around when this PR is merged as a service worker does add another level of caching that can sometimes complicate development. The level of debugging available in the console for 3.1.0 of Workbox has been vastly improved so a developer gets a much clearer picture of what is happening. We could hide all this behind a 'development' / 'production' check or even a simple boolean to disable when required. 