### PR TITLE
Correct the product name in GA cookies table

### DIFF
--- a/src/cookies.md.njk
+++ b/src/cookies.md.njk
@@ -104,7 +104,7 @@ You will see a pop-up welcome message when you first visit the GOV.UK Design Sys
         "text": "_gid"
       },
       {
-        "text": "This helps us count how many people visit the Prototype Kit site by tracking if you’ve visited before"
+        "text": "This helps us count how many people visit the GOV.UK Design System site by tracking if you’ve visited before"
       },
       {
         "text": "24 hours"


### PR DESCRIPTION
Change 'Prototype Kit' to 'GOV.UK Design System' to correct an error.