### PR TITLE
Update cookies page to include missing heading

### DIFF
--- a/src/cookies.md.njk
+++ b/src/cookies.md.njk
@@ -71,6 +71,8 @@ You will see a pop-up welcome message when you first visit the GOV.UK Design Sys
   ]
 }) }}
 
+## Universal analytics
+
 {{ govukTable({
   "caption": "Dates and amounts",
   "captionClasses": "govuk-h-visually-hidden",


### PR DESCRIPTION
Missing the heading "Universal analytics"