### PR TITLE
Remove get in touch link which leads to 404

### DIFF
--- a/src/components/warning-text/index.md.njk
+++ b/src/components/warning-text/index.md.njk
@@ -25,4 +25,4 @@ You might need to rewrite the hidden text ('Warning' in the example) to make it 
 
 ## Research on this component
 
-If you’ve used this component, [get in touch](Anchor link to Get in touch panel at bottom of page) to share your user research findings.
+If you’ve used this component, get in touch to share your user research findings.


### PR DESCRIPTION
This PR is a fix and removes the [get in touch](Anchor link to Get in touch panel at bottom of page) link  which points to a 404 from the warning text page