### PR TITLE
Fix cookie page

### DIFF
--- a/src/cookies.md.njk
+++ b/src/cookies.md.njk
@@ -15,28 +15,11 @@ These cookies aren’t used to identify you personally.
 
 You’ll see a message on the site before we store a cookie on your computer.
 
-Find out how to manage cookies.
+[Find out how to manage cookies.](https://ico.org.uk/for-the-public/online/cookies/)
 
-## Measuring website usage with Google Analytics
+## Our cookie message
 
-We use Google Analytics software to collect information about how you use the GOV.UK Design System. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
-
-Google Analytics stores information about:
-
-- the pages you visit
-- how long you spend on each page
-- how you got to the site
-- what you click on while you’re visiting the site.
-
-We don’t collect or store your personal information, so this data can’t be used to identify who you are. For more information visit our [privacy policy](/privacy-policy) page.
-
-We don’t allow Google to use or share our analytics data.
-
-Google Analytics sets the following cookies:
-
-## Our introductory message
-
-You will see a pop-up welcome message when you first visit the GOV.UK Design System. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.
+You will see a message about cookies when you first visit the GOV.UK Design System. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.
 
 {% from "table/macro.njk" import govukTable %}
 
@@ -71,7 +54,22 @@ You will see a pop-up welcome message when you first visit the GOV.UK Design Sys
   ]
 }) }}
 
-## Universal analytics
+## Measuring website usage with Google Analytics
+
+We use Google Analytics software to collect information about how you use the GOV.UK Design System. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
+
+Google Analytics stores information about:
+
+- the pages you visit
+- how long you spend on each page
+- how you got to the site
+- what you click on while you’re visiting the site.
+
+We don’t collect or store your personal information, so this data can’t be used to identify who you are. For more information visit our [privacy policy](/privacy-policy) page.
+
+We don’t allow Google to use or share our analytics data.
+
+Google Analytics sets the following cookies:
 
 {{ govukTable({
   "caption": "Dates and amounts",
@@ -120,7 +118,7 @@ You will see a pop-up welcome message when you first visit the GOV.UK Design Sys
         "text": "This is used to limit the rate at which page view requests are recorded by Google"
       },
       {
-        "text": "24 hours"
+        "text": "1 minute"
       }
     ]
   ]


### PR DESCRIPTION
- Fix link to guidance on managing cookies
- Moves 'Introductory message' out of Google Analytics section - it is not set by Google Analytics
- Rewords 'Introductory message' and 'welcome message' to more accurate 'cookie message'
- [Corrects the _gat cookie expiration time to 1 minute](https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage#analyticsjs)