### PR TITLE
Fix typo in layout example code

### DIFF
--- a/src/styles/layout/common-two-thirds.njk
+++ b/src/styles/layout/common-two-thirds.njk
@@ -13,8 +13,6 @@ layout: layout-example.njk
         <h1 class="govuk-heading-xl">Two-thirds column</h1>
         <p class="govuk-body">This is a paragraph inside a two-thirds wide column</p>
       </div>
-
-      </div>
     </div>
 
   </main>


### PR DESCRIPTION
- remove extra closing div tag from the layout example code