### PR TITLE
Change media query on mobile nav to from:tablet

### DIFF
--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -4,7 +4,7 @@
   &--active {
     display: block;
 
-    @include mq($from: desktop) {
+    @include mq($from: tablet) {
       display: none;
     }
   }


### PR DESCRIPTION
Issue - https://github.com/alphagov/govuk-design-system/issues/260

This sets  `.app-mobile-nav` to `$from: tablet` rather than `$from: desktop`