### PR TITLE
Add inline / stacked varients to radios component

### DIFF
--- a/src/components/radios/default.njk
+++ b/src/components/radios/default.njk
@@ -7,6 +7,7 @@ layout: layout-example.njk
 {{ govukRadios({
   "idPrefix": "changed-name",
   "name": "changed-name",
+  "classes": "govuk-c-radios--inline",
   "fieldset": {
     "legendHtml": '<h1 class="govuk-heading-xl">Have you changed your name?</h1>',
     "legendHintText": "This includes changing your last name or spelling your name differently."

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -23,6 +23,16 @@ Don’t use the Radios component if users might need to select more than one opt
 
 There are 2 ways to use the Radios component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
+### Stacked radios
+
+When there are more than 2 options, radios should be stacked, like so:
+
+{{ example({group: 'components', item: 'radios', example: 'stacked', html: true, nunjucks: true, open: true}) }}
+
+### Inline radios
+
+If there are only 2 options, you can either stack the radios or display them inline, like so:
+
 {{ example({group: 'components', item: 'radios', example: 'default', html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component

--- a/src/components/radios/stacked.njk
+++ b/src/components/radios/stacked.njk
@@ -1,0 +1,31 @@
+---
+layout: layout-example.njk
+---
+
+{% from 'radios/macro.njk' import govukRadios %}
+
+{{ govukRadios({
+  "idPrefix": "where-do-you-live",
+  "name": "changed-name",
+  "fieldset": {
+    "legendHtml": '<h1 class="govuk-heading-xl">Where do you live?</h1>'
+  },
+  "items": [
+    {
+      "value": "england",
+      "text": "England"
+    },
+    {
+      "value": "scotland",
+      "text": "Scotland"
+    },
+    {
+      "value": "wales",
+      "text": "Wales"
+    },
+    {
+      "value": "northern-ireland",
+      "text": "Northern Ireland"
+    }
+  ]
+}) }}


### PR DESCRIPTION
This PR:
- makes the default example an inline variant as it's a yes / no question
- adds a stacked variant
- adds associated content to explain when to use

It's been usable for some time but not documented in the Design System.