### PR TITLE
Simplify button guidance

### DIFF
--- a/src/components/button/disabled.njk
+++ b/src/components/button/disabled.njk
@@ -3,25 +3,7 @@ layout: layout-example.njk
 ---
 {% from "button/macro.njk" import govukButton %}
 
-<h3 class="govuk-heading-m">Input button</h3>
-
 {{ govukButton({
   "text": "Disabled button",
-  "disabled": true
-}) }}
-
-<h3 class="govuk-heading-m">Link button</h3>
-
-{{ govukButton({
-  "text": "Disabled link button",
-  "href": "/",
-  "disabled": true
-}) }}
-
-<h3 class="govuk-heading-m">&lt;button&gt;</h3>
-
-{{ govukButton({
-  "text": "Disabled <button>",
-  "element": "button",
   "disabled": true
 }) }}

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -23,15 +23,6 @@ Align the primary action button to the left edge of your form.
 
 There are 2 ways to use the Button component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'button', example: 'primary', html: true, nunjucks: true, open: true}) }}
-
-
-### Start buttons
-
-Use a start button as the main call to action on your service’s start page.
-
-{{ example({group: 'components', item: 'button', example: 'start', html: true, nunjucks: true, open: true}) }}
-
 ### Disabled buttons
 
 Disabled buttons have poor contrast and can confuse some users, so avoid them if&nbsp;possible.
@@ -39,6 +30,12 @@ Disabled buttons have poor contrast and can confuse some users, so avoid them if
 Only use disabled buttons if research shows it makes the user interface easier to&nbsp;understand.
 
 {{ example({group: 'components', item: 'button', example: 'disabled', html: true, nunjucks: true, open: true}) }}
+
+### Start buttons
+
+Use a start button as the main call to action on your service’s start page.
+
+{{ example({group: 'components', item: 'button', example: 'start', html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/button/primary.njk
+++ b/src/components/button/primary.njk
@@ -3,23 +3,6 @@ layout: layout-example.njk
 ---
 {% from "button/macro.njk" import govukButton %}
 
-<h3 class="govuk-heading-m">Input button</h3>
-
 {{ govukButton({
   "text": "Save and continue"
-}) }}
-
-<h3 class="govuk-heading-m">Link button</h3>
-
-{{ govukButton({
-  "text": "Link button",
-  "href": "#"
-}) }}
-
-<h3 class="govuk-heading-m">&lt;button&gt;</h3>
-
-{{ govukButton({
-  "name": "button",
-  "text": "Save and continue",
-  "element": "button"
 }) }}

--- a/src/components/button/start.njk
+++ b/src/components/button/start.njk
@@ -3,15 +3,6 @@ layout: layout-example.njk
 ---
 {% from "button/macro.njk" import govukButton %}
 
-<h3 class="govuk-heading-m">Input Start button</h3>
-
-{{ govukButton({
-  "text": "Start now button",
-  "classes": "govuk-button--start"
-}) }}
-
-<h3 class="govuk-heading-m">Link Start button</h3>
-
 {{ govukButton({
   "text": "Start now link button",
   "href": "#",

--- a/src/components/button/start.njk
+++ b/src/components/button/start.njk
@@ -4,7 +4,7 @@ layout: layout-example.njk
 {% from "button/macro.njk" import govukButton %}
 
 {{ govukButton({
-  "text": "Start now link button",
+  "text": "Start now",
   "href": "#",
   "classes": "govuk-button--start"
 }) }}


### PR DESCRIPTION
- Removes `input` example, input has some usability concerns since we cannot give extra touch area that we can for button and anchors, it is only required for IE6/7. We still support inputs being styled but should not recommend it's usage unless necessary. (See https://github.com/alphagov/govuk_elements/issues/545#event-1615721498 for details)

- Removes button 'start' button example, this is not how we expect this variant to be used, since this variant is intended for the start page of GOV.UK services.

Depends on: https://github.com/alphagov/govuk-frontend/pull/683

Trello: https://trello.com/c/gITiuXcS/765-use-button-by-default-for-buttons-rather-than-input-typebutton