### PR TITLE
‘Beautify’ example HTML

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -4,6 +4,8 @@ const fs = require('fs')
 const path = require('path')
 const nunjucks = require('nunjucks')
 
+const beautify = require('js-beautify').html
+
 // This helper function takes a path of a file and
 // returns the contents as string
 exports.getFileContents = path => {
@@ -51,7 +53,12 @@ exports.getHTMLCode = path => {
     }
   }
 
-  return html
+  return beautify(html.trim(), {
+    indent_size: 2,
+    end_with_newline: true,
+    // If there are multiple blank lines, reduce down to one blank new line.
+    max_preserve_newlines: 1
+  })
 }
 
 // This helper function takes a path and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1954,6 +1954,16 @@
         }
       }
     },
+    "config-chain": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+      "dev": true,
+      "requires": {
+        "ini": "1.3.5",
+        "proto-list": "1.2.4"
+      }
+    },
     "connect": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
@@ -2329,6 +2339,36 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "editorconfig": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
+      "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "commander": "2.14.1",
+        "lru-cache": "3.2.0",
+        "semver": "5.5.0",
+        "sigmund": "1.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+          "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
       }
     },
     "ee-first": {
@@ -5475,6 +5515,29 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
       "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA=="
     },
+    "js-beautify": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.7.5.tgz",
+      "integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
+      "dev": true,
+      "requires": {
+        "config-chain": "1.1.11",
+        "editorconfig": "0.13.3",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.1.1"
+          }
+        }
+      }
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -7461,6 +7524,12 @@
       "requires": {
         "asap": "2.0.6"
       }
+    },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp": "^3.9.1",
     "gulp-sass-lint": "^1.3.4",
     "iframe-resizer": "^3.5.16",
+    "js-beautify": "^1.7.5",
     "jstransformer-markdown": "^1.2.1",
     "jstransformer-nunjucks": "^0.5.0",
     "metalsmith": "^2.3.0",


### PR DESCRIPTION
Based of @nickcolley’s initial work in d868d4d (https://github.com/alphagov/govuk-design-system/pull/259).

Trimming whitespace from the start and end of the HTML string is necessary to prevent the beautifier from doing strange things with the indentation of the first line.

Using [`js-beautify`](https://www.npmjs.com/package/js-beautify). because that’s what pretty used under the hood, and it gives us more control as we can change the config that gets passed to js-beautify (e.g. controlling the indentation).

https://trello.com/c/7wZdB2pn/766-prettify-html-in-code-examples