### PR TITLE
Fix colour swatch styles for IE8

### DIFF
--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -183,6 +183,13 @@ $mq-breakpoint-widescreen: 1200px;
 
 $colour-list-breakpoint: 980px;
 
+// for IE8 we need to set that to 'desktop' so media queries get rasterised
+// $mq-static-breakpoint is set in Frontend
+@if $govuk-is-ie8 == true {
+  $colour-list-breakpoint: $mq-static-breakpoint;
+}
+
+
 .app-colour-list {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
By default static breakpoints is set to desktop and those media queries get rasterised.

For colour swatches we have a custom breakpoint that is higher than desktop so IE8 never gets those styles.

To fix, we check if `$govuk-is-ie8 == true` and if true we set the custom breakpoint to match desktop.

**Before**
<img width="1210" alt="screen shot 2018-05-20 at 00 10 13" src="https://user-images.githubusercontent.com/3758555/40273930-3ff5a23e-5bc2-11e8-9133-565c0d8027e9.png">

**After**
<img width="1193" alt="screen shot 2018-05-20 at 00 09 31" src="https://user-images.githubusercontent.com/3758555/40273932-400cc626-5bc2-11e8-823a-343b4c52e084.png">

Also fixes: https://github.com/alphagov/govuk-design-system/issues/126