### PR TITLE
Replace zero downtime Autopilot plugin with Blue/green deployment plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ before_deploy:
   # Install CloudFoundry
   - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&source=github"
   - tar xzvf $HOME/cf.tgz -C $HOME
-  # Install Autopilot plugin for zero-downtime-push
-  - travis_retry cf install-plugin autopilot -f -r CF-Community
+  # Install Blue/Green Deploy plugin for zero-downtime-push
+  - travis_retry cf install-plugin blue-green-deploy -f -r CF-Community
 
 # Deploy the Design System to production when the master branch is changed (1)
 #

--- a/bin/deploy-travis
+++ b/bin/deploy-travis
@@ -9,6 +9,6 @@ echo "Deploying ${APP_NAME} to ${CF_ORG}/${CF_SPACE}..."
 # $CF env variables are set by Travis and configured in ../.travis.yml
 cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
 
-# Zero downtime push comes from "Autopilot" which is installed in before_deploy
+# Zero downtime push comes from "Blue/Green Deploy plugin" which is installed in before_deploy
 # step in Travis
-cf zero-downtime-push $APP_NAME -f manifest.yml
+cf blue-green-deploy $APP_NAME -f manifest.yml


### PR DESCRIPTION
We had a recent incident on 2018-05-21 between 11:00 and 11:30 that resulted in downtime for users.

As part of a review of the incident we decided to make two actions:

1. Investigate our deployment method with GOV.UK PaaS.
2. Ensure uptime robot was running against the website.

This pull request is the result of the first action.

We found that the Autopilot plugin we were using failed to execute in the manner it describes https://github.com/contraband/autopilot#method

Instead it first deleted the current running application and after this created a new instance of the application, this meant that when the upload failed the application was left in a broken state.

We have tested the plugin (which is [recommended by GOV.UK PaaS](https://docs.cloud.service.gov.uk/#404s-after-commands-that-restart-the-app)) and confirmed that the deployment steps ensure the health of the newly deployed application before switching from the old application.


Trello ticket: https://trello.com/c/hJjsHSBm/1013-replace-zero-downtime-autopilot-plugin-with-blue-green-deployment-plugin-for-the-design-system