### PR TITLE
Hide Nunjucks tab for ‘captions’ example

### DIFF
--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -58,7 +58,7 @@ If you need to show the high-level section, you can use the `govuk-caption` styl
 
 For example, ‘About you’:
 
-{{ example({group: 'patterns', item: 'question-pages', example: 'section-headings', html: true, nunjucks: true, open: true}) }}
+{{ example({group: 'patterns', item: 'question-pages', example: 'section-headings', html: true, open: true}) }}
 
 ### Continue button
 


### PR DESCRIPTION
The captions example does not use Nunjucks, so it does not make sense to show it for this example.