### PR TITLE
Update to frontend 0.0.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@govuk-frontend/frontend": {
-      "version": "0.0.29-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/frontend/-/frontend-0.0.29-alpha.tgz",
-      "integrity": "sha512-x4qu4gEMJXu+C498BPVYY1kXbzFY2xToHKJltChWWefUm1ir1xgUBp+4IlTaniWWA0i7nxbmHYBYk0h72uPCJA=="
+      "version": "0.0.30-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/frontend/-/frontend-0.0.30-alpha.tgz",
+      "integrity": "sha512-Egmy4kwQiZ+Qv6xO9FRZ1v3TGEEFXQlja4ZWSK4GlN60YWzAvAf5mKZZjtluX2HCZKAEFrkyAjFz0cW+KC6V4w=="
     },
     "@types/estree": {
       "version": "0.0.38",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-frontend/frontend": "0.0.29-alpha",
+    "@govuk-frontend/frontend": "0.0.30-alpha",
     "clipboard": "^2.0.0",
     "html5shiv": "^3.7.3",
     "jquery": "^1.12.4",

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -8,7 +8,7 @@
 // removing this affects the positioning of the underline and causes other
 // issues with the display of the focus style in IE8-11.
 
-@include govuk-exports("header") {
+@include govuk-exports("app-header") {
 
   .app-header {
     padding: $govuk-spacing-scale-2 $govuk-spacing-scale-3;

--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -1,4 +1,4 @@
-@include govuk-exports("pane") {
+@include govuk-exports("app-pane") {
   $toc-width: 300px;
 
   .app-pane {

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -1,4 +1,4 @@
-@include govuk-exports("subnav") {
+@include govuk-exports("app-subnav") {
 
   .app-subnav {
     padding: $govuk-spacing-scale-3;


### PR DESCRIPTION
Update Design Sytem to use the latest version of govuk-frontend.
Because the SCSS are conflicting, `app-` prefix to the SCSS exports was added in this PR.