### PR TITLE
Handle form submissions by redirecting to referrer

### DIFF
--- a/deploy/nginx/conf/includes/form_handler.conf
+++ b/deploy/nginx/conf/includes/form_handler.conf
@@ -1,0 +1,16 @@
+# Handle form submissions from examples that contain forms by redirecting them
+# back to the referring example. This relies on form examples within the design
+# system being set up to POST to `/form-handler`.
+#
+# If for whatever reason there is no referrer, then redirect to the homepage
+# instead.
+#
+# Note that this will only work when deployed to CloudFoundry – Netlify does not
+# use this config at all.
+location /form-handler {
+  if ($http_referer) {
+    return 302 $http_referer;
+  }
+
+  return 302 /;
+}

--- a/src/patterns/page-not-found-pages/reason-not-known/index.njk
+++ b/src/patterns/page-not-found-pages/reason-not-known/index.njk
@@ -20,7 +20,7 @@ layout: layout-example.njk
           <li>report the page not found</li>
         </ul>
         <p class="govuk-body">If you want us to tell you when we have fixed the link or button, give us your name and email address.</p>
-        <form action="/url/of/next/page" method="post">
+        <form action="/form-handler" method="post">
           {{ govukInput({
             label: {
               text: "Name (optional)"

--- a/src/patterns/question-pages/default/index.njk
+++ b/src/patterns/question-pages/default/index.njk
@@ -15,7 +15,7 @@ layout: layout-example.njk
   <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <form action="/url/of/next/page" method="post">
+        <form action="/form-handler" method="post">
 
           {{ govukDateInput({
             id: 'dob',

--- a/src/patterns/question-pages/passport/index.njk
+++ b/src/patterns/question-pages/passport/index.njk
@@ -18,7 +18,7 @@ layout: layout-example.njk
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">Passport details</h1>
 
-        <form action="/url/of/next/page" method="post">
+        <form action="/form-handler" method="post">
 
           {{ govukInput({
             label: {

--- a/src/patterns/question-pages/postcode/index.njk
+++ b/src/patterns/question-pages/postcode/index.njk
@@ -16,7 +16,7 @@ layout: layout-example.njk
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
-        <form action="/url/of/next/page" method="post">
+        <form action="/form-handler" method="post">
 
           {{ govukInput({
             label: {


### PR DESCRIPTION
Handle form submissions from examples that contain forms by redirecting them back to the referring example. This relies on updating the form examples within the design system to POST to `/form-handler`.

If for whatever reason there is no referrer, then redirect to the homepage instead.

Note that this will only work when deployed to CloudFoundry – Netlify does not use the nginx config at all.

Preview on PaaS: https://govuk-design-system-production-form-handler.cloudapps.digital/

https://trello.com/c/A2N92zjA/806-spike-how-to-handle-form-submissions-in-the-question-page-examples-in-the-design-system