### PR TITLE
Anchored headings

### DIFF
--- a/lib/markdown-renderer.js
+++ b/lib/markdown-renderer.js
@@ -1,0 +1,20 @@
+const marked = require('marked')
+
+let renderer = new marked.Renderer()
+
+renderer.heading = function (text, level) {
+  var escapedText = text.toLowerCase().replace(/[^\w]+/g, '-')
+  return `
+    <h${level} class="app-content-heading" id="${escapedText}">
+      ${text}
+      <a class="app-content-heading__anchor" href="#${escapedText}" aria-label="Link to '${text}' heading">
+        <svg height="25" width="25" viewBox="0 0 512 512" class="app-content-heading__icon">
+          <path d="M220.1 317.9a26 26 0 0 1-18.4-7.6 122.1 122.1 0 0 1 0-172.6l96-96C320.7 18.7 351.4 6 384 6s63.2 12.7 86.3 35.7a122.1 122.1 0 0 1 0 172.6l-44 43.8a26 26 0 1 1-36.7-36.7l43.9-43.9a70 70 0 0 0-99-99l-96 96a70 70 0 0 0 0 99 26 26 0 0 1-18.4 44.4z"/>
+          <path d="M128 506a122.1 122.1 0 0 1-86.3-208.3l44-43.8a26 26 0 0 1 36.7 36.7l-43.9 43.9a70 70 0 0 0 99 99l96-96a70 70 0 0 0 0-99 26 26 0 0 1 36.8-36.8 122.1 122.1 0 0 1 0 172.6l-96 96c-23 23-53.7 35.7-86.3 35.7z"/>
+        </svg>
+      </a>
+    </h${level}>
+  `
+}
+
+module.exports = renderer

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -18,6 +18,7 @@ const commonjs = require('rollup-plugin-commonjs')
 // const debug = require('./debug')                          // debug plugin
 const navigation = require('./navigation.js')                // navigation plugin
 const modernizrBuild = require('./modernizr-build.js')       // modernizr build plugin
+const markdownRenderer = require('./markdown-renderer.js')   // custom markdown rendering
 
 const colours = require('../lib/colours.js')                 // get colours data
 const fileHelper = require('../lib/file-helper.js')          // helper function to operate on files
@@ -177,7 +178,8 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
       outdent: true,
       code: true,
       inline: true
-    }
+    },
+    renderer: markdownRenderer
   }))
 
   // Use tag cleaner to remove <p> tags around images

--- a/src/stylesheets/components/_content-heading.scss
+++ b/src/stylesheets/components/_content-heading.scss
@@ -1,0 +1,26 @@
+@include govuk-exports("app-content-heading") {
+  // Anchored headings
+  // If the heading is not being interacted with, don't show anchor link.
+  .app-content-heading:not(:active):not(:hover) .app-content-heading__anchor {
+    @include govuk-visually-hidden-focusable;
+  }
+
+  // Remove focus styles on anchor, instead put them on the icon.
+  // Since we need padding to create whitespace between the anchor and the top of the screen.
+  .app-content-heading__anchor:focus {
+    /* Prose scope has high specificity requiring !importants */
+    outline: none !important;
+    background: transparent !important;
+  }
+
+  .app-content-heading__anchor:focus .app-content-heading__icon {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    outline-offset: 0;
+    background-color: $govuk-focus-colour;
+  }
+
+  .app-content-heading__icon {
+    width: .6em;
+    height: .6em;
+  }
+}

--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -1,8 +1,12 @@
 // Example styles
 .app-example-wrapper {
   @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");
-  @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
   @include govuk-font-regular-19;
+}
+
+.app-example-wrapper + .app-content-heading,
+.app-example-wrapper + p {
+  @include govuk-responsive-padding($govuk-spacing-responsive-6, "top");
 }
 
 .app-example {

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -6,6 +6,7 @@ $app-code-color: #dd1144;
 
 // App-specific components
 @import "components/contact-panel";
+@import "components/content-heading";
 @import "components/cookie-banner";
 @import "components/example";
 @import "components/footer";


### PR DESCRIPTION
Adds anchor links to headings to allow easier linking into sections.

This does not remove the trailing forwards slashes but that does not seem to impact anchoring.

When you hover over a heading, a link icon appears. If you click it, it adds the hash for that heading to the URL.

![image](https://user-images.githubusercontent.com/1132904/40780311-d734a8be-64cf-11e8-970a-9c78650103d7.png)

TODO:
- [] Test on mobile devices

Trello: https://trello.com/c/MdleLLSX/726-add-a-link-to-here-link-to-headers-in-the-design-system-to-make-it-easier-for-support-staff-to-send-links-to-users