### PR TITLE
Do not track users who have enabled 'DoNotTrack'

### DIFF
--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -16,7 +16,6 @@
     {% include "_tracking-head.njk" %}
   </head>
   <body>
-    {% include "_tracking-body.njk" %}
     <a href="#content" class="govuk-skip-link">Skip to main content</a>
     <div class="app-pane">
       {% include "_cookie-banner.njk" %}

--- a/views/partials/_tracking-body.njk
+++ b/views/partials/_tracking-body.njk
@@ -1,6 +1,0 @@
-{% if GTM_TAG %}
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ GTM_TAG }}"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
-{% endif %}

--- a/views/partials/_tracking-head.njk
+++ b/views/partials/_tracking-head.njk
@@ -1,9 +1,22 @@
 {% if GTM_TAG %}
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer', '{{ GTM_TAG }}');</script>
-<!-- End Google Tag Manager -->
+<script>
+// Normalize doNotTrack implementations, see https://caniuse.com/#feat=do-not-track
+var DO_NOT_TRACK_ENABLED = (
+  navigator.doNotTrack === '1' ||
+  navigator.doNotTrack === 'yes' || // Firefox 31 and below
+  navigator.msDoNotTrack === '1' || // IE 9 - 10
+  window.doNotTrack === '1' // IE 11 / Edge 16 and below
+)
+
+// If the user has enabled 'DoNotTrack', we should not load Google Tag Manager (and therefore, Google Analytics.)
+if (!DO_NOT_TRACK_ENABLED) {
+  // Google Tag Manager
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer', '{{ GTM_TAG }}');
+  // End Google Tag Manager
+}
+</script>
 {% endif %}


### PR DESCRIPTION
Adds a guard around Google Tag Manager script to prevent it from initialising,
for users who have indicated they do not want to be tracked.

Also removes the `<noscript></noscript>` include as we can't guard this.

If we were server rendering the site, we could take advantage of the ['DoNotTrack' header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DNT).

https://trello.com/c/jHVUmpdx/957-do-not-track-users-with-donottrack-enabled