### PR TITLE
Accessibility: improvements for examples

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -3,6 +3,7 @@
 const fs = require('fs')
 const path = require('path')
 const nunjucks = require('nunjucks')
+const matter = require('gray-matter')
 
 const beautify = require('js-beautify').html
 
@@ -37,6 +38,15 @@ exports.getNunjucksCode = path => {
   }
 
   return macro
+}
+
+// This helper function takes a path of a *.md.njk file and
+// returns the frontmatter as an object
+exports.getFrontmatter = path => {
+  let fileContents = this.getFileContents(path)
+
+  let parsedFile = matter(fileContents)
+  return parsedFile.data
 }
 
 // This helper function takes a path of a *.md.njk file and

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -28,16 +28,8 @@ exports.getFileContents = path => {
 exports.getNunjucksCode = path => {
   let fileContents = this.getFileContents(path)
 
-  let macro
-  try {
-    macro = fileContents.split('---')[2]
-  } catch (err) {
-    if (err) {
-      console.log('Could not get Nunjucks code from ' + path)
-    }
-  }
-
-  return macro
+  let parsedFile = matter(fileContents)
+  return parsedFile.content
 }
 
 // This helper function takes a path of a *.md.njk file and
@@ -54,9 +46,12 @@ exports.getFrontmatter = path => {
 exports.getHTMLCode = path => {
   let fileContents = this.getFileContents(path)
 
+  let parsedFile = matter(fileContents)
+  let content = parsedFile.content
+
   let html
   try {
-    html = nunjucks.renderString(fileContents.split('---')[2])
+    html = nunjucks.renderString(content)
   } catch (err) {
     if (err) {
       console.log('Could not get HTML code from ' + path)

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -162,6 +162,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
       trimBlocks: true, // automatically remove trailing newlines from a block/tag
       lstripBlocks: true, // automatically remove leading whitespace from a block/tag
       globals: {
+        getFrontmatter: fileHelper.getFrontmatter,
         getNunjucksCode: fileHelper.getNunjucksCode,
         getHTMLCode: fileHelper.getHTMLCode
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -303,7 +303,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -415,8 +414,7 @@
     "assert-plus": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-      "dev": true
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -478,8 +476,7 @@
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-      "dev": true
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
     },
     "aws4": {
       "version": "1.6.0",
@@ -1349,7 +1346,6 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -1953,8 +1949,7 @@
     "commander": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
-      "dev": true
+      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
     },
     "compare-versions": {
       "version": "3.2.1",
@@ -2146,7 +2141,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
       "requires": {
         "boom": "2.10.1"
       }
@@ -3048,8 +3042,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "esquery": {
       "version": "1.0.0",
@@ -3258,7 +3251,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
       "requires": {
         "is-extendable": "0.1.1"
       }
@@ -3950,7 +3942,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
@@ -5022,14 +5013,12 @@
     "generate-function": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
     },
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
       "requires": {
         "is-property": "1.0.2"
       }
@@ -5282,16 +5271,30 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "gray-matter": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-2.1.1.tgz",
-      "integrity": "sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=",
-      "dev": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.1.tgz",
+      "integrity": "sha512-p0MADBEBl1CohV7nRZ8sVinBexEe3CKVhh0A0QIHKpcbRoxB0VgeMpRPjW/HBHIPLAKrpIIIm5mZ6hKu3E+iQg==",
       "requires": {
-        "ansi-red": "0.1.1",
-        "coffee-script": "1.12.7",
-        "extend-shallow": "2.0.1",
-        "js-yaml": "3.10.0",
-        "toml": "2.3.3"
+        "js-yaml": "3.12.0",
+        "kind-of": "6.0.2",
+        "section-matter": "1.0.0",
+        "strip-bom-string": "1.0.0"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
       }
     },
     "growly": {
@@ -5548,7 +5551,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
       "requires": {
         "boom": "2.10.1",
         "cryptiles": "2.0.5",
@@ -5565,8 +5567,7 @@
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -5683,7 +5684,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
       "requires": {
         "assert-plus": "0.2.0",
         "jsprim": "1.4.1",
@@ -5996,8 +5996,7 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "1.0.0",
@@ -6046,7 +6045,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
       "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
-      "dev": true,
       "requires": {
         "generate-function": "2.0.0",
         "generate-object-property": "1.2.0",
@@ -6151,8 +6149,7 @@
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-regex": {
       "version": "1.0.4",
@@ -7767,8 +7764,7 @@
     "jsonpointer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -8505,6 +8501,21 @@
         "unyield": "0.0.1",
         "ware": "1.3.0",
         "win-fork": "1.1.1"
+      },
+      "dependencies": {
+        "gray-matter": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-2.1.1.tgz",
+          "integrity": "sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=",
+          "dev": true,
+          "requires": {
+            "ansi-red": "0.1.1",
+            "coffee-script": "1.12.7",
+            "extend-shallow": "2.0.1",
+            "js-yaml": "3.10.0",
+            "toml": "2.3.3"
+          }
+        }
       }
     },
     "metalsmith-assets": {
@@ -9177,11 +9188,17 @@
         "nan": "2.8.0",
         "node-gyp": "3.6.2",
         "npmlog": "4.1.2",
+        "request": "2.79.0",
         "sass-graph": "2.2.4",
         "stdout-stream": "1.4.0",
         "true-case-path": "1.0.2"
       },
       "dependencies": {
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+        },
         "gaze": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
@@ -9189,6 +9206,54 @@
           "requires": {
             "globule": "1.2.0"
           }
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.14.1",
+            "is-my-json-valid": "2.16.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
+        },
+        "request": {
+          "version": "2.79.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.1.0"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
         }
       }
     },
@@ -11687,6 +11752,22 @@
         "source-map": "0.4.4"
       }
     },
+    "section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "kind-of": "6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
@@ -12056,7 +12137,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -12252,8 +12332,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.13.1",
@@ -12617,8 +12696,7 @@
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -12637,6 +12715,11 @@
         "first-chunk-stream": "1.0.0",
         "is-utf8": "0.2.1"
       }
+    },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -14010,8 +14093,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@govuk-frontend/frontend": "0.0.30-alpha",
     "clipboard": "^2.0.0",
+    "gray-matter": "^4.0.1",
     "html5shiv": "^3.7.3",
     "jquery": "^1.12.4",
     "modernizr": "^3.6.0",

--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -23,7 +23,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  padding: 5px $govuk-spacing-scale-6 / 2;
+  padding: 5px $govuk-spacing-scale-2;
   @include govuk-font-regular-14;
   background: $govuk-grey-3;
   z-index: 1;
@@ -31,12 +31,6 @@
   a {
     color: $govuk-link-colour;
     text-decoration: none;
-  }
-
-  &:before {
-    @include govuk-font-regular-14;
-    content: "EXAMPLE";
-    margin-right: 10px;
   }
 }
 

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -119,17 +119,6 @@ $mq-breakpoint-widescreen: 1200px;
 
 .app-example-page {
   padding: $govuk-spacing-scale-6 * 2 $govuk-spacing-scale-6 $govuk-spacing-scale-6;
-
-  &:before {
-    content: "Resize";
-    position: fixed;
-    z-index: 2;
-    right: $govuk-spacing-scale-3;
-    bottom: 0;
-    color: $govuk-secondary-text-colour;
-    background: $govuk-white;
-    @include govuk-font-regular-16;
-  }
 }
 
 .app-example-page--full-page {

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -17,7 +17,7 @@
         example in a new window
       </a>
     </span>
-    <iframe class="app-example__frame app-example__frame--resizable js-example__frame" src="{{ exampleURL }}" frameBorder="0"></iframe>
+    <iframe title="{{ exampleTitle }}" class="app-example__frame app-example__frame--resizable js-example__frame" src="{{ exampleURL }}" frameBorder="0"></iframe>
   </div>
 
   {%- if (params.html and params.nunjucks) %}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -2,15 +2,21 @@
 {% set examplePath = "src/" + params.group + "/" + params.item + "/" + params.example + "/index.njk" %}
 {% set exampleURL = "/" + params.group + "/" + params.item + "/" + params.example + "/index.html" %}
 {% set exampleId = "example-" + params.example %}
+{% set exampleTitle = getFrontmatter(examplePath).title %}
 {% set frontendComponentName = params.frontendComponentName | default(params.item) %}
-
 {% if params.open %}
   {% set exampleId = exampleId + '-open' %}
 {% endif %}
 
 <div class="app-example-wrapper js-example" id="{{ exampleId }}">
   <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
-    <span class="app-example__new-window"><a href="{{ exampleURL }}" target="_blank">(open in new window)</a></span>
+    <span class="app-example__new-window">
+      <a href="{{ exampleURL }}" target="_blank">
+        Open this
+        <span class="govuk-visually-hidden"> "{{ exampleTitle }}" </span>
+        example in a new window
+      </a>
+    </span>
     <iframe class="app-example__frame app-example__frame--resizable js-example__frame" src="{{ exampleURL }}" frameBorder="0"></iframe>
   </div>
 


### PR DESCRIPTION
- Remove CSS only text
- Give 'open in window' links more context
- Add title to iframes
- Refactors file helpers to use more robust parsing of files

## Assistive Technology testing

Testing: https://deploy-preview-306--govuk-design-system-preview.netlify.com/components/button/

### VoiceOver in Safari
#### Before
VO + Down, to select the frame: 'frame 0' 

#### After
VO + Down, to select the frame: 'Button frame' (reads the title attribute on the iframe)

### JAWS 17, Internet Explorer 11
#### Before
JAWs key + down: 'Button - Example - GOV.UK Design System frame' (reads the <title> element inside the frame)
Tabbing onto iframe: 'Button - Example - GOV.UK Design System frame' (reads the <title> element inside the frame)

#### After
JAWs key + down: 'Button - Example - GOV.UK Design System frame' (reads the <title> element inside the frame)
Tabbing onto iframe: 'Button - Example - GOV.UK Design System frame' (reads the <title> element inside the frame)

### NVDA 2017.4, Firefox 52
#### Before
NVDA key + down: 'Frame resize button save and continue'
Tabbing onto iframe: Accepts focus but nothing is announced

#### After
NVDA key + down: 'Button frame, button save and continue'
Tabbing onto iframe:  Accepts focus but nothing is announced

This seems to be a known issue: https://github.com/nvaccess/nvda/issues/662

## Fixes 

- https://trello.com/c/eIZMsrtQ/1072-dac-audit-html-structure-css-disabled
- https://trello.com/c/CbwC3OES/1078-dac-audit-iframes-without-a-title
- https://trello.com/c/7Y7djlVY/1104-dac-audit-navigation-interactive-elements
- https://trello.com/c/bCiFcZmp/1093-dac-audit-resize-text-for-examples