### PR TITLE
Stop tabs from obstructing examples

### DIFF
--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -94,6 +94,24 @@
   border: 0;
 }
 
+// Ensure the copy button does not obstruct the examples.
+// Use relative units to allow this also to work when the user is zoomed 200%
+@media (min-width: 65.0625em) {
+  .app-tabs__container pre code {
+    // Account for the size of the copy button.
+    // On bigger screens the copy button is to not obstruct the content
+    // So instead shorten the length of the code block
+    max-width: calc(100% - 6em);
+  }
+}
+@media (max-width: 65em) {
+  .app-tabs__container pre {
+    // On smaller screens, we need all the width we can get,
+    // so instead add padding to the top of the example, which feels more balanced.
+    padding-top: 2em;
+  }
+}
+
 .app-tabs__container--with-close-button pre {
   padding-bottom: $govuk-spacing-scale-6;
 }


### PR DESCRIPTION
I have fixed the most urgent issue with the copy button covering up the examples, however I think we could do much better with the general layout when zoomed in, so I'll leave the trello card as unfinished and we can make this better when Dave is back.

https://trello.com/c/0WMsHdZ9/1075-dac-audit-relative-sizing