### PR TITLE
Update to Frontend 0.0.31

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -30,6 +30,7 @@ const views = [
   paths.layouts,
   paths.partials,
   paths.components,
+  paths.govukfrontend,
   paths.govukfrontendcomponents
 ]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "@govuk-frontend/frontend": {
-      "version": "0.0.30-alpha",
-      "resolved": "https://registry.npmjs.org/@govuk-frontend/frontend/-/frontend-0.0.30-alpha.tgz",
-      "integrity": "sha512-Egmy4kwQiZ+Qv6xO9FRZ1v3TGEEFXQlja4ZWSK4GlN60YWzAvAf5mKZZjtluX2HCZKAEFrkyAjFz0cW+KC6V4w=="
+      "version": "0.0.31-alpha",
+      "resolved": "https://registry.npmjs.org/@govuk-frontend/frontend/-/frontend-0.0.31-alpha.tgz",
+      "integrity": "sha512-eTgjF+BsKqHby3ozvkgezjlmWrDlrEegJ11elUtTVUpj5QXBvwolY/YnLqIGAj2ucqM9y5AMdx2yDxbONz/+Sw=="
     },
     "@types/estree": {
       "version": "0.0.38",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-frontend/frontend": "0.0.30-alpha",
+    "@govuk-frontend/frontend": "0.0.31-alpha",
     "clipboard": "^2.0.0",
     "gray-matter": "^4.0.1",
     "html5shiv": "^3.7.3",

--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -1,7 +1,7 @@
 @include govuk-exports("app-pane") {
   $toc-width: 300px;
 
-  .app-pane {
+  .app-pane.app-pane--enabled {
     $pane-height: 100vh;
 
     @include mq($from: tablet) {

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -1,38 +1,46 @@
-<!doctype html>
-<html lang="en" class="no-js">
-  <head>
-    <meta charset="utf-8">
-    <meta name="robots" content="noindex, nofollow">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ title }} – GOV.UK Design System</title>
-    <!--[if !IE 8]><!-->
-      <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
-    <!--<![endif]-->
-    <!--[if lt IE 9]>
-      <link href="/{{ fingerprint['stylesheets/main-ie8.css'] }}" rel="stylesheet" media="all" />
-      <script src="/{{ fingerprint['javascripts/ie.js'] }}"></script>
-    <![endif]-->
-    <script src="/javascripts/vendor/modernizr.js"></script>
-    {% include "_tracking-head.njk" %}
-  </head>
-  <body>
-    <a href="#content" class="govuk-skip-link">Skip to main content</a>
-    <div class="app-pane">
-      {% include "_cookie-banner.njk" %}
-      <div class="app-pane__header">
-        {% include "_header.njk" %}
-        {% include "_banner.njk" %}
-      </div>
-      <div class="app-pane__nav">
-        {% include "_navigation.njk" %}
-        {% include "_mobile-navigation.njk" %}
-      </div>
+{% extends "template.njk" %}
 
-      {% block body %}
-        {{ contents | safe }}
-      {% endblock %}
+{% set htmlClasses = 'no-js' %}
 
-    </div>
-    <script src="/{{ fingerprint['javascripts/application.js'] }}"></script>
-  </body>
-</html>
+{% block pageTitle %}{{ title }} – GOV.UK Design System{% endblock %}
+
+{% block head %}
+  <meta name="robots" content="noindex, nofollow">
+
+  <!--[if !IE 8]><!-->
+    <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
+  <!--<![endif]-->
+  <!--[if lt IE 9]>
+    <link href="/{{ fingerprint['stylesheets/main-ie8.css'] }}" rel="stylesheet" media="all" />
+    <script src="/{{ fingerprint['javascripts/ie.js'] }}"></script>
+  <![endif]-->
+  <script src="/javascripts/vendor/modernizr.js"></script>
+  {% include "_tracking-head.njk" %}
+{% endblock %}
+
+{# We provide our own header, so blank the one provided by the template #}
+{% block header %}{% endblock %}
+
+{% block main %}
+<div class="app-pane {% block appPaneClasses %}{% endblock %}">
+  {% include "_cookie-banner.njk" %}
+  <div class="app-pane__header">
+    {% include "_header.njk" %}
+    {% include "_banner.njk" %}
+  </div>
+  <div class="app-pane__nav">
+    {% include "_navigation.njk" %}
+    {% include "_mobile-navigation.njk" %}
+  </div>
+  {% block body %}
+    {{ contents | safe }}
+  {% endblock %}
+</div>
+{% endblock %}
+
+{# We provide our own footer, so blank the one provided by the template #}
+{% block footer %}{% endblock %}
+
+{% block bodyEnd %}
+<script src="/{{ fingerprint['javascripts/application.js'] }}"></script>
+{% endblock %}

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -1,12 +1,14 @@
 {% extends "_generic.njk" %}
 
+{% block appPaneClasses %}app-pane--enabled{% endblock %}
+
 {% block body %}
 <div class="app-pane__body">
   <div class="app-pane__subnav app-hide-mobile">
     {% include "_subnav.njk" %}
   </div>
   <div class="app-pane__content">
-    <main id="content" class="app-content" role="main">
+    <main id="main-content" class="app-content" role="main">
       <div class="app-content__header">
         <h1 class="govuk-heading-xl">
           <span class="govuk-caption-xl">

--- a/views/layouts/layout-single-page.njk
+++ b/views/layouts/layout-single-page.njk
@@ -2,7 +2,7 @@
 
 {% block body %}
 <div class="app-pane__content">
-  <main id="content" class="govuk-main-wrapper govuk-main-wrapper--l" role="main">
+  <main id="main-content" class="govuk-main-wrapper govuk-main-wrapper--l" role="main">
     <div class="govuk-width-container app-site-width-container">
       {{ contents | safe }}
     </div>


### PR DESCRIPTION
Update to Frontend 0.0.31 and modify the templates to extend from the template provided by GOV.UK Frontend.

Required a little bit of tweaking to prevent the body from displaying weirdly on pages which did not use the split page layout, since the `<html>` element now has a grey background and that was bleeding through.

Also updated the ids on the `<main>` content elements to use the default target of the skip link as provided in Frontend's template.njk.