### PR TITLE
Remove asset duplication on root pages

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -191,7 +191,9 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
   .use(tagcleaner())
 
   // apply a permalink pattern to files
-  .use(permalinks())
+  .use(permalinks({
+    relative: false // https://github.com/segmentio/metalsmith-permalinks#relative-files
+  }))
 
   // apply navigation
   .use(navigation())


### PR DESCRIPTION
Currently assets for root pages (what's changed, cookies, ..) duplicate assets from root in their folder.

Example:
https://govuk-design-system-production.cloudapps.digital/whats-changed/patterns/check-answers/check-answers-page.png
and 
https://govuk-design-system-production.cloudapps.digital/cookies/patterns/check-answers/check-answers-page.png

This can be fixed by setting
```
.use(permalinks({
  relative: false // https://github.com/segmentio/metalsmith-permalinks#relative-files
}))
```

Now those assets are no longer repllicated

https://deploy-preview-311--govuk-design-system-preview.netlify.com//whats-changed/patterns/check-answers/check-answers-page.png
and 
https://deploy-preview-311--govuk-design-system-preview.netlify.com//cookies/patterns/check-answers/check-answers-page.png

