### PR TITLE
Add guidance to header component

### DIFF
--- a/src/components/header/index.md.njk
+++ b/src/components/header/index.md.njk
@@ -3,13 +3,45 @@ title: Header
 section: Components
 backlog_issue_id: 97
 layout: layout-pane.njk
-status: Draft
 ---
 
 {% from "_example.njk" import example %}
 
+The GOV.UK header helps users know that they are on GOV.UK and which service they are using.
+
 {{ example({group: 'components', item: 'header', example: 'default', html: true, nunjucks: true, open: false}) }}
 
-### Header with navigation
+## When to use this component
 
-{{ example({group: 'components', item: 'header', example: 'with-navigation', html: true, nunjucks: true, open: false}) }}
+You should only use this component if your service is going to be hosted on one of these domains: 
+
+- gov.uk/myservice
+- myservice.service.gov.uk
+- myblog.blog.gov.uk
+
+If your service is being used on one of those domains then you must use the GOV.UK header at the top of every page.
+
+## How it works
+
+### Default header
+
+Use the default header if your service has 5 pages or less.
+
+{{ example({group: 'components', item: 'header', example: 'default', html: true, nunjucks: true, open: false}) }}
+
+### Header with service name
+
+Use the header with a service name if your service is more than 5 pages long - this can help users understand where they are.
+
+{{ example({group: 'components', item: 'header', example: 'with-service-name', html: true, nunjucks: true, open: false}) }}
+
+### Header with service name and navigation
+
+Use the header with navigation if you need to include basic navigation, contact or account management links.
+
+{{ example({group: 'components', item: 'header', example: 'with-service-name-and-navigation', html: true, nunjucks: true, open: false}) }}
+
+## Research on this component
+
+If you’ve used this component, get in touch to share your user research findings.
+

--- a/src/components/header/index.md.njk
+++ b/src/components/header/index.md.njk
@@ -7,31 +7,34 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-The GOV.UK header helps users know that they are on GOV.UK and which service they are using.
+The GOV.UK header shows users that they are on GOV.UK and which service they are using.
 
 {{ example({group: 'components', item: 'header', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
-You should only use this component if your service is going to be hosted on one of these domains: 
+You must use the GOV.UK header at the top of every page if your service is being hosted on one of these domains:
 
 - gov.uk/myservice
 - myservice.service.gov.uk
 - myblog.blog.gov.uk
 
-If your service is being used on one of those domains then you must use the GOV.UK header at the top of every page.
+## When not to use this component
+
+You must not use the GOV.UK header if your service is not being hosted on one of the above domains.
+
 
 ## How it works
 
 ### Default header
 
-Use the default header if your service has 5 pages or less.
+Use the default header if your service has 5 pages or fewer.
 
 {{ example({group: 'components', item: 'header', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ### Header with service name
 
-Use the header with a service name if your service is more than 5 pages long - this can help users understand where they are.
+Use the header with a service name if your service is more than 5 pages long - this can help users understand which service they are using.
 
 {{ example({group: 'components', item: 'header', example: 'with-service-name', html: true, nunjucks: true, open: false}) }}
 
@@ -44,4 +47,3 @@ Use the header with navigation if you need to include basic navigation, contact 
 ## Research on this component
 
 If you’ve used this component, get in touch to share your user research findings.
-

--- a/src/components/header/with-service-name-and-navigation/index.njk
+++ b/src/components/header/with-service-name-and-navigation/index.njk
@@ -6,7 +6,7 @@ layout: layout-example.njk
 
 {{ govukHeader({
   homepageUrl: "#",
-  serviceName: "Service Name",
+  serviceName: "Service name",
   serviceUrl: "/components/header",
   containerClasses: "govuk-width-container",
   navigation: [

--- a/src/components/header/with-service-name/index.njk
+++ b/src/components/header/with-service-name/index.njk
@@ -1,0 +1,12 @@
+---
+title: Header with navigation
+layout: layout-example.njk
+---
+{% from "header/macro.njk" import govukHeader %}
+
+{{ govukHeader({
+  homepageUrl: "#",
+  serviceName: "Service name",
+  serviceUrl: "/components/header",
+  containerClasses: "govuk-width-container"
+}) }}


### PR DESCRIPTION
This PR adds guidance and an extra example to the header component. These are based on the existing guidance and examples in the Service Manual.