### PR TITLE
Update code highlighting palette for WCAG Level AA contrast

### DIFF
--- a/src/styles/layout/grid-annotate.scss
+++ b/src/styles/layout/grid-annotate.scss
@@ -7,7 +7,7 @@
   @extend .govuk-body;
   display: block;
   @include govuk-responsive-padding($govuk-spacing-responsive-6);
-  background-color: $govuk-light-blue;
+  background-color: $govuk-blue;
   color: white;
   text-align: center;
   margin-bottom: 0;

--- a/src/styles/layout/grid-nested-annotate.scss
+++ b/src/styles/layout/grid-nested-annotate.scss
@@ -8,13 +8,13 @@
 .govuk-grid-row {
   [class^="govuk-grid-column"]  {
     background-color: white;
-    border: 4px solid $govuk-light-blue;
+    border: 4px solid $govuk-blue;
     padding-bottom: $govuk-spacing-scale-2;
   }
 
   [class^="govuk-grid-column"] > p {
     background-color: transparent;
-    color: $govuk-light-blue;
+    color: $govuk-blue;
   }
 
   .govuk-grid-row {
@@ -26,7 +26,7 @@
       @extend .govuk-body;
       display: block;
       @include govuk-responsive-padding($govuk-spacing-responsive-6);
-      background-color: $govuk-light-blue;
+      background-color: $govuk-blue;
       color: white;
       text-align: center;
       margin-bottom: 0;

--- a/src/stylesheets/components/_highlight.scss
+++ b/src/stylesheets/components/_highlight.scss
@@ -25,7 +25,7 @@
 .hljs-variable,
 .hljs-template-variable,
 .hljs-tag .hljs-attr {
-  color: #008080;
+  color: #007F80;
 }
 
 .hljs-string,
@@ -59,7 +59,7 @@
 
 .hljs-regexp,
 .hljs-link {
-  color: #009926;
+  color: #008020;
 }
 
 .hljs-symbol,
@@ -69,7 +69,7 @@
 
 .hljs-built_in,
 .hljs-builtin-name {
-  color: #0086b3;
+  color: #017ba5;
 }
 
 .hljs-meta {


### PR DESCRIPTION
## Code example colour changes (to meet 4.5:1)
Note: Not all the colours in our code highlighting stylesheet are currently used, in the examples below I modified the output to force certain colours to appear for the sake of this demo.

### Before
<img width="336" alt="screen shot 2018-06-12 at 11 24 22" src="https://user-images.githubusercontent.com/2445413/41285444-19a4930e-6e34-11e8-81f4-0b170edb9363.png">

### After
<img width="349" alt="screen shot 2018-06-12 at 11 24 34" src="https://user-images.githubusercontent.com/2445413/41285445-19bb2d76-6e34-11e8-81f9-28cdb121033e.png">

### Before
<img width="350" alt="screen shot 2018-06-12 at 11 25 26" src="https://user-images.githubusercontent.com/2445413/41285446-19e676d4-6e34-11e8-818b-4787e52e3da4.png">

### After
<img width="354" alt="screen shot 2018-06-12 at 11 25 29" src="https://user-images.githubusercontent.com/2445413/41285443-198d0504-6e34-11e8-81e6-47fc1aa2152f.png">

### Before
<img width="424" alt="screen shot 2018-06-12 at 11 23 42" src="https://user-images.githubusercontent.com/2445413/41285448-1a155a58-6e34-11e8-920a-73952765bdb7.png">

### After
<img width="362" alt="screen shot 2018-06-12 at 11 23 51" src="https://user-images.githubusercontent.com/2445413/41285447-19fe240a-6e34-11e8-9270-1d6de1132800.png">

---

### Before
<img width="755" alt="screen shot 2018-06-12 at 11 38 38" src="https://user-images.githubusercontent.com/2445413/41285849-711af2bc-6e35-11e8-8053-c1e0d5762553.png">

### After
<img width="787" alt="screen shot 2018-06-12 at 11 38 26" src="https://user-images.githubusercontent.com/2445413/41285850-71356b4c-6e35-11e8-9d3b-2bc06a5edb19.png">

https://trello.com/c/u1fMUipK/1076-dac-audit-design-system-colour-contrast
