### PR TITLE
Update "What's changed" page

### DIFF
--- a/src/design-system/whats-changed.md.njk
+++ b/src/design-system/whats-changed.md.njk
@@ -90,7 +90,7 @@ The tables below show the old and new names for components, classes and mixins, 
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell ">Inset text</td>
-      <td class="govuk-table__cell ">Deprecated: this component is not included in GOV.UK Frontend</td>
+      <td class="govuk-table__cell "><a class="govuk-link" href="../components/inset-text">Inset text component</a></td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell ">panel (object)<br>
@@ -250,7 +250,7 @@ GOV.UK Frontend uses ["Block, Element, Modifier" (BEM)](http://getbem.com/) and 
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell ">form-label-bold</td>
-      <td class="govuk-table__cell ">govuk-label--bold</td>
+      <td class="govuk-table__cell ">govuk-label--s</td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell ">form-control<br>form-control-3-4<br>form-control-2-3<br>form-control-1-2<br>form-control-1-3<br>form-control-1-4<br>form-control-1-8</td>


### PR DESCRIPTION
Corrections
- Inset text no longer deprecated
- Correct modifier class for a bold label