### PR TITLE
Update visual examples to include better alternative text

### DIFF
--- a/src/design-system/patterns/check-a-service-is-suitable/index.md.njk
+++ b/src/design-system/patterns/check-a-service-is-suitable/index.md.njk
@@ -14,7 +14,7 @@ Doing this helps users save time as it tells them upfront whether they are eligi
 
 It can also help reduce time and money spent processing queries from users confused about whether they’re eligible to use your service, or if it’s suitable for them.
 
-![Check a service is suitable example flow](check-a-service-is-suitable-flow.png)
+![‘Check a service is suitable’ flow diagram. Contains an introduction page followed by a series of simple questions. If at any point a user is deemed not eligible for the service they will be pointed to a page that explains why they are not eligible. Otherwise they will be presented a ‘results’ page. ](check-a-service-is-suitable-flow.png)
 
 See a complete [example of check a service is suitable](https://check-before-you-start-pattern.cloudapps.digital/)
 
@@ -64,7 +64,7 @@ If a user isn’t eligible to use your service, explain why and, if possible, te
 
 Here’s an example of a results page:
 
-![Check a service is suitable results example](check-a-service-is-suitable-result.png)
+![Screenshot of a results page, includes a heading that explains if the user is eligible, a summary of why, and a button to continue.](check-a-service-is-suitable-result.png)
 
 ## Research on this pattern
 

--- a/src/design-system/patterns/check-answers/index.md.njk
+++ b/src/design-system/patterns/check-answers/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 Let users check their answers before submitting information to a service.
 
-![Check answers example](check-answers-page.png)
+![Screenshot of a check answers page, includes a heading, and two sections for personal details and application details. Each section has details on the answers a user has given with a corresponding link to change their answer. At the bottom of the page there is a button to 'accept and send' the application.](check-answers-page.png)
 
 ## When to use this pattern
 

--- a/src/design-system/patterns/fill-in-a-form/index.md.njk
+++ b/src/design-system/patterns/fill-in-a-form/index.md.njk
@@ -129,9 +129,14 @@ Try improving the order, type or number of questions before adding a progress in
 
 Only include the total number of questions if you can do so reliably. As the user moves through the form, make sure the indicator updates to tell them which question they are on and the total number remaining.
 
-Don’t use this type of progress indicator:
+Don't use progress indicators that do all of the following:
+- show all questions at once
+- allow navigation to previous questions
+- show the current question
 
-![Horizontal progress indicator](progress_indicators_horizontal.png)
+An example of this looks like:
+
+![Screenshot of a progress indicator that shows five questions.](progress_indicators_horizontal.png)
 
 These can be problematic because they:
 - are often not noticed

--- a/src/design-system/patterns/task-list-pages/index.md.njk
+++ b/src/design-system/patterns/task-list-pages/index.md.njk
@@ -16,7 +16,7 @@ Task list pages help users understand:
 - the order they should complete tasks in
 - when they have completed tasks
 
-![A screenshot showing an example of the task list as used in a fictional service](task-list-whole.png)
+![A screenshot showing an example of the task list page, includes a heading, and three grouped sections that each contain tasks, some of these tasks are marked as completed.](task-list-whole.png)
 
 ## When to use this pattern
 
@@ -42,7 +42,7 @@ If there are lots of tasks to complete, you might also need to group them into s
 
 Whenever you show a Task list page, make it clear to users which tasks they’ve completed by labelling them ‘Completed’.
 
-![A screenshot showing a completed tag next to a list of fictional tasks within a service](task-list-statuses.png)
+![A screenshot showing a completed tag next to a list of tasks](task-list-statuses.png)
 
 ### Group related actions into tasks
 


### PR DESCRIPTION
I feel having live demos of patterns may be a better way to do this than a literal explaination, but I hope this is better than before. We should consider including users with access needs in future rounds of research.

https://trello.com/c/uZiLJNxP/1068-dac-audit-provide-appropriate-text-alternatives-for-non-text-content