### PR TITLE
Add telephone numbers pattern

### DIFF
--- a/src/patterns/telephone-numbers/default/index.njk
+++ b/src/patterns/telephone-numbers/default/index.njk
@@ -1,0 +1,16 @@
+---
+layout: layout-example.njk
+title: Default – Telephone numbers
+---
+
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "UK telephone number"
+  },
+  id: "telephone-number",
+  name: "telephone-number",
+  type: "tel",
+  classes: "govuk-input--width-20"
+}) }}

--- a/src/patterns/telephone-numbers/error-empty-field/index.njk
+++ b/src/patterns/telephone-numbers/error-empty-field/index.njk
@@ -1,0 +1,19 @@
+---
+layout: layout-example.njk
+title: Error, empty field – Telephone numbers
+---
+
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "UK telephone number"
+  },
+  errorMessage: {
+    text: "Enter a UK telephone number"
+  },
+  id: "telephone-number",
+  name: "telephone-number",
+  type: "tel",
+  classes: "govuk-input--width-20"
+}) }}

--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -1,0 +1,94 @@
+---
+title: Telephone numbers
+description: Help users enter a valid telephone number.
+section: Patterns
+theme: Ask users for...
+aliases:
+backlog_issue_id: 101
+layout: layout-pane.njk
+status: Experimental
+statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
+---
+
+{% from "_example.njk" import example %}
+
+{{ example({group: 'patterns', item: 'telephone-numbers', example: 'default', html: true, nunjucks: true, open: false}) }}
+
+## When to use this pattern
+
+Only collect telephone numbers from people if you genuinely need them. Not everyone has or can use a telephone, so make sure you give users a choice about how they can be contacted.
+
+
+## How it works
+
+### Allow different formats
+Users should be allowed to enter telephone numbers in whatever format is familiar to them. You should allow for additional spaces, hyphens, brackets and dashes, and be able to accommodate country and area codes.
+
+### Validate telephone numbers
+You should validate telephone numbers so you can let users know if they have entered one incorrectly. Google's [libphonenumber](https://github.com/googlei18n/libphonenumber) library can validate telephone numbers from most countries.
+
+Validation errors should be styled like this:
+
+{{ example({group: 'patterns', item: 'telephone-numbers', example: 'error-empty-field', html: true, nunjucks: true, open: false}) }}
+
+Some examples of common error messages are:
+
+- empty field: Enter a telephone number
+- not a real number: Enter a telephone number in the correct format, like examples
+- too short: Telephone number must have at least x numbers
+- too long: Telephone number cannot have more than x numbers
+- not a UK mobile phone number: Enter a UK mobile telephone number
+
+### Make it clear what type of telephone number you need
+Use the form label or hint text to tell users if you specifically need a UK, international or mobile telephone number.
+
+{{ example({group: 'patterns', item: 'telephone-numbers', example: 'international', html: true, nunjucks: true, open: false}) }}
+ 
+### Using example telephone numbers
+If you wish to include an example telephone number (in hint text for example), [Ofcom maintains a list of numbers](https://www.ofcom.org.uk/phones-telecoms-and-internet/information-for-industry/numbering/numbers-for-drama) that are reserved for use in media. These are:
+
+- UK non-geographic: 01632 960000 to 960999
+- UK London:  020 7946 0000 to 7946 0999
+- UK mobile: 07700 900000 to 900999
+
+### Explain why you need a telephone number
+Tell users why you might contact them and when.
+
+### Don’t display telephone numbers as links on devices that can’t make calls
+
+It’s possible to mark up telephone numbers as links, like this: 
+
+```
+<a href="tel:+442079476330">020 7947 6330</a>
+```
+
+However, doing this will style telephone numbers as links, which is confusing on devices that don’t support telephone calls, like most desktop machines.
+
+It’s also not necessary - most modern mobile browsers automatically detect telephone numbers and display them as links anyway.
+
+If you do need to mark up your telephone number as links, for example, to support a device that cannot automatically detect them, make sure they don’t display as links on devices that cannot make calls.
+### Write telephone numbers in the GOV.UK style
+See the [GOV.UK style for writing telephone numbers](https://via.hypothes.is/https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#telephone-numbers).
+
+### Avoid input masking
+
+Avoid [input masking](https://css-tricks.com/input-masking/) because it makes it harder for users to:
+
+- type a number in their preferred way
+- transcribe a number from another place and check that they’ve got it right
+
+### Avoid reformatting telephone numbers
+
+The GOV.UK Notify team have observed some users becoming confused when presented with a reformatted version of a telephone number that they provided, for example, with the +44 country code added.
+
+## Research on this pattern
+
+More research is needed on the best way to handle:
+
+- international numbers
+- extensions
+- SMS shortcodes
+
+
+
+

--- a/src/patterns/telephone-numbers/international/index.njk
+++ b/src/patterns/telephone-numbers/international/index.njk
@@ -1,0 +1,19 @@
+---
+layout: layout-example.njk
+title: International – Telephone numbers
+---
+
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "Telephone number"
+  },
+  hint: {
+    text: "For international numbers include the country code"
+  },
+  id: "telephone-number",
+  name: "telephone-number",
+  type: "tel",
+  classes: "govuk-input--width-20"
+}) }}


### PR DESCRIPTION
This pull request is to add a design pattern for telephone numbers. The guidance and examples were [approved by the working group on 26 April 2018](https://github.com/alphagov/govuk-design-system-backlog/issues/101#issuecomment-385634498).

This PR replaces: https://github.com/alphagov/govuk-design-system/pull/313