### PR TITLE
Add community section

### DIFF
--- a/config/navigation.json
+++ b/config/navigation.json
@@ -14,5 +14,9 @@
   {
     "label": "Patterns",
     "url": "design-system/patterns"
+  },
+  {
+    "label": "Community",
+    "url": "design-system/community"
   }
 ]

--- a/src/design-system/community/backlog/index.md.njk
+++ b/src/design-system/community/backlog/index.md.njk
@@ -1,0 +1,754 @@
+---
+title: Backlog
+description:
+section: Community
+layout: layout-pane.njk
+---
+
+The Design System is built upon the research and experience of teams across the whole of government.
+
+Anyone can propose, develop or contribute to new patterns and components, or improvements to existing ones.
+
+Here is a list of the components, patterns and updates currently on the Design System backlog. They can be:
+
+- **Proposed** - someone has suggested a new component or pattern
+- **To do** - the proposed component or pattern has been agreed and is ready to work on
+- **In progress** - someone is actively working on the component or pattern
+
+
+<table class="govuk-table">
+  <tbody><tr>
+    <th class="govuk-table__header">Name</th>
+    <th class="govuk-table__header" style="width: 90px; text-align: right">Status</th>
+  </tr>
+
+
+    <tr>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/1">Accordion</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/125">Additional information</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/2">Alerts</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/120">Ask users for a photo of themself</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/4">Autocomplete</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/5">Back-to-top link</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/112">Before you start page</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/6">Book an appointment</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/135">Border styles</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/7">Business details</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+    </tr>
+    <tr>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/123">Callout text</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/113">Card</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/109">Case summary page</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/67">Character count</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/8">Code block</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/114">Compare options</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/9">Confirm an action</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/10">Contact a department</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/11">Contact preferences</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/115">Contents links</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/12">Cookie banner</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/13">Cookie page</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/14">Country</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/68">Currency input</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/15">Dashboard page</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/16">Data</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/17">Date picker</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/18">Delegate authority</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/118">Department logos</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/19">Document history</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/116">Document metadata</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/20">Download links</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/21">Edit a list</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/128">Error messages: add guidance on how to write good ones</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/117">Feedback link</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/133">Filter a list</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/23">Find an address</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/69">Gender and sex</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/106">Get updates about a service</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/24">Icons</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/25">Identifying users</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/26">Illustrations</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/136">Inset text</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/27">Interruption card</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/28">Loading spinner</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/29">Make a declaration</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/75">Maps</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/30">Modal dialogue</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/127">Moving a user from offline to online</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/73">Nationality</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/76">Navigation</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/74">Number input</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/130">Page not found pages</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/77">Pagination</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/78">Passport details</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/79">Pay for something</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/80">Payment details</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/81">Personal details</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/82">Postcodes</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/110">Previous and next links</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/83">Protected characteristics</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/84">Recover an account</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/85">Reference numbers</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/86">Related links</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/87">Save their progress</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/132">Search box</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/88">Search for something</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/89">Sending emails</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/90">Sending letters</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/91">Sending text messages</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/124">Service unavailable</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/92">Set user permissions</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/119">Share links on social media</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/93">Share personal data</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/98">Showing status</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/126">Showing text changes</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/94">Sign in</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/95">Sign out</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/97">Site header</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/99">Supporting multiple languages</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/138">Tabbed navigation</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/100">Tabbed panel</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/129">Technical problem pages</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/101">Telephone numbers</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/102">Terms and conditions</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/105">Timeline</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/103">Timeout page</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/104">Timeout warning</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/107">Video</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/108">Web chat</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        To do
+      </td>
+    </tr>
+
+
+</tbody></table>

--- a/src/design-system/community/contribute/index.md.njk
+++ b/src/design-system/community/contribute/index.md.njk
@@ -1,0 +1,137 @@
+---
+title: How you can contribute
+description:
+section: Community
+layout: layout-pane.njk
+---
+
+{% from "table/macro.njk" import govukTable %}
+
+The GOV.UK Design System is currently in beta. The Design System team will be developing these contribution guidelines based on user research over the coming months.
+
+## Discussing styles, components and patterns
+
+You can discuss the existing styles, components and patterns in the Design System, or ones being developed, by commenting on issues in the [community backlog](/design-system/community/backlog). Alternatively, you can email [govuk-design-system-support@digital.cabinet-office.gov.uk](mailto: govuk-design-system-support@digital.cabinet-office.gov.uk).
+
+For example, you can:
+
+- ask questions about a style, component or pattern
+- answer questions from other contributors
+- share examples or demos of a style, component or pattern
+- share research relating to a style, component or pattern
+
+## Proposing new styles, components or patterns
+
+If you have an idea for a new style, component or pattern you can propose it by [raising an issue](https://github.com/alphagov/govuk-design-system-backlog/issues/new) or emailing the Design System team at [govuk-design-system-support@digital.cabinet-office.gov.uk](mailto: govuk-design-system-support@digital.cabinet-office.gov.uk).
+
+## Developing components and patterns
+
+If there’s something you’d be interested in working on, comment on its issue or email the Design System team at [govuk-design-system-support@digital.cabinet-office.gov.uk](mailto: govuk-design-system-support@digital.cabinet-office.gov.uk).
+
+If you're writing code, please follow the [GOV.UK Frontend coding standards](https://github.com/alphagov/govuk-frontend/blob/master/CONTRIBUTING.md#conventions-to-follow).
+
+## Design System criteria
+
+To help ensure that the contents of the GOV.UK Design System are of a high quality and meet user needs, all components and patterns must meet the following criteria.
+
+## New proposals
+
+To be considered for inclusion in the GOV.UK Design System, components and patterns must be:
+
+
+{{ govukTable({
+  head: [
+    {
+      text: "Criteria"
+    },
+    {
+      text: "Description"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "Useful"
+      },
+      {
+        text: "It addresses a user need that’s shared by multiple services or products."
+      }
+    ],
+    [
+      {
+        text: "Unique"
+      },
+      {
+        text: "It doesn’t duplicate something which already exists in the GOV.UK Design System, unless it’s intended to replace it."
+      }
+    ]
+  ]
+}) }}
+
+
+The [working group](/design-system/community/working-group) will review all proposals in the [community backlog](/design-system/community/backlog) to check they meet these criteria, before they are agreed.
+
+## Before publication
+
+Before new components and patterns are published into the GOV.UK Design System, the working group will review them again to make sure that they are:
+
+{{ govukTable({
+  head: [
+    {
+      text: "Criteria"
+    },
+    {
+      text: "Description"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "Usable"
+      },
+      {
+        text: "It’s been tested and shown to work with a representative sample of users, including those with disabilities."
+      }
+    ],
+    [
+      {
+        text: "Consistent"
+      },
+      {
+        text: "It uses existing styles and components in the GOV.UK Design System where relevant."
+      }
+    ],
+    [
+      {
+        text: "Versatile"
+      },
+      {
+        text: "It can be easily applied in different contexts."
+      }
+    ],
+    [
+      {
+        text: "Coded"
+      },
+      {
+        text: "Components are ready to merge in GOV.UK Frontend."
+      }
+    ],
+    [
+      {
+        text: "Tested"
+      },
+      {
+        html: "It’s been tested and shown to work with a range of <a href=\"https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices\">browsers, assistive technologies and devices</a>."
+      }
+    ],
+    [
+      {
+        text: "Considered"
+      },
+      {
+        text: "There are no obvious political, security or ethical implications."
+      }
+    ]
+  ]
+}) }}

--- a/src/design-system/community/index.md.njk
+++ b/src/design-system/community/index.md.njk
@@ -1,0 +1,10 @@
+---
+layout: layout-pane.njk
+title: Community
+---
+
+The GOV.UK Design System is for everyone, with a strong community sitting behind it. It brings together the latest research, design and development from across government to make it sure it’s representative and relevant for its users.
+
+Find out [how to contribute](contribute), or see what people are currently working on in the [community backlog](backlog).
+
+You can also learn how the cross-government [Design System working group](working-group) helps to quality assure the styles, components and patterns you’ll find here.

--- a/src/design-system/community/working-group/index.md.njk
+++ b/src/design-system/community/working-group/index.md.njk
@@ -1,0 +1,57 @@
+---
+title: Design System working group
+description:
+section: Community
+layout: layout-pane.njk
+---
+
+The Design System working group is a multi-disciplinary, cross-government group whose purpose is to ensure that any styles, components and patterns published in the GOV.UK Design System are of a high quality and meet user needs.
+
+They do this by:
+
+- developing the [Design System criteria](/design-system/community/contribute/#design-system-criteria)
+- reviewing new proposals against the criteria
+- approving new styles, components and patterns for publication
+- resolving queries escalated to them by the GOV.UK Design System team
+- representing the needs of users from their department
+
+## Working group guidelines
+
+The GOV.UK Design System is currently in beta. We will be developing this guidance based on user research over the coming months.
+
+These guidelines are designed to help the members of the working group review components and patterns on the backlog.
+
+## Reviewing contributions
+
+Anyone can propose a new component or pattern for the GOV.UK Design System by raising an issue in the [community backlog](/design-system/community/backlog). They can also volunteer their time to develop components and patterns in the 'Agreed' column in the backlog.
+
+It’s the job of the working group to review new proposals and contributions against the [Design System criteria](/design-system/community/contribute/#design-system-criteria).
+
+Members of the working group will meet once a month to review outstanding contributions. The GOV.UK Design System team will send a list of the contributions to the working group one week before each meeting, to allow them to look at them in advance.
+
+A member of the GOV.UK Design System team will facilitate the meeting and record the outcome for each proposal and contribution in a decision log. They will also record details of any recommendations which need to be fed back to the contributor.
+
+After the meeting, the GOV.UK Design System team will contact the contributors to let them know if their submission was:
+
+- agreed
+- not agreed
+- unable to be reviewed because more information was needed
+
+At this point, the contributors will also be given any recommendations from the working group.
+
+## Reviewing new proposals
+
+During the meeting, the group should go through each proposed idea one at a time, and decide whether it is useful and unique in accordance with the Design System criteria for new proposals.
+
+Decisions should be made based on the idea for a component or pattern, and not on any specific implementation which might have been shared in the issue.
+
+Once the contributors have been agreed, the Design System team will move issues for agreed proposals from the ‘Proposed’ column to the ‘Agreed’ column in the backlog.
+
+
+## Before publication
+
+As with new proposals, the working group should go through each contribution one at a time and decide whether it meets the Design System criteria for publication.
+
+After the review session, the Design System team will contact the contributor and arrange the final checks for successful components and patterns before publishing them into the GOV.UK Design System. At this point, the team will move the issue from 'In progress' to 'Published'.
+
+For any components and patterns which were not agreed, the Design System team will speak to the contributor and let them know of any extra work they might need to do.

--- a/src/design-system/index.njk
+++ b/src/design-system/index.njk
@@ -38,6 +38,26 @@ title: About
       </div>
 
       <div class="govuk-grid-column-two-thirds">
+        <h2 id="get-in-touch" class="govuk-heading-l">Community</h2>
+        <p class="govuk-body">
+          The GOV.UK Design System is built upon the research and experience of teams across the whole of government. </p>
+
+        <p class="govuk-body">
+          Anyone can contribute. To see what people are currently working on,
+           <a href="/design-system/community/backlog" class="govuk-link" data-hcontribute="guidelinegh">check the backlog</a>.
+        </p>
+
+        <p class="govuk-body govuk-!-mb-r0">
+          To propose or develop a style, component or pattern for the GOV.UK Design System find out <a href="/design-system/community/contribute" data-hcontribute="backloggb">how to contribute</a>.
+        </p>
+
+      </div>
+
+      <div class="govuk-grid-column-full">
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+      </div>
+
+      <div class="govuk-grid-column-two-thirds">
         <h2 id="get-in-touch" class="govuk-heading-l">Support</h2>
         <p class="govuk-body">
           The GOV.UK Design System is maintained by the Government Digital Service.
@@ -56,20 +76,6 @@ title: About
         </ul>
       </div>
 
-      <div class="govuk-grid-column-full">
-        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
-      </div>
-
-      <div class="govuk-grid-column-two-thirds govuk-!-mb-r4">
-        <h2 class="govuk-heading-l">Contribute</h2>
-        <p class="govuk-body">
-          To propose a new style, component or pattern for the GOV.UK Design System <a href="https://github.com/alphagov/govuk-design-system-backlog/blob/master/docs/CONTRIBUTING.md" class="govuk-link" data-hcontribute="guidelinegh">read the contribution guidelines on GitHub</a>.
-        </p>
-
-        <p class="govuk-body govuk-!-mb-r0">
-          You can see what’s currently being worked on in the <a href="https://github.com/alphagov/govuk-design-system-backlog" class="govuk-link" data-hcontribute="backloggb">GOV.UK Design System Backlog</a>.
-        </p>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Trello card: https://trello.com/c/sFg6nov6/1117-add-a-new-community-section-to-the-design-system

This work:

- adds a Community section
- adds Community to the navigation
- adds a Community section to the homepage

**Known issue:**

The Community section left nav is in the wrong order. Ordering is currently only alphabetical in the Design System. I intend to do a further PR to add ordering functionality to the Design System.