### PR TITLE
Add max-width and bottom margin to block code blocks in prose-scope

### DIFF
--- a/src/design-system/stylesheets/components/_tabs.scss
+++ b/src/design-system/stylesheets/components/_tabs.scss
@@ -91,6 +91,8 @@
 }
 
 .app-tabs__container pre {
+  max-width: inherit;
+  margin-bottom: 0;
   border: 0;
 }
 

--- a/src/design-system/stylesheets/main.scss
+++ b/src/design-system/stylesheets/main.scss
@@ -274,6 +274,8 @@ pre {
   overflow: auto;
   border: 1px solid $govuk-border-colour;
   background-color: $app-light-grey;
+  max-width: 38em;
+  @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
 }
 
 .no-js {


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-design-system/issues/299 which will be / is an issue in #322 
Also adds safe-guard for code blocks in example tabs.