### PR TITLE
Disable absolute redirects

### DIFF
--- a/deploy/nginx/conf/includes/disable_absolute_redirects.conf
+++ b/deploy/nginx/conf/includes/disable_absolute_redirects.conf
@@ -1,0 +1,20 @@
+# Disable absolute redirects
+#
+# The index directive (1) used in the nginx config within the buildpack means that
+# we send a 301 redirect when visiting a directory without a trailing slash
+# (e.g. /design-system will redirect to /design-system/) 
+# 
+# However by default nginx will use absolute URLs – including the hostname –
+# when redirecting, which means that users going to www.gov.uk/design-system
+# will end up being redirected to our 'origin domain'
+# (govuk-design-system-production.cloudapps.digital/design-system/)
+# which is less than ideal.
+#
+# Disabling absolute redirects (2) means that nginx will instead 301 to the
+# relative url /design-system, which means users won't be redirected away from
+# GOV.UK and everything is A-OK ✌️
+#
+# [1]: http://nginx.org/en/docs/http/ngx_http_index_module.html#index
+# [2]: http://nginx.org/en/docs/http/ngx_http_core_module.html#absolute_redirect
+
+absolute_redirect off;


### PR DESCRIPTION
This fixes an issue where users who visit www.gov.uk/design-system would get an absolute redirect to our origin domain (govuk-design-system-production.cloudapps.digital/design-system/).

## Before
```
curl -I https://govuk-design-system-production.cloudapps.digital/design-system
HTTP/1.1 301 Moved Permanently
Content-Length: 178
Content-Type: text/html
Date: Thu, 14 Jun 2018 15:27:34 GMT
Location: http://govuk-design-system-production.cloudapps.digital/design-system/
Server: nginx
X-Vcap-Request-Id: 1d8e596c-4bf5-491d-7ace-8082dd601ebc
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
```

## After
```
curl -I https://govuk-design-system-production-redirect-test.cloudapps.digital/design-system
HTTP/1.1 301 Moved Permanently
Content-Length: 178
Content-Type: text/html
Date: Thu, 14 Jun 2018 15:27:54 GMT
Location: /design-system/
Server: nginx
X-Vcap-Request-Id: ba3e50d4-956b-4cc6-6c29-594d44481934
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
```