### PR TITLE
Make postcode field 10 characters wide

### DIFF
--- a/src/components/fieldset/address-group/index.njk
+++ b/src/components/fieldset/address-group/index.njk
@@ -54,7 +54,7 @@ stylesheets:
     label: {
       html: 'Postcode'
     },
-    classes: 'govuk-!-width-one-third',
+    classes: 'govuk-input--width-10',
     id: "address-postcode",
     name: "address-postcode"
   }) }}

--- a/src/patterns/question-pages/postcode/index.njk
+++ b/src/patterns/question-pages/postcode/index.njk
@@ -25,6 +25,7 @@ layout: layout-example.njk
               isPageHeading: true,
               classes: "govuk-label--xl"
             },
+            classes: "govuk-input--width-10",
             id: "postcode",
             name: "postcode"
           }) }}


### PR DESCRIPTION
Fields that take short inputs of known length should be sized to reflect those inputs.