### PR TITLE
Add sitemap generator

### DIFF
--- a/lib/generate-sitemap.js
+++ b/lib/generate-sitemap.js
@@ -1,0 +1,96 @@
+const sm = require('sitemap')
+const path = require('path')
+const paths = require('../config/paths.json')
+const fs = require('fs-extra')
+const match = require('multimatch')
+
+// Only include keys that have values
+const removeEmptyKeys = (obj) => {
+  let newObj = {}
+  Object.keys(obj).forEach((prop) => {
+    if (obj[prop] !== '') {
+      newObj[prop] = obj[prop]
+    }
+  })
+  return newObj
+}
+
+/**
+ * Plugin to generate a sitemap with sitemap.js
+ *
+ * @param {Object} options
+ *  @property {String} hostname
+ *  @property {String} changefreq (optional)
+ *  @property {Date}   lastmod (optional)
+ *  @property {String} priority (optional)
+ *  @property {String} destination (optional)
+ *  @property {String} filename (optional)
+ *  @property {String} pattern (optional)
+ * @return {Function}
+ */
+
+const plugin = (opts) => {
+  opts = opts || {}
+
+  if (!opts.hostname) {
+    throw new Error('"hostname" is required')
+  }
+
+  // sitemap.js options
+  const hostname = opts.hostname
+  const changefreq = opts.changefreq
+  const lastmod = opts.lastmod
+  const priority = opts.priority
+
+  // additional options
+  const destination = opts.destination || paths.public
+  const filename = opts.filename || 'sitemap.xml'
+  const pattern = opts.pattern || '**/*.html'
+
+  return function (files, metalsmith, done) {
+    const sitemap = sm.createSitemap({
+      hostname: hostname
+    })
+
+    // Checks whether files should be processed
+    const checkPattern = (file, frontmatter) => {
+      // Only include files that match the pattern
+      if (!match(file, pattern)[0]) {
+        return false
+      }
+      // Ignore files if set to true
+      if (frontmatter.ignore_in_sitemap) {
+        return false
+      }
+      return true
+    }
+
+    Object.keys(files).sort().forEach(function (file) {
+      // Get the current file's frontmatter
+      const frontmatter = files[file]
+
+      // Only process files that pass the check
+      if (!checkPattern(file, frontmatter)) {
+        return
+      }
+
+      // Use canonical in frontmatter instead of the file's canonical data
+      // set by metalsmith-canonical plugin
+      let url = frontmatter.canonical ? frontmatter.canonical : files[file].canonical
+
+      let sitemapEntry = {
+        url: url,
+        changefreq: frontmatter.changefreq || changefreq,
+        lastmod: frontmatter.lastmod || lastmod,
+        priority: frontmatter.priority || priority
+      }
+
+      // Add the files to the sitemap and remove empty keys
+      sitemap.add(removeEmptyKeys(sitemapEntry))
+    })
+
+    // create a sitemap
+    fs.writeFile(path.join(destination, filename), sitemap.toString(), done)
+  }
+}
+module.exports = plugin

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -22,6 +22,7 @@ const commonjs = require('rollup-plugin-commonjs')           // rollup plugin to
 // const debug = require('./debug')                          // debug plugin
 const navigation = require('./navigation.js')                // navigation plugin
 const modernizrBuild = require('./modernizr-build.js')       // modernizr build plugin
+const generateSitemap = require('./generate-sitemap.js')     // modernizr build plugin
 
 const colours = require('../lib/colours.js')                 // get colours data
 const fileHelper = require('../lib/file-helper.js')          // helper function to operate on files
@@ -213,6 +214,12 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     default: 'layout.njk',
     directory: '../' + paths.layouts,
     pattern: '**/*.html'
+  }))
+
+  // generate a sitemap.xml in public/ folder
+  .use(generateSitemap({
+    hostname: 'http://design-system.service.gov.uk',
+    pattern: ['**/*.html', '!**/default/*.html']
   }))
 
   // check broken links

--- a/package-lock.json
+++ b/package-lock.json
@@ -12002,6 +12002,15 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "sitemap": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-1.13.0.tgz",
+      "integrity": "sha1-Vpy+IYAgKSamKiZs094Jyc60P4M=",
+      "dev": true,
+      "requires": {
+        "underscore": "1.7.0"
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "request": "^2.87.0",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-node-resolve": "^3.3.0",
+    "sitemap": "^1.13.0",
     "standard": "^10.0.3"
   },
   "engines": {

--- a/src/components/button/disabled/index.njk
+++ b/src/components/button/disabled/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Disabled button
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 {% from "button/macro.njk" import govukButton %}
 

--- a/src/components/button/start/index.njk
+++ b/src/components/button/start/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Start now button
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 {% from "button/macro.njk" import govukButton %}
 

--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Checkboxes with conditionally revealing content
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from 'checkboxes/macro.njk' import govukCheckboxes %}

--- a/src/components/date-input/error/index.njk
+++ b/src/components/date-input/error/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Date input with errors
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "date-input/macro.njk" import govukDateInput %}

--- a/src/components/error-message/label/index.njk
+++ b/src/components/error-message/label/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Error message with Label
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "input/macro.njk" import govukInput %}

--- a/src/components/error-message/legend/index.njk
+++ b/src/components/error-message/legend/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Error message with Legend
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from 'checkboxes/macro.njk' import govukCheckboxes %}

--- a/src/components/fieldset/address-group/index.njk
+++ b/src/components/fieldset/address-group/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Fieldset address group
 layout: layout-example.njk
+ignore_in_sitemap: true
 stylesheets:
 - address-wrapper.css
 ---

--- a/src/components/footer/full/index.njk
+++ b/src/components/footer/full/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Footer with secondary navigation and links to meta information
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from 'footer/macro.njk' import govukFooter %}

--- a/src/components/footer/implicit/index.njk
+++ b/src/components/footer/implicit/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Footer
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from 'footer/macro.njk' import govukFooter %}

--- a/src/components/footer/with-meta/index.njk
+++ b/src/components/footer/with-meta/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Footer with links to meta information
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from 'footer/macro.njk' import govukFooter %}

--- a/src/components/footer/with-navigation/index.njk
+++ b/src/components/footer/with-navigation/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Footer with secondary navigation
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from 'footer/macro.njk' import govukFooter %}

--- a/src/components/header/implicit/index.njk
+++ b/src/components/header/implicit/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Header
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 {% from "header/macro.njk" import govukHeader %}
 

--- a/src/components/header/with-service-name-and-navigation/index.njk
+++ b/src/components/header/with-service-name-and-navigation/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Header with navigation
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 {% from "header/macro.njk" import govukHeader %}
 

--- a/src/components/header/with-service-name/index.njk
+++ b/src/components/header/with-service-name/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Header with navigation
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 {% from "header/macro.njk" import govukHeader %}
 

--- a/src/components/phase-banner/beta/index.njk
+++ b/src/components/phase-banner/beta/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Phase banner with beta text
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "phase-banner/macro.njk" import govukPhaseBanner %}

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Radios with conditionally revealing content
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from 'radios/macro.njk' import govukRadios %}

--- a/src/components/radios/stacked/index.njk
+++ b/src/components/radios/stacked/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Stacked radios
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from 'radios/macro.njk' import govukRadios %}

--- a/src/components/table/numbers/index.njk
+++ b/src/components/table/numbers/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Numbers in a table
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "table/macro.njk" import govukTable %}

--- a/src/components/text-input/input-fixed-width/index.njk
+++ b/src/components/text-input/input-fixed-width/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Fixed width inputs
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-fluid-width/index.njk
+++ b/src/components/text-input/input-fluid-width/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Fluid width inputs
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-hint-text/index.njk
+++ b/src/components/text-input/input-hint-text/index.njk
@@ -1,6 +1,7 @@
 ---
 title: National insurance numbers
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "input/macro.njk" import govukInput %}

--- a/src/components/textarea/specifying-rows/index.njk
+++ b/src/components/textarea/specifying-rows/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Textarea appropriately-sized with rows
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 {% from "textarea/macro.njk" import govukTextarea %}
 

--- a/src/errors/404.njk
+++ b/src/errors/404.njk
@@ -1,6 +1,7 @@
 ---
 title: 404 Page not found
 layout: layout-single-page.njk
+ignore_in_sitemap: true
 ---
 
 <div class="govuk-grid-row">

--- a/src/errors/generic.njk
+++ b/src/errors/generic.njk
@@ -1,6 +1,7 @@
 ---
 title: Sorry, there is a problem with the service
 layout: layout-single-page.njk
+ignore_in_sitemap: true
 ---
 
 <div class="govuk-grid-row">

--- a/src/google921002f57f264802.html
+++ b/src/google921002f57f264802.html
@@ -2,5 +2,6 @@
 permalink: false
 title: N/A
 layout: false
+ignore_in_sitemap: true
 ---
 google-site-verification: google921002f57f264802.html

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Multiple text inputs Addresses
 layout: layout-example.njk
+ignore_in_sitemap: true
 stylesheets:
 - address-wrapper.css
 ---

--- a/src/patterns/addresses/textarea/index.njk
+++ b/src/patterns/addresses/textarea/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Textarea addresses
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 

--- a/src/patterns/page-not-found-pages/reason-not-known/index.njk
+++ b/src/patterns/page-not-found-pages/reason-not-known/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Reason not known – Page not found pages
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "input/macro.njk" import govukInput %}

--- a/src/patterns/page-not-found-pages/user-mistake/index.njk
+++ b/src/patterns/page-not-found-pages/user-mistake/index.njk
@@ -1,6 +1,7 @@
 ---
 title: User mistake – Page not found pages
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 <div class="govuk-width-container">

--- a/src/patterns/problem-with-the-service-pages/link-to-another-service/index.njk
+++ b/src/patterns/problem-with-the-service-pages/link-to-another-service/index.njk
@@ -1,6 +1,7 @@
 ---
 title: A link to another service
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 <div class="govuk-width-container">

--- a/src/patterns/problem-with-the-service-pages/offline-support/index.njk
+++ b/src/patterns/problem-with-the-service-pages/offline-support/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Service has offline support but no specific page that includes numbers and opening times
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 <div class="govuk-width-container">

--- a/src/patterns/question-pages/passport/index.njk
+++ b/src/patterns/question-pages/passport/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Passport – Question pages
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "back-link/macro.njk" import govukBackLink %}

--- a/src/patterns/question-pages/postcode/index.njk
+++ b/src/patterns/question-pages/postcode/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Postcode – Question pages
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "back-link/macro.njk" import govukBackLink %}

--- a/src/patterns/question-pages/progress/index.njk
+++ b/src/patterns/question-pages/progress/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Progress indicator – Question pages
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 <h1 class="govuk-heading-xl">

--- a/src/patterns/question-pages/section-headings/index.njk
+++ b/src/patterns/question-pages/section-headings/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Section headings – Question pages
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 <h1 class="govuk-heading-xl">

--- a/src/patterns/service-unavailable-pages/after-service-closes/index.njk
+++ b/src/patterns/service-unavailable-pages/after-service-closes/index.njk
@@ -1,6 +1,7 @@
 ---
 title: After a service closes
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 <div class="govuk-width-container">

--- a/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
+++ b/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
@@ -1,6 +1,7 @@
 ---
 title: When you know when a service will be available
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 <div class="govuk-width-container">

--- a/src/patterns/service-unavailable-pages/before-service-opens/index.njk
+++ b/src/patterns/service-unavailable-pages/before-service-opens/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Before a service opens
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 <div class="govuk-width-container">

--- a/src/patterns/service-unavailable-pages/default/index.njk
+++ b/src/patterns/service-unavailable-pages/default/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Service unavailable
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 <div class="govuk-width-container">

--- a/src/patterns/service-unavailable-pages/general/index.njk
+++ b/src/patterns/service-unavailable-pages/general/index.njk
@@ -1,6 +1,7 @@
 ---
 title: General page
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 <div class="govuk-width-container">

--- a/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
+++ b/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
@@ -1,6 +1,7 @@
 ---
 title: A link to another service
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 <div class="govuk-width-container">

--- a/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
+++ b/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Nothing has replaced the service
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 <div class="govuk-width-container">

--- a/src/patterns/service-unavailable-pages/service-replaced/index.njk
+++ b/src/patterns/service-unavailable-pages/service-replaced/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Something has replaced the service
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 <div class="govuk-width-container">

--- a/src/patterns/telephone-numbers/error-empty-field/index.njk
+++ b/src/patterns/telephone-numbers/error-empty-field/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 title: Error, empty field – Telephone numbers
+ignore_in_sitemap: true
 ---
 
 {% from "input/macro.njk" import govukInput %}

--- a/src/patterns/telephone-numbers/international/index.njk
+++ b/src/patterns/telephone-numbers/international/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-example.njk
 title: International – Telephone numbers
+ignore_in_sitemap: true
 ---
 
 {% from "input/macro.njk" import govukInput %}


### PR DESCRIPTION
Simple metalsmith plugin to generate a sitemap with [sitemap.js](https://github.com/ekalinin/sitemap.js)

https://deploy-preview-337--govuk-design-system-preview.netlify.com/sitemap.xml

Required options: 
```
hostname
```

Optional options:
```
changefreq
lastmod
priority
filename -> default `sitemap.xml`
destination -> default `deploy/public/design-system`
pattern: -> default `**/*.html`
```

It will loop through all metalsmith files and check for two frontmatter properties:

`ignore_in_sitemap` `(Boolean)` : if set to `true` it will ignore the file
`canonical` `(String)` : url to be used instead of the canonical data set by metalsmith-canonical plugin. 
Url is relative to the `hostname`

This is related to https://trello.com/c/31ttWqd3/1047-add-site-map-to-the-design-system but not required to complete it

