### PR TITLE
Update text input example

### DIFF
--- a/src/components/text-input/default/index.njk
+++ b/src/components/text-input/default/index.njk
@@ -2,15 +2,16 @@
 title: Text input
 layout: layout-example.njk
 ---
+
 {% from "input/macro.njk" import govukInput %}
 
 {{ govukInput({
   label: {
-    text: "National insurance number"
+    text: "Email address"
   },
   hint: {
-    html: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    html: "We’ll only use this to send you a receipt"
   },
-  id: "national-insurance-number",
-  name: "national-insurance-number"
+  id: "email",
+  name: "email"
 }) }}


### PR DESCRIPTION
The current default example is for National Insurance numbers, but these should not be full width. This replaces it with the same example we use for the Email address pattern.