### PR TITLE
IE Fixes

### DIFF
--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -117,6 +117,12 @@
   }
 
   .no-flexbox {
+
+    .app-pane {
+      height: auto;
+      @include govuk-clearfix;
+    }
+
     .app-pane__body {
       display: block;
     }
@@ -125,10 +131,13 @@
       width: $toc-width;
       float: left;
       overflow-x: hidden;
+      border-right: none;
     }
 
     .app-pane__content {
       overflow-x: hidden;
+      border-left: 1px solid $govuk-border-colour;
+      margin-left: -1px;
     }
   }
 }

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -27,7 +27,7 @@
 
         In other browsers <image> is synonymous for the <img> tag and will be
         interpreted as such, displaying the fallback image. #}
-        <image src="/images/govuk-logotype-crown.png" xlink:href="" class="app-header__logotype-crown-fallback-image"></image>
+        <image src="/assets/images/govuk-logotype-crown.png" xlink:href="" class="app-header__logotype-crown-fallback-image"></image>
       </svg>
       <span class="app-header__logotype-text">
         GOV.UK


### PR DESCRIPTION
- Fix fallback behaviour for browsers that don't support flexbox.
- Fix header 'crown' fallback image path