### PR TITLE
Allow the Design System to be indexed by search engines

### DIFF
--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -5,8 +5,10 @@
 {% block pageTitle %}{{ title }} – GOV.UK Design System{% endblock %}
 
 {% block head %}
+{% if not TRAVIS_BRANCH or TRAVIS_BRANCH != 'master' %}
   <meta name="robots" content="noindex, nofollow">
-
+{% endif %}
+  
   <!--[if !IE 8]><!-->
     <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
   <!--<![endif]-->


### PR DESCRIPTION
Only its production (service domain) URL.
This excludes the examples which appear iframed in each page.

This is achieved by:
 - checking if `travis_branch` variable exists or is not equal to 'master' and including the robots meta tag in those instances

Trello ticket: 

https://trello.com/c/GFmYbIAE/1065-allow-design-system-to-be-indexed