### PR TITLE
update start page pattern guidance

### DIFF
--- a/src/patterns/start-pages/index.md.njk
+++ b/src/patterns/start-pages/index.md.njk
@@ -10,13 +10,17 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-If you’re building a digital service, you’ll need a starting point for users on GOV.UK.
+Use this pattern to test a start page in your prototype. 
+
+To get a start page for your public beta or live service, you need to [contact the GDS content team](https://www.gov.uk/service-manual/service-assessments/get-your-service-on-govuk) before your alpha assessment. 
 
 {{ example({group: 'patterns', item: 'start-pages', example: 'default', html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 
 If your service is in public beta or live, you must have a starting point hosted on GOV.UK. This will link your service to the rest of GOV.UK.
+
+You can use the coded example here to test what works best for your users in prototypes.
 
 ## How it works
 
@@ -32,19 +36,9 @@ Start pages include 4 main elements:
 
 This is a set pattern, so you won’t be able to customise it. 
 
+Read guidance on [what information should go on a start page](www.gov.uk/service-manual/design/govuk-content-transactions) in the Service Manual.
+
 {{ example({group: 'patterns', item: 'start-pages', example: 'default', html: true, nunjucks: true, open: true}) }}
-
-### Testing start pages in discovery and alpha
-
-If you want to prototype designs so you can test them with users, you can use the [start page template](https://govuk-prototype-kit-beta.herokuapp.com/docs/examples/start-page) in the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com/).
-
-### Get a start page for your public beta or live service
-
-[Contact the GDS content team](https://www.gov.uk/service-manual/service-assessments/get-your-service-on-govuk) before your alpha assessment to discuss start points for your service. 
-
-The GDS content team will create a start page for you in most cases. If this isn’t the best way to meet the user need, they’ll recommend another way of joining up with the rest of GOV.UK.
-
-GDS will only publish your start page when your service passes its beta assessment or self-certification and goes into public beta.
 
 ## Research on this pattern
 

--- a/src/patterns/start-pages/index.md.njk
+++ b/src/patterns/start-pages/index.md.njk
@@ -36,7 +36,7 @@ Start pages include 4 main elements:
 
 This is a set pattern, so you won’t be able to customise it. 
 
-Read guidance on [what information should go on a start page](www.gov.uk/service-manual/design/govuk-content-transactions) in the Service Manual.
+Read guidance on [what information should go on a start page](https://www.gov.uk/service-manual/design/govuk-content-transactions) in the Service Manual.
 
 {{ example({group: 'patterns', item: 'start-pages', example: 'default', html: true, nunjucks: true, open: true}) }}
 


### PR DESCRIPTION
Add links to Service Manual guidance from this page, to clarify that this pattern is just for prototyping. 