### PR TITLE
Fix subnav item padding

### DIFF
--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -14,7 +14,7 @@
     a:link,
     a:visited {
       display: block;
-      padding: 8px (govuk-spacing(6) * 2) 8px govuk-spacing(2);
+      padding: 8px govuk-spacing(6) 8px govuk-spacing(2);
       border-left: 4px solid transparent;
       color: $govuk-link-colour;
       background: inherit;


### PR DESCRIPTION
This PR reduces the excessive right padding on subnav items.

### Before
<img width="232" alt="screen shot 2018-06-20 at 11 16 53" src="https://user-images.githubusercontent.com/788096/41652641-93cc2dc0-747b-11e8-893d-695f011543db.png">

### After
<img width="227" alt="screen shot 2018-06-20 at 11 27 56" src="https://user-images.githubusercontent.com/788096/41653136-085a2574-747d-11e8-9f56-3325e2e28f9d.png">
