### PR TITLE
Add canonical url 

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -11,6 +11,8 @@ const markdown = require('metalsmith-markdown')              // convert markdown
 const metallic = require('metalsmith-metallic')              // highlight code in markdown files
 const tagcleaner = require('metalsmith-tagcleaner')          // Use tag cleaner to remove <p> tags around images
 const permalinks = require('metalsmith-permalinks')          // apply a permalink pattern to files
+const canonical = require('metalsmith-canonical')            // add a canonical url property to pages
+
 const sass = require('metalsmith-sass')                      // convert Sass files to CSS using LibSass
 
 const rollup = require('metalsmith-rollup')                  // used to build GOV.UK Frontend JavaScript
@@ -193,6 +195,13 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
   // apply a permalink pattern to files
   .use(permalinks({
     relative: false
+  }))
+
+  // add a canonical url property to pages
+  .use(canonical({
+    hostname: 'http://design-system.service.gov.uk',
+    omitIndex: true,
+    omitTrailingSlashes: false
   }))
 
   // apply navigation

--- a/package-lock.json
+++ b/package-lock.json
@@ -8589,6 +8589,25 @@
         }
       }
     },
+    "metalsmith-canonical": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/metalsmith-canonical/-/metalsmith-canonical-1.1.2.tgz",
+      "integrity": "sha512-3X43I36ckim1aIXv377iHoGbP4/DlSw/gOkaKegnT7V8KFZmBnGO6zbefQeq3CQ41dbIbnjYigZwSSqIoJOabg==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.10",
+        "multimatch": "2.1.0",
+        "url-join": "4.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
     "metalsmith-concat": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/metalsmith-concat/-/metalsmith-concat-6.0.0.tgz",
@@ -13621,6 +13640,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url-join": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
+      "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=",
       "dev": true
     },
     "use": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "metalsmith-assets": "^0.1.0",
     "metalsmith-broken-link-checker": "^1.0.1",
     "metalsmith-browser-sync": "^1.1.1",
+    "metalsmith-canonical": "^1.1.2",
     "metalsmith-concat": "^6.0.0",
     "metalsmith-env": "^2.1.1",
     "metalsmith-fingerprint-ignore": "^2.0.0",

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -14,6 +14,7 @@
     <link href="/{{ fingerprint['stylesheets/main-ie8.css'] }}" rel="stylesheet" media="all" />
     <script src="/{{ fingerprint['javascripts/ie.js'] }}"></script>
   <![endif]-->
+  <link rel="canonical" href="{{ canonical }}" />
   <script src="/javascripts/vendor/modernizr.js"></script>
   {% include "_tracking-head.njk" %}
 {% endblock %}


### PR DESCRIPTION
We only want the canonical URL for each page (exluding example pages) indexed – we don't want the *.cloudapps.digital URL to appear in search results for example.

Utilising [metalsmith-canonical](https://github.com/saintedlama/metalsmith-canonical)

Trello ticket: https://trello.com/c/E7l2Q77P/1127-add-canonical-urls-to-the-design-system