### PR TITLE
Order community section

### DIFF
--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -1,4 +1,4 @@
-// Navgation metalsmith plugin
+// Navigation metalsmith plugin
 // builds a navigation object based on config file and folder structure
 
 // files: array containing information about every page
@@ -34,7 +34,6 @@ module.exports = function () {
                 // If the page is labelled as a draft, do not show in the navigation.
                 continue
               }
-
               let subitem = {
                 'url': url,
                 'label': frontmatter.title
@@ -43,9 +42,18 @@ module.exports = function () {
               if (frontmatter.theme) {
                 subitem.theme = frontmatter.theme
               }
+              // if frontmatter contains 'order' data, use it for ordering the navigation
+              if (frontmatter.order) {
+                subitem.order = frontmatter.order
+              }
               // add subitem to navigation
               navigation[item].items.push(subitem)
             }
+          }
+
+          // if 'order' is set, use it to sort the navigation
+          if (navigation[item].items[0].order !== undefined) {
+            navigation[item].items.sort((a, b) => a.order - b.order)
           }
         }
       }

--- a/src/community/backlog/index.md.njk
+++ b/src/community/backlog/index.md.njk
@@ -3,6 +3,7 @@ title: Backlog
 description:
 section: Community
 layout: layout-pane.njk
+order: 1
 ---
 
 The Design System is built upon the research and experience of teams across the whole of government.

--- a/src/community/contribution-criteria/index.md.njk
+++ b/src/community/contribution-criteria/index.md.njk
@@ -3,6 +3,7 @@ title: Contribution criteria
 description:
 section: Community
 layout: layout-pane.njk
+order: 3
 ---
 
 {% from "table/macro.njk" import govukTable %}

--- a/src/community/design-system-working-group/index.md.njk
+++ b/src/community/design-system-working-group/index.md.njk
@@ -3,6 +3,7 @@ title: Design System working group
 description:
 section: Community
 layout: layout-pane.njk
+order: 4
 ---
 
 The Design System working group is a multi-disciplinary, cross-government group whose purpose is to ensure that any components and patterns published in the GOV.UK Design System are of a high quality and meet user needs.
@@ -59,5 +60,3 @@ Depending on the amount of work needed, it may take a few weeks to complete thes
 Once contributions are published, the Design System team will move the issue from ‘In progress’ to ‘Published’.
 
 For any components and patterns which were not agreed, the Design System team will speak to the contributor and let them know of any extra work they might need to do.
-
-

--- a/src/community/how-you-can-contribute/index.md.njk
+++ b/src/community/how-you-can-contribute/index.md.njk
@@ -3,6 +3,7 @@ title: How you can contribute
 description:
 section: Community
 layout: layout-pane.njk
+order: 2
 ---
 
 The GOV.UK Design System is currently in beta. The Design System team will be developing these contribution guidelines based on user research over the coming months.


### PR DESCRIPTION
This adds ordering functionality, and orders the Community section.

The ordering works by adding `order: 1`  or other number to the 'frontmatter' of every page in a section.