### PR TITLE
Change PaaS app name

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: govuk-design-system-production
+- name: govuk-design-system-origin
   # NGINX requires 20 MB of RAM to serve static assets. Reduce RAM allocation
   # from the default 1 GB allocated to containers by default to 64M.
   memory: 64M


### PR DESCRIPTION
This is so that we can re-use the existing cloudapps.digital domain and redirect anyone that visits it to the service domain.