### PR TITLE
Update basic auth username and password

### DIFF
--- a/deploy/nginx/.htpasswd
+++ b/deploy/nginx/.htpasswd
@@ -1,1 +1,1 @@
-designsystem:$apr1$F1Crj11o$htY5aGcSSV8ENGwle8pKh0
+origin:$apr1$lc1xPZfR$bkg2bwTNU2eEwNIoZTf4l.


### PR DESCRIPTION
Now that we've taken password off service domain, we still want to have basic auth on our cloud apps domain.