### PR TITLE
Remove instruction to log in to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,6 @@ npm run lint
 Design System consumes [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) packages via [NPM](https://www.npmjs.com/).
 These are defined in the [package.json](package.json) file.
 
----------------------
-**NOTE:**
-For the time being we are consuming private packages. To access private packages, you will first need to log in to NPM with
-
-`npm login`
-
 --------------------
 
 ## Automated Checks


### PR DESCRIPTION
This is no longer required