### PR TITLE
Update to frontend 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,8 @@ npm run lint
 
 ## GOV.UK Frontend packages
 
-Design System consumes [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) packages via [NPM](https://www.npmjs.com/).
-These are defined in the [package.json](package.json) file.
-
----------------------
-**NOTE:**
-For the time being we are consuming private packages. To access private packages, you will first need to log in to NPM with
-
-`npm login`
+Design System consumes the [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) package via [NPM](https://www.npmjs.com/).
+This is defined in the [package.json](package.json) file.
 
 --------------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5256,9 +5256,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-0.0.32.tgz",
-      "integrity": "sha512-3Hn27DY4c83ZbOGBDXT1pRw2ITZzrk1GTnBhujSXoX4ciVikG20Yg4Z/vPAVm7Q/AFvTxvNrCKYxTNTBbUYOhQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-1.0.0.tgz",
+      "integrity": "sha512-4qCRrwGEcDC0ybjb5lls3P8tDgM8/hpTy2Mesgp1wa1/HdtlXtShj0E0H41lkXNrX7ZQOoDCc4gUEoOgZD+QfA=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "clipboard": "^2.0.0",
-    "govuk-frontend": "0.0.32",
+    "govuk-frontend": "1.0.0",
     "gray-matter": "^4.0.1",
     "html5shiv": "^3.7.3",
     "jquery": "^1.12.4",

--- a/src/components/header/default/index.njk
+++ b/src/components/header/default/index.njk
@@ -5,6 +5,5 @@ layout: layout-example.njk
 {% from "header/macro.njk" import govukHeader %}
 
 {{ govukHeader({
-  homepageUrl: "#",
-  containerClasses: "govuk-width-container"
+  homepageUrl: "#"
 }) }}

--- a/src/components/header/with-service-name-and-navigation/index.njk
+++ b/src/components/header/with-service-name-and-navigation/index.njk
@@ -8,7 +8,6 @@ layout: layout-example.njk
   homepageUrl: "#",
   serviceName: "Service name",
   serviceUrl: "#",
-  containerClasses: "govuk-width-container",
   navigation: [
     {
       href: "#1",

--- a/src/components/header/with-service-name/index.njk
+++ b/src/components/header/with-service-name/index.njk
@@ -7,6 +7,5 @@ layout: layout-example.njk
 {{ govukHeader({
   homepageUrl: "#",
   serviceName: "Service name",
-  serviceUrl: "#",
-  containerClasses: "govuk-width-container"
+  serviceUrl: "#"
 }) }}

--- a/src/components/tabs/default/index.njk
+++ b/src/components/tabs/default/index.njk
@@ -1,0 +1,248 @@
+---
+title: Tabs
+layout: layout-example.njk
+---
+
+{% from 'tabs/macro.njk' import govukTabs %}
+{% from 'table/macro.njk' import govukTable %}
+
+{% set pastDayHtml %}
+<h2 class="govuk-heading-l">Past day</h2>
+{{ govukTable({
+  head: [
+    {
+      text: "Case manager"
+    },
+    {
+      text: "Cases opened"
+    },
+    {
+      text: "Cases closed"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "David Francis"
+      },
+      {
+        text: "3"
+      },
+      {
+        text: "0"
+      }
+    ],
+    [
+      {
+        text: "Paul Farmer"
+      },
+      {
+        text: "1"
+      },
+      {
+        text: "0"
+      }
+    ],
+    [
+      {
+        text: "Rita Patel"
+      },
+      {
+        text: "2"
+      },
+      {
+        text: "0"
+      }
+    ]
+  ]
+}) }}
+{% endset -%}
+
+{% set pastWeekHtml %}
+<h2 class="govuk-heading-l">Past week</h2>
+{{ govukTable({
+  head: [
+    {
+      text: "Case manager"
+    },
+    {
+      text: "Cases opened"
+    },
+    {
+      text: "Cases closed"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "David Francis"
+      },
+      {
+        text: "24"
+      },
+      {
+        text: "18"
+      }
+    ],
+    [
+      {
+        text: "Paul Farmer"
+      },
+      {
+        text: "16"
+      },
+      {
+        text: "20"
+      }
+    ],
+    [
+      {
+        text: "Rita Patel"
+      },
+      {
+        text: "24"
+      },
+      {
+        text: "27"
+      }
+    ]
+  ]
+}) }}
+{% endset -%}
+
+{% set pastMonthHtml %}
+<h2 class="govuk-heading-l">Past month</h2>
+{{ govukTable({
+  head: [
+    {
+      text: "Case manager"
+    },
+    {
+      text: "Cases opened"
+    },
+    {
+      text: "Cases closed"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "David Francis"
+      },
+      {
+        text: "98"
+      },
+      {
+        text: "95"
+      }
+    ],
+    [
+      {
+        text: "Paul Farmer"
+      },
+      {
+        text: "122"
+      },
+      {
+        text: "131"
+      }
+    ],
+    [
+      {
+        text: "Rita Patel"
+      },
+      {
+        text: "126"
+      },
+      {
+        text: "142"
+      }
+    ]
+  ]
+}) }}
+{% endset -%}
+
+{% set pastYearHtml %}
+<h2 class="govuk-heading-l">Past year</h2>
+{{ govukTable({
+  head: [
+    {
+      text: "Case manager"
+    },
+    {
+      text: "Cases opened"
+    },
+    {
+      text: "Cases closed"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "David Francis"
+      },
+      {
+        text: "1380"
+      },
+      {
+        text: "1472"
+      }
+    ],
+    [
+      {
+        text: "Paul Farmer"
+      },
+      {
+        text: "1129"
+      },
+      {
+        text: "1083"
+      }
+    ],
+    [
+      {
+        text: "Rita Patel"
+      },
+      {
+        text: "1539"
+      },
+      {
+        text: "1265"
+      }
+    ]
+  ]
+}) }}
+{% endset -%}
+
+{{ govukTabs({
+  items: [
+    {
+      label: "Past day",
+      id: "past-day",
+      panel: {
+        html: pastDayHtml
+      }
+    },
+    {
+      label: "Past week",
+      id: "past-week",
+      panel: {
+        html: pastWeekHtml
+      }
+    },
+    {
+      label: "Past month",
+      id: "past-month",
+      panel: {
+        html: pastMonthHtml
+      }
+    },
+    {
+      label: "Past year",
+      id: "past-year",
+      panel: {
+        html: pastYearHtml
+      }
+    }
+  ]
+}) }}

--- a/src/components/tabs/index.md.njk
+++ b/src/components/tabs/index.md.njk
@@ -1,0 +1,119 @@
+---
+title: Tabs
+description: Tabs can be a helpful way of letting users quickly switch between related information
+section: Components
+aliases:
+backlog_issue_id: 100
+layout: layout-pane.njk
+status: Experimental
+statusMessage: This component is currently experimental because <a class="govuk-link" href="#next-steps">more research</a> is needed to validate it.
+---
+
+{% from "_example.njk" import example %}
+
+The tabs component lets users navigate between related sections of content, displaying one section at a time.
+
+{{ example({group: 'components', item: 'tabs', example: 'default', html: true, nunjucks: true, open: false}) }}
+
+## When to use this component
+
+Tabs can be a helpful way of letting users quickly switch between related information if:
+
+- your content can be usefully separated into clearly labelled sections
+- the first section is more relevant than the others for most users
+- users won’t need to view all the sections at once
+
+Tabs can work well for people who use a service regularly, for example, users of a caseworking system. Their need to perform tasks quickly may be greater than their need for simplicity of first-time use.
+
+## When not to use this component
+
+Do not use the tabs component if the total amount of content the tabs contain will make the page slow to load. For this reason, do not use the tabs component as a form of page navigation.
+
+Tabs hide content from users and not everyone will notice them or understand how they work.
+
+Do not use tabs if your users might need to:
+
+- read through all of the content in order, for example, to understand a step-by-step process
+- compare information in different tabs - having to memorise the information and switch backwards and forwards can be frustrating and difficult
+
+Test your content without tabs first. Consider if it’s better to:
+
+- simplify and reduce the amount of content
+- split the content across multiple pages
+- keep the content on a single page, separated by headings
+- use a table of contents to let users navigate quickly to specific sections of content
+
+## How it works
+
+There are 2 ways to use the tabs component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com/), you can use the Nunjucks macro.
+
+{{ example({group: 'components', item: 'tabs', example: 'default', html: true, nunjucks: true, open: true}) }}
+
+More research is needed on the best way to display the tabs component on small screen sizes.
+
+Currently, on small screens, the component will display the tabbed content on a single page, in order from first to last, with a table of contents that links to each of the sections.
+
+### Use clear labels
+
+Tabs hide content, so the tab labels need to make it very clear what they link to, otherwise users won’t know if they need to click on them.
+
+If you struggle to come up with clear labels, it might be because the way you’ve separated the content isn’t clear.
+
+
+### Order the tabs according to user needs
+
+The first tab should be the most commonly-needed section. Arrange the other tabs in the order that makes most sense for your users.
+
+
+### Do not disable tabs
+
+Disabling elements is normally confusing for users. If there is no content for a tab, either remove the tab or, if that would be confusing for your users, explain why there is no content when the tab is selected.
+
+
+### Avoid tabs that wrap over more than one line
+
+If you use too many tabs or they have long labels then they may wrap over more than one line. This makes it harder for users to see the connection between the selected tab and its content.
+
+
+## Research and testing
+
+This component is experimental because it has not yet been tried in research with users.
+
+The design, code and guidance here are based on recommendations from [Inclusive Components](https://inclusive-components.design/tabbed-interfaces/) and the [Nielsen Norman Group](https://www.nngroup.com/articles/tabs-used-right/) as well as user research findings and examples of tabs in the following services:
+
+- Manage bereavement support payment (DWP)
+- Support for check your state pension (DWP)
+- Access to work integrated system (DWP)
+- Bank holidays (GDS)
+- Universal Credit (DWP)
+- Criminal Justice Services (CPP)
+- Judiciary UI internal systems (HMCTS)
+- Rural Payments (Defra)
+
+### Browser testing
+
+The tabs component has been tested with the following browsers and devices:
+
+- Google Chrome 66
+- Firefox 59 (including tests with custom colors)
+- Safari 11.1
+- Internet Explorer 11
+- Internet Explorer 10
+- Internet Explorer 9 (no support for matchMedia and degrades gracefully)
+
+### Testing with assistive technologies
+
+- The tabs component has been tested with the following assistive technologies:
+- JAWS 16, 17 and 18 on Internet Explorer 11
+- NVDA on Firefox 54
+- VoiceOver on Safari 11.1
+- ZoomText 10 on Internet Explorer 11
+- Dragon NaturallySpeaking on Internet Explorer 11
+
+### <a name="next-steps"></a>Next steps
+
+User research is needed to confirm:
+
+- which types of services tabs work best in
+- that this approach to tabs is the best option for screen reader users and sighted keyboard users
+- how this component should behave on small screen sizes

--- a/src/components/tabs/index.md.njk
+++ b/src/components/tabs/index.md.njk
@@ -45,7 +45,7 @@ Test your content without tabs first. Consider if it’s better to:
 
 ## How it works
 
-There are 2 ways to use the tabs component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit-beta.herokuapp.com/), you can use the Nunjucks macro.
+There are 2 ways to use the tabs component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
 
 {{ example({group: 'components', item: 'tabs', example: 'default', html: true, nunjucks: true, open: true}) }}
 

--- a/src/javascripts/govuk-frontend.js
+++ b/src/javascripts/govuk-frontend.js
@@ -5,6 +5,7 @@ import Checkboxes from 'govuk-frontend/components/checkboxes/checkboxes'
 // import ErrorSummary from 'govuk-frontend/components/error-summary/error-summary'
 import Radios from 'govuk-frontend/components/radios/radios'
 import Header from 'govuk-frontend/components/header/header'
+import Tabs from 'govuk-frontend/components/tabs/tabs'
 
 new Button(document).init()
 
@@ -26,4 +27,9 @@ if ($radio) {
 var $header = document.querySelector('[data-module="header"]')
 if ($header) {
   new Header($header).init()
+}
+
+var $tabs = document.querySelector('[data-module="tabs"]')
+if ($tabs) {
+  new Tabs($tabs).init()
 }


### PR DESCRIPTION
This PR:
- updates the Design System to use [govuk-frontend 1.0.0](https://github.com/alphagov/govuk-frontend/releases/tag/v1.0.0) 🎉
- adds the tab component example and guidance
- removes the container class from the header examples (as now the container class is being added by default)
- removes the `npm login` instructions for the Design System

[Trello card](https://trello.com/c/noTIT53J)