### PR TITLE
Add metadata description to pages

### DIFF
--- a/src/community/backlog/index.md.njk
+++ b/src/community/backlog/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Backlog
-description:
+description: Anyone can propose, develop or contribute to new patterns and components, or improvements to existing ones.
 section: Community
 layout: layout-pane.njk
 order: 1

--- a/src/community/contribution-criteria/index.md.njk
+++ b/src/community/contribution-criteria/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Contribution criteria
-description:
+description: To help ensure that the contents of the GOV.UK Design System are of a high quality and meet user needs, all components and patterns must meet the following criteria
 section: Community
 layout: layout-pane.njk
 order: 3

--- a/src/community/design-system-working-group/index.md.njk
+++ b/src/community/design-system-working-group/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Design System working group
-description:
+description: The Design System working group is a multi-disciplinary, cross-government group whose purpose is to ensure that any components and patterns published in the GOV.UK Design System are of a high quality and meet user needs
 section: Community
 layout: layout-pane.njk
 order: 4

--- a/src/community/how-you-can-contribute/index.md.njk
+++ b/src/community/how-you-can-contribute/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: How you can contribute
-description:
+description: The Design System team will be developing these contribution guidelines based on user research over the coming months
 section: Community
 layout: layout-pane.njk
 order: 2

--- a/src/community/index.md.njk
+++ b/src/community/index.md.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-pane.njk
 title: Community
+description:  The GOV.UK Design System brings together the latest research, design and development from across government to make it sure it’s representative and relevant for its users
 ---
 
 The GOV.UK Design System is for everyone, with a strong community sitting behind it. It brings together the latest research, design and development from across government to make it sure it’s representative and relevant for its users.

--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Back link
-description: Use the Back link component to help users go back to the previous page in a multi-page transaction.
+description: Use the back link component to help users go back to the previous page in a multi-page transaction
 section: Components
 aliases:
 backlog_issue_id: 32

--- a/src/components/breadcrumbs/index.md.njk
+++ b/src/components/breadcrumbs/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Breadcrumbs
-description: Help users orientate themselves and navigate pages within a hierarchical structure.
+description: Help users orientate themselves and navigate pages within a hierarchical structure
 section: Components
 aliases: navigation path, cookie crumb
 backlog_issue_id: 33

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Button
-description: GOV.UK Button
+description: Use the button component to help users carry out an action on a GOV.UK page
 section: Components
 aliases:
 backlog_issue_id: 34

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Checkboxes
-description: Let users select one or more options by using the Checkboxes component.
+description: Let users select one or more options by using the Checkboxes component
 section: Components
 aliases:
 backlog_issue_id: 37

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Date input
-description: Use the Date input component to help users enter a memorable date.
+description: Use the date input component to help users enter a memorable date
 section: Components
 aliases:
 backlog_issue_id: 42

--- a/src/components/details/index.md.njk
+++ b/src/components/details/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Details
-description: Make a page easier to scan by letting users reveal more detailed information only if they need it.
+description: Make a page easier to scan by letting users reveal more detailed information only if they need it
 section: Components
 aliases:
 backlog_issue_id: 44

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Error message
-description:
+description: Use an error message when a there is a validation error. Explain what went wrong and how to fix it
 section: Components
 aliases:
 backlog_issue_id: 47

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Error summary
-description:
+description: Use an error summary when a there is a validation error
 section: Components
 aliases:
 backlog_issue_id: 46

--- a/src/components/fieldset/index.md.njk
+++ b/src/components/fieldset/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Fieldset
-description: Use the Fieldset component to group related form inputs.
+description: Use the fieldset component to group related form inputs
 section: Components
 aliases:
 backlog_issue_id: 48

--- a/src/components/file-upload/index.md.njk
+++ b/src/components/file-upload/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: File upload
-description: Help users select and upload a file.
+description: Help users select and upload a file
 section: Components
 aliases:
 backlog_issue_id: 49

--- a/src/components/footer/index.md.njk
+++ b/src/components/footer/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Footer
-description: The footer provides copyright, licensing and other information about your service and department.
+description: The footer provides copyright, licensing and other information about your service and department
 section: Components
 aliases:
 backlog_issue_id: 96

--- a/src/components/header/index.md.njk
+++ b/src/components/header/index.md.njk
@@ -1,5 +1,6 @@
 ---
 title: Header
+description: The GOV.UK header shows users that they are on GOV.UK and which service they are using
 section: Components
 backlog_issue_id: 97
 layout: layout-pane.njk

--- a/src/components/inset-text/index.md.njk
+++ b/src/components/inset-text/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Inset text
-description:
+description: Use the inset text component to differentiate a block of text from the content that surrounds it
 section: Components
 aliases:
 backlog_issue_id: 136

--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Panel
-description: The Panel component is a visible container used on confirmation or results pages.
+description: The panel component is a visible container used on confirmation or results pages
 section: Components
 aliases:
 backlog_issue_id: 55

--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Phase banner
-description: Use the Phase banner component to show users your service is still being worked on.
+description: Use the phase banner component to show users your service is still being worked on
 section: Components
 aliases:
 backlog_issue_id: 57

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Radios
-description: Let users select a single option from a list using the Radios component.
+description: Let users select a single option from a list using the radios component
 section: Components
 aliases:
 backlog_issue_id: 59

--- a/src/components/select/index.md.njk
+++ b/src/components/select/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Select
-description: Help users select an item from a dropdown list.
+description: Help users select an item from a dropdown list
 section: Components
 aliases:
 backlog_issue_id: 60

--- a/src/components/skip-link/index.md.njk
+++ b/src/components/skip-link/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Skip link
-description: Use the Skip link component to help keyboard-only users skip to the main content on a page.
+description: Use the skip link component to help keyboard-only users skip to the main content on a page
 section: Components
 aliases:
 backlog_issue_id: 66

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Table
-description: Use the Table component to make information easier to compare and scan for users.
+description: Use the table component to make information easier to compare and scan for users
 section: Components
 aliases:
 backlog_issue_id: 61

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Tag
-description: indicate the status of something, such as an item on a Task list or a Phase banner.
+description: The tag component indicates the status of something, such as an item on a task list or a phase banner
 section: Components
 aliases:
 backlog_issue_id: 62

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Text input
-description: Help users enter information with the Text input component.
+description: Help users enter information with the text input component
 section: Components
 aliases:
 backlog_issue_id: 51

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Textarea
-description: Help users provide detailed information using the Textarea component.
+description: Help users provide detailed information using the textarea component
 section: Components
 aliases:
 backlog_issue_id: 65

--- a/src/components/warning-text/index.md.njk
+++ b/src/components/warning-text/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Warning text
-description:
+description: Use the warning text component when you need to warn users about something important, such as legal consequences of an action, or lack of action, that they might take
 section: Components
 aliases:
 backlog_issue_id: 71

--- a/src/cookies.md.njk
+++ b/src/cookies.md.njk
@@ -1,5 +1,6 @@
 ---
 title: Cookies
+description: The GOV.UK Design System puts small files (known as ‘cookies’) on to your computer
 layout: layout-single-page-prose.njk
 ---
 

--- a/src/get-in-touch.njk
+++ b/src/get-in-touch.njk
@@ -1,5 +1,6 @@
 ---
 title: Get in touch
+description: If you’ve got a question, idea or suggestion get in touch with the Design System team
 layout: layout-single-page.njk
 ---
 

--- a/src/get-started/index.md.njk
+++ b/src/get-started/index.md.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-pane.njk
 title: Get started
+description: The following introductory guides will help you to get set up
 ---
 
 The examples in the GOV.UK Design System come with code, to make it easy for you to use them in your prototype or in production. The following introductory guides will help you to get set up.

--- a/src/get-started/production/index.md.njk
+++ b/src/get-started/production/index.md.njk
@@ -2,6 +2,7 @@
 layout: layout-pane.njk
 title: Using the Design System in production
 order: 2
+description: This guide explains how to set up your project so you can start using the styles and coded examples in the GOV.UK Design System in production
 ---
 
 {% from "_example.njk" import example %}

--- a/src/get-started/prototyping/index.md.njk
+++ b/src/get-started/prototyping/index.md.njk
@@ -2,6 +2,7 @@
 layout: layout-pane.njk
 title: Prototyping with the Design System
 order: 1
+description: This guide explains how to create prototypes using the GOV.UK Design System and GOV.UK Prototype Kit
 ---
 
 {% from "_example.njk" import example %}

--- a/src/get-started/updating/index.md.njk
+++ b/src/get-started/updating/index.md.njk
@@ -2,6 +2,7 @@
 layout: layout-pane.njk
 title: Updating your code
 order: 3
+description: Updating your code to work with the GOV.UK Design System
 ---
 
 [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) is the frontend codebase that replaces GOV.UK Elements, Frontend&nbsp;Toolkit and parts of GOV.UK Template.

--- a/src/index.njk
+++ b/src/index.njk
@@ -1,5 +1,6 @@
 ---
-title: About
+title: Home
+description: Design your service using GOV.UK styles, components and patterns
 ---
 
 {% include "../views/partials/_masthead.njk" %}

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Addresses
-description: Help users provide an address.
+description: Help users provide an address
 section: Patterns
 theme: Ask users for...
 aliases:

--- a/src/patterns/check-a-service-is-suitable/index.md.njk
+++ b/src/patterns/check-a-service-is-suitable/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Check a service is suitable
-description: Ask users questions to help them work out if they can or should use your service.
+description: Ask users questions to help them work out if they can or should use your service
 section: Patterns
 theme: Help users to...
 aliases:

--- a/src/patterns/check-answers/index.md.njk
+++ b/src/patterns/check-answers/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Check answers
-description: Let users check their answers before submitting information to a service.
+description: Let users check their answers before submitting information to a service
 section: Patterns
 theme: Help users to...
 aliases:

--- a/src/patterns/confirm-an-email-address/index.md.njk
+++ b/src/patterns/confirm-an-email-address/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Confirm an email address
-description: Use an email confirmation loop to check that a user has access to a specific email.
+description: Use an email confirmation loop to check that a user has access to a specific email
 section: Patterns
 theme: Help users to...
 aliases:

--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Confirmation pages
-description: Let users know they’ve completed a transaction.
+description: Let users know they’ve completed a transaction
 section: Patterns
 theme: Pages
 aliases:

--- a/src/patterns/create-a-username/index.md.njk
+++ b/src/patterns/create-a-username/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Create a username
-description: Help users to create a unique and memorable username to sign into a service with.
+description: Help users to create a unique and memorable username to sign into a service with
 section: Patterns
 theme: Help users to...
 aliases:

--- a/src/patterns/create-accounts/index.md.njk
+++ b/src/patterns/create-accounts/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Create accounts
-description: Help users create an account for your service.
+description: Help users create an account for your service
 section: Patterns
 theme: Help users to...
 aliases:

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Dates
-description: Help users enter or select a date.
+description: Help users enter or select a date
 section: Patterns
 theme: Ask users for...
 aliases:

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Email addresses
-description: Help users enter a valid email address.
+description: Help users enter a valid email address
 section: Patterns
 theme: Ask users for...
 aliases:

--- a/src/patterns/gender-or-sex/index.md.njk
+++ b/src/patterns/gender-or-sex/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Gender or sex
-description: This pattern explains how to ask users about gender or sex.
+description: This pattern explains how to ask users about gender or sex
 section: Patterns
 theme: Ask users for...
 aliases:

--- a/src/patterns/index.md.njk
+++ b/src/patterns/index.md.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-pane.njk
 title: Patterns
+description: Patterns are best practice design solutions for specific user-focused tasks and page types
 ---
 
 Patterns are best practice design solutions for specific user-focused tasks and page&nbsp;types.

--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Names
-description: Help users correctly enter their name.
+description: Help users correctly enter their name
 section: Patterns
 theme: Ask users for...
 aliases:

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: National Insurance numbers
-description: Ask users to provide their National Insurance number.
+description: Ask users to provide their National Insurance number
 section: Patterns
 theme: Ask users for...
 aliases:

--- a/src/patterns/page-not-found-pages/index.md.njk
+++ b/src/patterns/page-not-found-pages/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Page not found pages
-description: A page not found tells someone the page they were trying to view cannot be found. They are also known as 404 pages.
+description: A page not found tells someone the page they were trying to view cannot be found. They are also known as 404 pages
 section: Patterns
 theme: Pages
 aliases:

--- a/src/patterns/passwords/index.md.njk
+++ b/src/patterns/passwords/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Passwords
-description: Help users to create and enter secure and memorable passwords.
+description: Help users to create and enter secure and memorable passwords
 section: Patterns
 theme: Ask users for...
 aliases:

--- a/src/patterns/problem-with-the-service-pages/index.md.njk
+++ b/src/patterns/problem-with-the-service-pages/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: There is a problem with the service pages
-description: This is a page that tells someone there is something wrong with the service. They are also known as 500 pages.
+description: This is a page that tells someone there is something wrong with the service. They are also known as 500 pages
 section: Patterns
 theme: Pages
 aliases:

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Question pages
-description: Follow this pattern whenever you need to ask users questions within your service.
+description: Follow this pattern whenever you need to ask users questions within your service
 section: Patterns
 theme: Pages
 aliases:

--- a/src/patterns/service-unavailable-pages/index.md.njk
+++ b/src/patterns/service-unavailable-pages/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Service unavailable pages
-description: This is a page that tells someone a service is unavailable. It should say when the service will be available or what to do if it is permanently closed.
+description: This is a page that tells someone a service is unavailable. It should say when the service will be available or what to do if it is permanently closed
 section: Patterns
 theme: Pages
 aliases:

--- a/src/patterns/start-pages/index.md.njk
+++ b/src/patterns/start-pages/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Start pages
-description:
+description: A starting point for your digital service on GOV.UK
 section: Patterns
 theme: Pages
 aliases:

--- a/src/patterns/task-list-pages/index.md.njk
+++ b/src/patterns/task-list-pages/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Task list pages
-description:
+description: Task list pages help users understand tasks involved in completing a transaction, the order they should complete tasks in and when they have completed tasks
 section: Patterns
 theme: Pages
 aliases:

--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Telephone numbers
-description: Help users enter a valid telephone number.
+description: Help users enter a valid telephone number
 section: Patterns
 theme: Ask users for...
 aliases:

--- a/src/privacy-policy.md.njk
+++ b/src/privacy-policy.md.njk
@@ -1,5 +1,6 @@
 ---
 title: Privacy Policy
+description: We collect certain information and data about you when you use the GOV.UK Design System
 layout: layout-single-page-prose.njk
 ---
 

--- a/src/roadmap.md.njk
+++ b/src/roadmap.md.njk
@@ -1,5 +1,6 @@
 ---
 title: Roadmap
+description: The roadmap shows what the Design System team at GDS is currently planning to work on over the coming year
 layout: layout-single-page-prose.njk
 ---
 

--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Colour
-description:
+description: Always use the GOV.UK colour palette
 section: Styles
 aliases:
 backlog_issue_id: 38

--- a/src/styles/images/index.md.njk
+++ b/src/styles/images/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Images
-description: GOV.UK Images
+description: Only use images if there’s a real user need
 section: Styles
 backlog_issue_id: 70
 layout: layout-pane.njk

--- a/src/styles/index.md.njk
+++ b/src/styles/index.md.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-pane.njk
 title: Styles
+description: Make your service look and feel like GOV.UK
 ---
 
 Make your service look and feel like GOV.UK.

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Layout
-description:
+description: Organise the layout of the page into blocks
 section: Styles
 aliases:
 backlog_issue_id:

--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Page template
-description: GOV.UK Images
+description: Template combines the boilerplate markup and components needed for a basic GOV.UK page
 section: Styles
 layout: layout-pane.njk
 ---

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Spacing
-description:
+description: The Design System uses a responsive spacing scale which adapts based on screen size
 section: Styles
 aliases:
 backlog_issue_id:

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Typography
-description: GOV.UK Typography
+description: If your service is on the service.gov.uk subdomain you must use the GDS Transport font
 section: Styles
 backlog_issue_id: 64
 layout: layout-pane.njk

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -8,6 +8,7 @@
 {% if not TRAVIS_BRANCH or TRAVIS_BRANCH != 'master' %}
   <meta name="robots" content="noindex, nofollow">
 {% endif %}
+<meta name="description" content="{{description}}">
   
   <!--[if !IE 8]><!-->
     <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -9,7 +9,7 @@
   <meta name="robots" content="noindex, nofollow">
 {% endif %}
 <meta name="description" content="{{description}}">
-  
+<meta property="og:image" content="https://design-system.service.gov.uk/assets/images/govuk-opengraph-image.png">
   <!--[if !IE 8]><!-->
     <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
   <!--<![endif]-->


### PR DESCRIPTION
Add suitable description meta tag to every page, excluding examples

Iframely: 
<img width="1156" alt="screen shot 2018-06-21 at 16 38 57" src="https://user-images.githubusercontent.com/3758555/41729721-d5cff96c-7571-11e8-9a24-152b290c4979.png">


Trello ticket: https://trello.com/c/bca6gUOv/1048-ensure-metadata-for-pages-in-the-design-system-is-appropriate