### PR TITLE
Fix Safari page overflow bug

### DIFF
--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -6,7 +6,7 @@
 
     @include govuk-media-query($from: tablet) {
       display: flex;
-      height: $pane-height;
+      min-height: $pane-height;
       flex-direction: column;
     }
 
@@ -16,7 +16,7 @@
       grid-template-rows: repeat(3, auto);
 
       @include govuk-media-query($from: tablet) {
-        height: $pane-height;
+        min-height: $pane-height;
         // `min-content` for header, `max-content` for body(incl. footer)
         grid-template-rows: min-content max-content;
       }


### PR DESCRIPTION
Fixes: #373 
Safari short page

<img width="1630" alt="screen shot 2018-06-21 at 16 29 24" src="https://user-images.githubusercontent.com/3758555/41729159-68e45420-7570-11e8-8359-78284d30a366.png">

Safari long page
<img width="1629" alt="screen shot 2018-06-21 at 16 29 11" src="https://user-images.githubusercontent.com/3758555/41729160-6901c3a2-7570-11e8-812f-0768f25a51de.png">

