### PR TITLE
Fixes for Safari on macOS

### DIFF
--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -17,4 +17,10 @@
     margin-bottom: 0;
     border-bottom: 0;
   }
+
+  // Fix the visually hidden 'Support links' heading causing Safari to pad out
+  // the bottom of the page or... something.
+  .app-footer .govuk-visually-hidden {
+    position: relative;
+  }
 }

--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -9,18 +9,6 @@
       height: $pane-height;
       flex-direction: column;
     }
-
-    @supports (display: grid) {
-      display: grid;
-      grid-template-columns: minmax(100%, 1fr);
-      grid-template-rows: repeat(3, auto);
-
-      @include govuk-media-query($from: tablet) {
-        height: $pane-height;
-        // `min-content` for header, `max-content` for body(incl. footer)
-        grid-template-rows: min-content max-content;
-      }
-    }
   }
 
   .app-pane__header {
@@ -32,10 +20,6 @@
       > * {
         flex: 1 0 auto;
       }
-    }
-
-    @supports (display: grid) {
-      grid-column: span 1;
     }
   }
 
@@ -52,18 +36,6 @@
         -ms-overflow-style: none;
       }
     }
-
-    @supports (display: grid) {
-      grid-column: span 1;
-
-      @include govuk-media-query($from: tablet) {
-        display: grid;
-        grid-template-columns: $toc-width 1fr;
-        grid-template-rows: auto;
-        grid-column: span 1;
-        grid-row: span 2;
-      }
-    }
   }
 
   .app-pane__subnav {
@@ -72,13 +44,6 @@
       width: $toc-width;
       border-right: 1px solid $govuk-border-colour;
       flex: 0 0 auto;
-    }
-
-    @supports (display: grid) {
-      @include govuk-media-query($from: tablet) {
-        width: auto;
-        grid-column: span 1;
-      }
     }
   }
 
@@ -99,25 +64,15 @@
         flex: 1 0 auto;
       }
     }
-
-    @supports (display: grid) {
-      @include govuk-media-query($from: tablet) {
-        margin-left: 0;
-        grid-column: span 1;
-      }
-    }
-
   }
 
   .no-js {
-
     .app-pane__subnav-mobile-overview {
       display: block; // No JS fallback for overview links
     }
   }
 
   .no-flexbox {
-
     .app-pane {
       height: auto;
       @include govuk-clearfix;


### PR DESCRIPTION
- Remove grid from the app layout
- Override the visually-hidden 'Support links' heading in the footer which fixes an issues with Safari scrolling past the end of the page.

Fixes #373 and #374 

Also fixes an issue where clicking one of the code tabs ('HTML' or 'Nunjucks') jumps you to the top of the page.