### PR TITLE
Fix old ie javascript

### DIFF
--- a/src/javascripts/components/cookie-banner.js
+++ b/src/javascripts/components/cookie-banner.js
@@ -55,7 +55,7 @@
     return null
   }
   root.GOVUK.addCookieMessage = function () {
-    var message = document.getElementsByClassName('js-cookie-banner')[0]
+    var message = document.querySelector('.js-cookie-banner')
     var hasCookieMessage = (message && root.GOVUK.cookie('seen_cookie_message') === null)
 
     if (hasCookieMessage) {

--- a/src/javascripts/main.js
+++ b/src/javascripts/main.js
@@ -1,5 +1,5 @@
-const $ = window.jQuery
-const GOVUK = window.GOVUK
+var $ = window.jQuery
+var GOVUK = window.GOVUK
 
 $(document).ready(function () {
   // Initialise example frames


### PR DESCRIPTION
If we also fix https://github.com/alphagov/govuk-design-system/issues/383 the Design System's JavaScript will work in IE8.