### PR TITLE
Mobile in page nav

### DIFF
--- a/src/components/index.md.njk
+++ b/src/components/index.md.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout-pane.njk
 title: Components
+show_subnav: true
 ---
 
 Components are reusable parts of the user interface that have been made to support a variety of applications.

--- a/src/patterns/index.md.njk
+++ b/src/patterns/index.md.njk
@@ -2,6 +2,7 @@
 layout: layout-pane.njk
 title: Patterns
 description: Patterns are best practice design solutions for specific user-focused tasks and page types
+show_subnav: true
 ---
 
 Patterns are best practice design solutions for specific user-focused tasks and page&nbsp;types.

--- a/src/styles/index.md.njk
+++ b/src/styles/index.md.njk
@@ -2,6 +2,7 @@
 layout: layout-pane.njk
 title: Styles
 description: Make your service look and feel like GOV.UK
+show_subnav: true
 ---
 
 Make your service look and feel like GOV.UK.

--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -47,10 +47,6 @@
     }
   }
 
-  .app-pane__subnav-mobile-overview {
-    display: none; // No JS fallback for overview links
-  }
-
   .app-pane__content {
     @include govuk-media-query($from: tablet) {
       display: flex;
@@ -63,12 +59,6 @@
         display: block;
         flex: 1 0 auto;
       }
-    }
-  }
-
-  .no-js {
-    .app-pane__subnav-mobile-overview {
-      display: block; // No JS fallback for overview links
     }
   }
 

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -32,6 +32,12 @@
       <div class="app-prose-scope">
         {{ contents | safe }}
       </div>
+
+      {# No JS fallback to show overview #}
+      {% if show_subnav %}
+        {% include "_in-page-subnav.njk" %}
+      {% endif %}
+
       {% if section %}
         {% include "_contact-panel.njk" %}
       {% endif %}
@@ -39,10 +45,6 @@
         <p class="govuk-body govuk-!-margin-bottom-0"><a class="govuk-link" href="https://github.com/alphagov/govuk-design-system-backlog/issues/{{backlog_issue_id}}">Discuss ‘{{title}}’ on GitHub</a></p>
       {% endif %}
     </main>
-    {# No JS fallback to show overview #}
-    <div class="app-pane__subnav-mobile-overview app-hide-desktop">
-      {% include "_subnav.njk" %}
-    </div>
     {% include "_footer.njk" %}
   </div>
 {% endblock %}

--- a/views/partials/_in-page-subnav.njk
+++ b/views/partials/_in-page-subnav.njk
@@ -5,11 +5,11 @@
       {% if item.items %}
         {% for theme, items in item.items | groupby("theme") %}
           {% if theme != 'undefined' %}
-            <h2 class="govuk-heading-m">{{ theme }}</h2>
+            <h2 class="govuk-heading-m govuk-!-padding-top-2">{{ theme }}</h2>
           {% endif %}
           <ul class="govuk-list">
           {% for subitem in items %}
-            <li >
+            <li class="govuk-!-margin-bottom-2">
               <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
             </li>
           {% endfor %}

--- a/views/partials/_in-page-subnav.njk
+++ b/views/partials/_in-page-subnav.njk
@@ -1,0 +1,22 @@
+<div class="app-pane__subnav-mobile-overview app-hide-desktop app-hide-tablet">
+  <nav>
+    {% for item in navigation %}
+      {% if item.url in path %}
+      {% if item.items %}
+        {% for theme, items in item.items | groupby("theme") %}
+          {% if theme != 'undefined' %}
+            <h2 class="govuk-heading-m">{{ theme }}</h2>
+          {% endif %}
+          <ul class="govuk-list">
+          {% for subitem in items %}
+            <li >
+              <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
+            </li>
+          {% endfor %}
+          </ul>
+        {% endfor %}
+      {% endif %}
+      {% endif %}
+    {% endfor %}
+  </div>
+</nav>


### PR DESCRIPTION
This PR duplicates the sub-navigation on the Styles, Components and Patterns landing pages for the mobile breakpoint.

<img width="406" alt="screen shot 2018-06-22 at 09 39 16" src="https://user-images.githubusercontent.com/23356842/41766924-33e0a914-7600-11e8-96bf-4567d3e79aa9.png">

Parts of this we'll want to clean up later...
