### PR TITLE
Add bottom margin to tabs

### DIFF
--- a/src/components/tabs/default/index.njk
+++ b/src/components/tabs/default/index.njk
@@ -215,6 +215,7 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukTabs({
+  classes: "govuk-!-margin-bottom-6",
   items: [
     {
       label: "Past day",


### PR DESCRIPTION
This adds a margin-bottom override to the tabs component to keep it in line with our other components

Once this has been added to GOV.UK Frontend we can remove this class from the example in the Design System.

Issue on GOV.UK Frontend here:
https://github.com/alphagov/govuk-frontend/issues/820