### PR TITLE
Refer to non-gov users as ‘public‘ not ‘citizens‘

### DIFF
--- a/src/components/select/index.md.njk
+++ b/src/components/select/index.md.njk
@@ -13,7 +13,7 @@ layout: layout-pane.njk
 
 ## When to use this component
 
-The select component should only be used as a last resort in citizen-facing services because research shows that some users find selects very difficult to use.
+The select component should only be used as a last resort in public-facing services because research shows that some users find selects very difficult to use.
 
 ## How it works
 


### PR DESCRIPTION
I think that citizens is a problematic word because:

- the opposite of a citizen is someone who is stateless, which is not the distinction we’re trying to make here
- people who aren’t citizens sometimes need to use government services, for example those applying for asylum

I think ‘public’ is a better word – we are public servants, delivering public services.

***

The reason for making this distinction at all is because we design differently for people who use a service repeatedly. I don’t think that having a catch-all word for these users is realistic because there’s such a wide variety of them. In individual services it’s probably better to refer to them by the role or task they’re employed to do, for example case worker, solicitor, team leader. But ‘non-public’ works to
differentiate these users when talking generally.