### PR TITLE
Fix description of snake/camel case in template.

### DIFF
--- a/src/get-started/updating-your-code/index.md.njk
+++ b/src/get-started/updating-your-code/index.md.njk
@@ -21,7 +21,7 @@ If you are not using Nunjucks you can [get the page template HTML](../../styles/
 
 Where possible we have kept the new page template the same as GOV.UK Template.
 
-The main change is changing variables from [camelCase](https://en.wikipedia.org/wiki/Camel_case) to [snake_case](https://en.wikipedia.org/wiki/Snake_case).
+The main change is changing variables from [snake_case](https://en.wikipedia.org/wiki/Snake_case) to [camelCase](https://en.wikipedia.org/wiki/Camel_case).
 
 <table class="govuk-table app-table--fixed">
   <caption class="govuk-table__caption govuk-visually-hidden">Nunjucks Template</caption>


### PR DESCRIPTION
GOV.UK Template used snake case; GOV.UK Frontend uses camel case. So this sentence is backwards.