### PR TITLE
Fix format inconsistencies

### DIFF
--- a/src/community/design-system-working-group/index.md.njk
+++ b/src/community/design-system-working-group/index.md.njk
@@ -23,7 +23,7 @@ These guidelines are designed to help the members of the working group review co
 
 ## Reviewing contributions
 
-Anyone can propose a new component or pattern for the GOV.UK Design System by [raising an issue](https://github.com/alphagov/govuk-design-system-backlog/issues/new) in the community backlog. They can also volunteer their time to develop components and patterns in the 'To do' column in the backlog.
+Anyone can propose a new component or pattern for the GOV.UK Design System by [raising an issue](https://github.com/alphagov/govuk-design-system-backlog/issues/new) in the community backlog. They can also volunteer their time to develop components and patterns in the ‘To do’ column in the backlog.
 
 It’s the job of the working group to review new proposals and contributions against the [Design System criteria](../contribution-criteria).
 

--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use the back link component to help users go back to the previous page in a multi-page transaction.
 
-{{ example({group: 'components', item: 'back-link', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -31,7 +31,7 @@ Make sure the link takes users to the previous page and that it works even when 
 
 There are 2 ways to use the back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'back-link', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/breadcrumbs/index.md.njk
+++ b/src/components/breadcrumbs/index.md.njk
@@ -11,8 +11,7 @@ layout: layout-pane.njk
 
 The breadcrumbs component helps users to understand where they are within a website’s structure and move between levels.
 
-{{ example({group: 'components', item: 'breadcrumbs', example: 'default', html: true, nunjucks: true, open: false}) }}
-
+{{ example({group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false}) }}
 ## When to use this component
 
 Use the breadcrumbs component when you need to help users understand and move between the multiple levels of a website.
@@ -29,7 +28,7 @@ The breadcrumbs component should include the user’s current page, which should
 
 There are 2 ways to use the breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'breadcrumbs', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'button', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -29,13 +29,13 @@ Disabled buttons have poor contrast and can confuse some users, so avoid them if
 
 Only use disabled buttons if research shows it makes the user interface easier to&nbsp;understand.
 
-{{ example({group: 'components', item: 'button', example: 'disabled', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "button", example: "disabled", html: true, nunjucks: true, open: true}) }}
 
 ### Start buttons
 
 Use a start button as the main call to action on your service’s start page.
 
-{{ example({group: 'components', item: 'button', example: 'start', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "button", example: "start", html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -4,7 +4,7 @@ layout: layout-example.njk
 ignore_in_sitemap: true
 ---
 
-{% from 'checkboxes/macro.njk' import govukCheckboxes %}
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
 {% from "input/macro.njk" import govukInput %}
 
 {% set emailHtml %}

--- a/src/components/checkboxes/default/index.njk
+++ b/src/components/checkboxes/default/index.njk
@@ -3,16 +3,16 @@ title: Checkboxes
 layout: layout-example.njk
 ---
 
-{% from 'checkboxes/macro.njk' import govukCheckboxes %}
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
   idPrefix: "nationality",
   name: "nationality",
   fieldset: {
     legend: {
-      text: 'What is your nationality?',
+      text: "What is your nationality?",
       isPageHeading: true,
-      classes: 'govuk-fieldset__legend--xl'
+      classes: "govuk-fieldset__legend--xl"
     }
   },
   hint: {

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Let users select one or more options by using the checkboxes component.
 
-{{ example({group: 'components', item: 'checkboxes', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -28,13 +28,13 @@ Don’t use the checkboxes component if users can only choose one option from a 
 
 There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'checkboxes', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ### Conditionally revealing content
 
 You can add conditionally revealing content to checkboxes, so users only see content when it’s relevant to them. For example, you could reveal a phone number input only when a user chooses to be contacted by phone.
 
-{{ example({group: 'components', item: 'checkboxes', example: 'conditional-reveal', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "checkboxes", example: "conditional-reveal", html: true, nunjucks: true, open: false}) }}
 
 Keep it simple - if you need to add a lot of content, consider showing it on the next page in the process instead.
 

--- a/src/components/date-input/default/index.njk
+++ b/src/components/date-input/default/index.njk
@@ -6,27 +6,27 @@ layout: layout-example.njk
 {% from "date-input/macro.njk" import govukDateInput %}
 
 {{ govukDateInput({
-  id: 'dob',
-  name: 'dob',
+  id: "dob",
+  name: "dob",
   fieldset: {
     legend: {
-      text: 'What is your date of birth?',
+      text: "What is your date of birth?",
       isPageHeading: true,
-      classes: 'govuk-fieldset__legend--xl'
+      classes: "govuk-fieldset__legend--xl"
     }
   },
   hint: {
-    text: 'For example, 31 3 1980'
+    text: "For example, 31 3 1980"
   },
   items: [
     {
-      name: 'day'
+      name: "day"
     },
     {
-      name: 'month'
+      name: "month"
     },
     {
-      name: 'year'
+      name: "year"
     }
   ]
 }) }}

--- a/src/components/date-input/error/index.njk
+++ b/src/components/date-input/error/index.njk
@@ -7,33 +7,33 @@ ignore_in_sitemap: true
 {% from "date-input/macro.njk" import govukDateInput %}
 
 {{ govukDateInput({
-  id: 'dob',
-  name: 'dob',
+  id: "dob",
+  name: "dob",
   fieldset: {
     legend: {
-      text: 'What is your date of birth?',
+      text: "What is your date of birth?",
       isPageHeading: true,
-      classes: 'govuk-fieldset__legend--xl'
+      classes: "govuk-fieldset__legend--xl"
     }
   },
   hint: {
-    text: 'For example, 31 3 1980'
+    text: "For example, 31 3 1980"
   },
   errorMessage: {
     text: "Date of birth must be in the past"
   },
   items: [
     {
-      name: 'day',
-      value: '6'
+      name: "day",
+      value: "6"
     },
     {
-      name: 'month',
-      value: '3'
+      name: "month",
+      value: "3"
     },
     {
-      name: 'year',
-      value: '2076'
+      name: "year",
+      value: "2076"
     }
   ]
 }) }}

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use the date input component to help users enter a memorable date.
 
-{{ example({group: 'components', item: 'date-input', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -29,7 +29,7 @@ The date input component consists of 3 fields to let users enter a day, month an
 
 There are 2 ways to use the date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'date-input', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: true}) }}
 
 Don’t automatically tab users between the fields of the Date input because this can be confusing and may clash with normal keyboard controls.
 
@@ -37,7 +37,7 @@ Don’t automatically tab users between the fields of the Date input because thi
 
 Check that a valid date is entered by the user. Invalid dates should be reported to the user like this:
 
-{{ example({group: 'components', item: 'date-input', example: 'error', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "date-input", example: "error", html: true, nunjucks: true, open: false}) }}
 
 ## Research on this component
 

--- a/src/components/details/index.md.njk
+++ b/src/components/details/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Make a page easier to scan by letting users reveal more detailed information only if they need it.
 
-{{ example({group: 'components', item: 'details', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -27,7 +27,7 @@ The details component is a short link that expands into more detailed help text 
 
 There are 2 ways to use the details component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'details', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ### Write clear link text
 

--- a/src/components/error-message/default/index.njk
+++ b/src/components/error-message/default/index.njk
@@ -8,31 +8,31 @@ layout: layout-example.njk
 {{ govukDateInput({
   fieldset: {
     legend: {
-      text: 'What is your date of birth?',
+      text: "What is your date of birth?",
       isPageHeading: true,
-      classes: 'govuk-fieldset__legend--xl'
+      classes: "govuk-fieldset__legend--xl"
     }
   },
   hint: {
-    text: 'For example, 31 3 1980'
+    text: "For example, 31 3 1980"
   },
   errorMessage: {
     text: "Date of birth must be in the past"
   },
-  id: 'dob',
-  name: 'dob',
+  id: "dob",
+  name: "dob",
   items: [
     {
-      name: 'day',
-      value: '6'
+      name: "day",
+      value: "6"
     },
     {
-      name: 'month',
-      value: '3'
+      name: "month",
+      value: "3"
     },
     {
-      name: 'year',
-      value: '2076'
+      name: "year",
+      value: "2076"
     }
   ]
 }) }}

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use an error message when a there is a validation error. Explain what went wrong and how to fix it.
 
-{{ example({group: 'components', item: 'error-message', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "error-message", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -49,11 +49,11 @@ There are 2 ways to use the error message component. You can use HTML or, if you
 
 ### Legend
 
-{{ example({group: 'components', item: 'error-message', example: 'legend', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "error-message", example: "legend", html: true, nunjucks: true, open: true}) }}
 
 ### Label
 
-{{ example({group: 'components', item: 'error-message', example: 'label', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "error-message", example: "label", html: true, nunjucks: true, open: true}) }}
 
 ### Be clear and concise
 
@@ -66,7 +66,7 @@ Do not use:
 - ‘please’ because it implies a choice
 - ‘sorry’ because it does not help fix the problem
 - ‘valid’ and ‘invalid’ because they do not add anything to the message
-- humourous, informal language like 'oops'
+- humourous, informal language like ‘oops’
 
 Above all, aim for clarity.
 
@@ -110,7 +110,7 @@ Some errors work better as instructions and some work better as descriptions. Fo
 - ‘Enter a first name that is 35 characters or less’ is wordier, less direct and natural than ‘First name must be 35 characters or less’
 - ‘Enter a date after 31 August 2017 for when you started the course’ is wordier, less direct and natural than ‘Date you started the course must be after 31 August 2017’
 
-Use both instructions and descriptions, but use them consistently. For example, use an instruction for empty fields like 'Enter your name', but a description like 'Name must be 35 characters or less' for entries that are too long.
+Use both instructions and descriptions, but use them consistently. For example, use an instruction for empty fields like ‘Enter your name’, but a description like ‘Name must be 35 characters or less’ for entries that are too long.
 
 ### Track errors
 

--- a/src/components/error-message/legend/index.njk
+++ b/src/components/error-message/legend/index.njk
@@ -4,16 +4,16 @@ layout: layout-example.njk
 ignore_in_sitemap: true
 ---
 
-{% from 'checkboxes/macro.njk' import govukCheckboxes %}
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
   idPrefix: "nationality",
   name: "nationality",
   fieldset: {
     legend: {
-      text: 'What is your nationality?',
+      text: "What is your nationality?",
       isPageHeading: true,
-      classes: 'govuk-fieldset__legend--xl'
+      classes: "govuk-fieldset__legend--xl"
     }
   },
   hint: {

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use an error summary when a there is a validation error. The error summary uses the error message that explains what went wrong and how to fix it.
 
-{{ example({group: 'components', item: 'error-summary', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -24,13 +24,13 @@ You must:
 - add ‘Error: ’ to the beginning of the `<title>` so screen readers read it out as soon as possible
 - show an error summary at the top of a page
 - move keyboard focus to the error summary
-- include the heading 'There is a problem'
+- include the heading ‘There is a problem’
 - link to each of the validation errors
 - show the same error messages next to the inputs with errors
 
 There are 2 ways to use the error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'error-summary', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/fieldset/address-group/index.njk
+++ b/src/components/fieldset/address-group/index.njk
@@ -35,27 +35,27 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      text: 'Town or city'
+      text: "Town or city"
     },
-    classes: 'govuk-!-width-two-thirds',
+    classes: "govuk-!-width-two-thirds",
     id: "address-town",
     name: "address-town"
   }) }}
 
   {{ govukInput({
     label: {
-      text: 'County'
+      text: "County"
     },
-    classes: 'govuk-!-width-two-thirds',
+    classes: "govuk-!-width-two-thirds",
     id: "address-county",
     name: "address-county"
   }) }}
 
   {{ govukInput({
     label: {
-      text: 'Postcode'
+      text: "Postcode"
     },
-    classes: 'govuk-input--width-10',
+    classes: "govuk-input--width-10",
     id: "address-postcode",
     name: "address-postcode"
   }) }}

--- a/src/components/fieldset/index.md.njk
+++ b/src/components/fieldset/index.md.njk
@@ -11,13 +11,13 @@ layout: layout-pane.njk
 
 Use the fieldset component to group related form inputs.
 
-{{ example({group: 'components', item: 'fieldset', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "fieldset", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
 Use the fieldset component when you need to show a relationship between multiple form inputs. For example, you may need to group a set of text inputs into a single fieldset when [asking for an address](../../patterns/addresses).
 
-{{ example({group: 'components', item: 'fieldset', example: 'address-group', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "fieldset", example: "address-group", html: true, nunjucks: true, open: true}) }}
 
 If you’re using the examples or macros for [radios](../radios), [checkboxes](../checkboxes) or [date input](../date-input), the fieldset will already be included.
 
@@ -25,7 +25,7 @@ If you’re using the examples or macros for [radios](../radios), [checkboxes](.
 
 The first element inside a fieldset must be a `legend` which describes the group of inputs. This could be a question, such as ‘What is your current address?’ or a statement like ‘Personal details’.
 
-{{ example({group: 'components', item: 'fieldset', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "fieldset", example: "default", html: true, nunjucks: true, open: true}) }}
 
 On [question pages](../../patterns/question-pages) containing a group of inputs, including the question as the legend helps users of screenreaders to understand that the inputs are all related to that&nbsp;question.
 

--- a/src/components/file-upload/default/index.njk
+++ b/src/components/file-upload/default/index.njk
@@ -6,9 +6,9 @@ layout: layout-example.njk
 {% from "file-upload/macro.njk" import govukFileUpload %}
 
 {{ govukFileUpload({
-  id: 'file-upload-1',
-  name: 'file-upload-1',
+  id: "file-upload-1",
+  name: "file-upload-1",
   label: {
-    text: 'Upload a file'
+    text: "Upload a file"
   }
 }) }}

--- a/src/components/file-upload/index.md.njk
+++ b/src/components/file-upload/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Help users select and upload a file.
 
-{{ example({group: 'components', item: 'file-upload', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -21,7 +21,7 @@ You should only ask users to upload something if it’s critical to the delivery
 
 There are 2 ways to use the file upload component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'file-upload', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/footer/default/index.njk
+++ b/src/components/footer/default/index.njk
@@ -3,6 +3,6 @@ title: Footer
 layout: layout-example.njk
 ---
 
-{% from 'footer/macro.njk' import govukFooter %}
+{% from "footer/macro.njk" import govukFooter %}
 
 {{ govukFooter({}) }}

--- a/src/components/footer/full/index.njk
+++ b/src/components/footer/full/index.njk
@@ -4,7 +4,7 @@ layout: layout-example.njk
 ignore_in_sitemap: true
 ---
 
-{% from 'footer/macro.njk' import govukFooter %}
+{% from "footer/macro.njk" import govukFooter %}
 
 {{ govukFooter({
   navigation: [

--- a/src/components/footer/index.md.njk
+++ b/src/components/footer/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 The footer provides copyright, licensing and other information about your service and department.
 
-{{ example({group: 'components', item: 'footer', example: 'default', id: 'default-1', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "footer", example: "default", id: "default-1", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -27,21 +27,21 @@ You can add links to:
 
 ### Default footer
 
-{{ example({group: 'components', item: 'footer', example: 'default', id: 'default-2', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "footer", example: "default", id: "default-2", html: true, nunjucks: true, open: false}) }}
 
 ### Footer with secondary navigation
 
-{{ example({group: 'components', item: 'footer', example: 'with-navigation', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "footer", example: "with-navigation", html: true, nunjucks: true, open: false}) }}
 
 ### Footer with links to meta information
 
 You can also include links to meta information about a site, like cookies and contact details in the footer, like this:
 
-{{ example({group: 'components', item: 'footer', example: 'with-meta', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "footer", example: "with-meta", html: true, nunjucks: true, open: false}) }}
 
 ### Footer with secondary navigation and links to meta information
 
-{{ example({group: 'components', item: 'footer', example: 'full', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "footer", example: "full", html: true, nunjucks: true, open: false}) }}
 
 ## Research on this component
 

--- a/src/components/footer/with-meta/index.njk
+++ b/src/components/footer/with-meta/index.njk
@@ -4,7 +4,7 @@ layout: layout-example.njk
 ignore_in_sitemap: true
 ---
 
-{% from 'footer/macro.njk' import govukFooter %}
+{% from "footer/macro.njk" import govukFooter %}
 
 {{ govukFooter({
   meta: {

--- a/src/components/footer/with-navigation/index.njk
+++ b/src/components/footer/with-navigation/index.njk
@@ -4,7 +4,7 @@ layout: layout-example.njk
 ignore_in_sitemap: true
 ---
 
-{% from 'footer/macro.njk' import govukFooter %}
+{% from "footer/macro.njk" import govukFooter %}
 
 {{ govukFooter({
   navigation: [

--- a/src/components/header/index.md.njk
+++ b/src/components/header/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 The GOV.UK header shows users that they are on GOV.UK and which service they are using.
 
-{{ example({group: 'components', item: 'header', example: 'default', id: 'default-1', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "header", example: "default", id: "default-1", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -31,19 +31,19 @@ You must not use the GOV.UK header if your service is not being hosted on one of
 
 Use the default header if your service has 5 pages or fewer.
 
-{{ example({group: 'components', item: 'header', example: 'default', id: 'default-2', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "header", example: "default", id: "default-2", html: true, nunjucks: true, open: false}) }}
 
 ### Header with service name
 
 Use the header with a service name if your service is more than 5 pages long - this can help users understand which service they are using.
 
-{{ example({group: 'components', item: 'header', example: 'with-service-name', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "header", example: "with-service-name", html: true, nunjucks: true, open: false}) }}
 
 ### Header with service name and navigation
 
 Use the header with navigation if you need to include basic navigation, contact or account management links.
 
-{{ example({group: 'components', item: 'header', example: 'with-service-name-and-navigation', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "header", example: "with-service-name-and-navigation", html: true, nunjucks: true, open: false}) }}
 
 ## Research on this component
 

--- a/src/components/inset-text/index.md.njk
+++ b/src/components/inset-text/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'inset-text', example: 'default'}) }}
+{{ example({group: "components", item: "inset-text", example: "default"}) }}
 
 ## When to use this component
 
@@ -31,7 +31,7 @@ Use inset text very sparingly - it’s less effective if it’s overused.
 
 There are 2 ways to use the inset text component. You can use HTML or, if you’re using Nunjucks or the GOV.UK Prototype Kit, you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'inset-text', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 The panel component is a visible container used on confirmation or results pages to highlight important content.
 
-{{ example({group: 'components', item: 'panel', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -27,7 +27,7 @@ Don’t use the panel component to highlight important information within body c
 
 There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'panel', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use the phase banner component to show users your service is still being worked on.
 
-{{ example({group: 'components', item: 'phase-banner', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -24,9 +24,9 @@ Your banner must be directly under the black GOV.UK header and colour bar.
 
 There are 2 ways to use the phase banner component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'phase-banner', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: true}) }}
 
-{{ example({group: 'components', item: 'phase-banner', example: 'beta', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "phase-banner", example: "beta", html: true, nunjucks: true, open: false}) }}
 
 ### Add a feedback link
 

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -4,7 +4,7 @@ layout: layout-example.njk
 ignore_in_sitemap: true
 ---
 
-{% from 'radios/macro.njk' import govukRadios %}
+{% from "radios/macro.njk" import govukRadios %}
 {% from "input/macro.njk" import govukInput %}
 
 {% set emailHtml %}

--- a/src/components/radios/default/index.njk
+++ b/src/components/radios/default/index.njk
@@ -3,7 +3,7 @@ title: Inline radios
 layout: layout-example.njk
 ---
 
-{% from 'radios/macro.njk' import govukRadios %}
+{% from "radios/macro.njk" import govukRadios %}
 
 {{ govukRadios({
   classes: "govuk-radios--inline",
@@ -11,9 +11,9 @@ layout: layout-example.njk
   name: "changed-name",
   fieldset: {
     legend: {
-      text: 'Have you changed your name?',
+      text: "Have you changed your name?",
       isPageHeading: true,
-      classes: 'govuk-fieldset__legend--xl'
+      classes: "govuk-fieldset__legend--xl"
     }
   },
   hint: {

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'radios', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -27,19 +27,19 @@ There are 2 ways to use the radios component. You can use HTML or, if you are us
 
 When there are more than 2 options, radios should be stacked, like so:
 
-{{ example({group: 'components', item: 'radios', example: 'stacked', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "radios", example: "stacked", html: true, nunjucks: true, open: true}) }}
 
 ### Inline radios
 
 If there are only 2 options, you can either stack the radios or display them inline, like so:
 
-{{ example({group: 'components', item: 'radios', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ### Conditionally revealing content
 
 You can add conditionally revealing content to radios, so users only see content when it’s relevant to them. For example, you could reveal an email address input only when a user chooses to be contacted by email.
 
-{{ example({group: 'components', item: 'radios', example: 'conditional-reveal', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "radios", example: "conditional-reveal", html: true, nunjucks: true, open: false}) }}
 
 Keep it simple - if you need to add a lot of content, consider showing it on the next page in the process instead.
 

--- a/src/components/radios/stacked/index.njk
+++ b/src/components/radios/stacked/index.njk
@@ -4,16 +4,16 @@ layout: layout-example.njk
 ignore_in_sitemap: true
 ---
 
-{% from 'radios/macro.njk' import govukRadios %}
+{% from "radios/macro.njk" import govukRadios %}
 
 {{ govukRadios({
   idPrefix: "where-do-you-live",
   name: "where-do-you-live",
   fieldset: {
     legend: {
-      text: 'Where do you live?',
+      text: "Where do you live?",
       isPageHeading: true,
-      classes: 'govuk-fieldset__legend--xl'
+      classes: "govuk-fieldset__legend--xl"
     }
   },
   items: [

--- a/src/components/select/default/index.njk
+++ b/src/components/select/default/index.njk
@@ -13,20 +13,20 @@ layout: layout-example.njk
   },
   items: [
     {
-      value: 'published',
+      value: "published",
       text: "Recently published"
     },
     {
-      value: 'updated',
+      value: "updated",
       text: "Recently updated",
       selected: true
     },
     {
-      value: 'views',
+      value: "views",
       text: "Most views"
     },
     {
-      value: 'comments',
+      value: "comments",
       text: "Most comments"
     }
   ]

--- a/src/components/select/index.md.njk
+++ b/src/components/select/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'select', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -23,7 +23,7 @@ Asking questions means you’re less likely to need to use the select component,
 
 There are 2 ways to use the select component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com),  you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'select', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "select", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/skip-link/index.md.njk
+++ b/src/components/skip-link/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use the skip link component to help keyboard-only users skip to the main content on a page.
 
-{{ example({group: 'components', item: 'skip-link', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -27,7 +27,7 @@ The skip link component is visually hidden until a keyboard press activates it.
 
 There are 2 ways to use the skip link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'skip-link', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use the table component to make information easier to compare and scan for users.
 
-{{ example({group: 'components', item: 'table', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -33,13 +33,13 @@ Use table headers to tell users what the rows and columns represent. Use the `sc
 
 There are 2 ways to use the table component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'table', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ## Numbers in a table
 
 When comparing columns of numbers, align the numbers to the right in table cells.
 
-{{ example({group: 'components', item: 'table', example: 'numbers', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "table", example: "numbers", html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/tabs/default/index.njk
+++ b/src/components/tabs/default/index.njk
@@ -3,8 +3,8 @@ title: Tabs
 layout: layout-example.njk
 ---
 
-{% from 'tabs/macro.njk' import govukTabs %}
-{% from 'table/macro.njk' import govukTable %}
+{% from "tabs/macro.njk" import govukTabs %}
+{% from "table/macro.njk" import govukTable %}
 
 {% set pastDayHtml %}
 <h2 class="govuk-heading-l">Past day</h2>

--- a/src/components/tabs/index.md.njk
+++ b/src/components/tabs/index.md.njk
@@ -13,7 +13,7 @@ statusMessage: This component is currently experimental because <a class="govuk-
 
 The tabs component lets users navigate between related sections of content, displaying one section at a time.
 
-{{ example({group: 'components', item: 'tabs', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -47,7 +47,7 @@ Test your content without tabs first. Consider if it’s better to:
 
 There are 2 ways to use the tabs component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'tabs', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: true}) }}
 
 More research is needed on the best way to display the tabs component on small screen sizes.
 

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'tag', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -19,7 +19,7 @@ Use the tag component to indicate the status of something, such as an item on a 
 
 There are 2 ways to use the tag component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'tag', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ## Research on this component
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'text-input', frontendComponentName: 'input', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -23,7 +23,7 @@ Don’t use the text input component if you need to let users enter longer answe
 
 There are 2 ways to use the text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'text-input', frontendComponentName: 'input', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ### Label text inputs
 
@@ -45,7 +45,7 @@ Use fixed width inputs for content that has a specific, known length. Postcode i
 
 On fixed width inputs, the width will remain fixed on all screens unless it is wider than the viewport, in which case it will shrink to fit.
 
-{{ example({group: 'components', item: 'text-input', frontendComponentName: 'input', example: 'input-fixed-width', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "input-fixed-width", html: true, nunjucks: true, open: false}) }}
 
 #### Fluid width inputs
 
@@ -53,13 +53,13 @@ Use the width override classes to reduce the width of an input in relation to it
 
 Fluid width inputs will resize with the viewport.
 
-{{ example({group: 'components', item: 'text-input', frontendComponentName: 'input', example: 'input-fluid-width', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "input-fluid-width", html: true, nunjucks: true, open: false}) }}
 
 ### Using hint text
 
-Use hint for help that’s relevant to the majority of users - like how their information will be used, or where to find it. 
+Use hint for help that’s relevant to the majority of users - like how their information will be used, or where to find it.
 
-{{ example({group: 'components', item: 'text-input', frontendComponentName: 'input', example: 'input-hint-text', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "input-hint-text", html: true, nunjucks: true, open: false}) }}
 
 ### Don’t disable copy and paste
 

--- a/src/components/text-input/input-fixed-width/index.njk
+++ b/src/components/text-input/input-fixed-width/index.njk
@@ -12,7 +12,7 @@ ignore_in_sitemap: true
   label: {
     text: "Driving licence number"
   },
-  classes: 'govuk-input--width-20',
+  classes: "govuk-input--width-20",
   id: "driving-licence-number",
   name: "driving-licence-number"
 }) }}

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'textarea', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -23,7 +23,7 @@ Don’t use the textarea component if you need to let users enter shorter answer
 
 There are 2 ways to use the textarea component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'textarea', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ### Label textareas
 
@@ -35,7 +35,7 @@ Labels must be aligned above the textarea they refer to. They should be short, d
 
 Make the height of a textarea proportional to the amount of text you expect users to enter. You can set the height of a textarea by by specifying the `rows` attribute.
 
-{{ example({group: 'components', item: 'textarea', example: 'specifying-rows', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "textarea", example: "specifying-rows", html: true, nunjucks: true, open: true}) }}
 
 ### Don’t disable copy and paste
 

--- a/src/components/warning-text/index.md.njk
+++ b/src/components/warning-text/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'components', item: 'warning-text', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
@@ -19,9 +19,9 @@ Use the warning text component when you need to warn users about something impor
 
 There are 2 ways to use the warning text component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: 'components', item: 'warning-text', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: true}) }}
 
-You might need to rewrite the hidden text ('Warning' in the example) to make it appropriate for your context.
+You might need to rewrite the hidden text (‘Warning’ in the example) to make it appropriate for your context.
 
 ## Research on this component
 

--- a/src/cookies.md.njk
+++ b/src/cookies.md.njk
@@ -10,7 +10,7 @@ The GOV.UK Design System puts small files (known as ‘cookies’) on to your co
 
 We use cookies to:
 
-- record the notifications you've seen so we don't show them again
+- record the notifications you’ve seen so we don’t show them again
 - measure how you use the website so it can be updated and improved based on your activity
 
 These cookies aren’t used to identify you personally.

--- a/src/get-started/production/index.md.njk
+++ b/src/get-started/production/index.md.njk
@@ -50,7 +50,7 @@ You will not be able to:
 
 ## Start using the GOV.UK page template
 
-You can set up a basic page that is consistent with GOV.UK branding by using the [GOV.UK page template](/styles/page-template/). 
+You can set up a basic page that is consistent with GOV.UK branding by using the [GOV.UK page template](/styles/page-template/).
 
 ## Styling page elements
 
@@ -69,7 +69,7 @@ You can either use HTML or - if you’re using Nunjucks with node.js and you ins
 
 You can get the code from the HTML or Nunjucks tabs below any examples:
 
-{{ example({group: 'components', item: 'button', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ### Using Nunjucks macros
 

--- a/src/get-started/prototyping/index.md.njk
+++ b/src/get-started/prototyping/index.md.njk
@@ -35,7 +35,7 @@ There are 2 ways to use components in the Design System. You can either use HTML
 
 You can copy the code from the HTML or Nunjucks tabs below any examples:
 
-{{ example({group: 'components', item: 'button', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## Using Nunjucks macros
 

--- a/src/get-started/updating-your-code/index.md.njk
+++ b/src/get-started/updating-your-code/index.md.njk
@@ -79,7 +79,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
         <p>
           <pre><code>{% raw %}
 {% block skipLink %}
-  {{ govukSkipLink({ text: 'custom text' }) }}
+  {{ govukSkipLink({ text: "custom text" }) }}
 {% endblock %}{% endraw %}</code></pre>
         </p>
         <p>
@@ -103,7 +103,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
         <p>
           <pre><code>{% raw %}
 {% block header %}
-    {{ govukHeader({ classes: 'app-custom-classes' }) }}
+    {{ govukHeader({ classes: "app-custom-classes" }) }}
 {% endblock %}{% endraw %}</code></pre>
         </p>
         <p>
@@ -122,7 +122,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
         <p>
           <pre><code>{% raw %}
 {% block header %}
-    {{ govukHeader({ homepageUrl: '/custom-url' }) }}
+    {{ govukHeader({ homepageUrl: "/custom-url" }) }}
 {% endblock %}{% endraw %}</code></pre>
         </p>
         <p>
@@ -148,7 +148,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
         <p>
           <pre><code>{% raw %}
 {% block header %}
-    {{ govukHeader({ serviceName: 'Custom service name' }) }}
+    {{ govukHeader({ serviceName: "Custom service name" }) }}
 {% endblock %}{% endraw %}</code></pre>
         </p>
         <p>

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -42,7 +42,7 @@ When using an address lookup, you should:
 
 ## Multiple text inputs
 
-{{ example({group: 'patterns', item: 'addresses', example: 'multiple', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "addresses", example: "multiple", html: true, nunjucks: true, open: true}) }}
 
 ### When to use multiple text inputs
 
@@ -75,7 +75,7 @@ Royal Mail doesn’t need a county as long as the town and postcode are included
 
 ## Textarea
 
-{{ example({group: 'patterns', item: 'addresses', example: 'textarea', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "addresses", example: "textarea", html: true, nunjucks: true, open: true}) }}
 
 ### When to use textarea
 

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -35,27 +35,27 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      text: 'Town or city'
+      text: "Town or city"
     },
-    classes: 'govuk-!-width-two-thirds',
+    classes: "govuk-!-width-two-thirds",
     id: "address-town",
     name: "address-town"
   }) }}
 
   {{ govukInput({
     label: {
-      text: 'County'
+      text: "County"
     },
-    classes: 'govuk-!-width-two-thirds',
+    classes: "govuk-!-width-two-thirds",
     id: "address-county",
     name: "address-county"
   }) }}
 
   {{ govukInput({
     label: {
-      text: 'Postcode'
+      text: "Postcode"
     },
-    classes: 'govuk-input--width-10',
+    classes: "govuk-input--width-10",
     id: "address-postcode",
     name: "address-postcode"
   }) }}

--- a/src/patterns/check-answers/index.md.njk
+++ b/src/patterns/check-answers/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 Let users check their answers before submitting information to a service.
 
-![Screenshot of a check answers page, includes a heading, and two sections for personal details and application details. Each section has details on the answers a user has given with a corresponding link to change their answer. At the bottom of the page there is a button to 'accept and send' the application.](check-answers-page.png)
+![Screenshot of a check answers page, includes a heading, and two sections for personal details and application details. Each section has details on the answers a user has given with a corresponding link to change their answer. At the bottom of the page there is a button to ‘accept and send’ the application.](check-answers-page.png)
 
 ## When to use this pattern
 

--- a/src/patterns/confirmation-pages/default/index.njk
+++ b/src/patterns/confirmation-pages/default/index.njk
@@ -20,7 +20,7 @@ layout: layout-example.njk
 
         <h3 class="govuk-heading-m">What happens next</h3>
 
-        <p class="govuk-body">We've sent your application to Hackney Electoral Register Office.</p>
+        <p class="govuk-body">We’ve sent your application to Hackney Electoral Register Office.</p>
 
         <p class="govuk-body">They will contact you either to confirm your registration, or to ask for more information.</p>
 

--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -12,7 +12,7 @@ layout: layout-pane.njk
 
 Let users know they’ve completed a transaction.
 
-{{ example({group: 'patterns', item: 'confirmation-pages', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 
@@ -31,7 +31,7 @@ Your confirmation page must include:
 - a link to your feedback page
 - a way for users to save a record of the transaction, for example, as a PDF
 
-{{ example({group: 'patterns', item: 'confirmation-pages', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ### Help users who bookmark the page
 

--- a/src/patterns/dates/default/index.njk
+++ b/src/patterns/dates/default/index.njk
@@ -6,27 +6,27 @@ layout: layout-example.njk
 {% from "date-input/macro.njk" import govukDateInput %}
 
 {{ govukDateInput({
-  id: 'dob',
-  name: 'dob',
+  id: "dob",
+  name: "dob",
   fieldset: {
     legend: {
-      text: 'What is your date of birth?',
+      text: "What is your date of birth?",
       isPageHeading: true,
-      classes: 'govuk-fieldset__legend--xl'
+      classes: "govuk-fieldset__legend--xl"
     }
   },
   hint: {
-    text: 'For example, 31 3 1980'
+    text: "For example, 31 3 1980"
   },
   items: [
     {
-      name: 'day'
+      name: "day"
     },
     {
-      name: 'month'
+      name: "month"
     },
     {
-      name: 'year'
+      name: "year"
     }
   ]
   })

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -12,7 +12,7 @@ layout: layout-pane.njk
 
 Help users enter or select a date.
 
-{{ example({group: 'patterns', item: 'dates', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "dates", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 
@@ -34,7 +34,7 @@ In some cases you might need users to pick a date from a given selection.
 
 Ask for memorable dates, like dates of birth, using the [date input](../../components/date-input) component.
 
-{{ example({group: 'patterns', item: 'dates', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "dates", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ### Asking for dates from documents and cards
 

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'patterns', item: 'email-addresses', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "email-addresses", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 
@@ -26,7 +26,7 @@ When asking users for their email address, you must:
 
 You may also need to check that users have access to the email account they give you.
 
-{{ example({group: 'patterns', item: 'email-addresses', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "email-addresses", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ### Make the field long enough
 

--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'patterns', item: 'names', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "names", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 
@@ -21,7 +21,7 @@ Only ask for people’s names if you need that information to deliver a service.
 
 Make it as easy as possible for a user to enter their name.
 
-{{ example({group: 'patterns', item: 'names', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "names", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ### Make sure the fields work for most of your users
 

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -12,7 +12,7 @@ layout: layout-pane.njk
 
 Ask users to provide their National Insurance number.
 
-{{ example({group: 'patterns', item: 'national-insurance-numbers', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "national-insurance-numbers", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 
@@ -34,7 +34,7 @@ You should:
 - allow upper and lower case letters and strip out spaces before validating
 - avoid using ‘AB 12 34 56 C’ as an example because it belongs to a real person and use ‘QQ 12 34 56 C’ instead
 
-{{ example({group: 'patterns', item: 'national-insurance-numbers', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "national-insurance-numbers", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ## Research on this pattern
 

--- a/src/patterns/page-not-found-pages/default/index.njk
+++ b/src/patterns/page-not-found-pages/default/index.njk
@@ -24,7 +24,7 @@ layout: layout-example.njk
         <p class="govuk-body">Opening times:<br>
           <strong class="govuk-!-font-weight-bold">Monday to Friday: 8am to 8pm</strong>
         </p>
-        <p class="govuk-body">Closed Easter Sunday, Christmas Day, Boxing Day and New Year's Day.</p>
+        <p class="govuk-body">Closed Easter Sunday, Christmas Day, Boxing Day and New Year’s Day.</p>
 
       </div>
     </div>

--- a/src/patterns/page-not-found-pages/index.md.njk
+++ b/src/patterns/page-not-found-pages/index.md.njk
@@ -14,7 +14,7 @@ statusMessage: This pattern is currently experimental because <a class="govuk-li
 
 A page not found tells someone we cannot find the page they were trying to view. They are also known as 404 pages.
 
-{{ example({group: 'patterns', item: 'page-not-found-pages', example: 'default', html: true}) }}
+{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true}) }}
 
 ## When to use this pattern
 
@@ -57,15 +57,15 @@ Do not use:
 
 ### Service mistake
 
-{{ example({group: 'patterns', item: 'page-not-found-pages', example: 'default', html: true}) }}
+{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true}) }}
 
 ### User mistake
 
-{{ example({group: 'patterns', item: 'page-not-found-pages', example: 'user-mistake', html: true}) }}
+{{ example({group: "patterns", item: "page-not-found-pages", example: "user-mistake", html: true}) }}
 
 ### If you do not know why the page is not found
 
-{{ example({group: 'patterns', item: 'page-not-found-pages', example: 'reason-not-known', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "page-not-found-pages", example: "reason-not-known", html: true, nunjucks: true, open: false}) }}
 
 When a user submits the form, take them to a confirmation page which has:
 

--- a/src/patterns/passwords/index.md.njk
+++ b/src/patterns/passwords/index.md.njk
@@ -35,11 +35,11 @@ Choose constraints that meet the security needs of your service. If you need add
 Make sure you:
 
 - set a minimum length of at least 8 characters
-- don't set a maximum length
+- don’t set a maximum length
 - explain the constraints to users
 - use a blacklist of commonly used passwords
 
-### Don't make users keep changing their passwords
+### Don’t make users keep changing their passwords
 
 Some services force users to change their passwords periodically, for example every&nbsp;month.
 
@@ -93,7 +93,7 @@ Always email the user when a password reset has happened, in case it was trigger
 
 ### Avoid password reset questions
 
-You shouldn't use password reset questions because they often ask for information that’s:
+You shouldn’t use password reset questions because they often ask for information that’s:
 
 - too obscure and therefore just as hard to remember as a password
 - too easy for someone else to find out, for example ‘mother’s maiden name’

--- a/src/patterns/problem-with-the-service-pages/index.md.njk
+++ b/src/patterns/problem-with-the-service-pages/index.md.njk
@@ -13,7 +13,7 @@ statusMessage: This pattern is currently experimental because <a class="govuk-li
 
 This is a page that tells someone there is something wrong with the service. They are also known as 500 and internal server error pages.
 
-{{ example({group: 'patterns', item: 'problem-with-the-service-pages', example: 'default', html: true, open: false}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, open: false}) }}
 
 ## When to use this pattern
 
@@ -48,15 +48,15 @@ Have clear and concise content and do not use:
 
 ### Service has a specific page that includes numbers and opening times
 
-{{ example({group: 'patterns', item: 'problem-with-the-service-pages', example: 'default', html: true, open: false}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, open: false}) }}
 
 ### Service has offline support but no specific page that includes numbers and opening times
 
-{{ example({group: 'patterns', item: 'problem-with-the-service-pages', example: 'offline-support', html: true, open: false}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "offline-support", html: true, open: false}) }}
 
 ### A link to another service
 
-{{ example({group: 'patterns', item: 'problem-with-the-service-pages', example: 'link-to-another-service', html: true, open: false}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "link-to-another-service", html: true, open: false}) }}
 
 ## Research on this pattern
 

--- a/src/patterns/problem-with-the-service-pages/offline-support/index.njk
+++ b/src/patterns/problem-with-the-service-pages/offline-support/index.njk
@@ -26,7 +26,7 @@ ignore_in_sitemap: true
       <p class="govuk-body">Opening times:<br>
         <strong class="govuk-!-font-weight-bold">Monday to Friday: 8am to 8pm</strong>
       </p>
-      <p class="govuk-body">Closed Easter Sunday, Christmas Day, Boxing Day and New Year's Day.</p>
+      <p class="govuk-body">Closed Easter Sunday, Christmas Day, Boxing Day and New Year’s Day.</p>
 
       </div>
     </div>

--- a/src/patterns/question-pages/default/index.njk
+++ b/src/patterns/question-pages/default/index.njk
@@ -19,27 +19,27 @@ layout: layout-example.njk
         <form action="/form-handler" method="post">
 
           {{ govukDateInput({
-            id: 'dob',
-            name: 'dob',
+            id: "dob",
+            name: "dob",
             fieldset: {
               legend: {
-                text: 'What is your date of birth?',
+                text: "What is your date of birth?",
                 isPageHeading: true,
-                classes: 'govuk-fieldset__legend--xl'
+                classes: "govuk-fieldset__legend--xl"
               }
             },
             hint: {
-              text: 'For example, 31 3 1980'
+              text: "For example, 31 3 1980"
             },
             items: [
               {
-                name: 'day'
+                name: "day"
               },
               {
-                name: 'month'
+                name: "month"
               },
               {
-                name: 'year'
+                name: "year"
               }
             ]
             })

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -12,7 +12,7 @@ layout: layout-pane.njk
 
 This pattern explains when to use question pages and what elements they need to include.
 
-{{ example({group: 'patterns', item: 'question-pages', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "question-pages", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 
@@ -46,13 +46,13 @@ If you’re only asking for one piece of information on a page, make the questio
 
 For example:
 
-{{ example({group: 'patterns', item: 'question-pages', example: 'postcode', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "question-pages", example: "postcode", html: true, nunjucks: true, open: true}) }}
 
 If you need to ask for multiple related things on a page, use a statement as the heading.
 
 For example:
 
-{{ example({group: 'patterns', item: 'question-pages', example: 'passport', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "question-pages", example: "passport", html: true, nunjucks: true, open: true}) }}
 
 Don’t duplicate the same page heading across multiple pages.
 
@@ -62,7 +62,7 @@ If you need to show the high-level section, you can use the `govuk-caption` styl
 
 For example, ‘About you’:
 
-{{ example({group: 'patterns', item: 'question-pages', example: 'section-headings', html: true, open: true}) }}
+{{ example({group: "patterns", item: "question-pages", example: "section-headings", html: true, open: true}) }}
 
 ### Continue button
 
@@ -77,11 +77,11 @@ Start by testing your form without a progress indicator to see if it’s simple 
 
 Try improving the order, type or number of questions before adding a progress indicator. If people still have difficulty, try adding a simple step or question indicator like this one.
 
-{{ example({group: 'patterns', item: 'question-pages', example: 'progress', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "question-pages", example: "progress", html: true, nunjucks: true, open: true}) }}
 
 Only include the total number of questions if you can do so reliably. As the user moves through the form, make sure the indicator updates to tell them which question they are on and the total number remaining.
 
-Don't use progress indicators that do all of the following:
+Don’t use progress indicators that do all of the following:
 
 - show all questions at once
 - allow navigation to previous questions
@@ -111,13 +111,13 @@ Read more about how starting with [one thing per page](https://www.gov.uk/servic
 
 ### Asking users questions
 
-You should make sure you know why you're asking every question and only ask users for information you really need. 
+You should make sure you know why you’re asking every question and only ask users for information you really need.
 
 To help you work out what to ask, you can carry out a [question protocol](https://www.uxmatters.com/mt/archives/2010/06/the-question-protocol-how-to-make-sure-every-form-field-is-necessary.php)
 
 On every question page you should:
 
-- make sure it's clear to users why you're asking each questio
+- make sure it’s clear to users why you’re asking each questio
 - allow users to answer ‘I don’t know’ or ‘I’m not sure’ if they are valid responses
 
 ## Research on this pattern

--- a/src/patterns/question-pages/passport/index.njk
+++ b/src/patterns/question-pages/passport/index.njk
@@ -35,23 +35,23 @@ ignore_in_sitemap: true
           }) }}
 
           {{ govukDateInput({
-            id: 'expiry',
-            name: 'expiry',
+            id: "expiry",
+            name: "expiry",
             fieldset: {
               legend: {
-                text: 'Expiry date',
-                classes: 'govuk-fieldset__legend--m'
+                text: "Expiry date",
+                classes: "govuk-fieldset__legend--m"
               }
             },
             hint: {
-              text: 'For example, 31 3 1980'
+              text: "For example, 31 3 1980"
             },
             items: [
               {
-                name: 'month'
+                name: "month"
               },
               {
-                name: 'year'
+                name: "year"
               }
             ]
             })

--- a/src/patterns/service-unavailable-pages/index.md.njk
+++ b/src/patterns/service-unavailable-pages/index.md.njk
@@ -13,7 +13,7 @@ statusMessage: This pattern is currently experimental because <a class="govuk-li
 
 This is a page that tells someone a service is unavailable on purpose. These are also known as 503 and shutter pages.
 
-{{ example({group: 'patterns', item: 'service-unavailable-pages', example: 'default', html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "default", html: true, open: false}) }}
 
 ## When to use this pattern
 
@@ -47,15 +47,15 @@ Have clear and concise content and do not use:
 
 ### General page
 
-{{ example({group: 'patterns', item: 'service-unavailable-pages', example: 'general', html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "general", html: true, open: false}) }}
 
 ### When you know when a service will be available
 
-{{ example({group: 'patterns', item: 'service-unavailable-pages', example: 'available-at-known-date', html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "available-at-known-date", html: true, open: false}) }}
 
 ### A link to another service
 
-{{ example({group: 'patterns', item: 'service-unavailable-pages', example: 'link-to-another-service', html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "link-to-another-service", html: true, open: false}) }}
 
 ### Service is closed for part of the year
 
@@ -63,23 +63,23 @@ This is for a service like tax credit renewals.
 
 #### After a service closes
 
-{{ example({group: 'patterns', item: 'service-unavailable-pages', example: 'after-service-closes', html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "after-service-closes", html: true, open: false}) }}
 
 #### Before a service opens
 
 Do not include any contact information.
 
-{{ example({group: 'patterns', item: 'service-unavailable-pages', example: 'before-service-opens', html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "before-service-opens", html: true, open: false}) }}
 
 ### Service is closed forever
 
 #### Nothing has replaced the service
 
-{{ example({group: 'patterns', item: 'service-unavailable-pages', example: 'no-replacement-service', html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "no-replacement-service", html: true, open: false}) }}
 
 #### Something has replaced the service
 
-{{ example({group: 'patterns', item: 'service-unavailable-pages', example: 'service-replaced', html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "service-replaced", html: true, open: false}) }}
 
 ## Research on this pattern
 

--- a/src/patterns/start-pages/index.md.njk
+++ b/src/patterns/start-pages/index.md.njk
@@ -10,11 +10,11 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-Use this pattern to test a start page in your prototype. 
+Use this pattern to test a start page in your prototype.
 
-To get a start page for your public beta or live service, you need to [contact the GDS content team](https://www.gov.uk/service-manual/service-assessments/get-your-service-on-govuk) before your alpha assessment. 
+To get a start page for your public beta or live service, you need to [contact the GDS content team](https://www.gov.uk/service-manual/service-assessments/get-your-service-on-govuk) before your alpha assessment.
 
-{{ example({group: 'patterns', item: 'start-pages', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "start-pages", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 
@@ -34,12 +34,12 @@ Start pages include 4 main elements:
 
 4. A list of other ways to access your service.
 
-This is a set pattern, so you won’t be able to customise it. 
+This is a set pattern, so you won’t be able to customise it.
 
 Read guidance on [what information should go on a start page](https://www.gov.uk/service-manual/design/govuk-content-transactions) in the Service Manual.
 
-{{ example({group: 'patterns', item: 'start-pages', example: 'default', html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "start-pages", example: "default", html: true, nunjucks: true, open: true}) }}
 
 ## Research on this pattern
 
-If you’ve used this pattern, get in touch to share your user research findings. 
+If you’ve used this pattern, get in touch to share your user research findings.

--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -12,7 +12,7 @@ statusMessage: This pattern is currently experimental because <a class="govuk-li
 
 {% from "_example.njk" import example %}
 
-{{ example({group: 'patterns', item: 'telephone-numbers', example: 'default', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "telephone-numbers", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 
@@ -25,11 +25,11 @@ Only collect telephone numbers from people if you genuinely need them. Not every
 Users should be allowed to enter telephone numbers in whatever format is familiar to them. You should allow for additional spaces, hyphens, brackets and dashes, and be able to accommodate country and area codes.
 
 ### Validate telephone numbers
-You should validate telephone numbers so you can let users know if they have entered one incorrectly. Google's [libphonenumber](https://github.com/googlei18n/libphonenumber) library can validate telephone numbers from most countries.
+You should validate telephone numbers so you can let users know if they have entered one incorrectly. Google’s [libphonenumber](https://github.com/googlei18n/libphonenumber) library can validate telephone numbers from most countries.
 
 Validation errors should be styled like this:
 
-{{ example({group: 'patterns', item: 'telephone-numbers', example: 'error-empty-field', html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "telephone-numbers", example: "error-empty-field", html: true, nunjucks: true, open: false}) }}
 
 Some examples of common error messages are:
 
@@ -42,8 +42,8 @@ Some examples of common error messages are:
 ### Make it clear what type of telephone number you need
 Use the form label or hint text to tell users if you specifically need a UK, international or mobile telephone number.
 
-{{ example({group: 'patterns', item: 'telephone-numbers', example: 'international', html: true, nunjucks: true, open: false}) }}
- 
+{{ example({group: "patterns", item: "telephone-numbers", example: "international", html: true, nunjucks: true, open: false}) }}
+
 ### Using example telephone numbers
 If you wish to include an example telephone number (in hint text for example), [Ofcom maintains a list of numbers](https://www.ofcom.org.uk/phones-telecoms-and-internet/information-for-industry/numbering/numbers-for-drama) that are reserved for use in media. These are:
 
@@ -56,7 +56,7 @@ Tell users why you might contact them and when.
 
 ### Don’t display telephone numbers as links on devices that can’t make calls
 
-It’s possible to mark up telephone numbers as links, like this: 
+It’s possible to mark up telephone numbers as links, like this:
 
 ```
 <a href="tel:+442079476330">020 7947 6330</a>

--- a/src/styles/images/index.md.njk
+++ b/src/styles/images/index.md.njk
@@ -16,19 +16,19 @@ Avoid unnecessary decoration. Only use images if there’s a real user need.
 
 The aspect ratio for photographs should be 3:2.
 
-{{ example({group: 'styles', item: 'images', example: 'default', html: false, open: false}) }}
+{{ example({group: "styles", item: "images", example: "default", html: false, open: false}) }}
 
 
 ### Illustrations or representative imagery
 
 If your image represents something physical, such as a letter, document or credit card you should use the aspect ratio of that item.
 
-{{ example({group: 'styles', item: 'images', example: 'representative', html: false, open: false}) }}
+{{ example({group: "styles", item: "images", example: "representative", html: false, open: false}) }}
 
 ## Alt text
 
 All images must have an alt tag. You should include a description of the image inside the tag to help users who are unable to see it.
 
-{{ example({group: 'styles', item: 'images', example: 'alt-text', html: true, open: true}) }}
+{{ example({group: "styles", item: "images", example: "alt-text", html: true, open: true}) }}
 
 If your image is purely decorative and a description would be confusing you should still include the alt tag, but leave it empty so it will be ignored by screen readers.

--- a/src/styles/layout/common-two-thirds-one-third/index.njk
+++ b/src/styles/layout/common-two-thirds-one-third/index.njk
@@ -6,7 +6,10 @@ layout: layout-example.njk
 {% from "back-link/macro.njk" import govukBackLink %}
 
 <div class="govuk-width-container">
-  {{ govukBackLink({href: '#', text: 'Back'}) }}
+  {{ govukBackLink({
+    href: "#",
+    text: "Back"
+  }) }}
   <main class="govuk-main-wrapper">
 
     <div class="govuk-grid-row">

--- a/src/styles/layout/common-two-thirds-two-thirds-one-third/index.njk
+++ b/src/styles/layout/common-two-thirds-two-thirds-one-third/index.njk
@@ -6,7 +6,10 @@ layout: layout-example.njk
 {% from "back-link/macro.njk" import govukBackLink %}
 
 <div class="govuk-width-container">
-  {{ govukBackLink({href: '#', text: 'Back'}) }}
+  {{ govukBackLink({
+    href: "#",
+    text: "Back"
+  }) }}
   <main class="govuk-main-wrapper">
 
     <div class="govuk-grid-row">

--- a/src/styles/layout/common-two-thirds/index.njk
+++ b/src/styles/layout/common-two-thirds/index.njk
@@ -6,7 +6,10 @@ layout: layout-example.njk
 {% from "back-link/macro.njk" import govukBackLink %}
 
 <div class="govuk-width-container">
-  {{ govukBackLink({href: '#', text: 'Back'}) }}
+  {{ govukBackLink({
+    href: "#",
+    text: "Back"
+  }) }}
   <main class="govuk-main-wrapper">
 
     <div class="govuk-grid-row">

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -22,16 +22,16 @@ The default maximum page width is 1020px, but you can make it wider if your cont
 
 ### Two-thirds
 
-{{ example({group: 'styles', item: 'layout', example: 'common-two-thirds', html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "common-two-thirds", html: true, open: true}) }}
 
 ### Two-thirds / One-third
 
-{{ example({group: 'styles', item: 'layout', example: 'common-two-thirds-one-third', html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "common-two-thirds-one-third", html: true, open: true}) }}
 
 
 ### Row 1: Two-thirds <br>Row 2: Two-thirds / One-third
 
-{{ example({group: 'styles', item: 'layout', example: 'common-two-thirds-two-thirds-one-third', html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "common-two-thirds-two-thirds-one-third", html: true, open: true}) }}
 
 
 ## Building your own layout
@@ -52,13 +52,13 @@ Within `govuk-width-container` you should add the `govuk-main-wrapper` class to 
 
 ### Exploded view of page wrappers
 
-{{ example({group: 'styles', item: 'layout', example: 'layout-wrappers', html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "layout-wrappers", html: true, open: true}) }}
 
 ### Exploded view of page wrappers without back link, breadcrumbs or phase Banner
 
 If you’re not using the [breadcrumbs](../../components/breadcrumbs), [back link](../../components/back-link) or [phase banner](../../components/phase-banner) components in your design, use a modifier class `govuk-main-wrapper--l` to increase the vertical space above the content.
 
-{{ example({group: 'styles', item: 'layout', example: 'layout-wrappers-l', html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "layout-wrappers-l", html: true, open: true}) }}
 
 ## <a name="grid-system"></a>Grid system
 
@@ -78,28 +78,28 @@ The available widths are:
 
 ### Full width
 
-{{ example({group: 'styles', item: 'layout', example: 'full-width', html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "full-width", html: true, open: true}) }}
 
 ### One-half
 
-{{ example({group: 'styles', item: 'layout', example: 'one-half', html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "one-half", html: true, open: true}) }}
 
 ### One-third
 
-{{ example({group: 'styles', item: 'layout', example: 'one-third', html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "one-third", html: true, open: true}) }}
 
 ### Two-thirds
 
-{{ example({group: 'styles', item: 'layout', example: 'two-thirds', html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "two-thirds", html: true, open: true}) }}
 
 ### One-quarter
 
-{{ example({group: 'styles', item: 'layout', example: 'one-quarter', html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "one-quarter", html: true, open: true}) }}
 
 ### Example combinations
 
-{{ example({group: 'styles', item: 'layout', example: 'combinations', html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "combinations", html: true, open: true}) }}
 
 ### Nested grids
 
-{{ example({group: 'styles', item: 'layout', example: 'nested', html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "nested", html: true, open: true}) }}

--- a/src/styles/layout/layout-wrappers/index.njk
+++ b/src/styles/layout/layout-wrappers/index.njk
@@ -9,7 +9,10 @@ stylesheets:
 {% from "back-link/macro.njk" import govukBackLink %}
 
 <div class="govuk-width-container">
-  {{ govukBackLink({href: '#', text: 'Back'}) }}
+  {{ govukBackLink({
+    href: "#",
+    text: "Back"
+  }) }}
   <main class="govuk-main-wrapper">
 
     <div class="govuk-grid-row">

--- a/src/styles/page-template/block-areas/index.njk
+++ b/src/styles/page-template/block-areas/index.njk
@@ -10,7 +10,7 @@ stylesheets:
 {% set bodyClasses = "app-example-page" %}
 
 {% block head -%}
-  {# Since we're not extending the Design System layout we need to add this manually #}
+  {# Since we’re not extending the Design System layout we need to add this manually #}
   <meta name="robots" content="noindex, nofollow">
 
   <!--[if !IE 8]><!-->
@@ -61,7 +61,7 @@ stylesheets:
   <div class="app-annotate-block">
     <span class="app-annotate-block__label">block: beforeContent</span>
     {{ super() }}
-    {% from 'back-link/macro.njk' import govukBackLink %}
+    {% from "back-link/macro.njk" import govukBackLink %}
 
     {{ govukBackLink({
       href: "/",
@@ -89,7 +89,7 @@ stylesheets:
   <div class="app-annotate-block">
     <span class="app-annotate-block__label">block: bodyEnd</span>
     {{ super() }}
-    {# Since we're not extending the Design System layout we need to add this manually #}
+    {# Since we’re not extending the Design System layout we need to add this manually #}
     <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
     <script src="/{{ fingerprint['javascripts/govuk-frontend.js'] }}"></script>
   </div>

--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -13,13 +13,13 @@ layout: false
 
 {% extends "template.njk" %}
 
-{% set htmlClasses = 'app-html-class' %}
-{% set htmlLang = 'fr' %}
-{% set assetPath = '' %}
-{% set themeColor = 'blue' %}
-{% set bodyClasses = 'app-body-class' %}
+{% set htmlClasses = "app-html-class" %}
+{% set htmlLang = "fr" %}
+{% set assetPath = "" %}
+{% set themeColor = "blue" %}
+{% set bodyClasses = "app-body-class" %}
 
-{% block pageTitle %}GOV.UK - Le meilleur endroit pour trouver des services gouvernementaux et de l'information{% endblock %}
+{% block pageTitle %}GOV.UK - Le meilleur endroit pour trouver des services gouvernementaux et de l’information{% endblock %}
 
 {% block headIcons %}
     {{ super() }}
@@ -47,8 +47,8 @@ layout: false
 
 {% block skipLink %}
   {{ govukSkipLink({
-    href: '#main-content',
-    text: 'Passer au contenu principal'
+    href: "#main-content",
+    text: "Passer au contenu principal"
   }) }}
 {% endblock %}
 
@@ -60,23 +60,23 @@ layout: false
     serviceUrl: "#",
     navigation: [
       {
-        href: '#1',
-        text: 'Élément de navigation 1',
+        href: "#1",
+        text: "Élément de navigation 1",
         active: true
       },
       {
-        href: '#2',
-        text: 'Élément de navigation 2'
+        href: "#2",
+        text: "Élément de navigation 2"
       },
       {
-        href: '#3',
-        text: 'Élément de navigation 3'
+        href: "#3",
+        text: "Élément de navigation 3"
       }
     ]
   }) }}
 {% endblock %}
 
-{% set mainClasses = 'app-main-class' %}
+{% set mainClasses = "app-main-class" %}
 
 {% block main %}
   {{ super() }}
@@ -87,11 +87,11 @@ layout: false
     tag: {
       text: "alpha"
     },
-    html: 'C\'est un nouveau service - vos <a class="govuk-link" href="#">commentaires</a> nous aideront à l\'améliorer.'
+    html: 'C’est un nouveau service - vos <a class="govuk-link" href="#">commentaires</a> nous aideront à l’améliorer.'
   }) }}
   {{ govukBackLink({
-    "href": "#",
-    "text": "Retourner"
+    href: "#",
+    text: "Retourner"
   }) }}
 {% endblock %}
 
@@ -101,19 +101,19 @@ layout: false
 
 {% block footer %}
   {{ govukFooter({
-    "meta": {
-      "items": [
+    meta: {
+      items: [
         {
-          "href": "#1",
-          "text": "Aidez-moi"
+          href: "#1",
+          text: "Aidez-moi"
         },
         {
-          "href": "#2",
-          "text": "Politique de confidentialité"
+          href: "#2",
+          text: "Politique de confidentialité"
         },
         {
-          "href": "#3",
-          "text": "Contactez-nous"
+          href: "#3",
+          text: "Contactez-nous"
         }
       ]
     }

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -13,13 +13,13 @@ layout: false
 
 {% extends "template.njk" %}
 
-{% set htmlClasses = 'app-html-class' %}
-{% set htmlLang = 'fr' %}
-{% set assetPath = '' %}
-{% set themeColor = 'blue' %}
-{% set bodyClasses = 'app-body-class' %}
+{% set htmlClasses = "app-html-class" %}
+{% set htmlLang = "fr" %}
+{% set assetPath = "" %}
+{% set themeColor = "blue" %}
+{% set bodyClasses = "app-body-class" %}
 
-{% block pageTitle %}GOV.UK - Le meilleur endroit pour trouver des services gouvernementaux et de l'information{% endblock %}
+{% block pageTitle %}GOV.UK - Le meilleur endroit pour trouver des services gouvernementaux et de l’information{% endblock %}
 
 {% block headIcons %}
     {{ super() }}
@@ -42,8 +42,8 @@ layout: false
 
 {% block skipLink %}
   {{ govukSkipLink({
-    href: '#main-content',
-    text: 'Passer au contenu principal'
+    href: "#main-content",
+    text: "Passer au contenu principal"
   }) }}
 {% endblock %}
 
@@ -55,23 +55,23 @@ layout: false
     serviceUrl: "#",
     navigation: [
       {
-        href: '#1',
-        text: 'Élément de navigation 1',
+        href: "#1",
+        text: "Élément de navigation 1",
         active: true
       },
       {
-        href: '#2',
-        text: 'Élément de navigation 2'
+        href: "#2",
+        text: "Élément de navigation 2"
       },
       {
-        href: '#3',
-        text: 'Élément de navigation 3'
+        href: "#3",
+        text: "Élément de navigation 3"
       }
     ]
   }) }}
 {% endblock %}
 
-{% set mainClasses = 'app-main-class' %}
+{% set mainClasses = "app-main-class" %}
 
 {% block main %}
   {{ super() }}
@@ -82,11 +82,11 @@ layout: false
     tag: {
       text: "alpha"
     },
-    html: 'C\'est un nouveau service - vos <a class="govuk-link" href="#">commentaires</a> nous aideront à l\'améliorer.'
+    html: 'C’est un nouveau service - vos <a class="govuk-link" href="#">commentaires</a> nous aideront à l’améliorer.'
   }) }}
   {{ govukBackLink({
-    "href": "#",
-    "text": "Retourner"
+    href: "#",
+    text: "Retourner"
   }) }}
 {% endblock %}
 
@@ -96,19 +96,19 @@ layout: false
 
 {% block footer %}
   {{ govukFooter({
-    "meta": {
-      "items": [
+    meta: {
+      items: [
         {
-          "href": "#1",
-          "text": "Aidez-moi"
+          href: "#1",
+          text: "Aidez-moi"
         },
         {
-          "href": "#2",
-          "text": "Politique de confidentialité"
+          href: "#2",
+          text: "Politique de confidentialité"
         },
         {
-          "href": "#3",
-          "text": "Contactez-nous"
+          href: "#3",
+          text: "Contactez-nous"
         }
       ]
     }

--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -17,29 +17,29 @@ This page template combines the boilerplate markup and [components](../../compon
 
 In the examples provided, we show both HTML and Nunjucks.
 
-You can use the HTML examples if you aren't able to use Nunjucks. If you use HTML you'll need to update it manually when new versions are released.
+You can use the HTML examples if you aren’t able to use Nunjucks. If you use HTML you’ll need to update it manually when new versions are released.
 
-If you are using Nunjucks you can get this page template by installing GOV.UK Frontend, you'll get updates to the page template when we update GOV.UK Frontend.
+If you are using Nunjucks you can get this page template by installing GOV.UK Frontend, you’ll get updates to the page template when we update GOV.UK Frontend.
 
 ## Default
 
 This example shows the minimum required for a GOV.UK page.
 
-{{ example({group: 'styles', item: 'page-template', example: 'default', customCode: true, html: true, nunjucks: true, open: false }) }}
+{{ example({group: "styles", item: "page-template", example: "default", customCode: true, html: true, nunjucks: true, open: false }) }}
 
 ## Customised page template
 
-{{ example({group: 'styles', item: 'page-template', example: 'custom', customCode: true, html: true, nunjucks: true, open: false }) }}
+{{ example({group: "styles", item: "page-template", example: "custom", customCode: true, html: true, nunjucks: true, open: false }) }}
 
 ## Nunjucks
 
 
 ### Configuring Nunjucks
 
-When using Nunjucks you'll need to add `node_modules/govuk-frontend/` as an available view:
+When using Nunjucks you’ll need to add `node_modules/govuk-frontend/` as an available view:
 
 ```
-nunjucks.configure('node_modules/govuk-frontend/', {
+nunjucks.configure("node_modules/govuk-frontend/", {
   autoescape: true
 })
 ```
@@ -127,7 +127,7 @@ To change the components that are included by default, set their equivalent bloc
 {% raw %}
 {% block header %}
   {{ header({
-    homepageUrl: '/custom-url'
+    homepageUrl: "/custom-url"
   }) }}
 {% endblock %}
 {% endraw %}
@@ -225,4 +225,4 @@ To change the components that are included by default, set their equivalent bloc
 
 #### Exploded view of the page template block areas
 
-{{ example({group: 'styles', item: 'page-template', example: 'block-areas', html: false, open: false }) }}
+{{ example({group: "styles", item: "page-template", example: "block-areas", html: false, open: false }) }}

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -97,9 +97,9 @@ The last part of the class represents the value you want to apply. For example, 
 
 ### Examples
 
-{{ example({group: 'styles', item: 'spacing', example: 'spacing-scale-padding', html: true, open: false}) }}
+{{ example({group: "styles", item: "spacing", example: "spacing-scale-padding", html: true, open: false}) }}
 
-{{ example({group: 'styles', item: 'spacing', example: 'spacing-scale-margin', html: true, open: false}) }}
+{{ example({group: "styles", item: "spacing", example: "spacing-scale-margin", html: true, open: false}) }}
 
 ## Spacing on custom components
 
@@ -126,4 +126,4 @@ If you need to constrain the width of an element independently of the [grid syst
 
 As with the spacing override classes the width override classes start with `govuk-!-`. The second part of the class name signifies the width on larger screen sizes. For example, `govuk-!-width-one-half`  will apply a width of 50% and `govuk-!-width-two-thirds`will apply a width of 66.66%.
 
-{{ example({group: 'styles', item: 'spacing', example: 'input-width', html: true, open: true}) }}
+{{ example({group: "styles", item: "spacing", example: "input-width", html: true, open: true}) }}

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -24,13 +24,13 @@ Markup headings semantically using the appropriate <h#> level HTML element and u
 
 Write all headings in sentence case.
 
-{{ example({group: 'styles', item: 'typography', example: 'headings', html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "headings", html: true, open: true}) }}
 
 ### Headings with captions
 
 Sometimes you may need to make it clear that a heading is part of a larger section or group. To do this, you can use a heading with a caption.
 
-{{ example({group: 'styles', item: 'typography', example: 'captions', html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "captions", html: true, open: true}) }}
 
 ## Paragraphs
 
@@ -38,7 +38,7 @@ Sometimes you may need to make it clear that a heading is part of a larger secti
 
 The default paragraph font size is 19px on large screens and 16px on small screens.
 
-{{ example({group: 'styles', item: 'typography', example: 'body', html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "body", html: true, open: true}) }}
 
 You can also add classes to create a lead paragraph or smaller body copy to convey hierarchy in your page.
 
@@ -46,7 +46,7 @@ You can also add classes to create a lead paragraph or smaller body copy to conv
 
 A lead paragraph is an introductory paragraph that you can use at the top of a page to summarise the content. Lead paragraphs use 24px type on desktop and should only be used once per page if needed.
 
-{{ example({group: 'styles', item: 'typography', example: 'lead', html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "lead", html: true, open: true}) }}
 
 ### Body small
 
@@ -54,7 +54,7 @@ You can use the `govuk-body-s` class sparingly to make your paragraph font size 
 
 The majority of your body copy should use the standard 19px paragraph size.
 
-{{ example({group: 'styles', item: 'typography', example: 'small', html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "small", html: true, open: true}) }}
 
 ## Font override classes
 
@@ -64,35 +64,35 @@ You might need to set the font size or font weight of an element outside of the 
 
 The full GOV.UK typography scale goes from 14px up to 80px on large screens. You can add these font size override classes to any other typographic class or element and they will change the font size.
 
-{{ example({group: 'styles', item: 'typography', example: 'font-size', html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "font-size", html: true, open: true}) }}
 
 ### Font weight
 
 As with the font size, you can add a font weight override class to any other typographic class or element to change the font weight to regular or bold weight.
 
-{{ example({group: 'styles', item: 'typography', example: 'font-weight', html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "font-weight", html: true, open: true}) }}
 
 ## Links
 
 Links are blue and underlined by default. If your link is at the end of a sentence or paragraph, make sure that the linked text doesn’t include the full stop.
 
-{{ example({group: 'styles', item: 'typography', example: 'link', html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "link", html: true, open: true}) }}
 
 Use the `govuk-link--no-visited-state` modifier class where it is not helpful to distinguish between visited and unvisited states, for example when linking to pages with frequently-changing content such as the dashboard for an admin interface.
 
-{{ example({group: 'styles', item: 'typography', example: 'link-no-visited-state', html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "link-no-visited-state", html: true, open: true}) }}
 
 ## Lists
 
 Use lists to make blocks of text easier to read, and to break information into manageable chunks.
 
-{{ example({group: 'styles', item: 'typography', example: 'list', html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "list", html: true, open: true}) }}
 
 ### Bulleted lists
 
 Introduce bulleted lists with a lead-in line ending in a colon. Start each item with a lowercase letter, and don’t use a full stop at the end.
 
-{{ example({group: 'styles', item: 'typography', example: 'list-bullet', html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "list-bullet", html: true, open: true}) }}
 
 ### Numbered lists
 
@@ -100,7 +100,7 @@ Use numbered lists instead of bulleted lists when the order of the items is rele
 
 You don’t need to use a lead-in line for numbered lists. Items in a numbered list should end in a full stop because each should be a complete sentence.
 
-{{ example({group: 'styles', item: 'typography', example: 'list-number', html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "list-number", html: true, open: true}) }}
 
 ## Section break
 
@@ -108,4 +108,4 @@ You can use the `govuk-section-break` classes on an `<hr>` element to create a t
 
 By default `govuk-section-break` is only visible by its margin. You can add the `govuk-section-break--visible` class to make it visible with a separator line.
 
-{{ example({group: 'styles', item: 'typography', example: 'section-break', html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "section-break", html: true, open: true}) }}


### PR DESCRIPTION
1. Nunjucks code is formatted consistently using straight double quotes:
```
{% from "macro.njk" import function %}

{{ function({
  attribute: "value"
}) }}
```
Exceptions:
- when having straight double quotes inside the string: e.g. `html: '<a href="#">'`
- when having a boolean value

2. The published guidance is formatted consistently using opening/closing single and double quotes instead of straight single and double quotes.

This PR along with https://github.com/alphagov/govuk-frontend/pull/830 are fixing https://github.com/alphagov/govuk-frontend/issues/756

[Trello card](https://trello.com/c/nOCjRleu)