### PR TITLE
Fix invalid HTML

### DIFF
--- a/src/get-started/updating-your-code/index.md.njk
+++ b/src/get-started/updating-your-code/index.md.njk
@@ -76,12 +76,10 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the skip link by rendering your own,
           which can include custom <code>text</code>
         </p>
-        <p>
-          <pre><code>{% raw %}
+        <pre><code>{% raw %}
 {% block skipLink %}
   {{ govukSkipLink({ text: "custom text" }) }}
 {% endblock %}{% endraw %}</code></pre>
-        </p>
         <p>
           See the <a class="govuk-link" href="../../components/skip-link">skip link component</a> for more details.
         </p>
@@ -100,12 +98,10 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the header component by rendering your own,
           which can include custom <code>classes</code>
         </p>
-        <p>
-          <pre><code>{% raw %}
+        <pre><code>{% raw %}
 {% block header %}
     {{ govukHeader({ classes: "app-custom-classes" }) }}
 {% endblock %}{% endraw %}</code></pre>
-        </p>
         <p>
           See the <a class="govuk-link" href="../../components/header">header component</a> for more details.
         </p>
@@ -119,12 +115,10 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the header component by rendering your own,
           which can include custom <code>homepageUrl</code>
         </p>
-        <p>
-          <pre><code>{% raw %}
+        <pre><code>{% raw %}
 {% block header %}
     {{ govukHeader({ homepageUrl: "/custom-url" }) }}
 {% endblock %}{% endraw %}</code></pre>
-        </p>
         <p>
           See the <a class="govuk-link" href="../../components/header">header component</a> for more details.
         </p>
@@ -145,12 +139,10 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the header component by rendering your own,
           which can include a custom <code>serviceName</code>
         </p>
-        <p>
-          <pre><code>{% raw %}
+        <pre><code>{% raw %}
 {% block header %}
     {{ govukHeader({ serviceName: "Custom service name" }) }}
 {% endblock %}{% endraw %}</code></pre>
-        </p>
         <p>
           See the <a class="govuk-link" href="../../components/header">header component</a> for more details.
         </p>
@@ -164,12 +156,10 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the header component by rendering your own,
           which can include a custom <code>navigation</code>
         </p>
-        <p>
-          <pre><code>{% raw %}
+        <pre><code>{% raw %}
 {% block header %}
     {{ govukHeader({ navigation: [] }) }}
 {% endblock %}{% endraw %}</code></pre>
-        </p>
         <p>
           See the <a class="govuk-link" href="../../components/header">header component</a> for more details.
         </p>
@@ -206,12 +196,10 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the footer component by rendering your own,
           which can include a custom <code>navigation</code>
         </p>
-        <p>
-          <pre><code>{% raw %}
+        <pre><code>{% raw %}
 {% block header %}
     {{ govukFooter({ navigation: [] }) }}
 {% endblock %}{% endraw %}</code></pre>
-        </p>
         <p>
           See the <a class="govuk-link" href="../../components/footer">footer component</a> for more details.
         </p>
@@ -225,12 +213,10 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the footer component by rendering your own,
           which can include custom <code>meta</code> links
         </p>
-        <p>
-          <pre><code>{% raw %}
+        <pre><code>{% raw %}
 {% block header %}
     {{ govukFooter({ meta: [] }) }}
 {% endblock %}{% endraw %}</code></pre>
-        </p>
         <p>
           See the <a class="govuk-link" href="../../components/footer">footer component</a> for more details.
         </p>

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -47,4 +47,5 @@
     </main>
     {% include "_footer.njk" %}
   </div>
+</div>
 {% endblock %}

--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -10,8 +10,9 @@
         </li>
 
         {% for theme, items in item.items | groupby("theme") %}
+        <li>
           {% if theme != 'undefined' %}
-            <h4 class="app-mobile-nav__theme">{{ theme }}</h4>
+          <h4 class="app-mobile-nav__theme">{{ theme }}</h4>
           {% endif %}
           <ul class="app-mobile-nav__theme-nav">
           {% for subitem in items %}
@@ -20,6 +21,7 @@
             </li>
           {% endfor %}
           </ul>
+        </li>
         {% endfor %}
 
       </ul>


### PR DESCRIPTION
- Close unclosed `<div class="app-pane__body">` in layout-pane
- Nest ‘theme’ navigation within a `<li>` list item, rather than directly inside the `<ul>`
- Remove `<p>` tags wrapping a `<pre>` which is not valid as both are block-level elements.