### PR TITLE
Set overflow: hidden on app pane wrapper

### DIFF
--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -4,6 +4,7 @@
 
   .app-pane.app-pane--enabled {
     $pane-height: 100vh;
+    overflow: hidden;
 
     @include govuk-media-query($from: tablet) {
       display: flex;
@@ -76,6 +77,7 @@
   .no-flexbox {
     .app-pane {
       height: auto;
+      overflow: visible;
       @include govuk-clearfix;
     }
 


### PR DESCRIPTION
Fixes #373 (again) - where in Safari it’s possible to scroll ‘past’ the end of the page.