### PR TITLE
Remove duplicated shiv and unnecessary feature detects from Modernizr

### DIFF
--- a/config/modernizr.json
+++ b/config/modernizr.json
@@ -5,8 +5,6 @@
     "setClasses"
   ],
   "feature-detects": [
-    "test/history",
-    "test/css/flexbox",
-    "test/css/flexboxtweener"
+    "test/css/flexbox"
   ]
 }

--- a/config/modernizr.json
+++ b/config/modernizr.json
@@ -1,7 +1,6 @@
 {
   "minify": true,
   "options": [
-    "html5printshiv",
     "setClasses"
   ],
   "feature-detects": [


### PR DESCRIPTION
We don't use these feature detects, and we already bundle up a separate shiv in the IE8 javascript. This halves the size of the Modernizr javascript from a whopping 9.0KB (4.3KB gzipped) to 4.5KB (2.1KB gzipped)