### PR TITLE
Set sensible default iframe sizes for non-javascript users

### DIFF
--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Let users select one or more options by using the checkboxes component.
 
-{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ## When to use this component
 
@@ -28,13 +28,13 @@ Don’t use the checkboxes component if users can only choose one option from a 
 
 There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: true, size: "m"}) }}
 
 ### Conditionally revealing content
 
 You can add conditionally revealing content to checkboxes, so users only see content when it’s relevant to them. For example, you could reveal a phone number input only when a user chooses to be contacted by phone.
 
-{{ example({group: "components", item: "checkboxes", example: "conditional-reveal", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "checkboxes", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 Keep it simple - if you need to add a lot of content, consider showing it on the next page in the process instead.
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use the date input component to help users enter a memorable date.
 
-{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ## When to use this component
 
@@ -29,7 +29,7 @@ The date input component consists of 3 fields to let users enter a day, month an
 
 There are 2 ways to use the date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
 
 Don’t automatically tab users between the fields of the Date input because this can be confusing and may clash with normal keyboard controls.
 
@@ -37,7 +37,7 @@ Don’t automatically tab users between the fields of the Date input because thi
 
 Check that a valid date is entered by the user. Invalid dates should be reported to the user like this:
 
-{{ example({group: "components", item: "date-input", example: "error", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "date-input", example: "error", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ## Research on this component
 

--- a/src/components/details/index.md.njk
+++ b/src/components/details/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Make a page easier to scan by letting users reveal more detailed information only if they need it.
 
-{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ## When to use this component
 
@@ -27,7 +27,7 @@ The details component is a short link that expands into more detailed help text 
 
 There are 2 ways to use the details component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
 
 ### Write clear link text
 

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use an error message when a there is a validation error. Explain what went wrong and how to fix it.
 
-{{ example({group: "components", item: "error-message", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "error-message", example: "default", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ## When to use this component
 
@@ -49,11 +49,11 @@ There are 2 ways to use the error message component. You can use HTML or, if you
 
 ### Legend
 
-{{ example({group: "components", item: "error-message", example: "legend", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "error-message", example: "legend", html: true, nunjucks: true, open: true, size: "m"}) }}
 
 ### Label
 
-{{ example({group: "components", item: "error-message", example: "label", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "error-message", example: "label", html: true, nunjucks: true, open: true, size: "s"}) }}
 
 ### Be clear and concise
 

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use an error summary when a there is a validation error. The error summary uses the error message that explains what went wrong and how to fix it.
 
-{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ## When to use this component
 
@@ -30,7 +30,7 @@ You must:
 
 There are 2 ways to use the error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
 
 ## Research on this component
 

--- a/src/components/fieldset/index.md.njk
+++ b/src/components/fieldset/index.md.njk
@@ -17,7 +17,7 @@ Use the fieldset component to group related form inputs.
 
 Use the fieldset component when you need to show a relationship between multiple form inputs. For example, you may need to group a set of text inputs into a single fieldset when [asking for an address](../../patterns/addresses).
 
-{{ example({group: "components", item: "fieldset", example: "address-group", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "fieldset", example: "address-group", html: true, nunjucks: true, open: true, size: "xl"}) }}
 
 If you’re using the examples or macros for [radios](../radios), [checkboxes](../checkboxes) or [date input](../date-input), the fieldset will already be included.
 

--- a/src/components/footer/index.md.njk
+++ b/src/components/footer/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 The footer provides copyright, licensing and other information about your service and department.
 
-{{ example({group: "components", item: "footer", example: "default", id: "default-1", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "footer", example: "default", id: "default-1", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ## When to use this component
 
@@ -27,21 +27,21 @@ You can add links to:
 
 ### Default footer
 
-{{ example({group: "components", item: "footer", example: "default", id: "default-2", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "footer", example: "default", id: "default-2", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ### Footer with secondary navigation
 
-{{ example({group: "components", item: "footer", example: "with-navigation", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "footer", example: "with-navigation", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 ### Footer with links to meta information
 
 You can also include links to meta information about a site, like cookies and contact details in the footer, like this:
 
-{{ example({group: "components", item: "footer", example: "with-meta", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "footer", example: "with-meta", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ### Footer with secondary navigation and links to meta information
 
-{{ example({group: "components", item: "footer", example: "full", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "footer", example: "full", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 ## Research on this component
 

--- a/src/components/header/index.md.njk
+++ b/src/components/header/index.md.njk
@@ -43,7 +43,7 @@ Use the header with a service name if your service is more than 5 pages long - t
 
 Use the header with navigation if you need to include basic navigation, contact or account management links.
 
-{{ example({group: "components", item: "header", example: "with-service-name-and-navigation", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "header", example: "with-service-name-and-navigation", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ## Research on this component
 

--- a/src/components/inset-text/index.md.njk
+++ b/src/components/inset-text/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "components", item: "inset-text", example: "default"}) }}
+{{ example({group: "components", item: "inset-text", example: "default", size: "s"}) }}
 
 ## When to use this component
 
@@ -31,7 +31,7 @@ Use inset text very sparingly - it’s less effective if it’s overused.
 
 There are 2 ways to use the inset text component. You can use HTML or, if you’re using Nunjucks or the GOV.UK Prototype Kit, you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
 
 ## Research on this component
 

--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 The panel component is a visible container used on confirmation or results pages to highlight important content.
 
-{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ## When to use this component
 
@@ -27,7 +27,7 @@ Don’t use the panel component to highlight important information within body c
 
 There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: true, size: "m"}) }}
 
 ## Research on this component
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ## When to use this component
 
@@ -27,19 +27,19 @@ There are 2 ways to use the radios component. You can use HTML or, if you are us
 
 When there are more than 2 options, radios should be stacked, like so:
 
-{{ example({group: "components", item: "radios", example: "stacked", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "radios", example: "stacked", html: true, nunjucks: true, open: true, size: "m"}) }}
 
 ### Inline radios
 
 If there are only 2 options, you can either stack the radios or display them inline, like so:
 
-{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
 
 ### Conditionally revealing content
 
 You can add conditionally revealing content to radios, so users only see content when it’s relevant to them. For example, you could reveal an email address input only when a user chooses to be contacted by email.
 
-{{ example({group: "components", item: "radios", example: "conditional-reveal", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "radios", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 Keep it simple - if you need to add a lot of content, consider showing it on the next page in the process instead.
 

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use the table component to make information easier to compare and scan for users.
 
-{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ## When to use this component
 
@@ -33,13 +33,13 @@ Use table headers to tell users what the rows and columns represent. Use the `sc
 
 There are 2 ways to use the table component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: true, size: "m"}) }}
 
 ## Numbers in a table
 
 When comparing columns of numbers, align the numbers to the right in table cells.
 
-{{ example({group: "components", item: "table", example: "numbers", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "table", example: "numbers", html: true, nunjucks: true, open: true, size: "m"}) }}
 
 ## Research on this component
 

--- a/src/components/tabs/index.md.njk
+++ b/src/components/tabs/index.md.njk
@@ -13,7 +13,7 @@ statusMessage: This component is currently experimental because <a class="govuk-
 
 The tabs component lets users navigate between related sections of content, displaying one section at a time.
 
-{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 ## When to use this component
 
@@ -47,7 +47,7 @@ Test your content without tabs first. Consider if it’s better to:
 
 There are 2 ways to use the tabs component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: true, size: "xl"}) }}
 
 More research is needed on the best way to display the tabs component on small screen sizes.
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ## When to use this component
 
@@ -23,7 +23,7 @@ Don’t use the text input component if you need to let users enter longer answe
 
 There are 2 ways to use the text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
 
 ### Label text inputs
 
@@ -45,7 +45,7 @@ Use fixed width inputs for content that has a specific, known length. Postcode i
 
 On fixed width inputs, the width will remain fixed on all screens unless it is wider than the viewport, in which case it will shrink to fit.
 
-{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "input-fixed-width", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "input-fixed-width", html: true, nunjucks: true, open: false, size: "l"}) }}
 
 #### Fluid width inputs
 
@@ -53,13 +53,13 @@ Use the width override classes to reduce the width of an input in relation to it
 
 Fluid width inputs will resize with the viewport.
 
-{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "input-fluid-width", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "input-fluid-width", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 ### Using hint text
 
 Use hint for help that’s relevant to the majority of users - like how their information will be used, or where to find it.
 
-{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "input-hint-text", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ### Don’t disable copy and paste
 

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ## When to use this component
 
@@ -23,7 +23,7 @@ Don’t use the textarea component if you need to let users enter shorter answer
 
 There are 2 ways to use the textarea component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: true, size: "m"}) }}
 
 ### Label textareas
 
@@ -35,7 +35,7 @@ Labels must be aligned above the textarea they refer to. They should be short, d
 
 Make the height of a textarea proportional to the amount of text you expect users to enter. You can set the height of a textarea by by specifying the `rows` attribute.
 
-{{ example({group: "components", item: "textarea", example: "specifying-rows", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "textarea", example: "specifying-rows", html: true, nunjucks: true, open: true, size: "l"}) }}
 
 ### Don’t disable copy and paste
 

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -42,7 +42,7 @@ When using an address lookup, you should:
 
 ## Multiple text inputs
 
-{{ example({group: "patterns", item: "addresses", example: "multiple", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "addresses", example: "multiple", html: true, nunjucks: true, open: true, size: "xl"}) }}
 
 ### When to use multiple text inputs
 
@@ -75,7 +75,7 @@ Royal Mail doesn’t need a county as long as the town and postcode are included
 
 ## Textarea
 
-{{ example({group: "patterns", item: "addresses", example: "textarea", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "addresses", example: "textarea", html: true, nunjucks: true, open: true, size: "s"}) }}
 
 ### When to use textarea
 

--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -12,7 +12,7 @@ layout: layout-pane.njk
 
 Let users know they’ve completed a transaction.
 
-{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 ## When to use this pattern
 
@@ -31,7 +31,7 @@ Your confirmation page must include:
 - a link to your feedback page
 - a way for users to save a record of the transaction, for example, as a PDF
 
-{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: true, size: "xl"}) }}
 
 ### Help users who bookmark the page
 

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -12,7 +12,7 @@ layout: layout-pane.njk
 
 Help users enter or select a date.
 
-{{ example({group: "patterns", item: "dates", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "dates", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ## When to use this pattern
 
@@ -34,7 +34,7 @@ In some cases you might need users to pick a date from a given selection.
 
 Ask for memorable dates, like dates of birth, using the [date input](../../components/date-input) component.
 
-{{ example({group: "patterns", item: "dates", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "dates", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
 
 ### Asking for dates from documents and cards
 

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "patterns", item: "email-addresses", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "email-addresses", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ## When to use this pattern
 
@@ -26,7 +26,7 @@ When asking users for their email address, you must:
 
 You may also need to check that users have access to the email account they give you.
 
-{{ example({group: "patterns", item: "email-addresses", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "email-addresses", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
 
 ### Make the field long enough
 

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -12,7 +12,7 @@ layout: layout-pane.njk
 
 Ask users to provide their National Insurance number.
 
-{{ example({group: "patterns", item: "national-insurance-numbers", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "national-insurance-numbers", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ## When to use this pattern
 
@@ -34,7 +34,7 @@ You should:
 - allow upper and lower case letters and strip out spaces before validating
 - avoid using ‘AB 12 34 56 C’ as an example because it belongs to a real person and use ‘QQ 12 34 56 C’ instead
 
-{{ example({group: "patterns", item: "national-insurance-numbers", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "national-insurance-numbers", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
 
 ## Research on this pattern
 

--- a/src/patterns/page-not-found-pages/index.md.njk
+++ b/src/patterns/page-not-found-pages/index.md.njk
@@ -14,7 +14,7 @@ statusMessage: This pattern is currently experimental because <a class="govuk-li
 
 A page not found tells someone we cannot find the page they were trying to view. They are also known as 404 pages.
 
-{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true}) }}
+{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true, size: "xl"}) }}
 
 ## When to use this pattern
 
@@ -57,15 +57,15 @@ Do not use:
 
 ### Service mistake
 
-{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true}) }}
+{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true, size: "xl"}) }}
 
 ### User mistake
 
-{{ example({group: "patterns", item: "page-not-found-pages", example: "user-mistake", html: true}) }}
+{{ example({group: "patterns", item: "page-not-found-pages", example: "user-mistake", html: true, size: "l"}) }}
 
 ### If you do not know why the page is not found
 
-{{ example({group: "patterns", item: "page-not-found-pages", example: "reason-not-known", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "page-not-found-pages", example: "reason-not-known", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 When a user submits the form, take them to a confirmation page which has:
 

--- a/src/patterns/problem-with-the-service-pages/index.md.njk
+++ b/src/patterns/problem-with-the-service-pages/index.md.njk
@@ -13,7 +13,7 @@ statusMessage: This pattern is currently experimental because <a class="govuk-li
 
 This is a page that tells someone there is something wrong with the service. They are also known as 500 and internal server error pages.
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, open: false}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, open: false, size: "l"}) }}
 
 ## When to use this pattern
 
@@ -48,15 +48,15 @@ Have clear and concise content and do not use:
 
 ### Service has a specific page that includes numbers and opening times
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, open: false}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, open: false, size: "l"}) }}
 
 ### Service has offline support but no specific page that includes numbers and opening times
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "offline-support", html: true, open: false}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "offline-support", html: true, open: false, size: "xl"}) }}
 
 ### A link to another service
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "link-to-another-service", html: true, open: false}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "link-to-another-service", html: true, open: false, size: "l"}) }}
 
 ## Research on this pattern
 

--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -29,7 +29,7 @@ You should validate telephone numbers so you can let users know if they have ent
 
 Validation errors should be styled like this:
 
-{{ example({group: "patterns", item: "telephone-numbers", example: "error-empty-field", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "telephone-numbers", example: "error-empty-field", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 Some examples of common error messages are:
 
@@ -42,7 +42,7 @@ Some examples of common error messages are:
 ### Make it clear what type of telephone number you need
 Use the form label or hint text to tell users if you specifically need a UK, international or mobile telephone number.
 
-{{ example({group: "patterns", item: "telephone-numbers", example: "international", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "telephone-numbers", example: "international", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ### Using example telephone numbers
 If you wish to include an example telephone number (in hint text for example), [Ofcom maintains a list of numbers](https://www.ofcom.org.uk/phones-telecoms-and-internet/information-for-industry/numbering/numbers-for-drama) that are reserved for use in media. These are:

--- a/src/styles/images/index.md.njk
+++ b/src/styles/images/index.md.njk
@@ -16,19 +16,19 @@ Avoid unnecessary decoration. Only use images if there’s a real user need.
 
 The aspect ratio for photographs should be 3:2.
 
-{{ example({group: "styles", item: "images", example: "default", html: false, open: false}) }}
+{{ example({group: "styles", item: "images", example: "default", html: false, open: false, size: "l"}) }}
 
 
 ### Illustrations or representative imagery
 
 If your image represents something physical, such as a letter, document or credit card you should use the aspect ratio of that item.
 
-{{ example({group: "styles", item: "images", example: "representative", html: false, open: false}) }}
+{{ example({group: "styles", item: "images", example: "representative", html: false, open: false, size: "l"}) }}
 
 ## Alt text
 
 All images must have an alt tag. You should include a description of the image inside the tag to help users who are unable to see it.
 
-{{ example({group: "styles", item: "images", example: "alt-text", html: true, open: true}) }}
+{{ example({group: "styles", item: "images", example: "alt-text", html: true, open: true, size: "l"}) }}
 
 If your image is purely decorative and a description would be confusing you should still include the alt tag, but leave it empty so it will be ignored by screen readers.

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -22,16 +22,16 @@ The default maximum page width is 1020px, but you can make it wider if your cont
 
 ### Two-thirds
 
-{{ example({group: "styles", item: "layout", example: "common-two-thirds", html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "common-two-thirds", html: true, open: true, size: "m"}) }}
 
 ### Two-thirds / One-third
 
-{{ example({group: "styles", item: "layout", example: "common-two-thirds-one-third", html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "common-two-thirds-one-third", html: true, open: true, size: "m"}) }}
 
 
 ### Row 1: Two-thirds <br>Row 2: Two-thirds / One-third
 
-{{ example({group: "styles", item: "layout", example: "common-two-thirds-two-thirds-one-third", html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "common-two-thirds-two-thirds-one-third", html: true, open: true, size: "l"}) }}
 
 
 ## Building your own layout
@@ -52,13 +52,13 @@ Within `govuk-width-container` you should add the `govuk-main-wrapper` class to 
 
 ### Exploded view of page wrappers
 
-{{ example({group: "styles", item: "layout", example: "layout-wrappers", html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "layout-wrappers", html: true, open: true, size: "l"}) }}
 
 ### Exploded view of page wrappers without back link, breadcrumbs or phase Banner
 
 If you’re not using the [breadcrumbs](../../components/breadcrumbs), [back link](../../components/back-link) or [phase banner](../../components/phase-banner) components in your design, use a modifier class `govuk-main-wrapper--l` to increase the vertical space above the content.
 
-{{ example({group: "styles", item: "layout", example: "layout-wrappers-l", html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "layout-wrappers-l", html: true, open: true, size: "l"}) }}
 
 ## <a name="grid-system"></a>Grid system
 
@@ -78,28 +78,28 @@ The available widths are:
 
 ### Full width
 
-{{ example({group: "styles", item: "layout", example: "full-width", html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "full-width", html: true, open: true, size: "s"}) }}
 
 ### One-half
 
-{{ example({group: "styles", item: "layout", example: "one-half", html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "one-half", html: true, open: true, size: "s"}) }}
 
 ### One-third
 
-{{ example({group: "styles", item: "layout", example: "one-third", html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "one-third", html: true, open: true, size: "s"}) }}
 
 ### Two-thirds
 
-{{ example({group: "styles", item: "layout", example: "two-thirds", html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "two-thirds", html: true, open: true, size: "s"}) }}
 
 ### One-quarter
 
-{{ example({group: "styles", item: "layout", example: "one-quarter", html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "one-quarter", html: true, open: true, size: "s"}) }}
 
 ### Example combinations
 
-{{ example({group: "styles", item: "layout", example: "combinations", html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "combinations", html: true, open: true, size: "xl"}) }}
 
 ### Nested grids
 
-{{ example({group: "styles", item: "layout", example: "nested", html: true, open: true}) }}
+{{ example({group: "styles", item: "layout", example: "nested", html: true, open: true, size: "m"}) }}

--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -25,13 +25,13 @@ If you are using Nunjucks you can get this page template by installing GOV.UK Fr
 
 This example shows the minimum required for a GOV.UK page.
 
-{{ example({group: "styles", item: "page-template", example: "default", customCode: true, html: true, nunjucks: true, open: false }) }}
+{{ example({group: "styles", item: "page-template", example: "default", customCode: true, html: true, nunjucks: true, open: false, size: "l" }) }}
 
 ## Customised page template
 
 You can customise the page template, for example, by adding a service name and navigation or adding a block before the main contain to include a [back link](../../components/back-link/) or [phase banner](../../components/phase-banner/).
 
-{{ example({group: "styles", item: "page-template", example: "custom", customCode: true, html: true, nunjucks: true, open: false }) }}
+{{ example({group: "styles", item: "page-template", example: "custom", customCode: true, html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 ## Nunjucks
 

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -97,9 +97,9 @@ The last part of the class represents the value you want to apply. For example, 
 
 ### Examples
 
-{{ example({group: "styles", item: "spacing", example: "spacing-scale-padding", html: true, open: false}) }}
+{{ example({group: "styles", item: "spacing", example: "spacing-scale-padding", html: true, open: false, size: "l"}) }}
 
-{{ example({group: "styles", item: "spacing", example: "spacing-scale-margin", html: true, open: false}) }}
+{{ example({group: "styles", item: "spacing", example: "spacing-scale-margin", html: true, open: false, size: "xl"}) }}
 
 ## Spacing on custom components
 
@@ -126,4 +126,4 @@ If you need to constrain the width of an element independently of the [grid syst
 
 As with the spacing override classes the width override classes start with `govuk-!-`. The second part of the class name signifies the width on larger screen sizes. For example, `govuk-!-width-one-half`  will apply a width of 50% and `govuk-!-width-two-thirds`will apply a width of 66.66%.
 
-{{ example({group: "styles", item: "spacing", example: "input-width", html: true, open: true}) }}
+{{ example({group: "styles", item: "spacing", example: "input-width", html: true, open: true, size: "xl"}) }}

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -24,13 +24,13 @@ Markup headings semantically using the appropriate <h#> level HTML element and u
 
 Write all headings in sentence case.
 
-{{ example({group: "styles", item: "typography", example: "headings", html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "headings", html: true, open: true, size: "m"}) }}
 
 ### Headings with captions
 
 Sometimes you may need to make it clear that a heading is part of a larger section or group. To do this, you can use a heading with a caption.
 
-{{ example({group: "styles", item: "typography", example: "captions", html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "captions", html: true, open: true, size: "l"}) }}
 
 ## Paragraphs
 
@@ -64,7 +64,7 @@ You might need to set the font size or font weight of an element outside of the 
 
 The full GOV.UK typography scale goes from 14px up to 80px on large screens. You can add these font size override classes to any other typographic class or element and they will change the font size.
 
-{{ example({group: "styles", item: "typography", example: "font-size", html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "font-size", html: true, open: true, size: "xl"}) }}
 
 ### Font weight
 
@@ -86,13 +86,13 @@ Use the `govuk-link--no-visited-state` modifier class where it is not helpful to
 
 Use lists to make blocks of text easier to read, and to break information into manageable chunks.
 
-{{ example({group: "styles", item: "typography", example: "list", html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "list", html: true, open: true, size: "s"}) }}
 
 ### Bulleted lists
 
 Introduce bulleted lists with a lead-in line ending in a colon. Start each item with a lowercase letter, and don’t use a full stop at the end.
 
-{{ example({group: "styles", item: "typography", example: "list-bullet", html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "list-bullet", html: true, open: true, size: "s"}) }}
 
 ### Numbered lists
 
@@ -100,7 +100,7 @@ Use numbered lists instead of bulleted lists when the order of the items is rele
 
 You don’t need to use a lead-in line for numbered lists. Items in a numbered list should end in a full stop because each should be a complete sentence.
 
-{{ example({group: "styles", item: "typography", example: "list-number", html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "list-number", html: true, open: true, size: "s"}) }}
 
 ## Section break
 
@@ -108,4 +108,4 @@ You can use the `govuk-section-break` classes on an `<hr>` element to create a t
 
 By default `govuk-section-break` is only visible by its margin. You can add the `govuk-section-break--visible` class to make it visible with a separator line.
 
-{{ example({group: "styles", item: "typography", example: "section-break", html: true, open: true}) }}
+{{ example({group: "styles", item: "typography", example: "section-break", html: true, open: true, size: "m"}) }}

--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -43,6 +43,28 @@
   background: govuk-colour("white");
 }
 
+// Default size
+.app-example__iframe,
+.app-example__frame--xs {
+  height: 150px;
+}
+
+.app-example__frame--s {
+  height: 250px;
+}
+
+.app-example__frame--m {
+  height: 350px;
+}
+
+.app-example__frame--l {
+  height: 450px;
+}
+
+.app-example__frame--xl {
+  height: 550px;
+}
+
 .app-example__frame--resizable {
   min-width: 230px;
   min-height: govuk-spacing(6) * 2;

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -24,7 +24,7 @@
         example in a new window
       </a>
     </span>
-    <iframe title="{{ exampleTitle }}" class="app-example__frame app-example__frame--resizable js-example__frame" src="{{ exampleURL }}" frameBorder="0"></iframe>
+    <iframe title="{{ exampleTitle }}" class="app-example__frame app-example__frame--resizable js-example__frame{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0"></iframe>
   </div>
 
   {%- if (multipleTabs) %}


### PR DESCRIPTION
For users that have disabled JavaScript, or when JavaScript fails to execute, the iframe sizer will not work which means iframes will all be sized to 150px (the default size for an iframe) regardless of their content.

The iframes are resizable, but we can provide a better experience for these users by setting a better 'default' size for each example.

https://trello.com/c/3hKfCmwo/1201-use-sensible-default-example-size-when-javascript-is-disabled