### PR TITLE
Add sitemap with alias support

### DIFF
--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -46,6 +46,10 @@ module.exports = function () {
               if (frontmatter.order) {
                 subitem.order = frontmatter.order
               }
+              if (frontmatter.aliases) {
+                subitem.aliases = frontmatter.aliases.split(',').map(string => string.trim())
+              }
+
               // add subitem to navigation
               navigation[item].items.push(subitem)
             }

--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -2,7 +2,7 @@
 title: Back link
 description: Use the back link component to help users go back to the previous page in a multi-page transaction
 section: Components
-aliases:
+aliases: return link, back button
 backlog_issue_id: 32
 layout: layout-pane.njk
 ---

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -2,7 +2,7 @@
 title: Checkboxes
 description: Let users select one or more options by using the Checkboxes component
 section: Components
-aliases:
+aliases: check boxes, tickboxes, tick boxes
 backlog_issue_id: 37
 layout: layout-pane.njk
 ---

--- a/src/components/details/index.md.njk
+++ b/src/components/details/index.md.njk
@@ -2,7 +2,7 @@
 title: Details
 description: Make a page easier to scan by letting users reveal more detailed information only if they need it
 section: Components
-aliases:
+aliases: reveal, progressive disclosure, hidden text
 backlog_issue_id: 44
 layout: layout-pane.njk
 ---

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -2,7 +2,7 @@
 title: Error message
 description: Use an error message when a there is a validation error. Explain what went wrong and how to fix it
 section: Components
-aliases:
+aliases: validation message
 backlog_issue_id: 47
 layout: layout-pane.njk
 ---

--- a/src/components/fieldset/index.md.njk
+++ b/src/components/fieldset/index.md.njk
@@ -2,7 +2,7 @@
 title: Fieldset
 description: Use the fieldset component to group related form inputs
 section: Components
-aliases:
+aliases: form group
 backlog_issue_id: 48
 layout: layout-pane.njk
 ---

--- a/src/components/inset-text/index.md.njk
+++ b/src/components/inset-text/index.md.njk
@@ -2,7 +2,7 @@
 title: Inset text
 description: Use the inset text component to differentiate a block of text from the content that surrounds it
 section: Components
-aliases:
+aliases: highlighted text, callout
 backlog_issue_id: 136
 layout: layout-pane.njk
 ---

--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -2,7 +2,7 @@
 title: Panel
 description: The panel component is a visible container used on confirmation or results pages
 section: Components
-aliases:
+aliases: confirmation box, results box
 backlog_issue_id: 55
 layout: layout-pane.njk
 ---

--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -2,7 +2,7 @@
 title: Phase banner
 description: Use the phase banner component to show users your service is still being worked on
 section: Components
-aliases:
+aliases: alpha banner, beta banner, prototype banner, status banner
 backlog_issue_id: 57
 layout: layout-pane.njk
 ---

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -2,7 +2,7 @@
 title: Radios
 description: Let users select a single option from a list using the radios component
 section: Components
-aliases:
+aliases: radio buttons, option buttons
 backlog_issue_id: 59
 layout: layout-pane.njk
 ---

--- a/src/components/select/index.md.njk
+++ b/src/components/select/index.md.njk
@@ -1,8 +1,8 @@
 ---
 title: Select
-description: Help users select an item from a dropdown list
+description: Help users select an item from a list
 section: Components
-aliases:
+aliases: drop down menu, list box, drop down list, combo box, pop-up menu
 backlog_issue_id: 60
 layout: layout-pane.njk
 ---

--- a/src/components/skip-link/index.md.njk
+++ b/src/components/skip-link/index.md.njk
@@ -2,7 +2,7 @@
 title: Skip link
 description: Use the skip link component to help keyboard-only users skip to the main content on a page
 section: Components
-aliases:
+aliases: Skip navigation link
 backlog_issue_id: 66
 layout: layout-pane.njk
 ---

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -2,7 +2,7 @@
 title: Tag
 description: The tag component indicates the status of something, such as an item on a task list or a phase banner
 section: Components
-aliases:
+aliases: chip, badge, flag, token
 backlog_issue_id: 62
 layout: layout-pane.njk
 ---

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -2,7 +2,7 @@
 title: Text input
 description: Help users enter information with the text input component
 section: Components
-aliases:
+aliases: text box, text field, input field, text entry box
 backlog_issue_id: 51
 layout: layout-pane.njk
 ---

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -2,7 +2,7 @@
 title: Textarea
 description: Help users provide detailed information using the textarea component
 section: Components
-aliases:
+aliases: multi-line text box, multi-line text field
 backlog_issue_id: 65
 layout: layout-pane.njk
 ---

--- a/src/components/warning-text/index.md.njk
+++ b/src/components/warning-text/index.md.njk
@@ -2,7 +2,7 @@
 title: Warning text
 description: Use the warning text component when you need to warn users about something important, such as legal consequences of an action, or lack of action, that they might take
 section: Components
-aliases:
+aliases: important text, legal text
 backlog_issue_id: 71
 layout: layout-pane.njk
 ---

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -1,0 +1,7 @@
+---
+title: Sitemap
+description: Overview of the GOV.UK Design System
+layout: layout-sitemap.njk
+---
+{# We have to generate the sitemap in the layout because we don't have access
+to the navigation when evaluating 'inplace' nunjucks #}

--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -2,7 +2,7 @@
 title: Colour
 description: Always use the GOV.UK colour palette
 section: Styles
-aliases:
+aliases: palette
 backlog_issue_id: 38
 layout: layout-pane.njk
 ---

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -2,7 +2,7 @@
 title: Layout
 description: Organise the layout of the page into blocks
 section: Styles
-aliases:
+aliases: grid
 backlog_issue_id:
 layout: layout-pane.njk
 ---

--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -2,6 +2,7 @@
 title: Page template
 description: Template combines the boilerplate markup and components needed for a basic GOV.UK page
 section: Styles
+aliases: boilerplate
 layout: layout-pane.njk
 ---
 

--- a/views/layouts/layout-sitemap.njk
+++ b/views/layouts/layout-sitemap.njk
@@ -3,7 +3,7 @@
 {% set contents %}
   <h1 class="govuk-heading-xl">Sitemap</h1>
   {% for item in navigation %}
-    <h2 class="govuk-heading-l"><a class="govuk-link govuk-link--text-colour" href="/{{ item.url }}">{{ item.label }}</a></h2>
+    <h2 class="govuk-heading-l"><a class="govuk-link" href="/{{ item.url }}">{{ item.label }}</a></h2>
     {% if item.items %}
       {% for theme, items in item.items | groupby("theme") %}
         {% if theme != 'undefined' %}

--- a/views/layouts/layout-sitemap.njk
+++ b/views/layouts/layout-sitemap.njk
@@ -13,6 +13,9 @@
         {% for subitem in items %}
           <li class="govuk-!-margin-bottom-2">
             <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
+            {% if subitem.aliases %}
+              &mdash; also known as {% for alias in subitem.aliases %}{{ ", " if not (loop.first or loop.last) }}{{ " or " if loop.last and loop.length > 1 }}{{ alias | lower }}{% endfor %}
+            {% endif %}
           </li>
         {% endfor %}
         </ul>

--- a/views/layouts/layout-sitemap.njk
+++ b/views/layouts/layout-sitemap.njk
@@ -1,0 +1,22 @@
+{% extends "layout-single-page.njk" %}
+
+{% set contents %}
+  <h1 class="govuk-heading-xl">Sitemap</h1>
+  {% for item in navigation %}
+    <h2 class="govuk-heading-l"><a class="govuk-link govuk-link--text-colour" href="/{{ item.url }}">{{ item.label }}</a></h2>
+    {% if item.items %}
+      {% for theme, items in item.items | groupby("theme") %}
+        {% if theme != 'undefined' %}
+          <h2 class="govuk-heading-m">{{ theme }}</h2>
+        {% endif %}
+        <ul class="govuk-list">
+        {% for subitem in items %}
+          <li class="govuk-!-margin-bottom-2">
+            <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
+          </li>
+        {% endfor %}
+        </ul>
+      {% endfor %}
+    {% endif %}
+  {% endfor %}
+{% endset %}

--- a/views/partials/_footer.njk
+++ b/views/partials/_footer.njk
@@ -22,6 +22,10 @@
   "meta": {
     "items": [
       {
+        "href": "/sitemap",
+        "text": "Sitemap"
+      },
+      {
         "href": "/cookies",
         "text": "Cookies"
       },


### PR DESCRIPTION
Adds a sitemap at `/sitemap` which lists out the contents of the Design System along with common aliases for some of the pages (for example, some users may refer to the Select component as a 'drop-down menu'.

These aliases will eventually be exposed as part of a client-side search feature, but this allows us to make this information available now, and may also eventually act as the 'fallback' for users without javascript enabled.

![localhost_3000_sitemap_ 1](https://user-images.githubusercontent.com/121939/42993317-fa7666d2-8c02-11e8-880a-9cee8819c5e3.png)

https://trello.com/c/UnL6P9mM/1193-develop-site-map-page-with-aliases