### PR TITLE
Update 'pages' examples to include the header and footer; use beforeContent and content blocks correctly

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -33,7 +33,16 @@ exports.getNunjucksCode = path => {
   let fileContents = this.getFileContents(path)
 
   let parsedFile = matter(fileContents)
-  return parsedFile.content
+
+  // Omit any `{% extends "foo.njk" %}` nunjucks code, because we extend
+  // templates that only exist within the Design System – it's not useful to
+  // include this in the code we expect others to copy.
+  let content = parsedFile.content.replace(
+    /{%\s*extends\s*\S*\s*%}\s+/,
+    ''
+  )
+
+  return content
 }
 
 // This helper function takes a path of a *.md.njk file and

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -1,11 +1,15 @@
 'use strict'
 
+const paths = require('../config/paths.json')
+
 const fs = require('fs')
 const path = require('path')
 const nunjucks = require('nunjucks')
 const matter = require('gray-matter')
 
 const beautify = require('js-beautify').html
+
+nunjucks.configure(paths.layouts)
 
 // This helper function takes a path of a file and
 // returns the contents as string

--- a/src/patterns/confirmation-pages/default/index.njk
+++ b/src/patterns/confirmation-pages/default/index.njk
@@ -1,32 +1,35 @@
 ---
 title: Confirmation pages
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ---
+
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
 {% from "panel/macro.njk" import govukPanel %}
 
-<div class="govuk-width-container">
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukPanel({
+        titleText: "Application complete",
+        html: "Your reference number<br><strong>HDJ2123F</strong>"
+      }) }}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        {{ govukPanel({
-          headingLevel: 1,
-          titleText: "Application complete",
-          html: "Your reference number<br><strong>HDJ2123F</strong>"
-        }) }}
+      <p class="govuk-body">We have sent you a confirmation email.</p>
 
-        <p class="govuk-body">We have sent you a confirmation email.</p>
+      <h3 class="govuk-heading-m">What happens next</h3>
 
-        <h3 class="govuk-heading-m">What happens next</h3>
+      <p class="govuk-body">
+        We’ve sent your application to Hackney Electoral Register Office.
+      </p>
+      <p class="govuk-body">
+        They will contact you either to confirm your registration, or to ask for more information.
+      </p>
 
-        <p class="govuk-body">We’ve sent your application to Hackney Electoral Register Office.</p>
-
-        <p class="govuk-body">They will contact you either to confirm your registration, or to ask for more information.</p>
-
-        <p class="govuk-body"><a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)</p>
-      </div>
+      <p class="govuk-body">
+        <a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+      </p>
     </div>
   </div>
-
-</div>
+{% endblock %}

--- a/src/patterns/page-not-found-pages/default/index.njk
+++ b/src/patterns/page-not-found-pages/default/index.njk
@@ -1,33 +1,41 @@
 ---
 title: Page not found pages
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ---
 
-<div class="govuk-width-container">
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">Page not found</h1>
-        <p class="govuk-body">We have reported this to the team that manages the service and they will fix it as soon as possible.</p>
-        <p class="govuk-body">Contact us if you need to speak to someone about your tax credits.</p>
-        <p class="govuk-body">Telephone:<br>
+        <p class="govuk-body">
+          We have reported this to the team that manages the service and they will fix it as soon as possible.
+        </p>
+        <p class="govuk-body">
+          Contact us if you need to speak to someone about your tax credits.
+        </p>
+        <p class="govuk-body">
+          Telephone:<br>
           <strong class="govuk-!-font-weight-bold">0808 157 3900</strong>
         </p>
-        <p class="govuk-body">Textphone:<br>
+        <p class="govuk-body">
+          Textphone:<br>
           <strong class="govuk-!-font-weight-bold">0808 157 3909</strong>
         </p>
-        <p class="govuk-body">Outside UK:<br>
+        <p class="govuk-body">
+          Outside UK:<br>
           <strong class="govuk-!-font-weight-bold">+44 0808 157 0192</strong>
         </p>
-        <p class="govuk-body">Opening times:<br>
+        <p class="govuk-body">
+          Opening times:<br>
           <strong class="govuk-!-font-weight-bold">Monday to Friday: 8am to 8pm</strong>
         </p>
-        <p class="govuk-body">Closed Easter Sunday, Christmas Day, Boxing Day and New Year’s Day.</p>
-
+        <p class="govuk-body">
+          Closed Easter Sunday, Christmas Day, Boxing Day and New Year’s Day.
+        </p>
       </div>
     </div>
   </div>
-
-</div>
+{% endblock %}

--- a/src/patterns/page-not-found-pages/reason-not-known/index.njk
+++ b/src/patterns/page-not-found-pages/reason-not-known/index.njk
@@ -1,51 +1,57 @@
 ---
 title: Reason not known – Page not found pages
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
+
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
 {% from "input/macro.njk" import govukInput %}
 {% from "button/macro.njk" import govukButton %}
 
-<div class="govuk-width-container">
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Page not found</h1>
+      <p class="govuk-body">
+        If you typed the web address, check it is correct.
+      </p>
+      <p class="govuk-body">
+        If you pasted the web address, check you copied the entire address.
+      </p>
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">
+        If the web address is correct or you selected a link or button, you can:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><a class="govuk-list" href="#">contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits</li>
+        <li>report the page not found</li>
+      </ul>
 
-        <h1 class="govuk-heading-xl">Page not found</h1>
-        <p class="govuk-body">If you typed the web address, check it is correct.</p>
-        <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
-        <p class="govuk-body">If the web address is correct or you selected a link or button, you can:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li><a class="govuk-list" href="#">contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits</li>
-          <li>report the page not found</li>
-        </ul>
-        <p class="govuk-body">If you want us to tell you when we have fixed the link or button, give us your name and email address.</p>
-        <form action="/form-handler" method="post">
-          {{ govukInput({
-            label: {
-              text: "Name (optional)"
-            },
-            id: "name",
-            name: "name"
-          }) }}
+      <p class="govuk-body">If you want us to tell you when we have fixed the link or button, give us your name and email address.</p>
+      <form action="/form-handler" method="post">
+        {{ govukInput({
+          label: {
+            text: "Name (optional)"
+          },
+          id: "name",
+          name: "name"
+        }) }}
 
-          {{ govukInput({
-            label: {
-              text: "Email address"
-            },
-            id: "email",
-            name: "email",
-            type: "email"
-          }) }}
+        {{ govukInput({
+          label: {
+            text: "Email address"
+          },
+          id: "email",
+          name: "email",
+          type: "email"
+        }) }}
 
-          {{ govukButton({
-            text: "Report a page not found"
-          }) }}
-        </form>
-      </div>
+        {{ govukButton({
+          text: "Report a page not found"
+        }) }}
+      </form>
     </div>
   </div>
-
-</div>
+{% endblock %}

--- a/src/patterns/page-not-found-pages/user-mistake/index.njk
+++ b/src/patterns/page-not-found-pages/user-mistake/index.njk
@@ -1,22 +1,25 @@
 ---
 title: User mistake – Page not found pages
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
 
-<div class="govuk-width-container">
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
-        <h1 class="govuk-heading-xl">Page not found</h1>
-        <p class="govuk-body">If you typed the web address, check it is correct.</p>
-        <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
-        <p class="govuk-body"><a class="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits.</p>
-
-      </div>
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Page not found</h1>
+      <p class="govuk-body">
+        If you typed the web address, check it is correct.
+      </p>
+      <p class="govuk-body">
+        If you pasted the web address, check you copied the entire address.
+      </p>
+      <p class="govuk-body">
+        <a class="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits.
+      </p>
     </div>
   </div>
-
-</div>
+{% endblock %}

--- a/src/patterns/problem-with-the-service-pages/default/index.njk
+++ b/src/patterns/problem-with-the-service-pages/default/index.njk
@@ -1,21 +1,20 @@
 ---
 title: Service has a specific page that includes numbers and opening times
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ---
 
-<div class="govuk-width-container">
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
       <p class="govuk-body">Try again later.</p>
       <p class="govuk-body">We saved your answers. They will be available for 30 days.</p>
-      <p class="govuk-body"><a class="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.</p>
-
-      </div>
+      <p class="govuk-body">
+        <a class="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
+      </p>
     </div>
   </div>
-
-</div>
+{% endblock %}

--- a/src/patterns/problem-with-the-service-pages/link-to-another-service/index.njk
+++ b/src/patterns/problem-with-the-service-pages/link-to-another-service/index.njk
@@ -1,22 +1,23 @@
 ---
 title: A link to another service
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
 
-<div class="govuk-width-container">
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
       <p class="govuk-body">Try again later.</p>
-      <p class="govuk-body">You can <a class="govuk-link" href="#">change other VAT details</a>.</p>
-      <p class="govuk-body"><a class="govuk-link" href="#">Contact the Income Tax Helpline</a> if you need to speak to someone about your tax calculation.</p>
-
-      </div>
+      <p class="govuk-body">
+        You can <a class="govuk-link" href="#">change other VAT details</a>.
+      </p>
+      <p class="govuk-body">
+        <a class="govuk-link" href="#">Contact the Income Tax Helpline</a> if you need to speak to someone about your tax calculation.
+      </p>
     </div>
   </div>
-
-</div>
+{% endblock %}

--- a/src/patterns/problem-with-the-service-pages/offline-support/index.njk
+++ b/src/patterns/problem-with-the-service-pages/offline-support/index.njk
@@ -1,35 +1,42 @@
 ---
 title: Service has offline support but no specific page that includes numbers and opening times
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
 
-<div class="govuk-width-container">
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
       <p class="govuk-body">Try again later.</p>
-      <p class="govuk-body">We have not saved your answers. When the service is available, you will have to start again.</p>
-      <p class="govuk-body">Contact the Tax Credit Helpline if you have any questions.</p>
-      <p class="govuk-body">Telephone:><br>
+      <p class="govuk-body">
+        We have not saved your answers. When the service is available, you will have to start again.
+      </p>
+      <p class="govuk-body">
+        Contact the Tax Credit Helpline if you have any questions.
+      </p>
+      <p class="govuk-body">
+        Telephone:><br>
         <strong class="govuk-!-font-weight-bold">0808 157 3900</strong>
       </p>
-      <p class="govuk-body">Textphone:<br>
+      <p class="govuk-body">
+        Textphone:<br>
         <strong class="govuk-!-font-weight-bold">0808 157 3909</strong>
       </p>
-      <p class="govuk-body">Outside UK:<br>
+      <p class="govuk-body">
+        Outside UK:<br>
         <strong class="govuk-!-font-weight-bold">+44 0808 157 0192</strong>
       </p>
-      <p class="govuk-body">Opening times:<br>
+      <p class="govuk-body">
+        Opening times:<br>
         <strong class="govuk-!-font-weight-bold">Monday to Friday: 8am to 8pm</strong>
       </p>
-      <p class="govuk-body">Closed Easter Sunday, Christmas Day, Boxing Day and New Year’s Day.</p>
-
-      </div>
+      <p class="govuk-body">
+        Closed Easter Sunday, Christmas Day, Boxing Day and New Year’s Day.
+      </p>
     </div>
   </div>
-
-</div>
+{% endblock %}

--- a/src/patterns/question-pages/default/index.njk
+++ b/src/patterns/question-pages/default/index.njk
@@ -1,56 +1,55 @@
 ---
 title: Question pages
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ---
+
+{% extends "example-wrappers/full-page.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "date-input/macro.njk" import govukDateInput %}
 {% from "button/macro.njk" import govukButton %}
 
-<div class="govuk-width-container">
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back"
+  }) }}
+{% endblock %}
 
-{{ govukBackLink({
-  text: "Back"
-}) }}
-
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <form action="/form-handler" method="post">
-
-          {{ govukDateInput({
-            id: "dob",
-            name: "dob",
-            fieldset: {
-              legend: {
-                text: "What is your date of birth?",
-                isPageHeading: true,
-                classes: "govuk-fieldset__legend--xl"
-              }
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="/form-handler" method="post">
+        {{ govukDateInput({
+          id: "dob",
+          name: "dob",
+          fieldset: {
+            legend: {
+              text: "What is your date of birth?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--xl"
+            }
+          },
+          hint: {
+            text: "For example, 31 3 1980"
+          },
+          items: [
+            {
+              name: "day"
             },
-            hint: {
-              text: "For example, 31 3 1980"
+            {
+              name: "month"
             },
-            items: [
-              {
-                name: "day"
-              },
-              {
-                name: "month"
-              },
-              {
-                name: "year"
-              }
-            ]
-            })
-          }}
+            {
+              name: "year"
+            }
+          ]
+          })
+        }}
 
-          {{ govukButton({
-            text: "Continue"
-          }) }}
-        </form>
-
-      </div>
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
     </div>
   </div>
-</div>
+{% endblock %}

--- a/src/patterns/question-pages/passport/index.njk
+++ b/src/patterns/question-pages/passport/index.njk
@@ -1,70 +1,69 @@
 ---
 title: Passport – Question pages
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
+
+{% extends "example-wrappers/full-page.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "input/macro.njk" import govukInput %}
 {% from "date-input/macro.njk" import govukDateInput %}
 {% from "button/macro.njk" import govukButton %}
 
-<div class="govuk-width-container">
-
+{% block beforeContent %}
   {{ govukBackLink({
     text: "Back"
   }) }}
+{% endblock %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">Passport details</h1>
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Passport details</h1>
 
-        <form action="/form-handler" method="post">
+      <form action="/form-handler" method="post">
 
-          {{ govukInput({
-            label: {
-              text: "Passport number",
-              classes: "govuk-label--m"
+        {{ govukInput({
+          label: {
+            text: "Passport number",
+            classes: "govuk-label--m"
+          },
+          hint: {
+            text: "For example, 502135326"
+          },
+          id: "passport-number",
+          name: "passport-number"
+        }) }}
+
+        {{ govukDateInput({
+          id: "expiry",
+          name: "expiry",
+          fieldset: {
+            legend: {
+              text: "Expiry date",
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          hint: {
+            text: "For example, 31 3 1980"
+          },
+          items: [
+            {
+              name: "month"
             },
-            hint: {
-              text: "For example, 502135326"
-            },
-            id: "passport-number",
-            name: "passport-number"
-          }) }}
+            {
+              name: "year"
+            }
+          ]
+          })
+        }}
 
-          {{ govukDateInput({
-            id: "expiry",
-            name: "expiry",
-            fieldset: {
-              legend: {
-                text: "Expiry date",
-                classes: "govuk-fieldset__legend--m"
-              }
-            },
-            hint: {
-              text: "For example, 31 3 1980"
-            },
-            items: [
-              {
-                name: "month"
-              },
-              {
-                name: "year"
-              }
-            ]
-            })
-          }}
+        {{ govukButton({
+          text: "Continue"
+        }) }}
 
-          {{ govukButton({
-            text: "Continue"
-          }) }}
-
-        </form>
-
-      </div>
+      </form>
     </div>
   </div>
-
-</div>
+{% endblock %}

--- a/src/patterns/question-pages/postcode/index.njk
+++ b/src/patterns/question-pages/postcode/index.njk
@@ -1,42 +1,40 @@
 ---
 title: Postcode – Question pages
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
+
+{% extends "example-wrappers/full-page.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "input/macro.njk" import govukInput %}
 {% from "button/macro.njk" import govukButton %}
 
-<div class="govuk-width-container">
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back"
+  }) }}
+{% endblock %}
 
-{{ govukBackLink({
-  text: "Back"
-}) }}
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form action="/form-handler" method="post">
+      {{ govukInput({
+        label: {
+          text: "What is your home postcode?",
+          isPageHeading: true,
+          classes: "govuk-label--xl"
+        },
+        classes: "govuk-input--width-10",
+        id: "postcode",
+        name: "postcode"
+      }) }}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
-        <form action="/form-handler" method="post">
-
-          {{ govukInput({
-            label: {
-              text: "What is your home postcode?",
-              isPageHeading: true,
-              classes: "govuk-label--xl"
-            },
-            classes: "govuk-input--width-10",
-            id: "postcode",
-            name: "postcode"
-          }) }}
-
-          {{ govukButton({
-            text: "Continue"
-          }) }}
-        </form>
-
-      </div>
-    </div>
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
   </div>
 </div>
+{% endblock %}

--- a/src/patterns/service-unavailable-pages/after-service-closes/index.njk
+++ b/src/patterns/service-unavailable-pages/after-service-closes/index.njk
@@ -1,28 +1,31 @@
 ---
 title: After a service closes
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
 
-<div class="govuk-width-container">
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
-        <h1 class="govuk-heading-xl">Service unavailable</h1>
-        <p class="govuk-body-l">You cannot use the online service to renew your tax credits.</p>
-        <p class="govuk-body"><a class="govuk-link" href="#">Contact the Tax Credit Helpline</a> to renew your tax credits by phone or letter.</p>
-        <p class="govuk-body">You can use the tax credits service to:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>find out more about your payments</li>
-          <li>see who is on your claim</li>
-          <li>make changes to your claim</li>
-          <li>check the status of your renewal</li>
-        </ul>
-
-      </div>
-    </div>
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Service unavailable</h1>
+    <p class="govuk-body-l">
+      You cannot use the online service to renew your tax credits.
+    </p>
+    <p class="govuk-body">
+      <a class="govuk-link" href="#">Contact the Tax Credit Helpline</a> to renew your tax credits by phone or letter.
+    </p>
+    <p class="govuk-body">
+      You can use the tax credits service to:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>find out more about your payments</li>
+      <li>see who is on your claim</li>
+      <li>make changes to your claim</li>
+      <li>check the status of your renewal</li>
+    </ul>
   </div>
-
 </div>
+{% endblock %}

--- a/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
+++ b/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
@@ -1,22 +1,25 @@
 ---
 title: When you know when a service will be available
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
 
-<div class="govuk-width-container">
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
-        <h1 class="govuk-heading-xl">Service unavailable</h1>
-        <p class="govuk-body-l">You will be able to use the service on Monday 19&nbsp;November&nbsp;2018.</p>
-        <p class="govuk-body">We have not saved your answers. When the service is available, you will have to start again.</p>
-        <p class="govuk-body"><a class ="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.</p>
-
-      </div>
-    </div>
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Service unavailable</h1>
+    <p class="govuk-body-l">
+      You will be able to use the service on Monday 19&nbsp;November&nbsp;2018.
+    </p>
+    <p class="govuk-body">
+      We have not saved your answers. When the service is available, you will have to start again.
+    </p>
+    <p class="govuk-body">
+      <a class ="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
+    </p>
   </div>
-
 </div>
+{% endblock %}

--- a/src/patterns/service-unavailable-pages/before-service-opens/index.njk
+++ b/src/patterns/service-unavailable-pages/before-service-opens/index.njk
@@ -1,27 +1,30 @@
 ---
 title: Before a service opens
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
 
-<div class="govuk-width-container">
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
-        <h1 class="govuk-heading-xl">Service unavailable</h1>
-        <p class="govuk-body-l">You will be able renew your tax credits from Tuesday 24&nbsp;April&nbsp;2018.</p>
-        <p class="govuk-body"><a class="govuk-link" href="#">Contact the Tax Credit Helpline</a> to renew your tax credits by phone or letter.</p>
-        <p class="govuk-body">You can <a class="govuk-link" href="#">use the tax credits service</a> to:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>find out more about your payments</li>
-          <li>see who is on your claim</li>
-          <li>make changes to your claim</li>
-        </ul>
-
-      </div>
-    </div>
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Service unavailable</h1>
+    <p class="govuk-body-l">
+      You will be able renew your tax credits from Tuesday 24&nbsp;April&nbsp;2018.
+    </p>
+    <p class="govuk-body"><a class="govuk-link" href="#">
+      Contact the Tax Credit Helpline</a> to renew your tax credits by phone or letter.
+    </p>
+    <p class="govuk-body">
+      You can <a class="govuk-link" href="#">use the tax credits service</a> to:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>find out more about your payments</li>
+      <li>see who is on your claim</li>
+      <li>make changes to your claim</li>
+    </ul>
   </div>
-
 </div>
+{% endblock %}

--- a/src/patterns/service-unavailable-pages/default/index.njk
+++ b/src/patterns/service-unavailable-pages/default/index.njk
@@ -1,21 +1,22 @@
 ---
 title: Service unavailable
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
 
-<div class="govuk-width-container">
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
-        <h1 class="govuk-heading-xl">Service unavailable</h1>
-        <p class="govuk-body-l">You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.</p>
-        <p class="govuk-body"><a class ="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.</p>
-
-      </div>
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Service unavailable</h1>
+      <p class="govuk-body-l">
+        You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.
+      </p>
+      <p class="govuk-body">
+        <a class ="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
+      </p>
     </div>
   </div>
-
-</div>
+{% endblock %}

--- a/src/patterns/service-unavailable-pages/general/index.njk
+++ b/src/patterns/service-unavailable-pages/general/index.njk
@@ -1,22 +1,25 @@
 ---
 title: General page
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
 
-<div class="govuk-width-container">
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
-        <h1 class="govuk-heading-xl">Service unavailable</h1>
-        <p class="govuk-body-l">You will be able to use the service later.</p>
-  	    <p class="govuk-body">We saved your answers. They will be available for 30 days.</p>
-        <p class="govuk-body"><a class="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.</p>
-
-      </div>
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Service unavailable</h1>
+      <p class="govuk-body-l">
+        You will be able to use the service later.
+      </p>
+      <p class="govuk-body">
+        We saved your answers. They will be available for 30 days.
+      </p>
+      <p class="govuk-body"><a class="govuk-link" href="#">
+        Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
+      </p>
     </div>
   </div>
-
-</div>
+{% endblock %}

--- a/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
+++ b/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
@@ -1,22 +1,25 @@
 ---
 title: A link to another service
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
 
-<div class="govuk-width-container">
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
-        <h1 class="govuk-heading-xl">Service unavailable</h1>
-        <p class="govuk-body-l">You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.</p>
-        <p class="govuk-body">You can <a class="govuk-link" href="#">change other VAT details</a>.</p>
-        <p class="govuk-body"><a class="govuk-link" href="#">Contact the Income Tax Helpline</a> if you need to speak to someone about your tax calculation.</p>
-
-      </div>
-    </div>
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Service unavailable</h1>
+    <p class="govuk-body-l">
+      You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.
+    </p>
+    <p class="govuk-body">
+      You can <a class="govuk-link" href="#">change other VAT details</a>.
+    </p>
+    <p class="govuk-body">
+      <a class="govuk-link" href="#">Contact the Income Tax Helpline</a> if you need to speak to someone about your tax calculation.
+    </p>
   </div>
-
 </div>
+{% endblock %}

--- a/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
+++ b/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
@@ -1,27 +1,28 @@
 ---
 title: Nothing has replaced the service
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
 
-<div class="govuk-width-container">
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
-        <h1 class="govuk-heading-xl">Service unavailable</h1>
-        <p class="govuk-body-l">The submit an employment intermediary report service has closed.</p>
-	      <p class="govuk-body">Contact us if you need to speak to someone about the service and your reports.</p>
-        <p class="govuk-body">Telephone:<br>
-          <strong class="govuk-!-font-weight-bold">0808 157 3900</span>
-        </p>
-        <p class="govuk-body">Opening times:<br>
-          <strong class="govuk-!-font-weight-bold">Monday to Friday: 8:30am to 4:30pm</strong>
-        </p>
-
-      </div>
-    </div>
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Service unavailable</h1>
+    <p class="govuk-body-l">
+      The submit an employment intermediary report service has closed.
+    </p>
+    <p class="govuk-body">
+      Contact us if you need to speak to someone about the service and your reports.
+    </p>
+    <p class="govuk-body">Telephone:<br>
+      <strong class="govuk-!-font-weight-bold">0808 157 3900</span>
+    </p>
+    <p class="govuk-body">Opening times:<br>
+      <strong class="govuk-!-font-weight-bold">Monday to Friday: 8:30am to 4:30pm</strong>
+    </p>
   </div>
-
 </div>
+{% endblock %}

--- a/src/patterns/service-unavailable-pages/service-replaced/index.njk
+++ b/src/patterns/service-unavailable-pages/service-replaced/index.njk
@@ -1,27 +1,26 @@
 ---
 title: Something has replaced the service
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
 
-<div class="govuk-width-container">
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
-        <h1 class="govuk-heading-xl">Service unavailable</h1>
-        <p class="govuk-body-l">Universal Credit has replaced tax credits.</p>
-  	    <p class="govuk-body"><a class="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits.</p>
-  	    <p class="govuk-body">You can:</p>
-  	    <ul class="govuk-list govuk-list--bullet">
-  		    <li><a class="govuk-link" href="#">find out more about Universal Credit</a></li>
-  		    <li><a class="govuk-link" href="#">apply for Universal Credit</a></li>
-  		    <li><a class="govuk-link" href="#">sign in to your Universal Credit account</a></li>
-  	    </ul>
-
-      </div>
-    </div>
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Service unavailable</h1>
+    <p class="govuk-body-l">Universal Credit has replaced tax credits.</p>
+    <p class="govuk-body"><a class="govuk-link" href="#">
+      Contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits.
+    </p>
+    <p class="govuk-body">You can:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><a class="govuk-link" href="#">find out more about Universal Credit</a></li>
+      <li><a class="govuk-link" href="#">apply for Universal Credit</a></li>
+      <li><a class="govuk-link" href="#">sign in to your Universal Credit account</a></li>
+    </ul>
   </div>
-
 </div>
+{% endblock %}

--- a/src/patterns/start-pages/default/index.njk
+++ b/src/patterns/start-pages/default/index.njk
@@ -1,15 +1,16 @@
 ---
 title: Start pages
-layout: layout-example.njk
+layout: layout-example-full-page.njk
 stylesheets:
 - related-items.css
 ---
 
+{% extends "example-wrappers/full-page.njk" %}
+
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "button/macro.njk" import govukButton %}
 
-<div class="govuk-width-container">
-
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     items: [
       {
@@ -25,69 +26,67 @@ stylesheets:
       }
     ]
   }) }}
+{% endblock %}
 
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Service name goes here</h1>
 
-        <h1 class="govuk-heading-xl">Service name goes here</h1>
+      <p class="govuk-body">Use this service to:</p>
 
-        <p class="govuk-body">Use this service to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>do something</li>
+        <li>update your name, address or other details</li>
+        <li>do something else</li>
+      </ul>
 
-        <ul class="govuk-list govuk-list--bullet">
-          <li>do something</li>
-          <li>update your name, address or other details</li>
-          <li>do something else</li>
-        </ul>
+      <p class="govuk-body">Registering takes around 5 minutes.</p>
 
-        <p class="govuk-body">Registering takes around 5 minutes.</p>
+      {{ govukButton({
+        text: "Start now",
+        href: "#",
+        classes: "govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"
+      }) }}
 
-        {{ govukButton({
-          text: "Start now",
-          href: "#",
-          classes: "govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"
-        }) }}
+      <h2 class="govuk-heading-m">Before you start</h2>
 
-        <h2 class="govuk-heading-m">Before you start</h2>
+      <p class="govuk-body">You can also <a class="govuk-link" href="#">register by post</a>.</p>
 
-        <p class="govuk-body">You can also <a class="govuk-link" href="#">register by post</a>.</p>
+      <p class="govuk-body">The online service is also available in <a class="govuk-link" href="#">Welsh (Cymraeg)</a>.</p>
 
-        <p class="govuk-body">The online service is also available in <a class="govuk-link" href="#">Welsh (Cymraeg)</a>.</p>
+      <p class="govuk-body">You can’t register for this service if you’re in the UK illegally.</p>
+    </div>
 
-        <p class="govuk-body">You can’t register for this service if you’re in the UK illegally.</p>
+    <div class="govuk-grid-column-one-third">
 
-      </div>
+      <!-- The Related items component is not part of GOV.UK Frontend but will be styled if used in the Prototype Kit -->
 
-      <div class="govuk-grid-column-one-third">
+      <aside class="app-related-items" role="complementary">
+        <h2 class="govuk-heading-m" id="subsection-title">
+          Subsection
+        </h2>
+        <nav role="navigation" aria-labelledby="subsection-title">
+          <ul class="govuk-list govuk-!-font-size-16">
+            <li>
+              <a href="#">
+                Related link
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Related link
+              </a>
+            </li>
+            <li>
+              <a href="#" class="govuk-!-font-weight-bold">
+                More <span class="govuk-visually-hidden">in Subsection</span>
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </aside>
 
-        <!-- The Related items component is not part of GOV.UK Frontend but will be styled if used in the Prototype Kit -->
-
-        <aside class="app-related-items" role="complementary">
-          <h2 class="govuk-heading-m" id="subsection-title">
-            Subsection
-          </h2>
-          <nav role="navigation" aria-labelledby="subsection-title">
-            <ul class="govuk-list govuk-!-font-size-16">
-              <li>
-                <a href="#">
-                  Related link
-                </a>
-              </li>
-              <li>
-                <a href="#">
-                  Related link
-                </a>
-              </li>
-              <li>
-                <a href="#" class="govuk-!-font-weight-bold">
-                  More <span class="govuk-visually-hidden">in Subsection</span>
-                </a>
-              </li>
-            </ul>
-          </nav>
-        </aside>
-
-        </div>
     </div>
   </div>
-</div>
+{% endblock %}

--- a/views/layouts/example-wrappers/full-page.njk
+++ b/views/layouts/example-wrappers/full-page.njk
@@ -1,0 +1,6 @@
+<div class="govuk-width-container">
+  {% block beforeContent %}{% endblock %}
+  <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main">
+    {% block content %}{% endblock %}
+  </main>
+</div>

--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -1,7 +1,7 @@
 {% extends "template.njk" %}
 {% set bodyClasses = 'app-example-page' %}
+{% block pageTitle %}{{ title }} – Example – GOV.UK Design System{% endblock %}
 {% block head %}
-  <title>{{ title }} – Example – GOV.UK Design System</title>
   <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
   {#- Include any additional stylesheets specified in the example frontmatter #}
   {% for stylesheet in stylesheets %}

--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -1,0 +1,21 @@
+{% extends "template.njk" %}
+{% set bodyClasses = 'app-example-page' %}
+{% block head %}
+  <title>{{ title }} – Example – GOV.UK Design System</title>
+  <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
+  {#- Include any additional stylesheets specified in the example frontmatter #}
+  {% for stylesheet in stylesheets %}
+  <link href="{{ stylesheet }}" rel="stylesheet" media="all" />
+  {%- endfor %}
+  <!--[if lt IE 9]>
+    <script src="/javascripts/ie.js"></script>
+  <![endif]-->
+  <script src="/javascripts/vendor/modernizr.js"></script>
+{% endblock %}
+{% block main %}
+  {{ contents | safe }}
+{% endblock %}
+{% block bodyEnd %}
+  <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
+  <script src="/{{ fingerprint['javascripts/govuk-frontend.js'] }}"></script>
+{% endblock %}


### PR DESCRIPTION
This is an alternative to #430 which tries to address some issues spotted whilst trying to move other pages to use full page examples:

- it uses `{% extends "foo.njk" %}` to allow us to define `beforeContent` and `content` blocks within examples – the approach in #430 which uses layouts does not allow us to do this because the page content is rendered to HTML _before_ it is injected into the layout, so the blocks are lost.
- It uses the `pageTitle` variable rather than defining `<title>` inside the `head` block, which means that the title ends up being set twice (once to the default value of "GOV.UK - The best place to find government services and information").
- It does not modify the non-full-page examples.

https://trello.com/c/cVyFXyRa/1180-resolve-inconsistencies-in-our-example-code