### PR TITLE
Update error summary guidance

### DIFF
--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -9,7 +9,9 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-Use an error summary when there is a validation error. The error summary uses the error message that explains what went wrong and how to fix it.
+Use this component at the top of a page to summarise any errors a user has made.
+
+When a user makes an error, you must show both an error summary and an [error message](../error-message/) next to each field that contains an error.
 
 {{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
@@ -27,6 +29,8 @@ You must:
 - include the heading ‘There is a problem’
 - link to each of the validation errors
 - show the same error messages next to the inputs with errors
+
+Read guidance on [writing good error messages](../error-message#be-clear-and-concise).
 
 There are 2 ways to use the error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 


### PR DESCRIPTION
This PR:

- clarifies the relationship between error summary and error message in the error summary guidance
- adds link to guidance on how to write good error messages from error summary how it works section

https://trello.com/c/rz1nYX2v/1225-clarify-intro-on-error-summary-component-page