### PR TITLE
Update Question page 'Passport details' example

### DIFF
--- a/src/patterns/question-pages/passport/index.njk
+++ b/src/patterns/question-pages/passport/index.njk
@@ -50,6 +50,9 @@ ignore_in_sitemap: true
           },
           items: [
             {
+              name: "day"
+            },
+            {
               name: "month"
             },
             {


### PR DESCRIPTION
- Adds missing day field to the date input
- Fixes #441 

