### PR TITLE
Check answers and task list pages

### DIFF
--- a/src/patterns/check-answers/index.md.njk
+++ b/src/patterns/check-answers/index.md.njk
@@ -12,6 +12,8 @@ Let users check their answers before submitting information to a service.
 
 ![Screenshot of a check answers page, includes a heading, and two sections for personal details and application details. Each section has details on the answers a user has given with a corresponding link to change their answer. At the bottom of the page there is a button to ‘accept and send’ the application.](check-answers-page.png)
 
+There is a [coded example of a check your answers page](https://govuk-prototype-kit.herokuapp.com/docs/examples/check-your-answers-page) in the GOV.UK prototyping kit.
+
 ## When to use this pattern
 
 Show a single Check answers page immediately before the confirmation screen for small to medium-sized transactions.

--- a/src/patterns/task-list-pages/index.md.njk
+++ b/src/patterns/task-list-pages/index.md.njk
@@ -18,6 +18,8 @@ Task list pages help users understand:
 
 ![A screenshot showing an example of the task list page, includes a heading, and three grouped sections that each contain tasks, some of these tasks are marked as completed.](task-list-whole.png)
 
+There is a [coded example of a task list page](https://govuk-prototype-kit.herokuapp.com/docs/examples/task-list-page) in the GOV.UK prototyping kit.
+
 ## When to use this pattern
 
 Only use a task list page for longer transactions involving multiple tasks that users may need to complete over a number of sessions.


### PR DESCRIPTION
Added links to the check answers and task list pages to link to the coded examples in the GOV.UK prototype kit.

There is no HTML or nunjucks code to use in the prototype kit so putting a link to a working example would help people with prototypes.