### PR TITLE
Use a more legible monospace font stack

### DIFF
--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -268,6 +268,10 @@ $colour-list-breakpoint: 980px;
   }
 }
 
+code {
+  font-family: monaco, Consolas, "Lucida Console", monospace;
+}
+
 pre {
   position: relative;
   margin: 0;


### PR DESCRIPTION
This mirrors the font-stack used for `code` in the tech docs.

## Before

<img width="1392" alt="screen shot 2018-07-24 at 15 27 49" src="https://user-images.githubusercontent.com/121939/43144989-468cba48-8f56-11e8-8dfe-bfb8ffe4a338.png">

## After

<img width="1392" alt="screen shot 2018-07-24 at 15 28 25" src="https://user-images.githubusercontent.com/121939/43145003-4a0f69fe-8f56-11e8-9dbb-f051b5c1edb7.png">
