### PR TITLE
Update GOV.UK Frontend to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5256,9 +5256,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-1.1.1.tgz",
-      "integrity": "sha512-Ut4BWcW4LZrHMe5E+0+Py6yScoguDnZ17GohA2okbTw/nzhp4st2p1AK9N9dvqaLYS1yw0pcfgRP5jzyCZ14QQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-1.2.0.tgz",
+      "integrity": "sha512-pHKghu9J1nB7F/MKpiYaimPoJXUJdmMZUGuORv9K1Ek1sVNdTRlEKR+rogpfR4GkroS0tS1LMwQJrQkiCvxIIw=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "clipboard": "^2.0.0",
-    "govuk-frontend": "^1.1.1",
+    "govuk-frontend": "^1.2.0",
     "gray-matter": "^4.0.1",
     "html5shiv": "^3.7.3",
     "jquery": "^1.12.4",

--- a/src/components/checkboxes/default/index.njk
+++ b/src/components/checkboxes/default/index.njk
@@ -6,30 +6,30 @@ layout: layout-example.njk
 {% from "checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
-  idPrefix: "nationality",
-  name: "nationality",
+  idPrefix: "waste",
+  name: "waste",
   fieldset: {
     legend: {
-      text: "What is your nationality?",
+      text: "Which types of waste do you transport?",
       isPageHeading: true,
       classes: "govuk-fieldset__legend--xl"
     }
   },
   hint: {
-    text: "If you have dual nationality, select all options that are relevant to you."
+    text: "Select all that apply."
   },
   items: [
     {
-      value: "british",
-      text: "British"
+      value: "carcasses",
+      text: "Waste from animal carcasses"
     },
     {
-      value: "irish",
-      text: "Irish"
+      value: "mines",
+      text: "Waste from mines or quarries"
     },
     {
-      value: "other",
-      text: "Citizen of another country"
+      value: "farm",
+      text: "Farm or agricultural waste"
     }
   ]
 }) }}

--- a/src/components/checkboxes/hint/index.njk
+++ b/src/components/checkboxes/hint/index.njk
@@ -1,0 +1,38 @@
+---
+title: Checkbox items with hint
+layout: layout-example.njk
+---
+
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  idPrefix: "nationality",
+  name: "nationality",
+  fieldset: {
+    legend: {
+      text: "What is your nationality?",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--xl"
+    }
+  },
+  hint: {
+    text: "If you have dual nationality, select all options that are relevant to you."
+  },
+  items: [
+    {
+      value: "british",
+      text: "British",
+      hint: {
+        text: "including English, Scottish, Welsh and Northern Irish"
+      }
+    },
+    {
+      value: "irish",
+      text: "Irish"
+    },
+    {
+      value: "other",
+      text: "Citizen of another country"
+    }
+  ]
+}) }}

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -36,6 +36,12 @@ There are 2 ways to use the checkboxes component. You can use HTML or, if you’
 
 {{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: true, size: "m"}) }}
 
+### Checkbox items with hints
+
+You can add a hint to a checkbox item, explaining what the option means.
+
+{{ example({group: "components", item: "checkboxes", example: "hint", html: true, nunjucks: true, open: true, size: "s"}) }}
+
 ### Conditionally revealing content
 
 You can add conditionally revealing content to checkboxes, so users only see content when it’s relevant to them. For example, you could reveal a phone number input only when a user chooses to be contacted by phone.

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -38,7 +38,7 @@ There are 2 ways to use the checkboxes component. You can use HTML or, if you’
 
 ### Checkbox items with hints
 
-You can add a hint to a checkbox item, explaining what the option means.
+You can add hints to checkbox items to provide additional information about the options.
 
 {{ example({group: "components", item: "checkboxes", example: "hint", html: true, nunjucks: true, open: true, size: "s"}) }}
 

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -47,7 +47,7 @@ ignore_in_sitemap: true
     legend: {
       text: "How do you want to be contacted?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--m"
+      classes: "govuk-fieldset__legend--xl"
     }
   },
   items: [

--- a/src/components/radios/divider/index.njk
+++ b/src/components/radios/divider/index.njk
@@ -1,0 +1,44 @@
+---
+title: Radios with a text divider
+layout: layout-example.njk
+ignore_in_sitemap: true
+---
+
+{% from "radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  idPrefix: "where-do-you-live",
+  name: "where-do-you-live",
+  fieldset: {
+    legend: {
+      text: "Where do you live?",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--xl"
+    }
+  },
+  items: [
+    {
+      value: "england",
+      text: "England"
+    },
+    {
+      value: "scotland",
+      text: "Scotland"
+    },
+    {
+      value: "wales",
+      text: "Wales"
+    },
+    {
+      value: "northern-ireland",
+      text: "Northern Ireland"
+    },
+    {
+      divider: "or"
+    },
+    {
+      value: "abroad",
+      text: "I am a British citizen living abroad"
+    }
+  ]
+}) }}

--- a/src/components/radios/hint/index.njk
+++ b/src/components/radios/hint/index.njk
@@ -16,21 +16,27 @@ layout: layout-example.njk
     }
   },
   hint: {
-    text: "You’ll need an account to prove your identity and complete your Self Assessment."
+    text: "You'll need an account to prove your identity and complete your Self Assessment."
   },
   items: [
     {
       value: "government-gateway",
       text: "Sign in with Government Gateway",
+      label: {
+        classes: "govuk-label--s"
+      },
       hint: {
-        text: "You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before."
+        text: "You'll have a user ID if you've registered for Self Assessment or filed a tax return online before."
       }
     },
     {
       value: "govuk-verify",
       text: "Sign in with GOV.UK Verify",
+      label: {
+        classes: "govuk-label--s"
+      },
       hint: {
-        text: "You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
+        text: "You'll have an account if you've already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
       }
     }
   ]

--- a/src/components/radios/hint/index.njk
+++ b/src/components/radios/hint/index.njk
@@ -1,0 +1,37 @@
+---
+title: Radio items with hint
+layout: layout-example.njk
+---
+
+{% from "radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  idPrefix: "sign-in",
+  name: "sign-in",
+  fieldset: {
+    legend: {
+      text: "How do you want to sign in?",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--xl"
+    }
+  },
+  hint: {
+    text: "You’ll need an account to prove your identity and complete your Self Assessment."
+  },
+  items: [
+    {
+      value: "government-gateway",
+      text: "Sign in with Government Gateway",
+      hint: {
+        text: "You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before."
+      }
+    },
+    {
+      value: "govuk-verify",
+      text: "Sign in with GOV.UK Verify",
+      hint: {
+        text: "You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
+      }
+    }
+  ]
+}) }}

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -47,6 +47,11 @@ You can add a hint to a radio item, explaining what the option means.
 
 {{ example({group: "components", item: "radios", example: "hint", html: true, nunjucks: true, open: true, size: "s"}) }}
 
+### Radio items with a text divider
+
+If some radio items are phrased differently from the others, it may make the page more readable if you separate the options that are different with an ‘or’.
+
+{{ example({group: "components", item: "radios", example: "divider", html: true, nunjucks: true, open: true, size: "s"}) }}
 
 ### Conditionally revealing content
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -43,13 +43,13 @@ If there are only 2 options, you can either stack the radios or display them inl
 
 ### Radio items with hints
 
-You can add a hint to a radio item, explaining what the option means.
+You can add hints to radio items to provide additional information about the options.
 
 {{ example({group: "components", item: "radios", example: "hint", html: true, nunjucks: true, open: true, size: "s"}) }}
 
 ### Radio items with a text divider
 
-If some radio items are phrased differently from the others, it may make the page more readable if you separate the options that are different with an ‘or’.
+If one or more of your radio options is different from the others, it can help users if you separate them using a text divider. The text is usually the word ‘or’. 
 
 {{ example({group: "components", item: "radios", example: "divider", html: true, nunjucks: true, open: true, size: "s"}) }}
 
@@ -57,7 +57,7 @@ If some radio items are phrased differently from the others, it may make the pag
 
 You can add conditionally revealing content to radios, so users only see content when it’s relevant to them. For example, you could reveal an email address input only when a user chooses to be contacted by email.
 
-{{ example({group: "components", item: "radios", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({group: "components", item: "radios", example: "conditional-reveal", html: true, nunjucks: true, open: true, size: "xl"}) }}
 
 Keep it simple - if you need to add a lot of content, consider showing it on the next page in the process instead.
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -41,6 +41,13 @@ If there are only 2 options, you can either stack the radios or display them inl
 
 {{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
 
+### Radio items with hints
+
+You can add a hint to a radio item, explaining what the option means.
+
+{{ example({group: "components", item: "radios", example: "hint", html: true, nunjucks: true, open: true, size: "s"}) }}
+
+
 ### Conditionally revealing content
 
 You can add conditionally revealing content to radios, so users only see content when it’s relevant to them. For example, you could reveal an email address input only when a user chooses to be contacted by email.

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -1,6 +1,7 @@
 {% extends "template.njk" %}
 
 {% set htmlClasses = 'no-js' %}
+{% set assetUrl = 'https://design-system.service.gov.uk/assets' %}
 
 {% block pageTitle %}{{ title }} – GOV.UK Design System{% endblock %}
 
@@ -9,7 +10,6 @@
   <meta name="robots" content="noindex, nofollow">
 {% endif %}
 <meta name="description" content="{{description}}">
-<meta property="og:image" content="https://design-system.service.gov.uk/assets/images/govuk-opengraph-image.png">
   <!--[if !IE 8]><!-->
     <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
   <!--<![endif]-->


### PR DESCRIPTION
- Update dependency
- Replace duplicate og:image meta tag declaration with new assetUrl variable definition
- Show examples of hint usage with [radios](https://deploy-preview-458--govuk-design-system-preview.netlify.com/components/radios#radio-items-with-hints) and [checkboxes](https://deploy-preview-458--govuk-design-system-preview.netlify.com/components/checkboxes#checkbox-items-with-hints)
- Show example of text divider usage in [radios](https://deploy-preview-458--govuk-design-system-preview.netlify.com/components/radios#radio-items-with-a-text-divider)

Trello ticket:
https://trello.com/c/aAlOAD9F/1269-update-design-system-with-v120-release

This PR doesnt include examples of how to add classes to labels in radio and checkbox items

Can we have eyes on the words @amyhupe?

