### PR TITLE
Move captions outside headings (where appropriate)

### DIFF
--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -2,7 +2,7 @@
 title: Addresses
 description: Help users provide an address
 section: Patterns
-theme: Ask users for...
+theme: Ask users for…
 aliases:
 backlog_issue_id: 31
 layout: layout-pane.njk

--- a/src/patterns/check-a-service-is-suitable/index.md.njk
+++ b/src/patterns/check-a-service-is-suitable/index.md.njk
@@ -2,7 +2,7 @@
 title: Check a service is suitable
 description: Ask users questions to help them work out if they can or should use your service
 section: Patterns
-theme: Help users to...
+theme: Help users to…
 aliases:
 backlog_issue_id: 35
 layout: layout-pane.njk

--- a/src/patterns/check-answers/index.md.njk
+++ b/src/patterns/check-answers/index.md.njk
@@ -2,7 +2,7 @@
 title: Check answers
 description: Let users check their answers before submitting information to a service
 section: Patterns
-theme: Help users to...
+theme: Help users to…
 aliases:
 backlog_issue_id: 36
 layout: layout-pane.njk

--- a/src/patterns/confirm-an-email-address/index.md.njk
+++ b/src/patterns/confirm-an-email-address/index.md.njk
@@ -2,7 +2,7 @@
 title: Confirm an email address
 description: Use an email confirmation loop to check that a user has access to a specific email
 section: Patterns
-theme: Help users to...
+theme: Help users to…
 aliases:
 backlog_issue_id: 39
 layout: layout-pane.njk

--- a/src/patterns/create-a-username/index.md.njk
+++ b/src/patterns/create-a-username/index.md.njk
@@ -2,7 +2,7 @@
 title: Create a username
 description: Help users to create a unique and memorable username to sign into a service with
 section: Patterns
-theme: Help users to...
+theme: Help users to…
 aliases:
 backlog_issue_id: 63
 layout: layout-pane.njk

--- a/src/patterns/create-accounts/index.md.njk
+++ b/src/patterns/create-accounts/index.md.njk
@@ -2,7 +2,7 @@
 title: Create accounts
 description: Help users create an account for your service
 section: Patterns
-theme: Help users to...
+theme: Help users to…
 aliases:
 backlog_issue_id: 41
 layout: layout-pane.njk

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -2,7 +2,7 @@
 title: Dates
 description: Help users enter or select a date
 section: Patterns
-theme: Ask users for...
+theme: Ask users for…
 aliases:
 backlog_issue_id: 43
 layout: layout-pane.njk

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -2,7 +2,7 @@
 title: Email addresses
 description: Help users enter a valid email address
 section: Patterns
-theme: Ask users for...
+theme: Ask users for…
 aliases:
 backlog_issue_id: 45
 layout: layout-pane.njk

--- a/src/patterns/gender-or-sex/index.md.njk
+++ b/src/patterns/gender-or-sex/index.md.njk
@@ -2,7 +2,7 @@
 title: Gender or sex
 description: This pattern explains how to ask users about gender or sex
 section: Patterns
-theme: Ask users for...
+theme: Ask users for…
 aliases:
 backlog_issue_id: 69
 layout: layout-pane.njk

--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -2,7 +2,7 @@
 title: Names
 description: Help users correctly enter their name
 section: Patterns
-theme: Ask users for...
+theme: Ask users for…
 aliases:
 backlog_issue_id: 53
 layout: layout-pane.njk

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -2,7 +2,7 @@
 title: National Insurance numbers
 description: Ask users to provide their National Insurance number
 section: Patterns
-theme: Ask users for...
+theme: Ask users for…
 aliases:
 backlog_issue_id: 54
 layout: layout-pane.njk

--- a/src/patterns/passwords/index.md.njk
+++ b/src/patterns/passwords/index.md.njk
@@ -2,7 +2,7 @@
 title: Passwords
 description: Help users to create and enter secure and memorable passwords
 section: Patterns
-theme: Ask users for...
+theme: Ask users for…
 aliases:
 backlog_issue_id: 56
 layout: layout-pane.njk

--- a/src/patterns/question-pages/progress/index.njk
+++ b/src/patterns/question-pages/progress/index.njk
@@ -4,7 +4,7 @@ layout: layout-example.njk
 ignore_in_sitemap: true
 ---
 
+<span class="govuk-caption-xl">Question 3 of 9</span>
 <h1 class="govuk-heading-xl">
- <span class="govuk-caption-xl">Question 3 of 9</span>
  Your details
 </h1>

--- a/src/patterns/question-pages/section-headings/index.njk
+++ b/src/patterns/question-pages/section-headings/index.njk
@@ -4,7 +4,7 @@ layout: layout-example.njk
 ignore_in_sitemap: true
 ---
 
+<span class="govuk-caption-xl">About you</span>
 <h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl">About you</span>
   What is your home adddress?
 </h1>

--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -2,7 +2,7 @@
 title: Telephone numbers
 description: Help users enter a valid telephone number
 section: Patterns
-theme: Ask users for...
+theme: Ask users for…
 aliases:
 backlog_issue_id: 101
 layout: layout-pane.njk

--- a/src/styles/typography/captions-inside/index.njk
+++ b/src/styles/typography/captions-inside/index.njk
@@ -1,0 +1,10 @@
+---
+title: Headings with captions – Typography
+layout: layout-example.njk
+ignore_in_sitemap: true
+---
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl">govuk-caption-xl</span>
+  govuk-heading-xl
+</h1>

--- a/src/styles/typography/captions/index.njk
+++ b/src/styles/typography/captions/index.njk
@@ -4,18 +4,11 @@ layout: layout-example.njk
 ignore_in_sitemap: true
 ---
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl">govuk-caption-xl</span>
-  govuk-heading-xl
-</h1>
+<span class="govuk-caption-xl">govuk-caption-xl</span>
+<h1 class="govuk-heading-xl">govuk-heading-xl</h1>
 
+<span class="govuk-caption-l">govuk-caption-l</span>
+<h2 class="govuk-heading-l">govuk-heading-l</h2>
 
-<h2 class="govuk-heading-l">
-  <span class="govuk-caption-l">govuk-caption-l</span>
-  govuk-heading-l
-</h2>
-
-<h3 class="govuk-heading-m">
-  <span class="govuk-caption-m">govuk-caption-m</span>
-  govuk-heading-m
-</h3>
+<span class="govuk-caption-m">govuk-caption-m</span>
+<h3 class="govuk-heading-m">govuk-heading-m</h3>

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -32,6 +32,10 @@ Sometimes you may need to make it clear that a heading is part of a larger secti
 
 {{ example({group: "styles", item: "typography", example: "captions", html: true, open: true, size: "l"}) }}
 
+If the caption should be considered part of the page heading, you can also nest the caption within the H1.
+
+{{ example({group: "styles", item: "typography", example: "captions-inside", html: true, open: true, size: "l"}) }}
+
 ## Paragraphs
 
 ### Body

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -1,5 +1,9 @@
 {% extends "_generic.njk" %}
 
+{# If the theme ends in '…', then we nest the caption inside the H1 so that the
+  H1 becomes e.g. 'Ask users for dates'. Otherwise, we put it before the H1. #}
+{% set includeThemeInPageHeading = theme and "…" in theme %}
+
 {% block appPaneClasses %}app-pane--enabled{% endblock %}
 
 {% block body %}
@@ -10,14 +14,17 @@
   <div class="app-pane__content">
     <main id="main-content" class="app-content" role="main">
       <div class="app-content__header">
+        {% if not includeThemeInPageHeading %}
+        <span class="govuk-caption-xl">
+          {{ theme if theme else section }}
+        </span>
+        {% endif %}
         <h1 class="govuk-heading-xl">
+          {% if includeThemeInPageHeading %}
           <span class="govuk-caption-xl">
-          {% if theme %}
-            {{ theme }}
-            {% else %}
-              {{ section }}
-            {% endif %}
+            {{ theme | replace("…", "") }}
           </span>
+          {% endif %}
           {{ title }}
           {% if status %}
           <div>


### PR DESCRIPTION
In most cases, the caption is an orientation device and should not form part of the H1 of the page.

For example, in our ‘question pages’ the captions we use are ‘Question 3 of 9’ and ‘About you’ – including these in the H1 would make the page headings ‘Question 3 of 9 Your details’ and ‘About you What is your home adddress?’ – neither of which really make sense.

There will be some cases where including the caption in the H1 _does_ make sense (e.g. within some of the themes in our patterns section as outlined below), but we think these will be generally be an exception.

This PR:

- moves the caption outside of the H1 in existing examples on the typography page and within the 'Question pages' pattern
- adds a new example to the typography page showing the caption inside the H1
- updates the Design System so that the caption is only within the H1 for pages in the themes 'Ask users for…' and 'Help users to…' – for all other pages the caption now sits outside the H1
- removes the ellipsis from the theme name when used in the caption (so the H1 becomes e.g. 'Ask users for Addresses' rather than 'Ask users for… Addresses'

As an example:

- the page ‘Addresses’ in the ‘Ask users for…’ theme would have the H1 ‘Asking users for Addresses’, where ‘Asking users for’ is styled as a caption.
- the page ‘Confirmation pages’ in the ‘Pages’ theme would have the H1 ‘Confirmation pages’ with a separate caption ‘Pages’.
- the page ‘Buttons’ in the ‘Components’ section would have the H1 ‘Buttons’ with a separate caption ‘Components’

There's a related discussion in Elements which is worth reviewing for context:
https://github.com/alphagov/govuk_elements/pull/434

We _think_ that this also fixes #445.

https://trello.com/c/VSmgafer/1229-titles-in-search-results-for-the-design-system-duplicate-the-category