### PR TITLE
Setup design system search

### DIFF
--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -1,0 +1,88 @@
+/* eslint-env jest */
+const configPaths = require('../config/paths.json')
+const PORT = configPaths.port
+
+let browser
+let page
+let baseUrl = 'http://localhost:' + PORT
+
+beforeEach(async (done) => {
+  browser = global.browser
+  page = await browser.newPage()
+  done()
+})
+
+afterEach(async (done) => {
+  await page.close()
+  done()
+})
+
+describe('Site search', () => {
+  it('does not return any results when searching for something that does not exist', async () => {
+    await page.goto(baseUrl, { waitUntil: 'load' })
+
+    await page.waitForSelector('.app-site-search__input')
+    await page.type('.app-site-search__input', 'lorem ipsum')
+    const optionResult = await page.$eval('.app-site-search__option', option => option.textContent)
+
+    expect(optionResult).toBe('No results found')
+  })
+  it('returns results that begin with a letter "d"', async () => {
+    await page.goto(baseUrl, { waitUntil: 'load' })
+
+    await page.waitForSelector('.app-site-search__input')
+    await page.type('.app-site-search__input', 'd')
+    const resultsArray = await page.evaluate(
+      () => [...document.querySelectorAll('.app-site-search__option')].map(elem => elem.innerText.toLowerCase())
+    )
+    expect(resultsArray.every(item => item.startsWith('d'))).toBeTruthy()
+  })
+  it('selecting "details" as the result takes you to the the "details" page', async () => {
+    await page.goto(baseUrl, { waitUntil: 'load' })
+
+    await page.waitForSelector('.app-site-search__input')
+    await page.click('.app-site-search__input')
+    await page.type('.app-site-search__input', 'details')
+    await Promise.all([
+      page.waitForNavigation(),
+      page.keyboard.press('Enter')
+    ])
+    let url = await page.url()
+
+    expect(url).toBe(baseUrl + '/components/details/')
+  })
+  it('shows user a message that the index has failed to download', async () => {
+    await page.setRequestInterception(true)
+    page.on('request', interceptedRequest => {
+      if (interceptedRequest.url().endsWith('search-index.json')) {
+        interceptedRequest.abort()
+      } else {
+        interceptedRequest.continue()
+      }
+    })
+    await page.goto(baseUrl, { waitUntil: 'load' })
+    await page.waitForSelector('.app-site-search__input')
+    await page.click('.app-site-search__input')
+    await page.type('.app-site-search__input', 'lorem')
+
+    const optionResult = await page.$eval('.app-site-search__option', option => option.textContent)
+    expect(optionResult).toBe('Failed to load the search index')
+  })
+
+  it('shows user a message that the search index is loading', async () => {
+    await page.setRequestInterception(true)
+    page.on('request', interceptedRequest => {
+      // Intentionally make the search-index request hang
+      if (!interceptedRequest.url().endsWith('search-index.json')) {
+        interceptedRequest.continue()
+      }
+    })
+    await page.goto(baseUrl, { waitUntil: 'load' })
+    await page.waitForSelector('.app-site-search__input')
+    await page.click('.app-site-search__input')
+    await page.type('.app-site-search__input', 'd')
+
+    const optionResult = await page.$eval('.app-site-search__option', option => option.textContent)
+    expect(optionResult).toBe('Loading search index')
+  })
+})

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -3,7 +3,7 @@ const PORT = configPaths.port
 
 module.exports = {
   server: {
-    command: 'node tasks/serve.js',
+    command: 'SEARCH=true node tasks/serve.js',
     launchTimeout: 20000,
     port: PORT
   }

--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -51,6 +51,9 @@ module.exports = function lunrPlugin () {
       // Disable stemming of search terms run against this index
       this.searchPipeline.remove(lunr.stemmer)
 
+      // Remove stop words filter from index pipeline
+      this.pipeline.remove(lunr.stopWordFilter)
+
       documents.forEach(doc => {
         store[doc.path] = {
           title: doc.title,

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -103,6 +103,22 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     destination: 'javascripts/vendor'
   }))
 
+  // build search.js
+  .use(rollup({
+    input: 'src/javascripts/components/search.js',
+    output: {
+      name: 'AppSearch',
+      legacy: true,
+      format: 'iife',
+      file: 'javascripts/search.js'
+    },
+    plugins: [
+      // TODO: Since we're not exporting ES6 Modules to NPM we need to import these as commonjs
+      resolve(),
+      commonjs()
+    ]
+  }))
+
   // concatenate javascript files
   .use(concat({
     files: [
@@ -112,6 +128,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
       'javascripts/components/example.js',
       'javascripts/components/tabs.js',
       'javascripts/components/copy.js',
+      'javascripts/search.js',
       'javascripts/components/mobile-navigation.js',
       'javascripts/components/cookie-banner.js',
       'javascripts/main.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,6 +116,15 @@
         }
       }
     },
+    "accessible-autocomplete": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-1.6.1.tgz",
+      "integrity": "sha512-75asizh6ld4NPzxId/IcL8IjT1MzZfARCkWp5eShv0gXBt3kKj6BGFRiS/qSkeep4OM8Fz20FqiftTuPSJNITw==",
+      "dev": true,
+      "requires": {
+        "preact": "8.2.9"
+      }
+    },
     "acorn": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
@@ -10197,6 +10206,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.1.tgz",
       "integrity": "sha1-uRepB5smF42aJK9aXNjLSpkdEbk=",
+      "dev": true
+    },
+    "preact": {
+      "version": "8.2.9",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.9.tgz",
+      "integrity": "sha512-ThuGXBmJS3VsT+jIP+eQufD3L8pRw/PY3FoCys6O9Pu6aF12Pn9zAJDX99TfwRAFOCEKm/P0lwiPTbqKMJp0fA==",
       "dev": true
     },
     "prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "sass-export": "^1.0.2"
   },
   "devDependencies": {
+    "accessible-autocomplete": "^1.6.1",
     "fs-extra": "^5.0.0",
     "gulp": "^3.9.1",
     "gulp-sass-lint": "^1.3.4",

--- a/src/javascripts/components/search.js
+++ b/src/javascripts/components/search.js
@@ -1,0 +1,105 @@
+/* global XMLHttpRequest */
+import accessibleAutocomplete from 'accessible-autocomplete'
+import lunr from 'lunr'
+
+// CONSTANTS
+var TIMEOUT = 10 // Time to wait before giving up fetching the search index
+var STATE_DONE = 4 // XHR client readyState DONE
+
+// LunrJS Seach index
+var searchIndex = null
+var documentStore = null
+
+var statusMessage = null
+var searchQuery = ''
+var searchCallback = function () {}
+
+var AppSearch = {
+  fetchSearchIndex: function (callback) {
+    var request = new XMLHttpRequest()
+    request.open('GET', '/search-index.json', true)
+    request.timeout = TIMEOUT * 1000
+    statusMessage = 'Loading search index'
+    request.onreadystatechange = function () {
+      if (request.readyState === STATE_DONE) {
+        if (request.status === 200) {
+          var response = request.responseText
+          var json = JSON.parse(response)
+          statusMessage = 'No results found'
+          searchIndex = lunr.Index.load(json.index)
+          documentStore = json.store
+          callback(json)
+        } else {
+          statusMessage = 'Failed to load the search index'
+          // Log to analytics?
+        }
+      }
+    }
+    request.open('GET', '/search-index.json', true)
+    request.send()
+  },
+  renderResults: function () {
+    var matchedResults = []
+    if (!searchIndex || !documentStore) {
+      return searchCallback(matchedResults)
+    }
+    var searchResults = searchIndex.query(function (q) {
+      q.term(lunr.tokenizer(searchQuery), {
+        wildcard: lunr.Query.wildcard.TRAILING,
+        presence: lunr.Query.presence.REQUIRED
+      })
+    })
+    matchedResults = searchResults.map(function (result) {
+      return documentStore[result.ref]
+    })
+    searchCallback(matchedResults)
+  },
+  handleSearchQuery: function (query, callback) {
+    searchQuery = query
+    searchCallback = callback
+    this.renderResults()
+  },
+  handleOnConfirm: function (result) {
+    var path = result.path
+    if (path) {
+      window.location.pathname = path
+    }
+  },
+  inputValueTemplate: function (result) {
+    if (result) {
+      return result.title
+    }
+  },
+  resultTemplate: function (result) {
+    if (result) {
+      // add rest of the data here to build the item
+      var itemTemplate = result.title
+      return itemTemplate
+    }
+  },
+  init: function (container, input) {
+    if (!document.querySelector(container)) {
+      return
+    }
+    accessibleAutocomplete({
+      element: document.querySelector(container),
+      id: input,
+      cssNamespace: 'app-site-search',
+      displayMenu: 'overlay',
+      placeholder: 'Search Design System',
+      confirmOnBlur: false,
+      autoselect: true,
+      source: this.handleSearchQuery.bind(this),
+      onConfirm: this.handleOnConfirm,
+      templates: {
+        inputValue: this.inputValueTemplate,
+        suggestion: this.resultTemplate
+      },
+      tNoResults: function () { return statusMessage }
+    })
+    this.fetchSearchIndex(function () {
+      this.renderResults()
+    }.bind(this))
+  }
+}
+export default AppSearch

--- a/src/javascripts/main.js
+++ b/src/javascripts/main.js
@@ -13,4 +13,7 @@ $(document).ready(function () {
 
   // Initialise mobile navigation
   GOVUK.mobileNav.init()
+
+  // Initialise search
+  window.AppSearch.init('.app-site-search', 'app-site-search__input')
 })

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -15,6 +15,7 @@
     border-bottom: 10px solid govuk-colour("blue");
     color: govuk-colour("white");
     background: govuk-colour("black");
+    @include govuk-clearfix;
   }
 
   .app-header__logotype {
@@ -47,7 +48,8 @@
 
     font-size: 30px; // We don't have a mixin that produces 30px font size\
     line-height: 30px;
-
+    @include govuk-clearfix;
+    
     &:link,
     &:visited {
       margin-bottom: -1px; // Negate transparent bottom border
@@ -93,7 +95,7 @@
 
   .app-header-mobile-nav-toggler-wrapper {
     display: block;
-    text-align: right;
+    float: right;
   }
 
   .app-header-mobile-nav-toggler {
@@ -104,6 +106,7 @@
     border: 1px solid govuk-colour("white");
     background-color: govuk-colour("black");
     box-shadow: 0 0 0 govuk-colour("black");
+    min-height: 40px; // match the height of the search box
 
     &:active,
     &:focus,

--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -1,0 +1,192 @@
+// Site search using Accessible autocomplete
+// below styles are based on the default accessible autocomplete stylesheet
+
+$icon-size: 40px;
+
+.app-site-search {
+  float: left;
+  margin-bottom: govuk-spacing(2);
+  margin-top: govuk-spacing(2);
+  max-width: calc(100% - 120px);
+  width: 100%;
+  position: relative;
+
+  @include govuk-media-query($from: tablet) {  
+    max-width: 100%;
+    width: 300px;
+    float: none;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    float: right;
+    margin: 0;
+    margin-top: -6px; //negative margin to vertically align search in header
+  }
+
+  .no-js & {
+    display: none;
+
+    @include govuk-media-query($from: tablet) {
+      display: block;
+    }
+
+    @include govuk-media-query($from: desktop) {
+      text-align: right;
+    }
+  }
+}
+
+.app-site-search__wrapper {
+  position: relative;
+  display: block;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='white'%3E%3C/path%3E%3C/svg%3E") govuk-colour("blue") no-repeat top left;
+  background-size: $icon-size $icon-size;
+  height: $icon-size;
+}
+
+.app-site-search__hint,
+.app-site-search__input {
+  min-height: $icon-size;
+  box-sizing: border-box;
+  width: 100%;
+  margin-bottom: 0; // BUG: Safari 10 on macOS seems to add an implicit margin.
+  border: 2px solid govuk-colour("white");
+  border-radius: 0; // Safari 10 on iOS adds implicit border rounding.
+  -webkit-appearance: none;
+}
+
+.app-site-search__hint {
+  position: absolute;
+  color: govuk-colour("grey-2");
+}
+
+.app-site-search__input {
+  margin-left: $icon-size;
+  width: calc(100% - #{$icon-size});
+  height: $icon-size;
+  position: relative;
+  background-color: govuk-colour("white");
+}
+
+.app-site-search__input--default {
+  padding: 9px govuk-spacing(2) govuk-spacing(1);
+}
+
+.app-site-search__input--focused {
+  outline: 3px solid $govuk-focus-colour;
+  outline-offset: 0;
+  margin-left: 0;
+  width: 100%;
+}
+
+.app-site-search__input--show-all-values {
+  padding: govuk-spacing(1) 34px govuk-spacing(1) govuk-spacing(1);
+  cursor: pointer;
+}
+
+.app-site-search__dropdown-arrow-down {
+  display: inline-block;
+  position: absolute;
+  z-index: -1;
+  top: govuk-spacing(2);
+  right: 8px;
+  width: 24px;
+  height: 24px;
+}
+
+.app-site-search__menu {
+  width: 100%;
+  width: calc(100% - 4px);
+  max-height: 342px;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+  border-top: 0;
+  color: govuk-colour("black");
+  background-color: govuk-colour("white");
+}
+
+.app-site-search__menu--visible {
+  display: block;
+}
+
+.app-site-search__menu--hidden {
+  display: none;
+}
+
+.app-site-search__menu--overlay {
+  position: absolute;
+  z-index: 100;
+  top: 100%;
+  left: 0;
+  box-shadow: rgba(govuk-colour("black"), .256863) 0 2px 6px;
+}
+
+.app-site-search__menu--inline {
+  position: relative;
+}
+
+.app-site-search__option {
+  display: block;
+  position: relative;
+  border-bottom: solid govuk-colour("grey-2");
+  border-width: 1px 0;
+  cursor: pointer;
+}
+
+.app-site-search__option > * {
+  pointer-events: none;
+}
+
+.app-site-search__option:first-of-type {
+  border-top-width: 0;
+}
+
+.app-site-search__option:last-of-type {
+  border-bottom-width: 0;
+}
+
+.app-site-search__option--odd {
+  background-color: #FAFAFA;
+}
+
+.app-site-search__option--focused,
+.app-site-search__option:hover {
+  border-color: govuk-colour("blue");
+  outline: none;
+  color: govuk-colour("white");
+  background-color: govuk-colour("blue");
+}
+
+.app-site-search__option--no-results {
+  background-color: govuk-colour("white");
+  color: govuk-colour("grey-1");
+  cursor: not-allowed;
+}
+
+.app-site-search__hint,
+.app-site-search__option {
+  padding: govuk-spacing(2);
+}
+
+.app-site-search__hint,
+.app-site-search__input,
+.app-site-search__option {
+  @include govuk-font($size: 19);
+}
+
+.app-site-search__link {
+  display: none;
+
+  .no-js & {
+    @include govuk-media-query($from: tablet) {
+      color: govuk-colour("white");
+      margin-top: 10px;
+      display: inline-block;
+      &:focus {
+        color: govuk-colour("black");
+      }
+    }
+  }
+}
+

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -16,6 +16,7 @@ $app-code-color: #dd1144;
 @import "components/mobile-navigation";
 @import "components/navigation";
 @import "components/pane";
+@import "components/site-search";
 @import "components/subnav";
 @import "components/tabs";
 @import "components/table";

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -37,10 +37,15 @@
       Design System
     </span>
   </a>
+  {% if SEARCH %}
+  <div class="app-site-search">
+    <label class="govuk-visually-hidden" for="app-site-search__input">Search Design system</label>
+    <a class="app-site-search__link govuk-link" href="/sitemap">Sitemap</a>
+  </div>
+  {% endif %}
   <div class="app-header-mobile-nav-toggler-wrapper">
     <button id="app-mobile-nav-toggler" class="govuk-button app-header-mobile-nav-toggler js-app-mobile-nav-toggler">
       Menu
     </button>
   </div>
-  {# </div> #}
 </header>


### PR DESCRIPTION
Enable users to search the Design System. 
Return search results from the generated search index based on user query
Utilising [Accessible autocomplete](https://github.com/alphagov/accessible-autocomplete) and [LunrJS](https://lunrjs.com/)

Trello ticket: https://trello.com/c/yqJxOj5e/1273-5-implement-client-side-search-interface

Thanks to Nick for added pair of hands.

<details>
<summary>AT testing</summary>

**JAWS 16,17 with IE11**

**EDIT: Jaws 15 announces the number of results, 16 and 17 don't
https://github.com/alphagov/accessible-autocomplete/issues/235**

1) tab to focus: _"Search design system edit combo. use arrow key or type in value"_ 
2) type "d": no number of results announced, selected item not announced
3) arrow down to select 2nw item:  _"list box details"_

**JAWS: 16 on Firefox**
1) tab to focus: _"Search design system edit combo. use arrow key or type in value"_ 
2) type "d": no number of results announced, _"outline level 2, details"_
3) arrow down to select 2nd item:  _"dates selected"_

**NVDA with Firefox**

1) tab to focus: _"combo box collapsed, search design system"_
2) type "d": 3 results available, details 1 of 3 is selected

**VoiceOver with Safari on macOS**

1) tab to focus: "search design system, edit box"
2) type "d": 3 results available, details 1 of 3 is selected

**VoiceOver with Safari on iOS**

1) swipe to focus: _"search design system"_
2) type d: _"3 results are available"_
3) swipe to scroll:
 - to first item: _"details, list start"_
 - last item: _"date input, list end"_
</details>
<details>
<summary>5s timeout error when fetching the search index</summary>
we don't show the search box in index failed to be fetched
<img width="1718" alt="screen shot 2018-08-07 at 13 24 48" src="https://user-images.githubusercontent.com/3758555/43775695-82c88e66-9a45-11e8-8135-a654560659bf.png">
</details>
<details>
<summary>Browser tests</summary>
<img width="1696" alt="ie8" src="https://user-images.githubusercontent.com/3758555/43769083-d86cead4-9a30-11e8-85f4-0aec5365cb5d.png">
<img width="1205" alt="ie9" src="https://user-images.githubusercontent.com/3758555/43907467-621db6ce-9bed-11e8-8948-9a4ad8e13640.png">
<img width="1205" alt="ie10" src="https://user-images.githubusercontent.com/3758555/43907465-61e9bd2e-9bed-11e8-88a3-c5f444e1a8d4.png">
<img width="1208" alt="ie11" src="https://user-images.githubusercontent.com/3758555/43907466-620593aa-9bed-11e8-8e57-7c2bb0418d95.png">
<img width="1214" alt="chrome68" src="https://user-images.githubusercontent.com/3758555/43907507-7cca7642-9bed-11e8-9dcb-5b15ad59dbf3.png">
<img width="1352" alt="safari11" src="https://user-images.githubusercontent.com/3758555/43907508-7ce36e7c-9bed-11e8-96ee-0285d919909a.png">
<img width="1193" alt="ff61" src="https://user-images.githubusercontent.com/3758555/43907550-9e4b3c52-9bed-11e8-9048-6866636473f4.png">
<img src="https://user-images.githubusercontent.com/3758555/43907516-80ce6a6e-9bed-11e8-93b6-d19a286af69e.PNG">
</details>