### PR TITLE
Added type to checkbox conditional reveal example 

### DIFF
--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -11,6 +11,7 @@ ignore_in_sitemap: true
 {{ govukInput({
   id: "contact-by-email",
   name: "contact-by-email",
+  type: "email",
   classes: "govuk-!-width-one-third",
   label: {
     text: "Email address"
@@ -22,6 +23,7 @@ ignore_in_sitemap: true
 {{ govukInput({
   id: "contact-by-phone",
   name: "contact-by-phone",
+  type: "tel",
   classes: "govuk-!-width-one-third",
   label: {
     text: "Phone number"
@@ -33,6 +35,7 @@ ignore_in_sitemap: true
 {{ govukInput({
   id: "contact-by-text",
   name: "contact-by-text",
+  type: "tel",
   classes: "govuk-!-width-one-third",
   label: {
     text: "Mobile phone number"


### PR DESCRIPTION
Checkboxes for this example all had a default "type" of text. This update makes these "type"s more reflective of actual content, and also better reflects the individual Patterns for Telephone Numbers and Email addresses.