### PR TITLE
Make the copy button a button

### DIFF
--- a/src/javascripts/components/copy.js
+++ b/src/javascripts/components/copy.js
@@ -7,18 +7,18 @@
   // This module is dependent on /vendor/clipboard.js
   GOVUK.copy = {
     init: function (selector) {
-      $(selector).parent().prepend('<a class="govuk-link app-link--copy" href="#copy" aria-live="assertive">Copy</a>')
+      $(selector).parent().prepend('<button class="app-copy-button js-copy-button" aria-live="assertive">Copy</button>')
       // Copy to clipboard
       try {
-        new ClipboardJS('.app-link--copy', {
+        new ClipboardJS('.js-copy-button', {
           target: function (trigger) {
             return trigger.nextElementSibling
           }
         }).on('success', function (e) {
-          e.trigger.text = 'Copied'
+          e.trigger.textContent = 'Copied'
           e.clearSelection()
           setTimeout(function () {
-            e.trigger.text = 'Copy'
+            e.trigger.textContent = 'Copy'
           }, 5000)
         })
       } catch (err) {

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -160,33 +160,25 @@ $app-breakpoint-widescreen: 1200px;
   vertical-align: top;
 }
 
-$app-link-colour: #00823b;
-
 // Copy button
-.app-link--copy {
-  &:link,
-  &:active,
-  &:visited,
-  &:hover {
-    @include govuk-font(16);
-    position: absolute;
-    z-index: 1;
-    top: govuk-spacing(3);
-    right: govuk-spacing(3);
-    min-width: 58px;
-    padding: 4px 10px 0;
-    border: 1px solid $app-link-colour;
-    color: $app-link-colour;
-    background-color: govuk-colour("white");
-    text-align: center;
-    text-decoration: none;
-    text-transform: uppercase;
+.app-copy-button {
+  $copy-button-colour: #00823b;
 
-    .app-prose-scope & {
-      color: $app-link-colour; // A specific selector to override .app-prose-scope a:link
-      background-color: govuk-colour("white"); // A specific selector to override .app-prose-scope a:focus
-    }
-  }
+  @include govuk-font(16);
+  @include govuk-focusable();
+  position: absolute;
+  z-index: 1;
+  top: govuk-spacing(3);
+  right: govuk-spacing(3);
+  min-width: 80px;
+  padding: 4px 10px 0;
+  border: 1px solid $copy-button-colour;
+  color: $copy-button-colour;
+  background-color: govuk-colour("white");
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  cursor: pointer;
 }
 
 $colour-list-breakpoint: 980px;


### PR DESCRIPTION
No change to the visual design of the button

Update copy JS:
- to append a button rather than a link
- to use a more sensible class name (now that it is no longer a link)
- to set `innerText` rather than `text` when changing text from ‘Copy’ to ‘Copied’ and back.

Update styling of copy element:
- remove link pseudo-selectors
- remove prose scope link overrides which are no longer required
- increase ‘max-width’ from 58px to 80px to account for border-box box-sizing model (links use content-box model)
- add pointer cursor to match button component
- add focus state

https://trello.com/c/w7jE1qer/1288-make-copy-and-close-links-into-buttons