### PR TITLE
Autoprefix generated CSS

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -14,6 +14,7 @@ const permalinks = require('metalsmith-permalinks')          // apply a permalin
 const canonical = require('metalsmith-canonical')            // add a canonical url property to pages
 
 const sass = require('metalsmith-sass')                      // convert Sass files to CSS using LibSass
+const postcss = require('metalsmith-postcss')
 
 const rollup = require('metalsmith-rollup')                  // used to build GOV.UK Frontend JavaScript
 const resolve = require('rollup-plugin-node-resolve')        // rollup plugin to resolve node_modules
@@ -63,6 +64,12 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
   // convert *.scss files to *.css
   .use(sass({
     includePaths: ['node_modules'] // an array of paths that sass can look in when attempt to resolve @import declarations
+  }))
+
+  .use(postcss({
+    plugins: {
+      'autoprefixer': {}
+    }
   }))
 
   // copy static assets from node_modules/@govukfrontend

--- a/package-lock.json
+++ b/package-lock.json
@@ -468,6 +468,41 @@
       "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
       "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI="
     },
+    "autoprefixer": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.1.0.tgz",
+      "integrity": "sha512-BbAIdxNdptG/x4DiGGfpkDVYyqu4nUyNdBB0Utr49Gn3+0RERV1MdHik2FSbbWwhMAuk1KrfVJHe7nEMheGdBA==",
+      "requires": {
+        "browserslist": "^4.0.1",
+        "caniuse-lite": "^1.0.30000872",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.2",
+        "postcss-value-parser": "^3.2.3"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.1.tgz",
+          "integrity": "sha512-QqiiIWchEIkney3wY53/huI7ZErouNAdvOkjorUALAwRcu3tEwOV3Sh6He0DnP38mz1JjBpCBb50jQBmaYuHPw==",
+          "requires": {
+            "caniuse-lite": "^1.0.30000865",
+            "electron-to-chromium": "^1.3.52",
+            "node-releases": "^1.0.0-alpha.10"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000874",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000874.tgz",
+          "integrity": "sha512-29nr1EPiHwrJTAHHsEmTt2h+55L8j2GNFdAcYPlRy2NX6iFz7ZZiepVI7kP/QqlnHLq3KvfWpbmGa0d063U09w=="
+        },
+        "electron-to-chromium": {
+          "version": "1.3.56",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.56.tgz",
+          "integrity": "sha512-h4FnvXgyfJaA1egXqCwfpecFu1k6U4sPqwvCeux2yEWbu+Avlsa9i07iB5M+M1M2iyfEUnuQDWYCkPCkfO5cpg=="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -1922,7 +1957,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
       "requires": {
         "color-name": "^1.1.1"
       }
@@ -1930,8 +1964,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.5",
@@ -5453,8 +5486,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-generators": {
       "version": "1.0.1",
@@ -8851,6 +8883,14 @@
         }
       }
     },
+    "metalsmith-postcss": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/metalsmith-postcss/-/metalsmith-postcss-4.2.0.tgz",
+      "integrity": "sha512-YJqZfZrSDWYX61Zudzr96xNBxhyyHD6qsC7Q6WqoaJ65iTApwmU82mmKj133LV0kw2BV5I4MJ11RXUAajyPMww==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "metalsmith-rollup": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/metalsmith-rollup/-/metalsmith-rollup-1.0.0.tgz",
@@ -9187,6 +9227,21 @@
         }
       }
     },
+    "node-releases": {
+      "version": "1.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.10.tgz",
+      "integrity": "sha512-BSQrRgOfN6L/MoKIa7pRUc7dHvflCXMcqyTBvphixcSsgJTuUd24vAFONuNfVsuwTyz28S1HEc9XN6ZKylk4Hg==",
+      "requires": {
+        "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        }
+      }
+    },
     "node-sass": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
@@ -9304,6 +9359,11 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -9332,6 +9392,11 @@
       "requires": {
         "boolbase": "~1.0.0"
       }
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -10035,6 +10100,54 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "postcss": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
+      "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
+      "requires": {
+        "chalk": "^2.4.1",
+        "source-map": "^0.6.1",
+        "supports-color": "^5.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-value-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
     },
     "postinstall-build": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
     ]
   },
   "dependencies": {
+    "autoprefixer": "^9.1.0",
     "clipboard": "^2.0.0",
     "govuk-frontend": "^1.2.0",
     "gray-matter": "^4.0.1",
     "html5shiv": "^3.7.3",
     "jquery": "^1.12.4",
     "lunr": "^2.3.1",
+    "metalsmith-postcss": "^4.2.0",
     "modernizr": "^3.6.0",
     "sass-export": "^1.0.2"
   },
@@ -76,5 +78,11 @@
   },
   "jest": {
     "preset": "jest-puppeteer"
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "ie 8",
+    "ie 9",
+    "iOS 9"
+  ]
 }


### PR DESCRIPTION
Autoprefix CSS using postcss and autoprefixer. This will fix the display of the close button’s chevron in IE9 (which requires `-ms-transform`) and probably some other stuff too.

This uses the same browserlist as we have in GOV.UK Frontend.

## Before

<img width="909" alt="screen shot 2018-08-09 at 16 17 23" src="https://user-images.githubusercontent.com/121939/43908403-d01e3232-9bef-11e8-9c07-dc630fee8eca.png">

## Example
<img width="908" alt="screen shot 2018-08-09 at 16 17 44" src="https://user-images.githubusercontent.com/121939/43908406-d2faf35a-9bef-11e8-8c1d-9d633b7f3640.png">
