### PR TITLE
Added optional fields guidance to question pages pattern

### DIFF
--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -117,7 +117,9 @@ You can also learn more about how starting with [one thing per page](https://www
 
 You should make sure you know why you’re asking every question and only ask users for information you really need.
 
-To help you work out what to ask, you can carry out a [question protocol](https://www.uxmatters.com/mt/archives/2010/06/the-question-protocol-how-to-make-sure-every-form-field-is-necessary.php)
+To help you work out what to ask, you can carry out a [question protocol](https://www.uxmatters.com/mt/archives/2010/06/the-question-protocol-how-to-make-sure-every-form-field-is-necessary.php).
+
+If you ask for optional information, mark the labels of optional fields with ‘(optional)’. Don’t mark mandatory fields with asterisks.
 
 On every question page you should:
 


### PR DESCRIPTION
This pull request:
- Adds optional fields guidance from elements to question pages pattern
- Fixes missing full stop after question protocol link 