### PR TITLE
Fix iframer source map

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -19,6 +19,7 @@ const postcss = require('metalsmith-postcss')
 const rollup = require('metalsmith-rollup')                  // used to build GOV.UK Frontend JavaScript
 const resolve = require('rollup-plugin-node-resolve')        // rollup plugin to resolve node_modules
 const commonjs = require('rollup-plugin-commonjs')           // rollup plugin to convert CommonJS modules to ES2015
+const uglify = require('metalsmith-uglify')                  // minify the JavaScript assets to reduce time it takes to download
 
 // const debug = require('./debug')                          // debug plugin
 const navigation = require('./navigation.js')                // navigation plugin
@@ -147,6 +148,16 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
       // TODO: Since we're not exporting ES6 Modules to NPM we need to import these as commonjs
       resolve(),
       commonjs()
+    ]
+  }))
+
+  // minify the JavaScript assets to reduce time it takes to download
+  .use(uglify({
+    sameName: true, // overwrite the original files, with the minified ones.
+    files: [
+      'javascripts/application.js',
+      'javascripts/ie.js',
+      'javascripts/govuk-frontend.js'
     ]
   }))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
       "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -29,7 +29,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -38,9 +38,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -49,7 +49,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -95,7 +95,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.18",
         "negotiator": "0.6.1"
       },
       "dependencies": {
@@ -111,7 +111,7 @@
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "dev": true,
           "requires": {
-            "mime-db": "~1.33.0"
+            "mime-db": "1.33.0"
           }
         }
       }
@@ -128,7 +128,7 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "^5.0.0"
+        "acorn": "5.1.2"
       }
     },
     "acorn-jsx": {
@@ -137,7 +137,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "^3.0.4"
+        "acorn": "3.3.0"
       },
       "dependencies": {
         "acorn": {
@@ -160,7 +160,7 @@
       "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
       "dev": true,
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
@@ -169,8 +169,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "json-stable-stringify": "^1.0.1"
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
       }
     },
     "ajv-keywords": {
@@ -185,9 +185,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "amdefine": {
@@ -232,8 +232,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "append-transform": {
@@ -242,7 +242,7 @@
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
       "dev": true,
       "requires": {
-        "default-require-extensions": "^1.0.0"
+        "default-require-extensions": "1.0.0"
       }
     },
     "aproba": {
@@ -261,8 +261,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -275,13 +275,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -289,7 +289,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -299,7 +299,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -308,7 +308,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -358,7 +358,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -379,8 +379,8 @@
       "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
       }
     },
     "arraybuffer.slice": {
@@ -473,12 +473,12 @@
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.1.0.tgz",
       "integrity": "sha512-BbAIdxNdptG/x4DiGGfpkDVYyqu4nUyNdBB0Utr49Gn3+0RERV1MdHik2FSbbWwhMAuk1KrfVJHe7nEMheGdBA==",
       "requires": {
-        "browserslist": "^4.0.1",
-        "caniuse-lite": "^1.0.30000872",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^7.0.2",
-        "postcss-value-parser": "^3.2.3"
+        "browserslist": "4.0.1",
+        "caniuse-lite": "1.0.30000874",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "7.0.2",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "browserslist": {
@@ -486,9 +486,9 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.1.tgz",
           "integrity": "sha512-QqiiIWchEIkney3wY53/huI7ZErouNAdvOkjorUALAwRcu3tEwOV3Sh6He0DnP38mz1JjBpCBb50jQBmaYuHPw==",
           "requires": {
-            "caniuse-lite": "^1.0.30000865",
-            "electron-to-chromium": "^1.3.52",
-            "node-releases": "^1.0.0-alpha.10"
+            "caniuse-lite": "1.0.30000874",
+            "electron-to-chromium": "1.3.56",
+            "node-releases": "1.0.0-alpha.10"
           }
         },
         "caniuse-lite": {
@@ -519,21 +519,21 @@
       "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-polyfill": "^6.26.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "chokidar": "^1.6.1",
-        "commander": "^2.11.0",
-        "convert-source-map": "^1.5.0",
-        "fs-readdir-recursive": "^1.0.0",
-        "glob": "^7.1.2",
-        "lodash": "^4.17.4",
-        "output-file-sync": "^1.1.2",
-        "path-is-absolute": "^1.0.1",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.6",
-        "v8flags": "^2.1.1"
+        "babel-core": "6.26.0",
+        "babel-polyfill": "6.26.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "chokidar": "1.7.0",
+        "commander": "2.14.1",
+        "convert-source-map": "1.5.1",
+        "fs-readdir-recursive": "1.1.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "v8flags": "2.1.1"
       },
       "dependencies": {
         "source-map": {
@@ -550,9 +550,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "babel-core": {
@@ -561,25 +561,25 @@
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "debug": "^2.6.8",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.7",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.6"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -596,14 +596,14 @@
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.6",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "source-map": {
@@ -620,9 +620,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-call-delegate": {
@@ -631,10 +631,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-define-map": {
@@ -643,10 +643,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -655,9 +655,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -666,11 +666,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -679,8 +679,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -689,8 +689,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -699,8 +699,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
@@ -709,9 +709,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -720,11 +720,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-replace-supers": {
@@ -733,12 +733,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -747,8 +747,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-jest": {
@@ -757,8 +757,8 @@
       "integrity": "sha1-u6079SP7IC2gXtCmVAtIyE7tE6Y=",
       "dev": true,
       "requires": {
-        "babel-plugin-istanbul": "^4.1.6",
-        "babel-preset-jest": "^23.0.1"
+        "babel-plugin-istanbul": "4.1.6",
+        "babel-preset-jest": "23.0.1"
       }
     },
     "babel-messages": {
@@ -767,7 +767,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -776,7 +776,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -785,10 +785,10 @@
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.13.0",
-        "find-up": "^2.1.0",
-        "istanbul-lib-instrument": "^1.10.1",
-        "test-exclude": "^4.2.1"
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "find-up": "2.1.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "test-exclude": "4.2.1"
       },
       "dependencies": {
         "find-up": {
@@ -797,7 +797,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         }
       }
@@ -838,9 +838,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -849,7 +849,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -858,7 +858,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -867,11 +867,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -880,15 +880,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -897,8 +897,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -907,7 +907,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -916,8 +916,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -926,7 +926,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -935,9 +935,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -946,7 +946,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -955,9 +955,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -966,10 +966,10 @@
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -978,9 +978,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -989,9 +989,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1000,8 +1000,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1010,12 +1010,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1024,8 +1024,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1034,7 +1034,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1043,9 +1043,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1054,7 +1054,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1063,7 +1063,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1072,9 +1072,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1083,9 +1083,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1094,7 +1094,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.10.0"
+        "regenerator-transform": "0.10.1"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1103,8 +1103,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-polyfill": {
@@ -1113,9 +1113,9 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -1132,36 +1132,36 @@
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-to-generator": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-        "babel-plugin-transform-es2015-classes": "^6.23.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-        "babel-plugin-transform-es2015-for-of": "^6.23.0",
-        "babel-plugin-transform-es2015-function-name": "^6.22.0",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-        "babel-plugin-transform-es2015-object-super": "^6.22.0",
-        "babel-plugin-transform-es2015-parameters": "^6.23.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-        "babel-plugin-transform-regenerator": "^6.22.0",
-        "browserslist": "^2.1.2",
-        "invariant": "^2.2.2",
-        "semver": "^5.3.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "2.9.1",
+        "invariant": "2.2.2",
+        "semver": "5.4.1"
       },
       "dependencies": {
         "semver": {
@@ -1178,8 +1178,8 @@
       "integrity": "sha1-YxzFRcbPAhlDATvK8i9F2H/mIZg=",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^23.0.1",
-        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+        "babel-plugin-jest-hoist": "23.0.1",
+        "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
     "babel-register": {
@@ -1188,13 +1188,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
@@ -1203,8 +1203,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
       }
     },
     "babel-template": {
@@ -1213,11 +1213,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.4"
       }
     },
     "babel-traverse": {
@@ -1226,15 +1226,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
       }
     },
     "babel-types": {
@@ -1243,10 +1243,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -1272,13 +1272,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1287,7 +1287,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "isobject": {
@@ -1322,7 +1322,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "beeper": {
@@ -1357,7 +1357,7 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
-        "inherits": "~2.0.0"
+        "inherits": "2.0.3"
       }
     },
     "bluebird": {
@@ -1377,7 +1377,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "2.16.3"
       }
     },
     "brace-expansion": {
@@ -1385,7 +1385,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1395,9 +1395,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "browser-process-hrtime": {
@@ -1429,17 +1429,17 @@
       "integrity": "sha512-loCO5NQKZXfBJrEvmLwF1TPSECCsPopNd29qduoysLmpw8op2lgolGMjz3oI/MjG4duzB9TfDs7k58djRSwPwg==",
       "dev": true,
       "requires": {
-        "browser-sync-ui": "v1.0.1",
+        "browser-sync-ui": "1.0.1",
         "bs-recipes": "1.3.4",
         "chokidar": "1.7.0",
         "connect": "3.5.0",
-        "connect-history-api-fallback": "^1.5.0",
-        "dev-ip": "^1.0.1",
+        "connect-history-api-fallback": "1.5.0",
+        "dev-ip": "1.0.1",
         "easy-extender": "2.3.2",
         "eazy-logger": "3.0.2",
-        "emitter-steward": "^1.0.0",
-        "etag": "^1.8.1",
-        "fresh": "^0.5.2",
+        "emitter-steward": "1.0.0",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
         "fs-extra": "3.0.1",
         "http-proxy": "1.15.2",
         "immutable": "3.8.2",
@@ -1470,9 +1470,9 @@
           "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^3.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "3.0.1",
+            "universalify": "0.1.1"
           }
         },
         "jsonfile": {
@@ -1481,7 +1481,7 @@
           "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         },
         "qs": {
@@ -1502,20 +1502,20 @@
           "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^4.1.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
           }
         },
         "yargs-parser": {
@@ -1524,7 +1524,7 @@
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0"
+            "camelcase": "3.0.0"
           }
         }
       }
@@ -1536,11 +1536,11 @@
       "dev": true,
       "requires": {
         "async-each-series": "0.1.1",
-        "connect-history-api-fallback": "^1.1.0",
-        "immutable": "^3.7.6",
+        "connect-history-api-fallback": "1.5.0",
+        "immutable": "3.8.2",
         "server-destroy": "1.0.1",
         "socket.io-client": "2.0.4",
-        "stream-throttle": "^0.1.3"
+        "stream-throttle": "0.1.3"
       }
     },
     "browserslist": {
@@ -1549,8 +1549,8 @@
       "integrity": "sha512-3n3nPdbUqn3nWmsy4PeSQthz2ja1ndpoXta+dwFFNhveGjMg6FXpWYe12vsTpNoXJbzx3j7GZXdtoVIdvh3JbA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000770",
-        "electron-to-chromium": "^1.3.27"
+        "caniuse-lite": "1.0.30000772",
+        "electron-to-chromium": "1.3.27"
       }
     },
     "bs-recipes": {
@@ -1565,7 +1565,7 @@
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "dev": true,
       "requires": {
-        "node-int64": "^0.4.0"
+        "node-int64": "0.4.0"
       }
     },
     "buffer-from": {
@@ -1585,15 +1585,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -1610,7 +1610,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsite": {
@@ -1635,8 +1635,8 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       }
     },
     "caniuse-lite": {
@@ -1651,7 +1651,7 @@
       "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
       "dev": true,
       "requires": {
-        "rsvp": "^3.3.3"
+        "rsvp": "3.6.2"
       }
     },
     "caseless": {
@@ -1666,8 +1666,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       },
       "dependencies": {
         "lazy-cache": {
@@ -1684,11 +1684,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "cheerio": {
@@ -1697,22 +1697,22 @@
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "dev": true,
       "requires": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash.assignin": "^4.0.9",
-        "lodash.bind": "^4.1.4",
-        "lodash.defaults": "^4.0.1",
-        "lodash.filter": "^4.4.0",
-        "lodash.flatten": "^4.2.0",
-        "lodash.foreach": "^4.3.0",
-        "lodash.map": "^4.4.0",
-        "lodash.merge": "^4.4.0",
-        "lodash.pick": "^4.2.1",
-        "lodash.reduce": "^4.4.0",
-        "lodash.reject": "^4.4.0",
-        "lodash.some": "^4.4.0"
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "lodash.assignin": "4.2.0",
+        "lodash.bind": "4.2.1",
+        "lodash.defaults": "4.2.0",
+        "lodash.filter": "4.6.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.foreach": "4.5.0",
+        "lodash.map": "4.6.0",
+        "lodash.merge": "4.6.1",
+        "lodash.pick": "4.4.0",
+        "lodash.reduce": "4.6.0",
+        "lodash.reject": "4.6.0",
+        "lodash.some": "4.6.0"
       }
     },
     "chokidar": {
@@ -1721,15 +1721,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.3",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "ci-info": {
@@ -1750,10 +1750,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -1762,7 +1762,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -1771,7 +1771,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -1780,7 +1780,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -1791,7 +1791,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -1800,7 +1800,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -1811,9 +1811,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "isobject": {
@@ -1836,7 +1836,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "1.0.1"
       }
     },
     "cli-width": {
@@ -1850,9 +1850,9 @@
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.0.tgz",
       "integrity": "sha512-gXzHBlzEVqCk2b8Wpkil89S0WSMAX7eZho2zANX+EEEa9LMutGe9ICU+wHRzsH7cCHaCbUzj900P+AXOM0FE3A==",
       "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
+        "good-listener": "1.2.2",
+        "select": "1.1.2",
+        "tiny-emitter": "2.0.2"
       }
     },
     "cliui": {
@@ -1860,9 +1860,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       }
     },
     "clone": {
@@ -1897,9 +1897,9 @@
       "integrity": "sha1-O2rXfPJhRTD2d7HPYmZPW6dWtyI=",
       "dev": true,
       "requires": {
-        "co-from-stream": "~0.0.0",
-        "fs-extra": "~0.26.5",
-        "thunkify-wrap": "~1.0.4"
+        "co-from-stream": "0.0.0",
+        "fs-extra": "0.26.7",
+        "thunkify-wrap": "1.0.4"
       },
       "dependencies": {
         "fs-extra": {
@@ -1908,11 +1908,11 @@
           "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.6.2"
           }
         },
         "jsonfile": {
@@ -1921,7 +1921,7 @@
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         }
       }
@@ -1949,8 +1949,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -1958,7 +1958,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -1971,7 +1971,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -2014,9 +2014,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -2031,13 +2031,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -2046,7 +2046,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -2057,8 +2057,8 @@
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
+        "ini": "1.3.5",
+        "proto-list": "1.2.4"
       }
     },
     "connect": {
@@ -2067,9 +2067,9 @@
       "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
       "dev": true,
       "requires": {
-        "debug": "~2.2.0",
+        "debug": "2.2.0",
         "finalhandler": "0.5.0",
-        "parseurl": "~1.3.1",
+        "parseurl": "1.3.2",
         "utils-merge": "1.0.0"
       },
       "dependencies": {
@@ -2107,7 +2107,7 @@
       "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
       "dev": true,
       "requires": {
-        "bluebird": "^3.1.1"
+        "bluebird": "3.5.1"
       }
     },
     "contains-path": {
@@ -2150,8 +2150,8 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "requires": {
-        "lru-cache": "^4.0.1",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.1",
+        "which": "1.3.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -2159,8 +2159,8 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
           "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         }
       }
@@ -2170,7 +2170,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
-        "boom": "2.x.x"
+        "boom": "2.10.1"
       }
     },
     "css-select": {
@@ -2179,10 +2179,10 @@
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
         "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
+        "nth-check": "1.0.1"
       }
     },
     "css-what": {
@@ -2203,7 +2203,7 @@
       "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
       "dev": true,
       "requires": {
-        "cssom": "0.3.x"
+        "cssom": "0.3.2"
       }
     },
     "currently-unhandled": {
@@ -2211,7 +2211,7 @@
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "cwd": {
@@ -2220,8 +2220,8 @@
       "integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
       "dev": true,
       "requires": {
-        "find-pkg": "^0.1.2",
-        "fs-exists-sync": "^0.1.0"
+        "find-pkg": "0.1.2",
+        "fs-exists-sync": "0.1.0"
       }
     },
     "d": {
@@ -2230,7 +2230,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.35"
       }
     },
     "dashdash": {
@@ -2238,7 +2238,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -2254,9 +2254,9 @@
       "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
       "dev": true,
       "requires": {
-        "abab": "^1.0.4",
-        "whatwg-mimetype": "^2.0.0",
-        "whatwg-url": "^6.4.0"
+        "abab": "1.0.4",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.4.1"
       }
     },
     "dateformat": {
@@ -2303,7 +2303,7 @@
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
       "dev": true,
       "requires": {
-        "strip-bom": "^2.0.0"
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -2312,7 +2312,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -2323,7 +2323,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2"
+        "clone": "1.0.3"
       }
     },
     "define-properties": {
@@ -2332,8 +2332,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       }
     },
     "define-property": {
@@ -2342,8 +2342,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -2360,12 +2360,12 @@
       "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
       "dev": true,
       "requires": {
-        "find-root": "^1.0.0",
-        "glob": "^7.0.5",
-        "ignore": "^3.0.9",
-        "pkg-config": "^1.1.0",
-        "run-parallel": "^1.1.2",
-        "uniq": "^1.0.1"
+        "find-root": "1.1.0",
+        "glob": "7.1.2",
+        "ignore": "3.3.7",
+        "pkg-config": "1.1.1",
+        "run-parallel": "1.1.6",
+        "uniq": "1.0.1"
       }
     },
     "del": {
@@ -2374,13 +2374,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "object-assign": {
@@ -2436,7 +2436,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "detect-newline": {
@@ -2463,8 +2463,8 @@
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "isarray": "^1.0.0"
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -2481,8 +2481,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -2505,7 +2505,7 @@
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "dev": true,
       "requires": {
-        "webidl-conversions": "^4.0.2"
+        "webidl-conversions": "4.0.2"
       }
     },
     "domhandler": {
@@ -2514,7 +2514,7 @@
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domutils": {
@@ -2523,8 +2523,8 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "duplexer": {
@@ -2539,7 +2539,7 @@
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.1.9"
+        "readable-stream": "1.1.14"
       }
     },
     "easy-extender": {
@@ -2548,7 +2548,7 @@
       "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
       "dev": true,
       "requires": {
-        "lodash": "^3.10.1"
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "lodash": {
@@ -2565,7 +2565,7 @@
       "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
       "dev": true,
       "requires": {
-        "tfunk": "^3.0.1"
+        "tfunk": "3.1.0"
       }
     },
     "ecc-jsbn": {
@@ -2574,7 +2574,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "editorconfig": {
@@ -2583,11 +2583,11 @@
       "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.0.5",
-        "commander": "^2.9.0",
-        "lru-cache": "^3.2.0",
-        "semver": "^5.1.0",
-        "sigmund": "^1.0.1"
+        "bluebird": "3.5.1",
+        "commander": "2.14.1",
+        "lru-cache": "3.2.0",
+        "semver": "5.5.0",
+        "sigmund": "1.0.1"
       },
       "dependencies": {
         "lru-cache": {
@@ -2596,7 +2596,7 @@
           "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.1"
+            "pseudomap": "1.0.2"
           }
         },
         "semver": {
@@ -2643,7 +2643,7 @@
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "dev": true,
       "requires": {
-        "once": "~1.3.0"
+        "once": "1.3.3"
       },
       "dependencies": {
         "once": {
@@ -2652,7 +2652,7 @@
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         }
       }
@@ -2663,13 +2663,13 @@
       "integrity": "sha512-D06ivJkYxyRrcEe0bTpNnBQNgP9d3xog+qZlLbui8EsMr/DouQpf5o9FzJnWYHEYE0YsFHllUv2R1dkgYZXHcA==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "uws": "~9.14.0",
-        "ws": "~3.3.1"
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "uws": "9.14.0",
+        "ws": "3.3.3"
       },
       "dependencies": {
         "debug": {
@@ -2691,14 +2691,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -2720,10 +2720,10 @@
       "dev": true,
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "~1.0.2"
+        "has-binary2": "1.0.2"
       }
     },
     "entities": {
@@ -2737,7 +2737,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -2746,11 +2746,11 @@
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -2759,9 +2759,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es5-ext": {
@@ -2770,8 +2770,8 @@
       "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.1",
-        "es6-symbol": "~3.1.1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-iterator": {
@@ -2780,9 +2780,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-map": {
@@ -2791,12 +2791,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
       }
     },
     "es6-promise": {
@@ -2811,7 +2811,7 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "^4.0.3"
+        "es6-promise": "4.2.4"
       }
     },
     "es6-set": {
@@ -2820,11 +2820,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
+        "event-emitter": "0.3.5"
       }
     },
     "es6-symbol": {
@@ -2833,8 +2833,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
       }
     },
     "es6-weak-map": {
@@ -2843,10 +2843,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-html": {
@@ -2866,11 +2866,11 @@
       "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -2894,10 +2894,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "^0.1.3",
-        "es6-weak-map": "^2.0.1",
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
       }
     },
     "eslint": {
@@ -2906,39 +2906,39 @@
       "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "concat-stream": "^1.4.6",
-        "debug": "^2.1.1",
-        "doctrine": "^1.2.2",
-        "es6-map": "^0.1.3",
-        "escope": "^3.6.0",
-        "espree": "^3.1.6",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^1.1.1",
-        "glob": "^7.0.3",
-        "globals": "^9.2.0",
-        "ignore": "^3.1.2",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^0.12.0",
-        "is-my-json-valid": "^2.10.0",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.5.1",
-        "json-stable-stringify": "^1.0.0",
-        "levn": "^0.3.0",
-        "lodash": "^4.0.0",
-        "mkdirp": "^0.5.0",
-        "optionator": "^0.8.1",
-        "path-is-absolute": "^1.0.0",
-        "path-is-inside": "^1.0.1",
-        "pluralize": "^1.2.1",
-        "progress": "^1.1.8",
-        "require-uncached": "^1.0.2",
-        "shelljs": "^0.6.0",
-        "strip-json-comments": "~1.0.1",
-        "table": "^3.7.8",
-        "text-table": "~0.2.0",
-        "user-home": "^2.0.0"
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "es6-map": "0.1.5",
+        "escope": "3.6.0",
+        "espree": "3.5.1",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.3.1",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.1",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "optionator": "0.8.2",
+        "path-is-absolute": "1.0.1",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.6.1",
+        "strip-json-comments": "1.0.4",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
       }
     },
     "eslint-config-standard": {
@@ -2959,9 +2959,9 @@
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
       "dev": true,
       "requires": {
-        "debug": "^2.2.0",
-        "object-assign": "^4.0.1",
-        "resolve": "^1.1.6"
+        "debug": "2.6.9",
+        "object-assign": "4.1.1",
+        "resolve": "1.5.0"
       },
       "dependencies": {
         "object-assign": {
@@ -2978,8 +2978,8 @@
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^1.0.0"
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
       }
     },
     "eslint-plugin-import": {
@@ -2988,16 +2988,16 @@
       "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.1.1",
-        "contains-path": "^0.1.0",
-        "debug": "^2.2.0",
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.2.0",
-        "eslint-module-utils": "^2.0.0",
-        "has": "^1.0.1",
-        "lodash.cond": "^4.3.0",
-        "minimatch": "^3.0.3",
-        "pkg-up": "^1.0.0"
+        "eslint-import-resolver-node": "0.2.3",
+        "eslint-module-utils": "2.1.1",
+        "has": "1.0.1",
+        "lodash.cond": "4.5.2",
+        "minimatch": "3.0.4",
+        "pkg-up": "1.0.0"
       }
     },
     "eslint-plugin-node": {
@@ -3006,10 +3006,10 @@
       "integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
       "dev": true,
       "requires": {
-        "ignore": "^3.0.11",
-        "minimatch": "^3.0.2",
-        "object-assign": "^4.0.1",
-        "resolve": "^1.1.7",
+        "ignore": "3.3.7",
+        "minimatch": "3.0.4",
+        "object-assign": "4.1.1",
+        "resolve": "1.5.0",
         "semver": "5.3.0"
       },
       "dependencies": {
@@ -3039,11 +3039,11 @@
       "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
       "dev": true,
       "requires": {
-        "array.prototype.find": "^2.0.1",
-        "doctrine": "^1.2.2",
-        "has": "^1.0.1",
-        "jsx-ast-utils": "^1.3.4",
-        "object.assign": "^4.0.4"
+        "array.prototype.find": "2.0.4",
+        "doctrine": "1.5.0",
+        "has": "1.0.1",
+        "jsx-ast-utils": "1.4.1",
+        "object.assign": "4.1.0"
       }
     },
     "eslint-plugin-standard": {
@@ -3058,8 +3058,8 @@
       "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "dev": true,
       "requires": {
-        "acorn": "^5.1.1",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "5.1.2",
+        "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
@@ -3073,7 +3073,7 @@
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
@@ -3082,8 +3082,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0",
-        "object-assign": "^4.0.1"
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -3123,8 +3123,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
       }
     },
     "event-stream": {
@@ -3133,13 +3133,13 @@
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
       }
     },
     "eventemitter3": {
@@ -3154,7 +3154,7 @@
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "dev": true,
       "requires": {
-        "merge": "^1.1.3"
+        "merge": "1.2.0"
       }
     },
     "execa": {
@@ -3163,13 +3163,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -3178,9 +3178,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
           }
         },
         "lru-cache": {
@@ -3189,8 +3189,8 @@
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         }
       }
@@ -3213,7 +3213,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -3222,7 +3222,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.3"
       }
     },
     "expand-tilde": {
@@ -3231,7 +3231,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "expect": {
@@ -3240,12 +3240,12 @@
       "integrity": "sha1-v9/VeiogFw2HWZnul4fMcfAcIF8=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "jest-diff": "^23.0.1",
-        "jest-get-type": "^22.1.0",
-        "jest-matcher-utils": "^23.0.1",
-        "jest-message-util": "^23.1.0",
-        "jest-regex-util": "^23.0.0"
+        "ansi-styles": "3.2.1",
+        "jest-diff": "23.0.1",
+        "jest-get-type": "22.4.3",
+        "jest-matcher-utils": "23.0.1",
+        "jest-message-util": "23.1.0",
+        "jest-regex-util": "23.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3254,7 +3254,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         }
       }
@@ -3275,7 +3275,7 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "requires": {
-        "is-extendable": "^0.1.0"
+        "is-extendable": "0.1.1"
       }
     },
     "extglob": {
@@ -3284,7 +3284,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extract-zip": {
@@ -3305,10 +3305,10 @@
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
+            "buffer-from": "1.1.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "typedarray": "0.0.6"
           }
         },
         "isarray": {
@@ -3329,13 +3329,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -3344,7 +3344,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -3360,8 +3360,8 @@
       "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "time-stamp": "^1.0.0"
+        "chalk": "1.1.3",
+        "time-stamp": "1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -3386,7 +3386,7 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.0.0"
       }
     },
     "fd-slicer": {
@@ -3395,7 +3395,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "figures": {
@@ -3404,8 +3404,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -3427,8 +3427,8 @@
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -3451,8 +3451,8 @@
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.3",
-        "minimatch": "^3.0.3"
+        "glob": "7.1.2",
+        "minimatch": "3.0.4"
       }
     },
     "fill-range": {
@@ -3461,11 +3461,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "finalhandler": {
@@ -3474,11 +3474,11 @@
       "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
       "dev": true,
       "requires": {
-        "debug": "~2.2.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "statuses": "~1.3.0",
-        "unpipe": "~1.0.0"
+        "debug": "2.2.0",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -3504,8 +3504,8 @@
       "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
       "dev": true,
       "requires": {
-        "fs-exists-sync": "^0.1.0",
-        "resolve-dir": "^0.1.0"
+        "fs-exists-sync": "0.1.0",
+        "resolve-dir": "0.1.1"
       },
       "dependencies": {
         "expand-tilde": {
@@ -3514,7 +3514,7 @@
           "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.1"
+            "os-homedir": "1.0.2"
           }
         },
         "global-modules": {
@@ -3523,8 +3523,8 @@
           "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
           "dev": true,
           "requires": {
-            "global-prefix": "^0.1.4",
-            "is-windows": "^0.2.0"
+            "global-prefix": "0.1.5",
+            "is-windows": "0.2.0"
           }
         },
         "global-prefix": {
@@ -3533,10 +3533,10 @@
           "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
           "dev": true,
           "requires": {
-            "homedir-polyfill": "^1.0.0",
-            "ini": "^1.3.4",
-            "is-windows": "^0.2.0",
-            "which": "^1.2.12"
+            "homedir-polyfill": "1.0.1",
+            "ini": "1.3.5",
+            "is-windows": "0.2.0",
+            "which": "1.3.0"
           }
         },
         "is-windows": {
@@ -3551,8 +3551,8 @@
           "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
           "dev": true,
           "requires": {
-            "expand-tilde": "^1.2.2",
-            "global-modules": "^0.2.3"
+            "expand-tilde": "1.2.2",
+            "global-modules": "0.2.3"
           }
         }
       }
@@ -3574,7 +3574,7 @@
       "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
       "dev": true,
       "requires": {
-        "find-file-up": "^0.1.2"
+        "find-file-up": "0.1.3"
       }
     },
     "find-root": {
@@ -3588,8 +3588,8 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "findup-sync": {
@@ -3598,10 +3598,10 @@
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.9",
+        "resolve-dir": "1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -3622,18 +3622,18 @@
           "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "kind-of": "^6.0.2",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "kind-of": "6.0.2",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -3642,7 +3642,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -3651,7 +3651,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -3662,13 +3662,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -3677,7 +3677,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -3686,7 +3686,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -3695,9 +3695,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -3714,8 +3714,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -3724,7 +3724,7 @@
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -3735,14 +3735,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -3751,7 +3751,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -3760,7 +3760,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -3771,10 +3771,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -3783,7 +3783,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -3794,7 +3794,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -3803,7 +3803,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -3814,7 +3814,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -3823,7 +3823,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -3840,7 +3840,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -3849,7 +3849,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -3858,7 +3858,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -3881,19 +3881,19 @@
           "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.1",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -3904,11 +3904,11 @@
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "is-plain-object": "^2.0.3",
-        "object.defaults": "^1.1.0",
-        "object.pick": "^1.2.0",
-        "parse-filepath": "^1.0.1"
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
       }
     },
     "first-chunk-stream": {
@@ -3929,10 +3929,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       }
     },
     "for-in": {
@@ -3947,7 +3947,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -3966,9 +3966,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.5",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
       }
     },
     "fragment-cache": {
@@ -3977,7 +3977,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -3998,7 +3998,7 @@
       "integrity": "sha1-91mDufL0E75ljJPf172M5AePXNs=",
       "dev": true,
       "requires": {
-        "js-yaml": "^3.4.6"
+        "js-yaml": "3.10.0"
       }
     },
     "fs-exists-sync": {
@@ -4013,9 +4013,9 @@
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
       }
     },
     "fs-readdir-recursive": {
@@ -4036,8 +4036,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.3.0",
-        "node-pre-gyp": "^0.6.39"
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -4052,8 +4052,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "ansi-regex": {
@@ -4073,8 +4073,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
           }
         },
         "asn1": {
@@ -4118,7 +4118,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "^0.14.3"
+            "tweetnacl": "0.14.5"
           }
         },
         "block-stream": {
@@ -4126,7 +4126,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "~2.0.0"
+            "inherits": "2.0.3"
           }
         },
         "boom": {
@@ -4134,7 +4134,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "brace-expansion": {
@@ -4142,7 +4142,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^0.4.1",
+            "balanced-match": "0.4.2",
             "concat-map": "0.0.1"
           }
         },
@@ -4173,7 +4173,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
@@ -4196,7 +4196,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "dashdash": {
@@ -4205,7 +4205,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -4254,7 +4254,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "extend": {
@@ -4280,9 +4280,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
           }
         },
         "fs.realpath": {
@@ -4295,10 +4295,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
           }
         },
         "fstream-ignore": {
@@ -4307,9 +4307,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "inherits": "2",
-            "minimatch": "^3.0.0"
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
           }
         },
         "gauge": {
@@ -4318,14 +4318,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "getpass": {
@@ -4334,7 +4334,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -4350,12 +4350,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-fs": {
@@ -4375,8 +4375,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
           }
         },
         "has-unicode": {
@@ -4390,10 +4390,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
@@ -4407,9 +4407,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
           }
         },
         "inflight": {
@@ -4417,8 +4417,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -4437,7 +4437,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-typedarray": {
@@ -4463,7 +4463,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "jsbn": {
@@ -4484,7 +4484,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsonify": "~0.0.0"
+            "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -4529,7 +4529,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "~1.27.0"
+            "mime-db": "1.27.0"
           }
         },
         "minimatch": {
@@ -4537,7 +4537,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.7"
           }
         },
         "minimist": {
@@ -4565,17 +4565,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
+            "detect-libc": "1.0.2",
             "hawk": "3.1.3",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
             "request": "2.81.0",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^2.2.1",
-            "tar-pack": "^3.4.0"
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
           }
         },
         "nopt": {
@@ -4584,8 +4584,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
           }
         },
         "npmlog": {
@@ -4594,10 +4594,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -4622,7 +4622,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -4643,8 +4643,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -4681,10 +4681,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -4700,13 +4700,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "buffer-shims": "~1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "request": {
@@ -4715,28 +4715,28 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
           }
         },
         "rimraf": {
@@ -4744,7 +4744,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -4775,7 +4775,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "sshpk": {
@@ -4784,15 +4784,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jodid25519": "^1.0.0",
-            "jsbn": "~0.1.0",
-            "tweetnacl": "~0.14.0"
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
           },
           "dependencies": {
             "assert-plus": {
@@ -4808,9 +4808,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -4818,7 +4818,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4832,7 +4832,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -4846,9 +4846,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
           }
         },
         "tar-pack": {
@@ -4857,14 +4857,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.2.0",
-            "fstream": "^1.0.10",
-            "fstream-ignore": "^1.0.5",
-            "once": "^1.3.3",
-            "readable-stream": "^2.1.4",
-            "rimraf": "^2.5.1",
-            "tar": "^2.2.1",
-            "uid-number": "^0.0.6"
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
           }
         },
         "tough-cookie": {
@@ -4873,7 +4873,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "punycode": "^1.4.1"
+            "punycode": "1.4.1"
           }
         },
         "tunnel-agent": {
@@ -4882,7 +4882,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.0.1"
           }
         },
         "tweetnacl": {
@@ -4923,7 +4923,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -4938,10 +4938,10 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
       }
     },
     "function-bind": {
@@ -4955,14 +4955,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
       },
       "dependencies": {
         "object-assign": {
@@ -4978,7 +4978,7 @@
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "dev": true,
       "requires": {
-        "globule": "~0.1.0"
+        "globule": "0.1.0"
       },
       "dependencies": {
         "glob": {
@@ -4987,9 +4987,9 @@
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "~1.2.0",
-            "inherits": "1",
-            "minimatch": "~0.2.11"
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
           }
         },
         "globule": {
@@ -4998,9 +4998,9 @@
           "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
           "dev": true,
           "requires": {
-            "glob": "~3.1.21",
-            "lodash": "~1.0.1",
-            "minimatch": "~0.2.11"
+            "glob": "3.1.21",
+            "lodash": "1.0.2",
+            "minimatch": "0.2.14"
           }
         },
         "graceful-fs": {
@@ -5027,8 +5027,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         }
       }
@@ -5043,7 +5043,7 @@
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "get-caller-file": {
@@ -5073,7 +5073,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -5088,12 +5088,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -5102,8 +5102,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -5112,7 +5112,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "glob-stream": {
@@ -5121,12 +5121,12 @@
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "dev": true,
       "requires": {
-        "glob": "^4.3.1",
-        "glob2base": "^0.0.12",
-        "minimatch": "^2.0.1",
-        "ordered-read-streams": "^0.1.0",
-        "through2": "^0.6.1",
-        "unique-stream": "^1.0.0"
+        "glob": "4.5.3",
+        "glob2base": "0.0.12",
+        "minimatch": "2.0.10",
+        "ordered-read-streams": "0.1.0",
+        "through2": "0.6.5",
+        "unique-stream": "1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -5135,10 +5135,10 @@
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
           }
         },
         "minimatch": {
@@ -5147,7 +5147,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "brace-expansion": "1.1.8"
           }
         },
         "readable-stream": {
@@ -5156,10 +5156,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "through2": {
@@ -5168,8 +5168,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -5180,7 +5180,7 @@
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
       "dev": true,
       "requires": {
-        "gaze": "^0.5.1"
+        "gaze": "0.5.2"
       }
     },
     "glob2base": {
@@ -5189,7 +5189,7 @@
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "dev": true,
       "requires": {
-        "find-index": "^0.1.1"
+        "find-index": "0.1.1"
       }
     },
     "global-modules": {
@@ -5198,9 +5198,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -5209,11 +5209,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.0"
       }
     },
     "globals": {
@@ -5228,12 +5228,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "object-assign": {
@@ -5249,9 +5249,9 @@
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "requires": {
-        "glob": "~7.1.1",
-        "lodash": "~4.17.4",
-        "minimatch": "~3.0.2"
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4"
       }
     },
     "glogg": {
@@ -5260,7 +5260,7 @@
       "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "gonzales-pe-sl": {
@@ -5269,7 +5269,7 @@
       "integrity": "sha1-aoaLw4BkXxQf7rBCxvl/zHG1n+Y=",
       "dev": true,
       "requires": {
-        "minimist": "1.1.x"
+        "minimist": "1.1.3"
       },
       "dependencies": {
         "minimist": {
@@ -5285,7 +5285,7 @@
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "requires": {
-        "delegate": "^3.1.2"
+        "delegate": "3.2.0"
       }
     },
     "govuk-frontend": {
@@ -5303,10 +5303,10 @@
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.1.tgz",
       "integrity": "sha512-p0MADBEBl1CohV7nRZ8sVinBexEe3CKVhh0A0QIHKpcbRoxB0VgeMpRPjW/HBHIPLAKrpIIIm5mZ6hKu3E+iQg==",
       "requires": {
-        "js-yaml": "^3.11.0",
-        "kind-of": "^6.0.2",
-        "section-matter": "^1.0.0",
-        "strip-bom-string": "^1.0.0"
+        "js-yaml": "3.12.0",
+        "kind-of": "6.0.2",
+        "section-matter": "1.0.0",
+        "strip-bom-string": "1.0.0"
       },
       "dependencies": {
         "js-yaml": {
@@ -5314,8 +5314,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
           "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
           }
         },
         "kind-of": {
@@ -5337,19 +5337,19 @@
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "chalk": "^1.0.0",
-        "deprecated": "^0.0.1",
-        "gulp-util": "^3.0.0",
-        "interpret": "^1.0.0",
-        "liftoff": "^2.1.0",
-        "minimist": "^1.1.0",
-        "orchestrator": "^0.3.0",
-        "pretty-hrtime": "^1.0.0",
-        "semver": "^4.1.0",
-        "tildify": "^1.0.0",
-        "v8flags": "^2.0.2",
-        "vinyl-fs": "^0.3.0"
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.8",
+        "interpret": "1.1.0",
+        "liftoff": "2.5.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.8",
+        "pretty-hrtime": "1.0.3",
+        "semver": "4.3.6",
+        "tildify": "1.2.0",
+        "v8flags": "2.1.1",
+        "vinyl-fs": "0.3.14"
       }
     },
     "gulp-sass-lint": {
@@ -5358,9 +5358,9 @@
       "integrity": "sha512-HjRwdVueJOQKV0+wVT3Ld5HFRk9fELXIHllQPS4cU9C2SC9RKIfExT7/RLDegZ2cQXeFRkVii4GFw4WnzV+epQ==",
       "dev": true,
       "requires": {
-        "gulp-util": "^3.0.6",
-        "sass-lint": "^1.12.0",
-        "through2": "^2.0.2"
+        "gulp-util": "3.0.8",
+        "sass-lint": "1.12.1",
+        "through2": "2.0.3"
       }
     },
     "gulp-util": {
@@ -5369,24 +5369,24 @@
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-uniq": "^1.0.2",
-        "beeper": "^1.0.0",
-        "chalk": "^1.0.0",
-        "dateformat": "^2.0.0",
-        "fancy-log": "^1.1.0",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash._reescape": "^3.0.0",
-        "lodash._reevaluate": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.template": "^3.0.0",
-        "minimist": "^1.1.0",
-        "multipipe": "^0.1.2",
-        "object-assign": "^3.0.0",
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.0",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl": "^0.5.0"
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
       }
     },
     "gulplog": {
@@ -5395,7 +5395,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "^1.0.0"
+        "glogg": "1.0.0"
       }
     },
     "handlebars": {
@@ -5404,10 +5404,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
       }
     },
     "har-schema": {
@@ -5421,8 +5421,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -5430,10 +5430,10 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "har-schema": {
@@ -5449,7 +5449,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -5457,7 +5457,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary2": {
@@ -5500,7 +5500,7 @@
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "has-symbols": {
@@ -5520,9 +5520,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -5539,8 +5539,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -5549,7 +5549,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5558,7 +5558,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -5569,7 +5569,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5579,10 +5579,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
       }
     },
     "highlight.js": {
@@ -5602,8 +5602,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "homedir-polyfill": {
@@ -5612,7 +5612,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -5626,7 +5626,7 @@
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "^1.0.1"
+        "whatwg-encoding": "1.0.3"
       }
     },
     "html5shiv": {
@@ -5640,12 +5640,12 @@
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.2",
+        "domutils": "1.5.1",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -5666,13 +5666,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -5681,7 +5681,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -5694,7 +5694,7 @@
       "requires": {
         "inherits": "2.0.3",
         "setprototypeof": "1.0.2",
-        "statuses": ">= 1.3.1 < 2"
+        "statuses": "1.3.1"
       }
     },
     "http-proxy": {
@@ -5703,8 +5703,8 @@
       "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.x.x",
-        "requires-port": "1.x.x"
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
       }
     },
     "http-signature": {
@@ -5712,9 +5712,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "requires": {
-        "assert-plus": "^0.2.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
       }
     },
     "https-proxy-agent": {
@@ -5723,8 +5723,8 @@
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
+        "agent-base": "4.2.0",
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -5768,8 +5768,8 @@
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "^2.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -5778,7 +5778,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "pkg-dir": {
@@ -5787,7 +5787,7 @@
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
           "dev": true,
           "requires": {
-            "find-up": "^2.1.0"
+            "find-up": "2.1.0"
           }
         }
       }
@@ -5808,7 +5808,7 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexof": {
@@ -5822,8 +5822,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -5843,7 +5843,7 @@
       "integrity": "sha1-Tg88DJ/WGzBYAbJpRLECVtSnYOs=",
       "dev": true,
       "requires": {
-        "require-one": "^1.0.2"
+        "require-one": "1.0.3"
       }
     },
     "inquirer": {
@@ -5852,19 +5852,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.1.0",
-        "ansi-regex": "^2.0.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^2.0.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "readline2": "^1.0.1",
-        "run-async": "^0.1.0",
-        "rx-lite": "^3.1.2",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
       }
     },
     "interpret": {
@@ -5879,7 +5879,7 @@
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "invert-kv": {
@@ -5899,8 +5899,8 @@
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
       }
     },
     "is-accessor-descriptor": {
@@ -5909,7 +5909,7 @@
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.0"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5931,7 +5931,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -5945,7 +5945,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
@@ -5960,7 +5960,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.3"
       }
     },
     "is-data-descriptor": {
@@ -5969,7 +5969,7 @@
       "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.0"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5992,9 +5992,9 @@
       "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
+        "is-accessor-descriptor": "1.0.0",
+        "is-data-descriptor": "1.0.0",
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6017,7 +6017,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -6036,7 +6036,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -6044,7 +6044,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-generator-fn": {
@@ -6059,7 +6059,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-module": {
@@ -6073,10 +6073,10 @@
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
       "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-number": {
@@ -6085,7 +6085,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-number-like": {
@@ -6094,7 +6094,7 @@
       "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
       "dev": true,
       "requires": {
-        "lodash.isfinite": "^3.3.2"
+        "lodash.isfinite": "3.3.2"
       }
     },
     "is-odd": {
@@ -6103,7 +6103,7 @@
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -6126,7 +6126,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.0"
       }
     },
     "is-path-inside": {
@@ -6135,7 +6135,7 @@
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-object": {
@@ -6144,7 +6144,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -6184,7 +6184,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "is-relative": {
@@ -6193,7 +6193,7 @@
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "^1.0.0"
+        "is-unc-path": "1.0.0"
       }
     },
     "is-resolvable": {
@@ -6202,7 +6202,7 @@
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
-        "tryit": "^1.0.1"
+        "tryit": "1.0.3"
       }
     },
     "is-stream": {
@@ -6228,7 +6228,7 @@
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
-        "unc-path-regex": "^0.1.2"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-utf8": {
@@ -6281,18 +6281,18 @@
       "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
       "dev": true,
       "requires": {
-        "async": "^2.1.4",
-        "compare-versions": "^3.1.0",
-        "fileset": "^2.0.2",
-        "istanbul-lib-coverage": "^1.2.0",
-        "istanbul-lib-hook": "^1.2.0",
-        "istanbul-lib-instrument": "^1.10.1",
-        "istanbul-lib-report": "^1.1.4",
-        "istanbul-lib-source-maps": "^1.2.4",
-        "istanbul-reports": "^1.3.0",
-        "js-yaml": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "once": "^1.4.0"
+        "async": "2.6.1",
+        "compare-versions": "3.2.1",
+        "fileset": "2.0.3",
+        "istanbul-lib-coverage": "1.2.0",
+        "istanbul-lib-hook": "1.2.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "istanbul-lib-report": "1.1.4",
+        "istanbul-lib-source-maps": "1.2.5",
+        "istanbul-reports": "1.3.0",
+        "js-yaml": "3.10.0",
+        "mkdirp": "0.5.1",
+        "once": "1.4.0"
       },
       "dependencies": {
         "async": {
@@ -6301,7 +6301,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "4.17.10"
           }
         },
         "lodash": {
@@ -6324,7 +6324,7 @@
       "integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
       "dev": true,
       "requires": {
-        "append-transform": "^0.4.0"
+        "append-transform": "0.4.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -6333,13 +6333,13 @@
       "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
       "dev": true,
       "requires": {
-        "babel-generator": "^6.18.0",
-        "babel-template": "^6.16.0",
-        "babel-traverse": "^6.18.0",
-        "babel-types": "^6.18.0",
-        "babylon": "^6.18.0",
-        "istanbul-lib-coverage": "^1.2.0",
-        "semver": "^5.3.0"
+        "babel-generator": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "istanbul-lib-coverage": "1.2.0",
+        "semver": "5.5.0"
       },
       "dependencies": {
         "semver": {
@@ -6356,10 +6356,10 @@
       "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "path-parse": "^1.0.5",
-        "supports-color": "^3.1.2"
+        "istanbul-lib-coverage": "1.2.0",
+        "mkdirp": "0.5.1",
+        "path-parse": "1.0.5",
+        "supports-color": "3.2.3"
       },
       "dependencies": {
         "has-flag": {
@@ -6374,7 +6374,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -6385,11 +6385,11 @@
       "integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
-        "istanbul-lib-coverage": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.1",
-        "source-map": "^0.5.3"
+        "debug": "3.1.0",
+        "istanbul-lib-coverage": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -6415,7 +6415,7 @@
       "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.0.3"
+        "handlebars": "4.0.11"
       }
     },
     "jest": {
@@ -6424,8 +6424,8 @@
       "integrity": "sha1-u7f4kxAKEadC3YvQ0EelSwlorRo=",
       "dev": true,
       "requires": {
-        "import-local": "^1.0.0",
-        "jest-cli": "^23.1.0"
+        "import-local": "1.0.0",
+        "jest-cli": "23.1.0"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -6446,7 +6446,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "camelcase": {
@@ -6461,9 +6461,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "cliui": {
@@ -6472,9 +6472,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           }
         },
         "find-up": {
@@ -6483,7 +6483,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -6498,41 +6498,41 @@
           "integrity": "sha1-64vdTODRUlCJLjGtm2m8mdKo9r8=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.1",
-            "exit": "^0.1.2",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "import-local": "^1.0.0",
-            "is-ci": "^1.0.10",
-            "istanbul-api": "^1.3.1",
-            "istanbul-lib-coverage": "^1.2.0",
-            "istanbul-lib-instrument": "^1.10.1",
-            "istanbul-lib-source-maps": "^1.2.4",
-            "jest-changed-files": "^23.0.1",
-            "jest-config": "^23.1.0",
-            "jest-environment-jsdom": "^23.1.0",
-            "jest-get-type": "^22.1.0",
-            "jest-haste-map": "^23.1.0",
-            "jest-message-util": "^23.1.0",
-            "jest-regex-util": "^23.0.0",
-            "jest-resolve-dependencies": "^23.0.1",
-            "jest-runner": "^23.1.0",
-            "jest-runtime": "^23.1.0",
-            "jest-snapshot": "^23.0.1",
-            "jest-util": "^23.1.0",
-            "jest-validate": "^23.0.1",
-            "jest-watcher": "^23.1.0",
-            "jest-worker": "^23.0.1",
-            "micromatch": "^2.3.11",
-            "node-notifier": "^5.2.1",
-            "realpath-native": "^1.0.0",
-            "rimraf": "^2.5.4",
-            "slash": "^1.0.0",
-            "string-length": "^2.0.0",
-            "strip-ansi": "^4.0.0",
-            "which": "^1.2.12",
-            "yargs": "^11.0.0"
+            "ansi-escapes": "3.1.0",
+            "chalk": "2.4.1",
+            "exit": "0.1.2",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "import-local": "1.0.0",
+            "is-ci": "1.1.0",
+            "istanbul-api": "1.3.1",
+            "istanbul-lib-coverage": "1.2.0",
+            "istanbul-lib-instrument": "1.10.1",
+            "istanbul-lib-source-maps": "1.2.5",
+            "jest-changed-files": "23.0.1",
+            "jest-config": "23.1.0",
+            "jest-environment-jsdom": "23.1.0",
+            "jest-get-type": "22.4.3",
+            "jest-haste-map": "23.1.0",
+            "jest-message-util": "23.1.0",
+            "jest-regex-util": "23.0.0",
+            "jest-resolve-dependencies": "23.0.1",
+            "jest-runner": "23.1.0",
+            "jest-runtime": "23.1.0",
+            "jest-snapshot": "23.0.1",
+            "jest-util": "23.1.0",
+            "jest-validate": "23.0.1",
+            "jest-watcher": "23.1.0",
+            "jest-worker": "23.0.1",
+            "micromatch": "2.3.11",
+            "node-notifier": "5.2.1",
+            "realpath-native": "1.0.0",
+            "rimraf": "2.6.2",
+            "slash": "1.0.0",
+            "string-length": "2.0.0",
+            "strip-ansi": "4.0.0",
+            "which": "1.3.0",
+            "yargs": "11.0.0"
           }
         },
         "os-locale": {
@@ -6541,9 +6541,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "string-width": {
@@ -6552,8 +6552,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -6562,7 +6562,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -6571,7 +6571,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "which-module": {
@@ -6586,18 +6586,18 @@
           "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           }
         },
         "yargs-parser": {
@@ -6606,7 +6606,7 @@
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -6617,7 +6617,7 @@
       "integrity": "sha1-95Vy0HIIROpd+EwqRI6GLCJU9gw=",
       "dev": true,
       "requires": {
-        "throat": "^4.0.0"
+        "throat": "4.1.0"
       }
     },
     "jest-config": {
@@ -6626,19 +6626,19 @@
       "integrity": "sha1-cIyg9DHTVu5CT7SJXTMIAGvdgkE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.0.0",
-        "babel-jest": "^23.0.1",
-        "chalk": "^2.0.1",
-        "glob": "^7.1.1",
-        "jest-environment-jsdom": "^23.1.0",
-        "jest-environment-node": "^23.1.0",
-        "jest-get-type": "^22.1.0",
-        "jest-jasmine2": "^23.1.0",
-        "jest-regex-util": "^23.0.0",
-        "jest-resolve": "^23.1.0",
-        "jest-util": "^23.1.0",
-        "jest-validate": "^23.0.1",
-        "pretty-format": "^23.0.1"
+        "babel-core": "6.26.0",
+        "babel-jest": "23.0.1",
+        "chalk": "2.4.1",
+        "glob": "7.1.2",
+        "jest-environment-jsdom": "23.1.0",
+        "jest-environment-node": "23.1.0",
+        "jest-get-type": "22.4.3",
+        "jest-jasmine2": "23.1.0",
+        "jest-regex-util": "23.0.0",
+        "jest-resolve": "23.1.0",
+        "jest-util": "23.1.0",
+        "jest-validate": "23.0.1",
+        "pretty-format": "23.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6647,7 +6647,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -6656,9 +6656,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -6667,7 +6667,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -6678,10 +6678,10 @@
       "integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "diff": "^3.2.0",
-        "jest-get-type": "^22.1.0",
-        "pretty-format": "^23.0.1"
+        "chalk": "2.4.1",
+        "diff": "3.5.0",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "23.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6690,7 +6690,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -6699,9 +6699,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -6710,7 +6710,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -6721,7 +6721,7 @@
       "integrity": "sha1-3t3RgzO+XcJBUmCgTvP86SdrVyU=",
       "dev": true,
       "requires": {
-        "detect-newline": "^2.1.0"
+        "detect-newline": "2.1.0"
       }
     },
     "jest-each": {
@@ -6730,8 +6730,8 @@
       "integrity": "sha1-FhRrWSw1SGelrl4TzfFcbGW2lsY=",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "pretty-format": "^23.0.1"
+        "chalk": "2.4.1",
+        "pretty-format": "23.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6740,7 +6740,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -6749,9 +6749,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -6760,7 +6760,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -6771,9 +6771,9 @@
       "integrity": "sha1-hZKZFOI77TV32sl1X0EG0Gl8R5w=",
       "dev": true,
       "requires": {
-        "jest-mock": "^23.1.0",
-        "jest-util": "^23.1.0",
-        "jsdom": "^11.5.1"
+        "jest-mock": "23.1.0",
+        "jest-util": "23.1.0",
+        "jsdom": "11.11.0"
       }
     },
     "jest-environment-node": {
@@ -6782,8 +6782,8 @@
       "integrity": "sha1-RSwL+UnPy7rNoeF2Lu7XC8eEx9U=",
       "dev": true,
       "requires": {
-        "jest-mock": "^23.1.0",
-        "jest-util": "^23.1.0"
+        "jest-mock": "23.1.0",
+        "jest-util": "23.1.0"
       }
     },
     "jest-environment-puppeteer": {
@@ -6792,13 +6792,13 @@
       "integrity": "sha1-kabS3I+gpIwpZdbfuRIiaspMs00=",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.0",
-        "cwd": "^0.10.0",
-        "lodash": "^4.17.5",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.2",
-        "spawnd": "^2.0.0",
-        "wait-port": "^0.2.2"
+        "chalk": "2.4.1",
+        "cwd": "0.10.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "spawnd": "2.0.0",
+        "wait-port": "0.2.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6807,7 +6807,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -6816,9 +6816,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "lodash": {
@@ -6833,7 +6833,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -6850,13 +6850,13 @@
       "integrity": "sha1-GObH1ajScTb5G32YUvhd4McHTEk=",
       "dev": true,
       "requires": {
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.1.11",
-        "jest-docblock": "^23.0.1",
-        "jest-serializer": "^23.0.1",
-        "jest-worker": "^23.0.1",
-        "micromatch": "^2.3.11",
-        "sane": "^2.0.0"
+        "fb-watchman": "2.0.0",
+        "graceful-fs": "4.1.11",
+        "jest-docblock": "23.0.1",
+        "jest-serializer": "23.0.1",
+        "jest-worker": "23.0.1",
+        "micromatch": "2.3.11",
+        "sane": "2.5.2"
       }
     },
     "jest-jasmine2": {
@@ -6865,17 +6865,17 @@
       "integrity": "sha1-SvqzFym2VN3NKwdK3YSTlvE7MLg=",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "co": "^4.6.0",
-        "expect": "^23.1.0",
-        "is-generator-fn": "^1.0.0",
-        "jest-diff": "^23.0.1",
-        "jest-each": "^23.1.0",
-        "jest-matcher-utils": "^23.0.1",
-        "jest-message-util": "^23.1.0",
-        "jest-snapshot": "^23.0.1",
-        "jest-util": "^23.1.0",
-        "pretty-format": "^23.0.1"
+        "chalk": "2.4.1",
+        "co": "4.6.0",
+        "expect": "23.1.0",
+        "is-generator-fn": "1.0.0",
+        "jest-diff": "23.0.1",
+        "jest-each": "23.1.0",
+        "jest-matcher-utils": "23.0.1",
+        "jest-message-util": "23.1.0",
+        "jest-snapshot": "23.0.1",
+        "jest-util": "23.1.0",
+        "pretty-format": "23.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6884,7 +6884,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -6893,9 +6893,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -6904,7 +6904,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -6915,7 +6915,7 @@
       "integrity": "sha1-nboHUFrDSVw50+wJrB5WRZnoYaA=",
       "dev": true,
       "requires": {
-        "pretty-format": "^23.0.1"
+        "pretty-format": "23.0.1"
       }
     },
     "jest-matcher-utils": {
@@ -6924,9 +6924,9 @@
       "integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "jest-get-type": "^22.1.0",
-        "pretty-format": "^23.0.1"
+        "chalk": "2.4.1",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "23.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6935,7 +6935,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -6944,9 +6944,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -6955,7 +6955,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -6966,11 +6966,11 @@
       "integrity": "sha1-moCbpIfsrFzlEdTmmO47XuJGHqk=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0-beta.35",
-        "chalk": "^2.0.1",
-        "micromatch": "^2.3.11",
-        "slash": "^1.0.0",
-        "stack-utils": "^1.0.1"
+        "@babel/code-frame": "7.0.0-beta.49",
+        "chalk": "2.4.1",
+        "micromatch": "2.3.11",
+        "slash": "1.0.0",
+        "stack-utils": "1.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6979,7 +6979,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -6988,9 +6988,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -6999,7 +6999,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -7016,8 +7016,8 @@
       "integrity": "sha1-rIhF2G/23RVNmDYczk5rechOmdw=",
       "dev": true,
       "requires": {
-        "expect-puppeteer": "^3.0.1",
-        "jest-environment-puppeteer": "^2.4.0"
+        "expect-puppeteer": "3.0.1",
+        "jest-environment-puppeteer": "2.4.0"
       }
     },
     "jest-regex-util": {
@@ -7032,9 +7032,9 @@
       "integrity": "sha1-ueMW7s69bwC8UKOWDRUnuuZXktI=",
       "dev": true,
       "requires": {
-        "browser-resolve": "^1.11.2",
-        "chalk": "^2.0.1",
-        "realpath-native": "^1.0.0"
+        "browser-resolve": "1.11.2",
+        "chalk": "2.4.1",
+        "realpath-native": "1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7043,7 +7043,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -7052,9 +7052,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -7063,7 +7063,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -7074,8 +7074,8 @@
       "integrity": "sha1-0BoQ3a2RUsTOzfXqwriFccS2pk0=",
       "dev": true,
       "requires": {
-        "jest-regex-util": "^23.0.0",
-        "jest-snapshot": "^23.0.1"
+        "jest-regex-util": "23.0.0",
+        "jest-snapshot": "23.0.1"
       }
     },
     "jest-runner": {
@@ -7084,19 +7084,19 @@
       "integrity": "sha1-+iCpM//3MaVDKzVh5/ZCZZT6KbU=",
       "dev": true,
       "requires": {
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.1.11",
-        "jest-config": "^23.1.0",
-        "jest-docblock": "^23.0.1",
-        "jest-haste-map": "^23.1.0",
-        "jest-jasmine2": "^23.1.0",
-        "jest-leak-detector": "^23.0.1",
-        "jest-message-util": "^23.1.0",
-        "jest-runtime": "^23.1.0",
-        "jest-util": "^23.1.0",
-        "jest-worker": "^23.0.1",
-        "source-map-support": "^0.5.6",
-        "throat": "^4.0.0"
+        "exit": "0.1.2",
+        "graceful-fs": "4.1.11",
+        "jest-config": "23.1.0",
+        "jest-docblock": "23.0.1",
+        "jest-haste-map": "23.1.0",
+        "jest-jasmine2": "23.1.0",
+        "jest-leak-detector": "23.0.1",
+        "jest-message-util": "23.1.0",
+        "jest-runtime": "23.1.0",
+        "jest-util": "23.1.0",
+        "jest-worker": "23.0.1",
+        "source-map-support": "0.5.6",
+        "throat": "4.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -7111,8 +7111,8 @@
           "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
           "dev": true,
           "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
+            "buffer-from": "1.1.0",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -7123,27 +7123,27 @@
       "integrity": "sha1-tK4OhyWeys/UqIS2OdsHz03WIK8=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.0.0",
-        "babel-plugin-istanbul": "^4.1.6",
-        "chalk": "^2.0.1",
-        "convert-source-map": "^1.4.0",
-        "exit": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graceful-fs": "^4.1.11",
-        "jest-config": "^23.1.0",
-        "jest-haste-map": "^23.1.0",
-        "jest-message-util": "^23.1.0",
-        "jest-regex-util": "^23.0.0",
-        "jest-resolve": "^23.1.0",
-        "jest-snapshot": "^23.0.1",
-        "jest-util": "^23.1.0",
-        "jest-validate": "^23.0.1",
-        "micromatch": "^2.3.11",
-        "realpath-native": "^1.0.0",
-        "slash": "^1.0.0",
+        "babel-core": "6.26.0",
+        "babel-plugin-istanbul": "4.1.6",
+        "chalk": "2.4.1",
+        "convert-source-map": "1.5.1",
+        "exit": "0.1.2",
+        "fast-json-stable-stringify": "2.0.0",
+        "graceful-fs": "4.1.11",
+        "jest-config": "23.1.0",
+        "jest-haste-map": "23.1.0",
+        "jest-message-util": "23.1.0",
+        "jest-regex-util": "23.0.0",
+        "jest-resolve": "23.1.0",
+        "jest-snapshot": "23.0.1",
+        "jest-util": "23.1.0",
+        "jest-validate": "23.0.1",
+        "micromatch": "2.3.11",
+        "realpath-native": "1.0.0",
+        "slash": "1.0.0",
         "strip-bom": "3.0.0",
-        "write-file-atomic": "^2.1.0",
-        "yargs": "^11.0.0"
+        "write-file-atomic": "2.3.0",
+        "yargs": "11.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7158,7 +7158,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "camelcase": {
@@ -7173,9 +7173,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "cliui": {
@@ -7184,9 +7184,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           }
         },
         "find-up": {
@@ -7195,7 +7195,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -7210,9 +7210,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "string-width": {
@@ -7221,8 +7221,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -7231,7 +7231,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "strip-bom": {
@@ -7246,7 +7246,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "which-module": {
@@ -7261,18 +7261,18 @@
           "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           }
         },
         "yargs-parser": {
@@ -7281,7 +7281,7 @@
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -7298,12 +7298,12 @@
       "integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "jest-diff": "^23.0.1",
-        "jest-matcher-utils": "^23.0.1",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^23.0.1"
+        "chalk": "2.4.1",
+        "jest-diff": "23.0.1",
+        "jest-matcher-utils": "23.0.1",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "pretty-format": "23.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7312,7 +7312,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -7321,9 +7321,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -7332,7 +7332,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -7343,14 +7343,14 @@
       "integrity": "sha1-wCUbrzRkTG3S/qeKli9CY6xVdy0=",
       "dev": true,
       "requires": {
-        "callsites": "^2.0.0",
-        "chalk": "^2.0.1",
-        "graceful-fs": "^4.1.11",
-        "is-ci": "^1.0.10",
-        "jest-message-util": "^23.1.0",
-        "mkdirp": "^0.5.1",
-        "slash": "^1.0.0",
-        "source-map": "^0.6.0"
+        "callsites": "2.0.0",
+        "chalk": "2.4.1",
+        "graceful-fs": "4.1.11",
+        "is-ci": "1.1.0",
+        "jest-message-util": "23.1.0",
+        "mkdirp": "0.5.1",
+        "slash": "1.0.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7359,7 +7359,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "callsites": {
@@ -7374,9 +7374,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -7391,7 +7391,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -7402,10 +7402,10 @@
       "integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "jest-get-type": "^22.1.0",
-        "leven": "^2.1.0",
-        "pretty-format": "^23.0.1"
+        "chalk": "2.4.1",
+        "jest-get-type": "22.4.3",
+        "leven": "2.1.0",
+        "pretty-format": "23.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7414,7 +7414,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -7423,9 +7423,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -7434,7 +7434,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -7445,9 +7445,9 @@
       "integrity": "sha1-qNWELjjZ+0r/+CPfartCpYrmzb0=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.1",
-        "string-length": "^2.0.0"
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "string-length": "2.0.0"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -7462,7 +7462,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -7471,9 +7471,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -7482,7 +7482,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -7493,7 +7493,7 @@
       "integrity": "sha1-nmSd2WP/QEYCb5HEAX8Dmmqkp7w=",
       "dev": true,
       "requires": {
-        "merge-stream": "^1.0.1"
+        "merge-stream": "1.0.1"
       }
     },
     "jquery": {
@@ -7512,10 +7512,10 @@
       "integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
       "dev": true,
       "requires": {
-        "config-chain": "~1.1.5",
-        "editorconfig": "^0.13.2",
-        "mkdirp": "~0.5.0",
-        "nopt": "~3.0.1"
+        "config-chain": "1.1.11",
+        "editorconfig": "0.13.3",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6"
       },
       "dependencies": {
         "nopt": {
@@ -7524,7 +7524,7 @@
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1"
+            "abbrev": "1.1.1"
           }
         }
       }
@@ -7541,8 +7541,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
       }
     },
     "jsbn": {
@@ -7557,32 +7557,32 @@
       "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
       "dev": true,
       "requires": {
-        "abab": "^1.0.4",
-        "acorn": "^5.3.0",
-        "acorn-globals": "^4.1.0",
-        "array-equal": "^1.0.0",
-        "cssom": ">= 0.3.2 < 0.4.0",
-        "cssstyle": ">= 0.3.1 < 0.4.0",
-        "data-urls": "^1.0.0",
-        "domexception": "^1.0.0",
-        "escodegen": "^1.9.0",
-        "html-encoding-sniffer": "^1.0.2",
-        "left-pad": "^1.2.0",
-        "nwsapi": "^2.0.0",
+        "abab": "1.0.4",
+        "acorn": "5.6.0",
+        "acorn-globals": "4.1.0",
+        "array-equal": "1.0.0",
+        "cssom": "0.3.2",
+        "cssstyle": "0.3.1",
+        "data-urls": "1.0.0",
+        "domexception": "1.0.1",
+        "escodegen": "1.9.1",
+        "html-encoding-sniffer": "1.0.2",
+        "left-pad": "1.3.0",
+        "nwsapi": "2.0.1",
         "parse5": "4.0.0",
-        "pn": "^1.1.0",
-        "request": "^2.83.0",
-        "request-promise-native": "^1.0.5",
-        "sax": "^1.2.4",
-        "symbol-tree": "^3.2.2",
-        "tough-cookie": "^2.3.3",
-        "w3c-hr-time": "^1.0.1",
-        "webidl-conversions": "^4.0.2",
-        "whatwg-encoding": "^1.0.3",
-        "whatwg-mimetype": "^2.1.0",
-        "whatwg-url": "^6.4.1",
-        "ws": "^4.0.0",
-        "xml-name-validator": "^3.0.0"
+        "pn": "1.1.0",
+        "request": "2.87.0",
+        "request-promise-native": "1.0.5",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.3",
+        "w3c-hr-time": "1.0.1",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.3",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.4.1",
+        "ws": "4.1.0",
+        "xml-name-validator": "3.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -7597,10 +7597,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "assert-plus": {
@@ -7627,9 +7627,9 @@
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
+            "asynckit": "0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "^2.1.12"
+            "mime-types": "2.1.17"
           },
           "dependencies": {
             "combined-stream": {
@@ -7638,7 +7638,7 @@
               "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
               "dev": true,
               "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
               }
             }
           }
@@ -7655,8 +7655,8 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "^5.1.0",
-            "har-schema": "^2.0.0"
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
           }
         },
         "http-signature": {
@@ -7665,9 +7665,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
           }
         },
         "performance-now": {
@@ -7688,26 +7688,26 @@
           "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.1",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
           }
         },
         "tunnel-agent": {
@@ -7716,7 +7716,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.1.1"
           }
         },
         "ws": {
@@ -7725,8 +7725,8 @@
           "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
           "dev": true,
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -7759,7 +7759,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -7779,7 +7779,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsonify": {
@@ -7817,8 +7817,8 @@
       "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.0.0",
-        "promise": "^7.0.1"
+        "is-promise": "2.1.0",
+        "promise": "7.3.1"
       }
     },
     "jstransformer-markdown": {
@@ -7827,7 +7827,7 @@
       "integrity": "sha512-rNLxNC3LIGAc26Qcro73eWoosKymqyNVDn909KIq2QHVHGWZ+d+JzOCrHsmUt3DNAKF+hkJQJ1JufAhFEdZ5gw==",
       "dev": true,
       "requires": {
-        "markdown": "^0.5.0"
+        "markdown": "0.5.0"
       }
     },
     "jstransformer-nunjucks": {
@@ -7836,8 +7836,8 @@
       "integrity": "sha1-gc+giFpUmgy7cXrXW9lZhl9tAcg=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "nunjucks": "^3.0.0"
+        "extend-shallow": "2.0.1",
+        "nunjucks": "3.1.2"
       }
     },
     "jsx-ast-utils": {
@@ -7852,7 +7852,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "klaw": {
@@ -7861,7 +7861,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.11"
       }
     },
     "known-css-properties": {
@@ -7876,7 +7876,7 @@
       "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
       "dev": true,
       "requires": {
-        "set-getter": "^0.1.0"
+        "set-getter": "0.1.0"
       }
     },
     "lcid": {
@@ -7884,7 +7884,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "left-pad": {
@@ -7905,8 +7905,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "liftoff": {
@@ -7915,14 +7915,14 @@
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "extend": "3.0.1",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.5.0"
       }
     },
     "limiter": {
@@ -7936,11 +7936,11 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -7948,7 +7948,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -7992,8 +7992,8 @@
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
           }
         },
         "qs": {
@@ -8008,28 +8008,28 @@
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
           }
         },
         "tunnel-agent": {
@@ -8038,7 +8038,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.1.1"
           }
         },
         "yargs": {
@@ -8047,12 +8047,12 @@
           "integrity": "sha1-GquWYOrnnYuPZ1vK7qtu40ws9pw=",
           "dev": true,
           "requires": {
-            "camelcase": "^1.2.1",
-            "cliui": "^3.0.3",
-            "decamelize": "^1.0.0",
-            "os-locale": "^1.4.0",
-            "window-size": "^0.1.2",
-            "y18n": "^3.2.0"
+            "camelcase": "1.2.1",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "os-locale": "1.4.0",
+            "window-size": "0.1.4",
+            "y18n": "3.2.1"
           }
         }
       }
@@ -8063,8 +8063,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -8180,7 +8180,7 @@
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "requires": {
-        "lodash._root": "^3.0.0"
+        "lodash._root": "3.0.1"
       }
     },
     "lodash.filter": {
@@ -8231,9 +8231,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.map": {
@@ -8301,15 +8301,15 @@
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash._basetostring": "^3.0.0",
-        "lodash._basevalues": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.restparam": "^3.0.0",
-        "lodash.templatesettings": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
       }
     },
     "lodash.templatesettings": {
@@ -8318,8 +8318,8 @@
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
       }
     },
     "longest": {
@@ -8334,7 +8334,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -8342,8 +8342,8 @@
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lru-cache": {
@@ -8363,7 +8363,7 @@
       "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "dev": true,
       "requires": {
-        "vlq": "^0.2.2"
+        "vlq": "0.2.3"
       }
     },
     "make-iterator": {
@@ -8372,7 +8372,7 @@
       "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.1.0"
+        "kind-of": "3.2.2"
       }
     },
     "makeerror": {
@@ -8381,7 +8381,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.x"
+        "tmpl": "1.0.4"
       }
     },
     "map-cache": {
@@ -8407,7 +8407,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "markdown": {
@@ -8416,7 +8416,7 @@
       "integrity": "sha1-KCBbVlqK51kt4gdGPWY33BgnIrI=",
       "dev": true,
       "requires": {
-        "nopt": "~2.1.1"
+        "nopt": "2.1.2"
       }
     },
     "marked": {
@@ -8431,7 +8431,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "meow": {
@@ -8439,16 +8439,16 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "object-assign": {
@@ -8470,7 +8470,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -8491,13 +8491,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -8506,7 +8506,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -8518,21 +8518,21 @@
       "dev": true,
       "requires": {
         "absolute": "0.0.1",
-        "chalk": "^1.1.3",
-        "clone": "^1.0.2",
-        "co-fs-extra": "^1.2.1",
-        "commander": "^2.6.0",
-        "gray-matter": "^2.0.0",
-        "has-generators": "^1.0.1",
-        "is": "^3.1.0",
-        "is-utf8": "~0.2.0",
-        "recursive-readdir": "^2.1.0",
-        "rimraf": "^2.2.8",
-        "stat-mode": "^0.2.0",
-        "thunkify": "^2.1.2",
+        "chalk": "1.1.3",
+        "clone": "1.0.3",
+        "co-fs-extra": "1.2.1",
+        "commander": "2.14.1",
+        "gray-matter": "2.1.1",
+        "has-generators": "1.0.1",
+        "is": "3.2.1",
+        "is-utf8": "0.2.1",
+        "recursive-readdir": "2.2.2",
+        "rimraf": "2.6.2",
+        "stat-mode": "0.2.2",
+        "thunkify": "2.1.2",
         "unyield": "0.0.1",
-        "ware": "^1.2.0",
-        "win-fork": "^1.1.1"
+        "ware": "1.3.0",
+        "win-fork": "1.1.1"
       },
       "dependencies": {
         "gray-matter": {
@@ -8541,11 +8541,11 @@
           "integrity": "sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=",
           "dev": true,
           "requires": {
-            "ansi-red": "^0.1.1",
-            "coffee-script": "^1.12.4",
-            "extend-shallow": "^2.0.1",
-            "js-yaml": "^3.8.1",
-            "toml": "^2.3.2"
+            "ansi-red": "0.1.1",
+            "coffee-script": "1.12.7",
+            "extend-shallow": "2.0.1",
+            "js-yaml": "3.10.0",
+            "toml": "2.3.3"
           }
         }
       }
@@ -8556,11 +8556,11 @@
       "integrity": "sha1-yDjUg/CXI+3oOHRJxr/amz2jzEA=",
       "dev": true,
       "requires": {
-        "async": "^0.7.0",
-        "debug": "^0.8.1",
-        "merge": "^1.1.3",
-        "recursive-readdir": "^1.0.0",
-        "stat-mode": "^0.2.0"
+        "async": "0.7.0",
+        "debug": "0.8.1",
+        "merge": "1.2.0",
+        "recursive-readdir": "1.3.0",
+        "stat-mode": "0.2.2"
       },
       "dependencies": {
         "async": {
@@ -8581,8 +8581,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         },
         "recursive-readdir": {
@@ -8602,9 +8602,9 @@
       "integrity": "sha1-8SuI1gYCfwo5CnNEHYBmoEgJZWk=",
       "dev": true,
       "requires": {
-        "cheerio": "^0.22.0",
-        "ramda": "^0.23.0",
-        "urijs": "^1.18.10"
+        "cheerio": "0.22.0",
+        "ramda": "0.23.0",
+        "urijs": "1.19.1"
       }
     },
     "metalsmith-browser-sync": {
@@ -8613,9 +8613,9 @@
       "integrity": "sha1-JCskqgPmTPAS8D9IXKMMUn9/0TA=",
       "dev": true,
       "requires": {
-        "browser-sync": "^2.6.5",
-        "debug": "^2.1.3",
-        "lodash": "^3.7.0"
+        "browser-sync": "2.23.6",
+        "debug": "2.6.9",
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "lodash": {
@@ -8632,9 +8632,9 @@
       "integrity": "sha512-3X43I36ckim1aIXv377iHoGbP4/DlSw/gOkaKegnT7V8KFZmBnGO6zbefQeq3CQ41dbIbnjYigZwSSqIoJOabg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10",
-        "multimatch": "^2.1.0",
-        "url-join": "^4.0.0"
+        "lodash": "4.17.10",
+        "multimatch": "2.1.0",
+        "url-join": "4.0.0"
       },
       "dependencies": {
         "lodash": {
@@ -8662,7 +8662,7 @@
           "integrity": "sha1-l4/EFV0fwwuLWPw/AgECstoC8qQ=",
           "dev": true,
           "requires": {
-            "lodash": "^4.8.0"
+            "lodash": "4.13.1"
           }
         },
         "balanced-match": {
@@ -8677,7 +8677,7 @@
           "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
           "dev": true,
           "requires": {
-            "balanced-match": "^0.4.1",
+            "balanced-match": "0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -8693,11 +8693,11 @@
           "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.5",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.0",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.0"
           }
         },
         "inflight": {
@@ -8706,8 +8706,8 @@
           "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
           "dev": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.3.3",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -8728,7 +8728,7 @@
           "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "brace-expansion": "1.1.4"
           }
         },
         "once": {
@@ -8737,7 +8737,7 @@
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -8760,12 +8760,12 @@
       "integrity": "sha512-zDl9q8wvvrk08d5C1Ql93Q/UakDgHuIN8RMRBupb/XuQ1Aj6SeCl4eXNS+sGnuqHa7b7v4ulYJYYLnQHRRFh3g==",
       "dev": true,
       "requires": {
-        "babel-cli": "^6.24.1",
-        "babel-preset-env": "^1.6.0",
-        "extend": "^3.0.0",
-        "inputformat-to-jstransformer": "^1.1.8",
-        "is-utf8": "^0.2.1",
-        "jstransformer": "^1.0.0"
+        "babel-cli": "6.26.0",
+        "babel-preset-env": "1.6.1",
+        "extend": "3.0.1",
+        "inputformat-to-jstransformer": "1.2.1",
+        "is-utf8": "0.2.1",
+        "jstransformer": "1.0.0"
       }
     },
     "metalsmith-env": {
@@ -8774,7 +8774,7 @@
       "integrity": "sha1-EBUQtzZAXob7gfGVIAtkkRcjPqY=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -8783,8 +8783,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -8793,7 +8793,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -8804,8 +8804,8 @@
       "integrity": "sha512-WzNu17SChB+dXdmhxXiCtTziA3D6rx1l2tohkU+c9KWpUFpt9uAWGdWDqkYop8K2aQXgfgiFQW4LWMRzAcUTbA==",
       "dev": true,
       "requires": {
-        "multimatch": "^2.0.0",
-        "slash": "^1.0.0"
+        "multimatch": "2.1.0",
+        "slash": "1.0.0"
       }
     },
     "metalsmith-in-place": {
@@ -8814,8 +8814,8 @@
       "integrity": "sha512-8bg+Sh+5z+iT0CknH8xnw5nWZ+M/h1nZEzgaGdih0vWE/wc+b18DVNRJYpxjbx5YmYvzVMu/jWWUz5c8XBzk7Q==",
       "dev": true,
       "requires": {
-        "metalsmith-engine-jstransformer": "^0.1.2",
-        "multimatch": "^2.1.0"
+        "metalsmith-engine-jstransformer": "0.1.2",
+        "multimatch": "2.1.0"
       }
     },
     "metalsmith-layouts": {
@@ -8824,14 +8824,14 @@
       "integrity": "sha1-o2XTmTnZFGzf5R+t7n2HVXP8y9w=",
       "dev": true,
       "requires": {
-        "async": "^1.3.0",
-        "consolidate": "^0.14.0",
-        "debug": "^2.2.0",
-        "extend": "^3.0.0",
-        "fs-readdir-recursive": "^1.0.0",
-        "is-utf8": "^0.2.0",
-        "lodash.omit": "^4.0.2",
-        "multimatch": "^2.0.0"
+        "async": "1.5.2",
+        "consolidate": "0.14.5",
+        "debug": "2.6.9",
+        "extend": "3.0.1",
+        "fs-readdir-recursive": "1.1.0",
+        "is-utf8": "0.2.1",
+        "lodash.omit": "4.5.0",
+        "multimatch": "2.1.0"
       }
     },
     "metalsmith-markdown": {
@@ -8840,8 +8840,8 @@
       "integrity": "sha512-2WMtfd2xhBagmoyRZXg04EHd/jmWnK21aGOvEZG5/eDEBTn9zGtkeptZrl+fQV+CNwhWtoggn1s9d+yi0+JLqQ==",
       "dev": true,
       "requires": {
-        "debug": "~0.7.4",
-        "marked": "~0.3.9"
+        "debug": "0.7.4",
+        "marked": "0.3.17"
       },
       "dependencies": {
         "debug": {
@@ -8858,9 +8858,9 @@
       "integrity": "sha1-CFtxoqSGr4ZVkptUtKNDdjhTkgY=",
       "dev": true,
       "requires": {
-        "debug": "~2.6.7",
-        "entities": "~1.1",
-        "highlight.js": "~9.7.0"
+        "debug": "2.6.9",
+        "entities": "1.1.1",
+        "highlight.js": "9.7.0"
       }
     },
     "metalsmith-permalinks": {
@@ -8869,9 +8869,9 @@
       "integrity": "sha1-D+xbHwaHgowZjTO11HnMHOxLGh8=",
       "dev": true,
       "requires": {
-        "debug": "~0.7.4",
-        "moment": "^2.5.1",
-        "slug-component": "~1.1.0",
+        "debug": "0.7.4",
+        "moment": "2.21.0",
+        "slug-component": "1.1.0",
         "substitute": "https://github.com/segmentio/substitute/archive/0.0.1.tar.gz"
       },
       "dependencies": {
@@ -8888,7 +8888,7 @@
       "resolved": "https://registry.npmjs.org/metalsmith-postcss/-/metalsmith-postcss-4.2.0.tgz",
       "integrity": "sha512-YJqZfZrSDWYX61Zudzr96xNBxhyyHD6qsC7Q6WqoaJ65iTApwmU82mmKj133LV0kw2BV5I4MJ11RXUAajyPMww==",
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "3.0.4"
       }
     },
     "metalsmith-rollup": {
@@ -8897,7 +8897,7 @@
       "integrity": "sha512-wDB/VSQFpNGqxuqN3xJHS2BaNyO9UiIpgIRlwWrPk4OpzJW/4YcrvTFNLKxzXlqOS4b3vLamMjhIZvtMpPj1Fw==",
       "dev": true,
       "requires": {
-        "rollup": "^0.58.1"
+        "rollup": "0.58.2"
       }
     },
     "metalsmith-sass": {
@@ -8906,8 +8906,8 @@
       "integrity": "sha1-3eLI1AjMugOJNaSdWErc433MVmw=",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
-        "node-sass": "^4.7.2"
+        "async": "2.6.0",
+        "node-sass": "4.7.2"
       },
       "dependencies": {
         "async": {
@@ -8916,7 +8916,7 @@
           "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
           "dev": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.4"
           }
         }
       }
@@ -8927,25 +8927,69 @@
       "integrity": "sha1-YO0FpppO+zl9VdB53DDlCrO/cYs=",
       "dev": true
     },
+    "metalsmith-uglify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/metalsmith-uglify/-/metalsmith-uglify-2.3.0.tgz",
+      "integrity": "sha512-wAOFSxafJkk+YG8RFb3lBR5+417G+t4q2Iq7hMHcGGg1ZAoN3x5GKBPxJd9L+d6A2T4ZFFFVUq5w+cVJWU/IKw==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0",
+        "terser": "3.8.1",
+        "uglify-js": "3.4.7"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+          "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.7.tgz",
+          "integrity": "sha512-J0M2i1mQA+ze3EdN9SBi751DNdAXmeFLfJrd/MDIkRc3G3Gbb9OPVSx7GIQvVwfWxQARcYV2DTxIkMyDAk3o9Q==",
+          "dev": true,
+          "requires": {
+            "commander": "2.16.0",
+            "source-map": "0.6.1"
+          }
+        }
+      }
+    },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "mime": {
@@ -8964,7 +9008,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "~1.30.0"
+        "mime-db": "1.30.0"
       }
     },
     "mimic-fn": {
@@ -8978,7 +9022,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
@@ -8992,8 +9036,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -9002,7 +9046,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -9032,7 +9076,7 @@
         "find-parent-dir": "0.3.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
-        "remarkable": "^1.6.2",
+        "remarkable": "1.7.1",
         "requirejs": "2.1.22",
         "yargs": "7.0.2"
       },
@@ -9042,8 +9086,8 @@
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.3.tgz",
           "integrity": "sha1-auxrvWLPid1JjK5wwO2fSdqHOmo=",
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         },
         "isarray": {
@@ -9071,10 +9115,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
       }
     },
     "multipipe": {
@@ -9103,18 +9147,18 @@
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -9135,8 +9179,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -9145,7 +9189,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         },
         "kind-of": {
@@ -9179,19 +9223,19 @@
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "2",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
+        "fstream": "1.0.11",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "nopt": "2.1.2",
+        "npmlog": "4.1.2",
+        "osenv": "0.1.4",
+        "request": "2.87.0",
+        "rimraf": "2.6.2",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "which": "1.3.0"
       },
       "dependencies": {
         "semver": {
@@ -9213,10 +9257,10 @@
       "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "dev": true,
       "requires": {
-        "growly": "^1.3.0",
-        "semver": "^5.4.1",
-        "shellwords": "^0.1.1",
-        "which": "^1.3.0"
+        "growly": "1.3.0",
+        "semver": "5.5.0",
+        "shellwords": "0.1.1",
+        "which": "1.3.0"
       },
       "dependencies": {
         "semver": {
@@ -9232,7 +9276,7 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.10.tgz",
       "integrity": "sha512-BSQrRgOfN6L/MoKIa7pRUc7dHvflCXMcqyTBvphixcSsgJTuUd24vAFONuNfVsuwTyz28S1HEc9XN6ZKylk4Hg==",
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.5.0"
       },
       "dependencies": {
         "semver": {
@@ -9247,25 +9291,25 @@
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
       "integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
       "requires": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^1.1.1",
-        "cross-spawn": "^3.0.0",
-        "gaze": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "glob": "^7.0.3",
-        "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "nan": "^2.3.2",
-        "node-gyp": "^3.3.1",
-        "npmlog": "^4.0.0",
-        "request": "~2.79.0",
-        "sass-graph": "^2.2.4",
-        "stdout-stream": "^1.4.0",
-        "true-case-path": "^1.0.2"
+        "async-foreach": "0.1.3",
+        "chalk": "1.1.3",
+        "cross-spawn": "3.0.1",
+        "gaze": "1.1.2",
+        "get-stdin": "4.0.1",
+        "glob": "7.1.2",
+        "in-publish": "2.0.0",
+        "lodash.assign": "4.2.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.mergewith": "4.6.0",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "nan": "2.8.0",
+        "node-gyp": "3.6.2",
+        "npmlog": "4.1.2",
+        "request": "2.79.0",
+        "sass-graph": "2.2.4",
+        "stdout-stream": "1.4.0",
+        "true-case-path": "1.0.2"
       },
       "dependencies": {
         "caseless": {
@@ -9278,7 +9322,7 @@
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
           "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
           "requires": {
-            "globule": "^1.0.0"
+            "globule": "1.2.0"
           }
         },
         "har-validator": {
@@ -9286,10 +9330,10 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
+            "chalk": "1.1.3",
+            "commander": "2.14.1",
+            "is-my-json-valid": "2.16.1",
+            "pinkie-promise": "2.0.1"
           }
         },
         "qs": {
@@ -9302,26 +9346,26 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.3.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.1.0"
           }
         },
         "tunnel-agent": {
@@ -9336,7 +9380,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
       "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -9344,10 +9388,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "4.3.6",
+        "validate-npm-package-license": "3.0.1"
       }
     },
     "normalize-path": {
@@ -9356,7 +9400,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-range": {
@@ -9370,7 +9414,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npmlog": {
@@ -9378,10 +9422,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "nth-check": {
@@ -9390,7 +9434,7 @@
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "dev": true,
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "num2fraction": {
@@ -9409,11 +9453,11 @@
       "integrity": "sha512-pJXncV07mmiuIDL9OqdNkcpvifuDMzMq9qBQT9SHasAS7AEwzNp/r/jHNl+9O0+zsldcdWG9ZtXo/nwu2cTqXA==",
       "dev": true,
       "requires": {
-        "a-sync-waterfall": "^1.0.0",
-        "asap": "^2.0.3",
-        "chokidar": "^1.6.0",
-        "postinstall-build": "^5.0.1",
-        "yargs": "^3.32.0"
+        "a-sync-waterfall": "1.0.0",
+        "asap": "2.0.6",
+        "chokidar": "1.7.0",
+        "postinstall-build": "5.0.1",
+        "yargs": "3.32.0"
       },
       "dependencies": {
         "yargs": {
@@ -9422,13 +9466,13 @@
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "dev": true,
           "requires": {
-            "camelcase": "^2.0.1",
-            "cliui": "^3.0.3",
-            "decamelize": "^1.1.1",
-            "os-locale": "^1.4.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.1.4",
-            "y18n": "^3.2.0"
+            "camelcase": "2.1.1",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "os-locale": "1.4.0",
+            "string-width": "1.0.2",
+            "window-size": "0.1.4",
+            "y18n": "3.2.1"
           }
         }
       }
@@ -9462,9 +9506,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -9473,7 +9517,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -9482,7 +9526,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-data-descriptor": {
@@ -9491,7 +9535,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-descriptor": {
@@ -9500,9 +9544,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
@@ -9533,7 +9577,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -9550,10 +9594,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.11"
       }
     },
     "object.defaults": {
@@ -9562,10 +9606,10 @@
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
-        "array-each": "^1.0.1",
-        "array-slice": "^1.0.0",
-        "for-own": "^1.0.0",
-        "isobject": "^3.0.0"
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -9574,7 +9618,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         },
         "isobject": {
@@ -9591,8 +9635,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
       }
     },
     "object.map": {
@@ -9601,8 +9645,8 @@
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.0"
       },
       "dependencies": {
         "for-own": {
@@ -9611,7 +9655,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -9622,8 +9666,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -9632,7 +9676,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -9657,7 +9701,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -9678,8 +9722,8 @@
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.0.1",
-        "pinkie-promise": "^2.0.0"
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "object-assign": {
@@ -9696,8 +9740,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "minimist": {
@@ -9720,12 +9764,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "orchestrator": {
@@ -9734,9 +9778,9 @@
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
       "dev": true,
       "requires": {
-        "end-of-stream": "~0.1.5",
-        "sequencify": "~0.0.7",
-        "stream-consume": "~0.1.0"
+        "end-of-stream": "0.1.5",
+        "sequencify": "0.0.7",
+        "stream-consume": "0.1.0"
       }
     },
     "ordered-read-streams": {
@@ -9755,7 +9799,7 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -9768,8 +9812,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "output-file-sync": {
@@ -9778,9 +9822,9 @@
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.4",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^4.1.0"
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -9803,7 +9847,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -9812,7 +9856,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-try": {
@@ -9827,9 +9871,9 @@
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
       }
     },
     "parse-glob": {
@@ -9838,10 +9882,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-json": {
@@ -9849,7 +9893,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse-passwd": {
@@ -9870,7 +9914,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -9879,7 +9923,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -9899,7 +9943,7 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -9931,7 +9975,7 @@
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -9945,9 +9989,9 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "pause-stream": {
@@ -9956,7 +10000,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "~2.3"
+        "through": "2.3.8"
       }
     },
     "pend": {
@@ -9986,7 +10030,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-conf": {
@@ -9995,8 +10039,8 @@
       "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "load-json-file": "^4.0.0"
+        "find-up": "2.1.0",
+        "load-json-file": "4.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -10005,7 +10049,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "load-json-file": {
@@ -10014,10 +10058,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "parse-json": {
@@ -10026,8 +10070,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
           }
         },
         "pify": {
@@ -10050,9 +10094,9 @@
       "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
       "dev": true,
       "requires": {
-        "debug-log": "^1.0.0",
-        "find-root": "^1.0.0",
-        "xtend": "^4.0.1"
+        "debug-log": "1.0.1",
+        "find-root": "1.1.0",
+        "xtend": "4.0.1"
       }
     },
     "pkg-dir": {
@@ -10061,7 +10105,7 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "1.1.2"
       }
     },
     "pkg-up": {
@@ -10070,7 +10114,7 @@
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "1.1.2"
       }
     },
     "pluralize": {
@@ -10092,7 +10136,7 @@
       "dev": true,
       "requires": {
         "async": "1.5.2",
-        "is-number-like": "^1.0.3"
+        "is-number-like": "1.0.8"
       }
     },
     "posix-character-classes": {
@@ -10106,9 +10150,9 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
       "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
       "requires": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
+        "chalk": "2.4.1",
+        "source-map": "0.6.1",
+        "supports-color": "5.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10116,7 +10160,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -10124,9 +10168,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -10139,7 +10183,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -10173,8 +10217,8 @@
       "integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0",
-        "ansi-styles": "^3.2.0"
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -10189,7 +10233,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         }
       }
@@ -10223,7 +10267,7 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "proto-list": {
@@ -10244,7 +10288,7 @@
       "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
       "dev": true,
       "requires": {
-        "event-stream": "~3.3.0"
+        "event-stream": "3.3.4"
       }
     },
     "pseudomap": {
@@ -10263,14 +10307,14 @@
       "integrity": "sha512-WDnC1FSHTedvRSS8BZB73tPAx2svUCWFdcxVjrybw8pbKOAB1v5S/pW0EamkqQoL1mXiBc+v8lyYjhhzMHIk1Q==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
-        "extract-zip": "^1.6.5",
-        "https-proxy-agent": "^2.1.0",
-        "mime": "^2.0.3",
-        "progress": "^2.0.0",
-        "proxy-from-env": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "ws": "^3.0.0"
+        "debug": "3.1.0",
+        "extract-zip": "1.6.7",
+        "https-proxy-agent": "2.2.1",
+        "mime": "2.3.1",
+        "progress": "2.0.0",
+        "proxy-from-env": "1.0.0",
+        "rimraf": "2.6.2",
+        "ws": "3.3.3"
       },
       "dependencies": {
         "debug": {
@@ -10313,8 +10357,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -10323,7 +10367,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -10332,7 +10376,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -10343,7 +10387,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -10359,9 +10403,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -10369,8 +10413,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
@@ -10379,10 +10423,10 @@
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
         "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "string_decoder": "0.10.31"
       }
     },
     "readdirp": {
@@ -10391,10 +10435,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.3",
+        "set-immediate-shim": "1.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -10409,13 +10453,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -10424,7 +10468,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -10435,8 +10479,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -10446,7 +10490,7 @@
       "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
       "dev": true,
       "requires": {
-        "util.promisify": "^1.0.0"
+        "util.promisify": "1.0.0"
       }
     },
     "rechoir": {
@@ -10455,7 +10499,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.5.0"
       }
     },
     "recursive-readdir": {
@@ -10472,8 +10516,8 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "regenerate": {
@@ -10494,9 +10538,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.18.0",
-        "babel-types": "^6.19.0",
-        "private": "^0.1.6"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -10505,7 +10549,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -10514,8 +10558,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -10524,8 +10568,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -10534,7 +10578,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -10545,9 +10589,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       }
     },
     "regjsgen": {
@@ -10562,7 +10606,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -10578,8 +10622,8 @@
       "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
       "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
       "requires": {
-        "argparse": "~0.1.15",
-        "autolinker": "~0.15.0"
+        "argparse": "0.1.16",
+        "autolinker": "0.15.3"
       },
       "dependencies": {
         "argparse": {
@@ -10587,8 +10631,8 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "requires": {
-            "underscore": "~1.7.0",
-            "underscore.string": "~2.4.0"
+            "underscore": "1.7.0",
+            "underscore.string": "2.4.0"
           }
         }
       }
@@ -10616,7 +10660,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-ext": {
@@ -10630,26 +10674,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.1",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -10667,9 +10711,9 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "requires": {
-            "asynckit": "^0.4.0",
+            "asynckit": "0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "^2.1.12"
+            "mime-types": "2.1.17"
           },
           "dependencies": {
             "combined-stream": {
@@ -10677,7 +10721,7 @@
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
               "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
               "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
               }
             }
           }
@@ -10687,9 +10731,9 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
           }
         },
         "performance-now": {
@@ -10705,7 +10749,7 @@
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "dev": true,
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "4.17.4"
       }
     },
     "request-promise-native": {
@@ -10715,8 +10759,8 @@
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.3"
       }
     },
     "require-directory": {
@@ -10741,8 +10785,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       }
     },
     "requirejs": {
@@ -10762,7 +10806,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-cwd": {
@@ -10771,7 +10815,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -10788,8 +10832,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -10810,8 +10854,8 @@
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
       "dev": true,
       "requires": {
-        "debug": "^2.2.0",
-        "minimatch": "^3.0.2"
+        "debug": "2.6.9",
+        "minimatch": "3.0.4"
       }
     },
     "restore-cursor": {
@@ -10820,8 +10864,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
       }
     },
     "ret": {
@@ -10837,7 +10881,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -10845,7 +10889,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "rollup": {
@@ -10855,7 +10899,7 @@
       "dev": true,
       "requires": {
         "@types/estree": "0.0.38",
-        "@types/node": "*"
+        "@types/node": "10.1.2"
       }
     },
     "rollup-plugin-commonjs": {
@@ -10864,10 +10908,10 @@
       "integrity": "sha512-g91ZZKZwTW7F7vL6jMee38I8coj/Q9GBdTmXXeFL7ldgC1Ky5WJvHgbKlAiXXTh762qvohhExwUgeQGFh9suGg==",
       "dev": true,
       "requires": {
-        "estree-walker": "^0.5.1",
-        "magic-string": "^0.22.4",
-        "resolve": "^1.5.0",
-        "rollup-pluginutils": "^2.0.1"
+        "estree-walker": "0.5.2",
+        "magic-string": "0.22.5",
+        "resolve": "1.5.0",
+        "rollup-pluginutils": "2.3.0"
       }
     },
     "rollup-plugin-node-resolve": {
@@ -10876,9 +10920,9 @@
       "integrity": "sha512-9zHGr3oUJq6G+X0oRMYlzid9fXicBdiydhwGChdyeNRGPcN/majtegApRKHLR5drboUvEWU+QeUmGTyEZQs3WA==",
       "dev": true,
       "requires": {
-        "builtin-modules": "^2.0.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.1.6"
+        "builtin-modules": "2.0.0",
+        "is-module": "1.0.0",
+        "resolve": "1.5.0"
       },
       "dependencies": {
         "builtin-modules": {
@@ -10895,8 +10939,8 @@
       "integrity": "sha512-xB6hsRsjdJdIYWEyYUJy/3ki5g69wrf0luHPGNK3ZSocV6HLNfio59l3dZ3TL4xUwEKgROhFi9jOCt6c5gfUWw==",
       "dev": true,
       "requires": {
-        "estree-walker": "^0.5.2",
-        "micromatch": "^2.3.11"
+        "estree-walker": "0.5.2",
+        "micromatch": "2.3.11"
       }
     },
     "rsvp": {
@@ -10911,7 +10955,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0"
+        "once": "1.4.0"
       }
     },
     "run-parallel": {
@@ -10943,7 +10987,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "sane": {
@@ -10952,15 +10996,15 @@
       "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "capture-exit": "^1.2.0",
-        "exec-sh": "^0.2.0",
-        "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.3",
-        "micromatch": "^3.1.4",
-        "minimist": "^1.1.1",
-        "walker": "~1.0.5",
-        "watch": "~0.18.0"
+        "anymatch": "2.0.0",
+        "capture-exit": "1.2.0",
+        "exec-sh": "0.2.1",
+        "fb-watchman": "2.0.0",
+        "fsevents": "1.2.4",
+        "micromatch": "3.1.10",
+        "minimist": "1.2.0",
+        "walker": "1.0.7",
+        "watch": "0.18.0"
       },
       "dependencies": {
         "anymatch": {
@@ -10969,8 +11013,8 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
           }
         },
         "arr-diff": {
@@ -10991,16 +11035,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -11009,7 +11053,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -11020,13 +11064,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -11035,7 +11079,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -11044,7 +11088,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -11053,9 +11097,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -11072,8 +11116,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -11082,7 +11126,7 @@
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -11093,14 +11137,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -11109,7 +11153,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -11118,7 +11162,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -11129,10 +11173,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -11141,7 +11185,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -11153,8 +11197,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "nan": "^2.9.2",
-            "node-pre-gyp": "^0.10.0"
+            "nan": "2.10.0",
+            "node-pre-gyp": "0.10.0"
           },
           "dependencies": {
             "abbrev": {
@@ -11180,8 +11224,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.6"
               }
             },
             "balanced-match": {
@@ -11194,7 +11238,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
               }
             },
@@ -11258,7 +11302,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "2.2.4"
               }
             },
             "fs.realpath": {
@@ -11273,14 +11317,14 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
               }
             },
             "glob": {
@@ -11289,12 +11333,12 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
               }
             },
             "has-unicode": {
@@ -11309,7 +11353,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "safer-buffer": "^2.1.0"
+                "safer-buffer": "2.1.2"
               }
             },
             "ignore-walk": {
@@ -11318,7 +11362,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minimatch": "^3.0.4"
+                "minimatch": "3.0.4"
               }
             },
             "inflight": {
@@ -11327,8 +11371,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
               }
             },
             "inherits": {
@@ -11347,7 +11391,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
               }
             },
             "isarray": {
@@ -11361,7 +11405,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
               }
             },
             "minimist": {
@@ -11374,8 +11418,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "^5.1.1",
-                "yallist": "^3.0.0"
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
               }
             },
             "minizlib": {
@@ -11384,7 +11428,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "2.2.4"
               }
             },
             "mkdirp": {
@@ -11407,9 +11451,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "debug": "^2.1.2",
-                "iconv-lite": "^0.4.4",
-                "sax": "^1.2.4"
+                "debug": "2.6.9",
+                "iconv-lite": "0.4.21",
+                "sax": "1.2.4"
               }
             },
             "node-pre-gyp": {
@@ -11418,16 +11462,16 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "detect-libc": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "needle": "^2.2.0",
-                "nopt": "^4.0.1",
-                "npm-packlist": "^1.1.6",
-                "npmlog": "^4.0.2",
-                "rc": "^1.1.7",
-                "rimraf": "^2.6.1",
-                "semver": "^5.3.0",
-                "tar": "^4"
+                "detect-libc": "1.0.3",
+                "mkdirp": "0.5.1",
+                "needle": "2.2.0",
+                "nopt": "4.0.1",
+                "npm-packlist": "1.1.10",
+                "npmlog": "4.1.2",
+                "rc": "1.2.7",
+                "rimraf": "2.6.2",
+                "semver": "5.5.0",
+                "tar": "4.4.1"
               }
             },
             "nopt": {
@@ -11436,8 +11480,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
+                "abbrev": "1.1.1",
+                "osenv": "0.1.5"
               }
             },
             "npm-bundled": {
@@ -11452,8 +11496,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
+                "ignore-walk": "3.0.1",
+                "npm-bundled": "1.0.3"
               }
             },
             "npmlog": {
@@ -11462,10 +11506,10 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
               }
             },
             "number-is-nan": {
@@ -11484,7 +11528,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
               }
             },
             "os-homedir": {
@@ -11505,8 +11549,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
               }
             },
             "path-is-absolute": {
@@ -11527,10 +11571,10 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "deep-extend": "^0.5.1",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
+                "deep-extend": "0.5.1",
+                "ini": "1.3.5",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
               },
               "dependencies": {
                 "minimist": {
@@ -11547,13 +11591,13 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "rimraf": {
@@ -11562,7 +11606,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.2"
               }
             },
             "safe-buffer": {
@@ -11605,9 +11649,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             },
             "string_decoder": {
@@ -11616,7 +11660,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.1"
               }
             },
             "strip-ansi": {
@@ -11624,7 +11668,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
               }
             },
             "strip-json-comments": {
@@ -11639,13 +11683,13 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "chownr": "^1.0.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.2.4",
-                "minizlib": "^1.1.0",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.1",
-                "yallist": "^3.0.2"
+                "chownr": "1.0.1",
+                "fs-minipass": "1.2.5",
+                "minipass": "2.2.4",
+                "minizlib": "1.1.0",
+                "mkdirp": "0.5.1",
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
               }
             },
             "util-deprecate": {
@@ -11660,7 +11704,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "string-width": "^1.0.2"
+                "string-width": "1.0.2"
               }
             },
             "wrappy": {
@@ -11681,7 +11725,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -11690,7 +11734,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -11701,7 +11745,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -11710,7 +11754,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -11721,7 +11765,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -11730,7 +11774,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -11753,19 +11797,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           }
         },
         "nan": {
@@ -11782,9 +11826,9 @@
       "resolved": "https://registry.npmjs.org/sass-export/-/sass-export-1.0.2.tgz",
       "integrity": "sha512-iU7dEqXXQkulTUTpYtCdihGwLnuZeus1k/hVkjuSEVU2SJgt54MlYzsOra1V2X9kze9HsQrvvDWe3yuwiEOpBw==",
       "requires": {
-        "glob": "^7.1.2",
-        "minimist": "^1.2.0",
-        "node-sass": "^4.5.2"
+        "glob": "7.1.2",
+        "minimist": "1.2.0",
+        "node-sass": "4.7.2"
       }
     },
     "sass-graph": {
@@ -11792,10 +11836,10 @@
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "requires": {
-        "glob": "^7.0.0",
-        "lodash": "^4.0.0",
-        "scss-tokenizer": "^0.2.3",
-        "yargs": "^7.0.0"
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "scss-tokenizer": "0.2.3",
+        "yargs": "7.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -11808,19 +11852,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
           }
         }
       }
@@ -11831,20 +11875,20 @@
       "integrity": "sha1-Yw9pwhaqIGuCMvsqqQe98zNrbYM=",
       "dev": true,
       "requires": {
-        "commander": "^2.8.1",
-        "eslint": "^2.7.0",
+        "commander": "2.14.1",
+        "eslint": "2.13.1",
         "front-matter": "2.1.2",
-        "fs-extra": "^3.0.1",
-        "glob": "^7.0.0",
-        "globule": "^1.0.0",
-        "gonzales-pe-sl": "^4.2.3",
-        "js-yaml": "^3.5.4",
-        "known-css-properties": "^0.3.0",
-        "lodash.capitalize": "^4.1.0",
-        "lodash.kebabcase": "^4.0.0",
-        "merge": "^1.2.0",
-        "path-is-absolute": "^1.0.0",
-        "util": "^0.10.3"
+        "fs-extra": "3.0.1",
+        "glob": "7.1.2",
+        "globule": "1.2.0",
+        "gonzales-pe-sl": "4.2.3",
+        "js-yaml": "3.10.0",
+        "known-css-properties": "0.3.0",
+        "lodash.capitalize": "4.2.1",
+        "lodash.kebabcase": "4.1.1",
+        "merge": "1.2.0",
+        "path-is-absolute": "1.0.1",
+        "util": "0.10.3"
       },
       "dependencies": {
         "fs-extra": {
@@ -11853,9 +11897,9 @@
           "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^3.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "3.0.1",
+            "universalify": "0.1.1"
           }
         },
         "jsonfile": {
@@ -11864,7 +11908,7 @@
           "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         }
       }
@@ -11880,8 +11924,8 @@
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "requires": {
-        "js-base64": "^2.1.8",
-        "source-map": "^0.4.2"
+        "js-base64": "2.4.0",
+        "source-map": "0.4.4"
       }
     },
     "section-matter": {
@@ -11889,8 +11933,8 @@
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
       "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "kind-of": "^6.0.0"
+        "extend-shallow": "2.0.1",
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -11917,18 +11961,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.4",
-        "depd": "~1.1.0",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.0",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.0",
-        "http-errors": "~1.6.1",
+        "http-errors": "1.6.2",
         "mime": "1.3.4",
         "ms": "1.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.3.1"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
       },
       "dependencies": {
         "debug": {
@@ -11963,7 +12007,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
+            "statuses": "1.3.1"
           },
           "dependencies": {
             "depd": {
@@ -12000,13 +12044,13 @@
       "integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.3",
+        "accepts": "1.3.5",
         "batch": "0.5.3",
-        "debug": "~2.2.0",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.5.0",
-        "mime-types": "~2.1.11",
-        "parseurl": "~1.3.1"
+        "debug": "2.2.0",
+        "escape-html": "1.0.3",
+        "http-errors": "1.5.1",
+        "mime-types": "2.1.17",
+        "parseurl": "1.3.2"
       },
       "dependencies": {
         "debug": {
@@ -12032,9 +12076,9 @@
       "integrity": "sha1-5UbicmCBuBtLzsjpCAjrzdMjr7o=",
       "dev": true,
       "requires": {
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.1",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.15.2"
       }
     },
@@ -12055,7 +12099,7 @@
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "dev": true,
       "requires": {
-        "to-object-path": "^0.3.0"
+        "to-object-path": "0.3.0"
       }
     },
     "set-immediate-shim": {
@@ -12070,10 +12114,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       }
     },
     "setprototypeof": {
@@ -12088,7 +12132,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -12126,8 +12170,8 @@
       "integrity": "sha1-Vpy+IYAgKSamKiZs094Jyc60P4M=",
       "dev": true,
       "requires": {
-        "underscore": "^1.7.0",
-        "url-join": "^1.1.0"
+        "underscore": "1.7.0",
+        "url-join": "1.1.0"
       },
       "dependencies": {
         "url-join": {
@@ -12162,14 +12206,14 @@
       "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^2.0.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "2.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -12178,7 +12222,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -12187,7 +12231,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -12196,7 +12240,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -12207,7 +12251,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -12216,7 +12260,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -12227,9 +12271,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -12252,9 +12296,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -12263,7 +12307,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "isobject": {
@@ -12280,7 +12324,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       }
     },
     "sntp": {
@@ -12288,7 +12332,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "2.16.3"
       }
     },
     "socket.io": {
@@ -12297,11 +12341,11 @@
       "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
       "dev": true,
       "requires": {
-        "debug": "~2.6.6",
-        "engine.io": "~3.1.0",
-        "socket.io-adapter": "~1.1.0",
+        "debug": "2.6.9",
+        "engine.io": "3.1.5",
+        "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.0.4",
-        "socket.io-parser": "~3.1.1"
+        "socket.io-parser": "3.1.3"
       }
     },
     "socket.io-adapter": {
@@ -12320,14 +12364,14 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~2.6.4",
-        "engine.io-client": "~3.1.0",
+        "debug": "2.6.9",
+        "engine.io-client": "3.1.5",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.1.1",
+        "socket.io-parser": "3.1.3",
         "to-array": "0.1.4"
       }
     },
@@ -12338,8 +12382,8 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "has-binary2": "~1.0.2",
+        "debug": "3.1.0",
+        "has-binary2": "1.0.2",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -12365,7 +12409,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "requires": {
-        "amdefine": ">=0.0.4"
+        "amdefine": "1.0.1"
       }
     },
     "source-map-resolve": {
@@ -12374,11 +12418,11 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "^2.0.0",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.0.3",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -12387,7 +12431,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -12416,10 +12460,10 @@
       "integrity": "sha1-0gIEA9xe9y7Kw/+rm0L6Fq6RdfU=",
       "dev": true,
       "requires": {
-        "exit": "^0.1.2",
-        "signal-exit": "^3.0.2",
-        "terminate": "^2.1.0",
-        "wait-port": "^0.2.2"
+        "exit": "0.1.2",
+        "signal-exit": "3.0.2",
+        "terminate": "2.1.0",
+        "wait-port": "0.2.2"
       }
     },
     "spdx-correct": {
@@ -12427,7 +12471,7 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-license-ids": "1.2.2"
       }
     },
     "spdx-expression-parse": {
@@ -12446,7 +12490,7 @@
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "split-string": {
@@ -12455,7 +12499,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -12464,8 +12508,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -12474,7 +12518,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -12489,14 +12533,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       },
       "dependencies": {
         "assert-plus": {
@@ -12518,15 +12562,15 @@
       "integrity": "sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==",
       "dev": true,
       "requires": {
-        "eslint": "~3.19.0",
+        "eslint": "3.19.0",
         "eslint-config-standard": "10.2.1",
         "eslint-config-standard-jsx": "4.0.2",
-        "eslint-plugin-import": "~2.2.0",
-        "eslint-plugin-node": "~4.2.2",
-        "eslint-plugin-promise": "~3.5.0",
-        "eslint-plugin-react": "~6.10.0",
-        "eslint-plugin-standard": "~3.0.1",
-        "standard-engine": "~7.0.0"
+        "eslint-plugin-import": "2.2.0",
+        "eslint-plugin-node": "4.2.3",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-react": "6.10.3",
+        "eslint-plugin-standard": "3.0.1",
+        "standard-engine": "7.0.0"
       },
       "dependencies": {
         "doctrine": {
@@ -12535,7 +12579,7 @@
           "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2"
+            "esutils": "2.0.2"
           }
         },
         "eslint": {
@@ -12544,41 +12588,41 @@
           "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "^6.16.0",
-            "chalk": "^1.1.3",
-            "concat-stream": "^1.5.2",
-            "debug": "^2.1.1",
-            "doctrine": "^2.0.0",
-            "escope": "^3.6.0",
-            "espree": "^3.4.0",
-            "esquery": "^1.0.0",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "file-entry-cache": "^2.0.0",
-            "glob": "^7.0.3",
-            "globals": "^9.14.0",
-            "ignore": "^3.2.0",
-            "imurmurhash": "^0.1.4",
-            "inquirer": "^0.12.0",
-            "is-my-json-valid": "^2.10.0",
-            "is-resolvable": "^1.0.0",
-            "js-yaml": "^3.5.1",
-            "json-stable-stringify": "^1.0.0",
-            "levn": "^0.3.0",
-            "lodash": "^4.0.0",
-            "mkdirp": "^0.5.0",
-            "natural-compare": "^1.4.0",
-            "optionator": "^0.8.2",
-            "path-is-inside": "^1.0.1",
-            "pluralize": "^1.2.1",
-            "progress": "^1.1.8",
-            "require-uncached": "^1.0.2",
-            "shelljs": "^0.7.5",
-            "strip-bom": "^3.0.0",
-            "strip-json-comments": "~2.0.1",
-            "table": "^3.7.8",
-            "text-table": "~0.2.0",
-            "user-home": "^2.0.0"
+            "babel-code-frame": "6.26.0",
+            "chalk": "1.1.3",
+            "concat-stream": "1.6.0",
+            "debug": "2.6.9",
+            "doctrine": "2.1.0",
+            "escope": "3.6.0",
+            "espree": "3.5.1",
+            "esquery": "1.0.0",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "file-entry-cache": "2.0.0",
+            "glob": "7.1.2",
+            "globals": "9.18.0",
+            "ignore": "3.3.7",
+            "imurmurhash": "0.1.4",
+            "inquirer": "0.12.0",
+            "is-my-json-valid": "2.16.1",
+            "is-resolvable": "1.0.0",
+            "js-yaml": "3.10.0",
+            "json-stable-stringify": "1.0.1",
+            "levn": "0.3.0",
+            "lodash": "4.17.4",
+            "mkdirp": "0.5.1",
+            "natural-compare": "1.4.0",
+            "optionator": "0.8.2",
+            "path-is-inside": "1.0.2",
+            "pluralize": "1.2.1",
+            "progress": "1.1.8",
+            "require-uncached": "1.0.3",
+            "shelljs": "0.7.8",
+            "strip-bom": "3.0.0",
+            "strip-json-comments": "2.0.1",
+            "table": "3.8.3",
+            "text-table": "0.2.0",
+            "user-home": "2.0.0"
           }
         },
         "file-entry-cache": {
@@ -12587,8 +12631,8 @@
           "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
           "dev": true,
           "requires": {
-            "flat-cache": "^1.2.1",
-            "object-assign": "^4.0.1"
+            "flat-cache": "1.3.0",
+            "object-assign": "4.1.1"
           }
         },
         "object-assign": {
@@ -12603,9 +12647,9 @@
           "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
           "dev": true,
           "requires": {
-            "glob": "^7.0.0",
-            "interpret": "^1.0.0",
-            "rechoir": "^0.6.2"
+            "glob": "7.1.2",
+            "interpret": "1.1.0",
+            "rechoir": "0.6.2"
           }
         },
         "strip-bom": {
@@ -12628,10 +12672,10 @@
       "integrity": "sha1-67d7nI/CyBZf+jU72Rug3/Qa9pA=",
       "dev": true,
       "requires": {
-        "deglob": "^2.1.0",
-        "get-stdin": "^5.0.1",
-        "minimist": "^1.1.0",
-        "pkg-conf": "^2.0.0"
+        "deglob": "2.1.0",
+        "get-stdin": "5.0.1",
+        "minimist": "1.2.0",
+        "pkg-conf": "2.1.0"
       },
       "dependencies": {
         "get-stdin": {
@@ -12654,8 +12698,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -12664,7 +12708,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -12673,7 +12717,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -12682,7 +12726,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -12693,7 +12737,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -12702,7 +12746,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -12713,9 +12757,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -12737,7 +12781,7 @@
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -12750,13 +12794,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -12764,7 +12808,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -12781,7 +12825,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1"
+        "duplexer": "0.1.1"
       }
     },
     "stream-consume": {
@@ -12796,8 +12840,8 @@
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
       "dev": true,
       "requires": {
-        "commander": "^2.2.0",
-        "limiter": "^1.0.5"
+        "commander": "2.14.1",
+        "limiter": "1.1.2"
       }
     },
     "string-length": {
@@ -12806,8 +12850,8 @@
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
-        "astral-regex": "^1.0.0",
-        "strip-ansi": "^4.0.0"
+        "astral-regex": "1.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12822,7 +12866,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -12832,9 +12876,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -12853,7 +12897,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -12862,8 +12906,8 @@
       "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "is-utf8": "^0.2.0"
+        "first-chunk-stream": "1.0.0",
+        "is-utf8": "0.2.1"
       }
     },
     "strip-bom-string": {
@@ -12882,7 +12926,7 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -12913,12 +12957,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "^4.7.0",
-        "ajv-keywords": "^1.0.0",
-        "chalk": "^1.1.1",
-        "lodash": "^4.0.0",
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
         "slice-ansi": "0.0.4",
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12939,8 +12983,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -12949,7 +12993,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -12959,9 +13003,9 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
       }
     },
     "terminate": {
@@ -12970,7 +13014,42 @@
       "integrity": "sha1-qH7kJL4BodKPLzAQRQQ6W81nmgU=",
       "dev": true,
       "requires": {
-        "ps-tree": "^1.1.0"
+        "ps-tree": "1.1.0"
+      }
+    },
+    "terser": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.8.1.tgz",
+      "integrity": "sha512-FRin3gKQ0vm0xPPLuxw1FqpVgv1b2pBpYCaFb5qe6A7sD749Fnq1VbDiX3CEFM0BV0fqDzFtBfgmxhxCdzKQIg==",
+      "dev": true,
+      "requires": {
+        "commander": "2.16.0",
+        "source-map": "0.6.1",
+        "source-map-support": "0.5.8"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+          "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.8",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.8.tgz",
+          "integrity": "sha512-WqAEWPdb78u25RfKzOF0swBpY0dKrNdjc4GvLwm7ScX/o9bj8Eh/YL8mcMhBHYDGl87UkkSXDOFnW4G7GhWhGg==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "1.1.0",
+            "source-map": "0.6.1"
+          }
+        }
       }
     },
     "test-exclude": {
@@ -12979,11 +13058,11 @@
       "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "micromatch": "^3.1.8",
-        "object-assign": "^4.1.0",
-        "read-pkg-up": "^1.0.1",
-        "require-main-filename": "^1.0.1"
+        "arrify": "1.0.1",
+        "micromatch": "3.1.10",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "require-main-filename": "1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -13004,16 +13083,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -13022,7 +13101,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -13033,13 +13112,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -13048,7 +13127,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -13057,7 +13136,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -13066,9 +13145,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -13085,8 +13164,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -13095,7 +13174,7 @@
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -13106,14 +13185,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -13122,7 +13201,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -13131,7 +13210,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -13142,10 +13221,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -13154,7 +13233,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -13165,7 +13244,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13174,7 +13253,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -13185,7 +13264,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13194,7 +13273,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -13205,7 +13284,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13214,7 +13293,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -13237,19 +13316,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           }
         },
         "object-assign": {
@@ -13272,8 +13351,8 @@
       "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "object-path": "^0.9.0"
+        "chalk": "1.1.3",
+        "object-path": "0.9.2"
       }
     },
     "throat": {
@@ -13294,8 +13373,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -13310,13 +13389,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -13325,7 +13404,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -13342,7 +13421,7 @@
       "integrity": "sha1-tSvlSN3+/aIOALWMYJZ2K0PdaIA=",
       "dev": true,
       "requires": {
-        "enable": "1"
+        "enable": "1.3.2"
       }
     },
     "tildify": {
@@ -13351,7 +13430,7 @@
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "time-stamp": {
@@ -13389,7 +13468,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "to-regex": {
@@ -13398,10 +13477,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -13410,8 +13489,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -13420,7 +13499,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -13431,8 +13510,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -13441,7 +13520,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -13457,7 +13536,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "tr46": {
@@ -13466,7 +13545,7 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       },
       "dependencies": {
         "punycode": {
@@ -13493,7 +13572,7 @@
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
       "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
       "requires": {
-        "glob": "^6.0.4"
+        "glob": "6.0.4"
       },
       "dependencies": {
         "glob": {
@@ -13501,11 +13580,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -13521,7 +13600,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "tweetnacl": {
@@ -13536,7 +13615,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "typedarray": {
@@ -13558,9 +13637,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "camelcase": {
@@ -13577,8 +13656,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
         },
@@ -13610,9 +13689,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -13653,10 +13732,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "set-value": {
@@ -13665,10 +13744,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -13703,8 +13782,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -13713,9 +13792,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -13755,7 +13834,7 @@
       "integrity": "sha1-FQ5l2kK/d0JEW5WKZOubhdHSsYA=",
       "dev": true,
       "requires": {
-        "co": "~3.1.0"
+        "co": "3.1.0"
       },
       "dependencies": {
         "co": {
@@ -13790,9 +13869,9 @@
       "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "lazy-cache": "^2.0.2"
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "lazy-cache": "2.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -13801,7 +13880,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -13810,7 +13889,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13819,7 +13898,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -13830,7 +13909,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13839,7 +13918,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -13850,9 +13929,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "isobject": {
@@ -13875,7 +13954,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "util": {
@@ -13906,8 +13985,8 @@
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+        "define-properties": "1.1.2",
+        "object.getownpropertydescriptors": "2.0.3"
       }
     },
     "utils-merge": {
@@ -13934,7 +14013,7 @@
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
       "requires": {
-        "user-home": "^1.1.1"
+        "user-home": "1.1.1"
       },
       "dependencies": {
         "user-home": {
@@ -13950,8 +14029,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
       }
     },
     "verror": {
@@ -13959,9 +14038,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -13977,8 +14056,8 @@
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
+        "clone": "1.0.3",
+        "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -13988,14 +14067,14 @@
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "dev": true,
       "requires": {
-        "defaults": "^1.0.0",
-        "glob-stream": "^3.1.5",
-        "glob-watcher": "^0.0.6",
-        "graceful-fs": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "strip-bom": "^1.0.0",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.0"
+        "defaults": "1.0.3",
+        "glob-stream": "3.1.18",
+        "glob-watcher": "0.0.6",
+        "graceful-fs": "3.0.11",
+        "mkdirp": "0.5.1",
+        "strip-bom": "1.0.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -14010,7 +14089,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "^1.1.0"
+            "natives": "1.1.0"
           }
         },
         "readable-stream": {
@@ -14019,10 +14098,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "through2": {
@@ -14031,8 +14110,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -14041,8 +14120,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -14059,7 +14138,7 @@
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
-        "browser-process-hrtime": "^0.1.2"
+        "browser-process-hrtime": "0.1.2"
       }
     },
     "wait-port": {
@@ -14068,9 +14147,9 @@
       "integrity": "sha1-1RpJHkhKF791qUfnEaLwErTm8uM=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "commander": "^2.9.0",
-        "debug": "^2.6.6"
+        "chalk": "1.1.3",
+        "commander": "2.14.1",
+        "debug": "2.6.9"
       }
     },
     "walker": {
@@ -14079,7 +14158,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.x"
+        "makeerror": "1.0.11"
       }
     },
     "ware": {
@@ -14088,7 +14167,7 @@
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "dev": true,
       "requires": {
-        "wrap-fn": "^0.1.0"
+        "wrap-fn": "0.1.5"
       }
     },
     "watch": {
@@ -14097,8 +14176,8 @@
       "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
       "dev": true,
       "requires": {
-        "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
+        "exec-sh": "0.2.1",
+        "minimist": "1.2.0"
       }
     },
     "webidl-conversions": {
@@ -14128,9 +14207,9 @@
       "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
       }
     },
     "which": {
@@ -14138,7 +14217,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -14151,7 +14230,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
-        "string-width": "^1.0.2"
+        "string-width": "1.0.2"
       }
     },
     "win-fork": {
@@ -14177,8 +14256,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrap-fn": {
@@ -14209,7 +14288,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {
@@ -14218,9 +14297,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "ws": {
@@ -14229,9 +14308,9 @@
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "ultron": "1.1.1"
       }
     },
     "xml-name-validator": {
@@ -14266,19 +14345,19 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.0.2.tgz",
       "integrity": "sha1-EVuX3xMhgj6Lhkjolox4JSEiH2c=",
       "requires": {
-        "camelcase": "^3.0.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.2",
-        "which-module": "^1.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^5.0.0"
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "5.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -14293,7 +14372,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "requires": {
-        "camelcase": "^3.0.0"
+        "camelcase": "3.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -14309,7 +14388,7 @@
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "fd-slicer": "1.0.1"
       }
     },
     "yeast": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "metalsmith-rollup": "^1.0.0",
     "metalsmith-sass": "^1.5.1",
     "metalsmith-tagcleaner": "0.0.2",
+    "metalsmith-uglify": "^2.3.0",
     "nunjucks": "^3.1.2",
     "puppeteer": "^1.4.0",
     "request": "^2.87.0",


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-design-system/issues/417 by minifying assets and generating a new sourcemap.

This has the side benefit of making the Design System faster, I will update this PR with the before and after.

https://govuk-design-system-preview.netlify.com/components/button/ vs https://deploy-preview-484--govuk-design-system-preview.netlify.com/components/button/

- Before: 554KB (179 KB gzipped)
- After: 470KB (94.9KB  gzipped)

Based on some quick lighthouse testing this seems to shave 100-200ms off time to first meaningful paint.