### PR TITLE
Fix prototype kit links

### DIFF
--- a/src/patterns/check-answers/index.md.njk
+++ b/src/patterns/check-answers/index.md.njk
@@ -12,7 +12,7 @@ Let users check their answers before submitting information to a service.
 
 ![Screenshot of a check answers page, includes a heading, and two sections for personal details and application details. Each section has details on the answers a user has given with a corresponding link to change their answer. At the bottom of the page there is a button to ‘accept and send’ the application.](check-answers-page.png)
 
-There is a [coded example of a check your answers page](https://govuk-prototype-kit.herokuapp.com/docs/examples/check-your-answers-page) in the GOV.UK Prototype Kit.
+There is a [coded example of a check your answers page](https://govuk-prototype-kit.herokuapp.com/docs/templates/check-your-answers) in the GOV.UK Prototype Kit.
 
 ## When to use this pattern
 

--- a/src/patterns/task-list-pages/index.md.njk
+++ b/src/patterns/task-list-pages/index.md.njk
@@ -18,7 +18,7 @@ Task list pages help users understand:
 
 ![A screenshot showing an example of the task list page, includes a heading, and three grouped sections that each contain tasks, some of these tasks are marked as completed.](task-list-whole.png)
 
-There is a [coded example of a task list page](https://govuk-prototype-kit.herokuapp.com/docs/examples/task-list-page) in the GOV.UK Prototype Kit.
+There is a [coded example of a task list page](https://govuk-prototype-kit.herokuapp.com/docs/templates/task-list) in the GOV.UK Prototype Kit.
 
 ## When to use this pattern
 


### PR DESCRIPTION
A couple of links just broke because we reorganised the templates in the kit