### PR TITLE
Colour contrast

### DIFF
--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -25,6 +25,8 @@ Don’t use the panel component to highlight important information within body c
 
 ## How it works
 
+To meet colour contrast ratio requirements, all content in the panel must be at least 24px normal weight or 19px bold.
+
 There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: true, size: "m"}) }}

--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -25,7 +25,7 @@ Don’t use the panel component to highlight important information within body c
 
 ## How it works
 
-To meet colour contrast ratio requirements, all content in the panel must be at least 24px normal weight or 19px bold.
+If you add extra content to the panel, to meet colour contrast ratio requirements use a font size of <code>govuk-body-l</code> for normal weight and <code>govuk-body</code> for bold.
 
 There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 

--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -31,7 +31,7 @@ Your confirmation page must include:
 - a link to your feedback page
 - a way for users to save a record of the transaction, for example, as a PDF
 
-To meet colour contrast ratio requirements, all content in the panel must be at least 24px normal weight or 19px bold.
+To meet colour contrast ratio requirements, all content in the [panel](../components/panel/) must be at least 24px normal weight or 19px bold.
 
 {{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: true, size: "xl"}) }}
 

--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -31,6 +31,8 @@ Your confirmation page must include:
 - a link to your feedback page
 - a way for users to save a record of the transaction, for example, as a PDF
 
+To meet colour contrast ratio requirements, all content in the panel must be at least 24px normal weight or 19px bold.
+
 {{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: true, size: "xl"}) }}
 
 ### Help users who bookmark the page

--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -31,7 +31,7 @@ Your confirmation page must include:
 - a link to your feedback page
 - a way for users to save a record of the transaction, for example, as a PDF
 
-To meet colour contrast ratio requirements, all content in the [panel](../components/panel/) must be at least 24px normal weight or 19px bold.
+To meet colour contrast ratio requirements, all content in the [panel](../../components/panel/) must be at least 24px normal weight or 19px bold.
 
 {{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: true, size: "xl"}) }}
 

--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -31,7 +31,7 @@ Your confirmation page must include:
 - a link to your feedback page
 - a way for users to save a record of the transaction, for example, as a PDF
 
-To meet colour contrast ratio requirements, all content in the [panel](../../components/panel/) must be at least 24px normal weight or 19px bold.
+If you add extra content to the panel, to meet colour contrast ratio requirements use a font size of <code>govuk-body-l</code> for normal weight and <code>govuk-body</code> for bold.
 
 {{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: true, size: "xl"}) }}
 


### PR DESCRIPTION
Added information about colour contrast and font size for the panel component. I put this on the component page and the confirmation page pattern page to make sure people see the information.

This used to be in the [colour section in Elements](http://govuk-elements.herokuapp.com/colour) and I think it was useful.