### PR TITLE
Fingerprint and cache the search index

### DIFF
--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -2,6 +2,9 @@
 const configPaths = require('../config/paths.json')
 const PORT = configPaths.port
 
+// Regex that can be used to match on fingerprinted search index files
+const isSearchIndex = /.*\/search-index-[0-9a-f]{32}.json$/
+
 let browser
 let page
 let baseUrl = 'http://localhost:' + PORT
@@ -54,7 +57,7 @@ describe('Site search', () => {
   it('shows user a message that the index has failed to download', async () => {
     await page.setRequestInterception(true)
     page.on('request', interceptedRequest => {
-      if (interceptedRequest.url().endsWith('search-index.json')) {
+      if (isSearchIndex.test(interceptedRequest.url())) {
         interceptedRequest.abort()
       } else {
         interceptedRequest.continue()
@@ -73,7 +76,7 @@ describe('Site search', () => {
     await page.setRequestInterception(true)
     page.on('request', interceptedRequest => {
       // Intentionally make the search-index request hang
-      if (!interceptedRequest.url().endsWith('search-index.json')) {
+      if (!isSearchIndex.test(interceptedRequest.url())) {
         interceptedRequest.continue()
       }
     })

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -93,6 +93,7 @@ http {
     text/html                       epoch;
     text/css                        max;
     application/javascript          max;
+    application/json                max;
     ~application/x-font             max;
     ~application/font               max;
     application/vnd.ms-fontobject   max;

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -178,17 +178,6 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     ]
   }))
 
-  // add hash to files
-  .use(hashAssets({
-    pattern: [
-      'stylesheets/main.css',
-      'stylesheets/main-ie8.css',
-      'javascripts/application.js',
-      'javascripts/ie.js',
-      'javascripts/govuk-frontend.js'
-    ]
-  }))
-
   // check titles are set
   .use(titleChecker())
 
@@ -244,6 +233,21 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
   // apply navigation
   .use(navigation())
 
+  // generate a search index
+  .use(lunr())
+
+  // add hash to files
+  .use(hashAssets({
+    pattern: [
+      'stylesheets/main.css',
+      'stylesheets/main-ie8.css',
+      'javascripts/application.js',
+      'javascripts/ie.js',
+      'javascripts/govuk-frontend.js',
+      'search-index.json'
+    ]
+  }))
+
   // apply layouts to source files
   .use(layouts({
     engine: 'nunjucks',
@@ -257,9 +261,6 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     hostname: 'http://design-system.service.gov.uk',
     pattern: ['**/*.html', '!**/default/*.html']
   }))
-
-  // generate a search index
-  .use(lunr())
 
   // check broken links
   .use(brokenLinkChecker({

--- a/src/javascripts/components/search.js
+++ b/src/javascripts/components/search.js
@@ -6,7 +6,7 @@ import lunr from 'lunr'
 var TIMEOUT = 10 // Time to wait before giving up fetching the search index
 var STATE_DONE = 4 // XHR client readyState DONE
 
-// LunrJS Seach index
+// LunrJS Search index
 var searchIndex = null
 var documentStore = null
 
@@ -15,9 +15,9 @@ var searchQuery = ''
 var searchCallback = function () {}
 
 var AppSearch = {
-  fetchSearchIndex: function (callback) {
+  fetchSearchIndex: function (indexUrl, callback) {
     var request = new XMLHttpRequest()
-    request.open('GET', '/search-index.json', true)
+    request.open('GET', indexUrl, true)
     request.timeout = TIMEOUT * 1000
     statusMessage = 'Loading search index'
     request.onreadystatechange = function () {
@@ -35,7 +35,6 @@ var AppSearch = {
         }
       }
     }
-    request.open('GET', '/search-index.json', true)
     request.send()
   },
   renderResults: function () {
@@ -77,12 +76,13 @@ var AppSearch = {
       return itemTemplate
     }
   },
-  init: function (container, input) {
-    if (!document.querySelector(container)) {
+  init: function (selector, input) {
+    var $container = document.querySelector(selector)
+    if (!$container) {
       return
     }
     accessibleAutocomplete({
-      element: document.querySelector(container),
+      element: $container,
       id: input,
       cssNamespace: 'app-site-search',
       displayMenu: 'overlay',
@@ -97,7 +97,8 @@ var AppSearch = {
       },
       tNoResults: function () { return statusMessage }
     })
-    this.fetchSearchIndex(function () {
+    var searchIndexUrl = $container.getAttribute('data-search-index')
+    this.fetchSearchIndex(searchIndexUrl, function () {
       this.renderResults()
     }.bind(this))
   }

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -38,7 +38,7 @@
     </span>
   </a>
   {% if SEARCH %}
-  <div class="app-site-search">
+  <div class="app-site-search" data-search-index="/{{ fingerprint['search-index.json'] }}">
     <label class="govuk-visually-hidden" for="app-site-search__input">Search Design system</label>
     <a class="app-site-search__link govuk-link" href="/sitemap">Sitemap</a>
   </div>


### PR DESCRIPTION
Fingerprint the search index in the same way we fingerprint other assets (stylesheets, JavaScript), allowing us to cache it indefinitely.

Update the search JavaScript to read the current fingerprinted search index from a data attribute on the container (`data-search-index`)

This should mean that:

- the browser should only download the (same version of the) search index once
- when a new page is added to the Design System, deploying should cause browsers to load the new version of the search index on the next page load, preventing the search from returning out-of-date results