### PR TITLE
Include section in search results

### DIFF
--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -23,7 +23,8 @@ module.exports = function lunrPlugin () {
           const documentPath = file.path || path
           return {
             path: documentPath,
-            title: file.title
+            title: file.title,
+            section: file.section
           }
         })
 
@@ -57,7 +58,8 @@ module.exports = function lunrPlugin () {
       documents.forEach(doc => {
         store[doc.path] = {
           title: doc.title,
-          path: doc.path
+          path: doc.path,
+          section: doc.section
         }
         this.add(doc)
       })

--- a/lib/metalsmith-lunr-index/index.test.js
+++ b/lib/metalsmith-lunr-index/index.test.js
@@ -52,6 +52,14 @@ describe('metalsmith-lunr-index plugin', () => {
       expect(checkboxesDocument.path).toEqual('checkboxes.html')
     })
 
+    it('contains the section that the document is in', () => {
+      const checkboxesDocument = Object.values(documentStore).find(document => {
+        return document.title === 'Checkboxes'
+      })
+
+      expect(checkboxesDocument.section).toEqual('Components')
+    })
+
     it('uses the permalink path if in document metadata', () => {
       const withPermalinkDocument = Object.values(documentStore).find(document => {
         return document.title === 'With Permalink'

--- a/src/javascripts/components/search.js
+++ b/src/javascripts/components/search.js
@@ -71,10 +71,17 @@ var AppSearch = {
     }
   },
   resultTemplate: function (result) {
+    // add rest of the data here to build the item
     if (result) {
-      // add rest of the data here to build the item
-      var itemTemplate = result.title
-      return itemTemplate
+      var elem = document.createElement('span')
+      elem.textContent = result.title
+
+      var section = document.createElement('span')
+      section.className = 'app-site-search--section'
+      section.textContent = result.section
+
+      elem.appendChild(section)
+      return elem.innerHTML
     }
   },
   init: function (container, input) {

--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -11,7 +11,7 @@ $icon-size: 40px;
   width: 100%;
   position: relative;
 
-  @include govuk-media-query($from: tablet) {  
+  @include govuk-media-query($from: tablet) {
     max-width: 100%;
     width: 300px;
     float: none;
@@ -155,6 +155,10 @@ $icon-size: 40px;
   outline: none;
   color: govuk-colour("white");
   background-color: govuk-colour("blue");
+
+  .app-site-search--section {
+    color: inherit;
+  }
 }
 
 .app-site-search__option--no-results {
@@ -189,3 +193,8 @@ $icon-size: 40px;
   }
 }
 
+.app-site-search--section {
+  display: block;
+  @include govuk-font($size: 16);
+  color: $govuk-secondary-text-colour;
+}


### PR DESCRIPTION
Store the section that a page is in as part of the document store, and present it as part of the search result in the interface.

We think this will help users to choose the most relevant match when presented with multiple results, and help them to understand the structure of the Design System.

<img width="1392" alt="screen shot 2018-08-16 at 10 57 50" src="https://user-images.githubusercontent.com/121939/44202221-3c383f00-a143-11e8-9281-f2597bceef25.png">

https://trello.com/c/QN7zxxXi/1275-2-include-the-category-and-or-theme-when-presenting-search-results