### PR TITLE
Remove width logic needed for bordered menu

### DIFF
--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -96,7 +96,6 @@ $icon-size: 40px;
 
 .app-site-search__menu {
   width: 100%;
-  width: calc(100% - 4px);
   max-height: 342px;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Since we do not have a border on the menu anymore, we can have it fit properly.

## Before
<img width="332" alt="screen shot 2018-08-16 at 13 02 48" src="https://user-images.githubusercontent.com/2445413/44207544-86c2b700-a155-11e8-817b-b5f5c225ba3c.png">

## After
<img width="335" alt="screen shot 2018-08-16 at 13 02 23" src="https://user-images.githubusercontent.com/2445413/44207543-862a2080-a155-11e8-824c-3b9d55eb3bd1.png">
