### PR TITLE
Extend jest-puppeteer launchTimeout

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -4,7 +4,7 @@ const PORT = configPaths.port
 module.exports = {
   server: {
     command: 'SEARCH=true node tasks/serve.js',
-    launchTimeout: 20000,
+    launchTimeout: 30000,
     port: PORT
   }
 }


### PR DESCRIPTION
We had very frequent failures to start the tests on Travis.

Extending the launchTimeout to 30s seems to have solved the issue.

Ran 3 consecutive builds on Travis and all completed OK. 
Tests still complete in roughly the same time as before

```
$ npm test -- --runInBand
> govuk_design_system@ test /home/travis/build/alphagov/govuk-design-system
> npm run lint && jest "--runInBand"
> govuk_design_system@ lint /home/travis/build/alphagov/govuk-design-system
> npm run lint:js && npm run lint:scss
> govuk_design_system@ lint:js /home/travis/build/alphagov/govuk-design-system
> standard
> govuk_design_system@ lint:scss /home/travis/build/alphagov/govuk-design-system
> gulp scss:lint

[12:26:11] Using gulpfile ~/build/alphagov/govuk-design-system/gulpfile.js
[12:26:11] Starting 'scss:lint'...
[12:26:11] Finished 'scss:lint' after 23 ms
PASS __tests__/search.test.js
PASS __tests__/tabs.test.js
PASS __tests__/mobile-navigation.test.js
PASS lib/metalsmith-lunr-index/index.test.js
Test Suites: 4 passed, 4 total
Tests:       22 passed, 22 total
Snapshots:   0 total
Time:        7.135s
Ran all test suites.
```