### PR TITLE
Update <main> element id to match skip-link target

### DIFF
--- a/views/layouts/layout.njk
+++ b/views/layouts/layout.njk
@@ -2,7 +2,7 @@
 
 {% block body %}
 <div class="app-pane__content">
-  <main id="content" role="main">
+  <main id="main-content" role="main">
     {{ contents | safe }}
   </main>
 


### PR DESCRIPTION
At the moment skip-link href is set to target `#main-content` which doesn't exist.