### PR TITLE
Make search terms optional

### DIFF
--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -52,9 +52,6 @@ module.exports = function lunrPlugin () {
       // Disable stemming of search terms run against this index
       this.searchPipeline.remove(lunr.stemmer)
 
-      // Remove stop words filter from index pipeline
-      this.pipeline.remove(lunr.stopWordFilter)
-
       documents.forEach(doc => {
         store[doc.path] = {
           title: doc.title,

--- a/src/javascripts/components/search.js
+++ b/src/javascripts/components/search.js
@@ -44,8 +44,7 @@ var AppSearch = {
     }
     var searchResults = searchIndex.query(function (q) {
       q.term(lunr.tokenizer(searchQuery), {
-        wildcard: lunr.Query.wildcard.TRAILING,
-        presence: lunr.Query.presence.REQUIRED
+        wildcard: lunr.Query.wildcard.TRAILING
       })
     })
     matchedResults = searchResults.map(function (result) {


### PR DESCRIPTION
Currently the search is configured so that every term (word) the user enters is required to match against a document for it to be returned as a result. This has the advantage that it only shows results which ‘perfectly’ match the entered terms – for example, searching for ‘date input’ will return only the date input component. This also means that entering additional terms will only ever refine the displayed results, ‘narrowing down’ the list.

![search-required](https://user-images.githubusercontent.com/121939/44218073-d19df800-a170-11e8-9f06-8b52d4a74edd.gif)

The disadvantage of this approach is that users searching for something like ‘user accounts’ will never find the ‘Create accounts’ pattern, because that pattern does not include the word ‘user’ in any field that we currently index.

![search-user-accounts-none](https://user-images.githubusercontent.com/121939/44218241-35282580-a171-11e8-8d96-d52d30bb01f1.gif)

We _could_ work around this specific case by adding ‘user accounts’ as an alias, but we think that making each term optional gives users the best change to find everything that relates to the thing they are searching for. This also means that searching for 'user accounts' will match 'create accounts'.

![search-user-accounts](https://user-images.githubusercontent.com/121939/44218254-3b1e0680-a171-11e8-8568-80089a1238b4.gif)

This will mean that searching for date _might_ not work the way users expect. As they enter the word ‘date’, they will see ‘date input’ and ‘asking for dates’, but as soon as they start typing the word input, additional results will start appearing. Once they’ve typed ‘i’, any pages in the design system with titles that start with the letter ‘i’ will appear in addition to the two date related pages, and as they complete the word ‘input’ the results will then narrow down to all pages that include the word ‘date’ OR the word ‘input’. Because lunr scores the results and sorts them by that score, ‘date input’ will appear at the top of this as it is the best match.

![search-any](https://user-images.githubusercontent.com/121939/44218055-c9de5380-a170-11e8-91fe-a1fcac5db945.gif)

We will make sure to look out for any confusion about this behaviour in user research.

Finally, because terms can be optional, we no longer need to remove the stop word filter from the indexing pipeline, because results will no longer be excluded because they ‘don’t contain the stop words’.