### PR TITLE
Revert "Fingerprint and cache the search index"

### DIFF
--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -2,9 +2,6 @@
 const configPaths = require('../config/paths.json')
 const PORT = configPaths.port
 
-// Regex that can be used to match on fingerprinted search index files
-const isSearchIndex = /.*\/search-index-[0-9a-f]{32}.json$/
-
 let browser
 let page
 let baseUrl = 'http://localhost:' + PORT
@@ -57,7 +54,7 @@ describe('Site search', () => {
   it('shows user a message that the index has failed to download', async () => {
     await page.setRequestInterception(true)
     page.on('request', interceptedRequest => {
-      if (isSearchIndex.test(interceptedRequest.url())) {
+      if (interceptedRequest.url().endsWith('search-index.json')) {
         interceptedRequest.abort()
       } else {
         interceptedRequest.continue()
@@ -76,7 +73,7 @@ describe('Site search', () => {
     await page.setRequestInterception(true)
     page.on('request', interceptedRequest => {
       // Intentionally make the search-index request hang
-      if (!isSearchIndex.test(interceptedRequest.url())) {
+      if (!interceptedRequest.url().endsWith('search-index.json')) {
         interceptedRequest.continue()
       }
     })

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -93,7 +93,6 @@ http {
     text/html                       epoch;
     text/css                        max;
     application/javascript          max;
-    application/json                max;
     ~application/x-font             max;
     ~application/font               max;
     application/vnd.ms-fontobject   max;

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -178,6 +178,17 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     ]
   }))
 
+  // add hash to files
+  .use(hashAssets({
+    pattern: [
+      'stylesheets/main.css',
+      'stylesheets/main-ie8.css',
+      'javascripts/application.js',
+      'javascripts/ie.js',
+      'javascripts/govuk-frontend.js'
+    ]
+  }))
+
   // check titles are set
   .use(titleChecker())
 
@@ -233,21 +244,6 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
   // apply navigation
   .use(navigation())
 
-  // generate a search index
-  .use(lunr())
-
-  // add hash to files
-  .use(hashAssets({
-    pattern: [
-      'stylesheets/main.css',
-      'stylesheets/main-ie8.css',
-      'javascripts/application.js',
-      'javascripts/ie.js',
-      'javascripts/govuk-frontend.js',
-      'search-index.json'
-    ]
-  }))
-
   // apply layouts to source files
   .use(layouts({
     engine: 'nunjucks',
@@ -261,6 +257,9 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     hostname: 'http://design-system.service.gov.uk',
     pattern: ['**/*.html', '!**/default/*.html']
   }))
+
+  // generate a search index
+  .use(lunr())
 
   // check broken links
   .use(brokenLinkChecker({

--- a/src/javascripts/components/search.js
+++ b/src/javascripts/components/search.js
@@ -6,7 +6,7 @@ import lunr from 'lunr'
 var TIMEOUT = 10 // Time to wait before giving up fetching the search index
 var STATE_DONE = 4 // XHR client readyState DONE
 
-// LunrJS Search index
+// LunrJS Seach index
 var searchIndex = null
 var documentStore = null
 
@@ -15,9 +15,9 @@ var searchQuery = ''
 var searchCallback = function () {}
 
 var AppSearch = {
-  fetchSearchIndex: function (indexUrl, callback) {
+  fetchSearchIndex: function (callback) {
     var request = new XMLHttpRequest()
-    request.open('GET', indexUrl, true)
+    request.open('GET', '/search-index.json', true)
     request.timeout = TIMEOUT * 1000
     statusMessage = 'Loading search index'
     request.onreadystatechange = function () {
@@ -35,6 +35,7 @@ var AppSearch = {
         }
       }
     }
+    request.open('GET', '/search-index.json', true)
     request.send()
   },
   renderResults: function () {
@@ -83,13 +84,12 @@ var AppSearch = {
       return elem.innerHTML
     }
   },
-  init: function (selector, input) {
-    var $container = document.querySelector(selector)
-    if (!$container) {
+  init: function (container, input) {
+    if (!document.querySelector(container)) {
       return
     }
     accessibleAutocomplete({
-      element: $container,
+      element: document.querySelector(container),
       id: input,
       cssNamespace: 'app-site-search',
       displayMenu: 'overlay',
@@ -104,8 +104,7 @@ var AppSearch = {
       },
       tNoResults: function () { return statusMessage }
     })
-    var searchIndexUrl = $container.getAttribute('data-search-index')
-    this.fetchSearchIndex(searchIndexUrl, function () {
+    this.fetchSearchIndex(function () {
       this.renderResults()
     }.bind(this))
   }

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -38,7 +38,7 @@
     </span>
   </a>
   {% if SEARCH %}
-  <div class="app-site-search" data-search-index="/{{ fingerprint['search-index.json'] }}">
+  <div class="app-site-search">
     <label class="govuk-visually-hidden" for="app-site-search__input">Search Design system</label>
     <a class="app-site-search__link govuk-link" href="/sitemap">Sitemap</a>
   </div>


### PR DESCRIPTION
This change introduced some rendering issues of the page template page, so we want to revert it since trying to find a fix seems to be taking a while.

We believe it the issue is due to moving the hashAssets step, but are struggling to get lunr to work correctly when we move it. 

Reverts alphagov/govuk-design-system#489
