### PR TITLE
Fix fingerprint in custom template example

### DIFF
--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -122,5 +122,5 @@ ignore_in_sitemap: true
 
 {% block bodyEnd %}
   <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
-  <script src="/public/all.js"></script>
+  <script src="/{{ fingerprint['javascripts/govuk-frontend.js'] }}"></script>
 {% endblock %}


### PR DESCRIPTION
It's currently calling the wrong file and without the hash (see console log): https://design-system.service.gov.uk/styles/page-template/
