### PR TITLE
Search aliases

### DIFF
--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -36,9 +36,36 @@ describe('Site search', () => {
     await page.waitForSelector('.app-site-search__input')
     await page.type('.app-site-search__input', 'd')
     const resultsArray = await page.evaluate(
-      () => [...document.querySelectorAll('.app-site-search__option')].map(elem => elem.innerText.toLowerCase())
+      () => [...document.querySelectorAll('.app-site-search__option')]
+      .map(elem => elem.innerText.toLowerCase())
+      .filter(elem => elem.startsWith('d'))
+    )
+
+    expect(resultsArray.every(item => item.startsWith('d'))).toBeTruthy()
+  })
+  it('returns results that contain aliases that start with the letter "d"', async () => {
+    await page.goto(baseUrl, { waitUntil: 'load' })
+
+    await page.waitForSelector('.app-site-search__input')
+    await page.type('.app-site-search__input', 'd')
+
+    const resultsArray = await page.evaluate(
+      () => [...document.querySelectorAll('.app-site-search__option')]
+      .filter(elem => !elem.textContent.toLowerCase().startsWith('d'))
+      .map(elem => elem.querySelector('.app-site-search__aliases').textContent)
     )
     expect(resultsArray.every(item => item.startsWith('d'))).toBeTruthy()
+  })
+  it('doesn\'t show any aliases if it finds any matches in the title', async () => {
+    await page.goto(baseUrl, { waitUntil: 'load' })
+
+    await page.waitForSelector('.app-site-search__input')
+    await page.type('.app-site-search__input', 'det')
+    const resultsArray = await page.evaluate(
+      () => [...document.querySelectorAll('.app-site-search__aliases')]
+      .map(elem => elem.querySelector('.app-site-search__aliases'))
+    )
+    expect(resultsArray).toHaveLength(0)
   })
   it('selecting "details" as the result takes you to the the "details" page', async () => {
     await page.goto(baseUrl, { waitUntil: 'load' })

--- a/lib/metalsmith-lunr-index/fixtures/src/radios.html
+++ b/lib/metalsmith-lunr-index/fixtures/src/radios.html
@@ -1,6 +1,7 @@
 ---
 title: Radios
 section: Components
+aliases: radio buttons, option buttons
 ---
 
 Contents

--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -24,7 +24,8 @@ module.exports = function lunrPlugin () {
           return {
             path: documentPath,
             title: file.title,
-            section: file.section
+            section: file.section,
+            aliases: file.aliases === null ? undefined : file.aliases
           }
         })
 
@@ -38,7 +39,8 @@ module.exports = function lunrPlugin () {
 
     const index = lunr(function () {
       this.ref('path')
-      this.field('title')
+      this.field('title', {boost: 100})
+      this.field('aliases', {boost: 10})
 
       // Stemming (reducing words to their stem e.g. fishing to fish) is not
       // useful in an 'autocomplete' scenario, where we search using a prefix
@@ -56,7 +58,8 @@ module.exports = function lunrPlugin () {
         store[doc.path] = {
           title: doc.title,
           path: doc.path,
-          section: doc.section
+          section: doc.section,
+          aliases: doc.aliases
         }
         this.add(doc)
       })

--- a/lib/metalsmith-lunr-index/index.test.js
+++ b/lib/metalsmith-lunr-index/index.test.js
@@ -83,5 +83,12 @@ describe('metalsmith-lunr-index plugin', () => {
 
       expect(documentStore[resultRef].title).toEqual('Radios')
     })
+
+    it('stores the aliases of the page in the metadata', () => {
+      const searchResults = searchIndex.search('radios')
+      const resultRef = searchResults[0].ref
+
+      expect(documentStore[resultRef].aliases).toEqual('radio buttons, option buttons')
+    })
   })
 })

--- a/src/javascripts/components/search.js
+++ b/src/javascripts/components/search.js
@@ -72,8 +72,28 @@ var AppSearch = {
     // add rest of the data here to build the item
     if (result) {
       var elem = document.createElement('span')
-      elem.textContent = result.title
-
+      var resultTitle = result.title
+      elem.textContent = resultTitle
+      if (result.aliases) {
+        var aliases = result.aliases.split(',').map(function (item) {
+          return item.trim()
+        })
+        var matchedAliases = []
+        // only show a matching alias if there are no matches in the title
+        if (resultTitle.toLowerCase().indexOf(searchQuery) === -1) {
+          // it would be confusing to show the user
+          // aliases that don't match the typed query
+          matchedAliases = aliases.filter(function (alias) {
+            return alias.indexOf(searchQuery) !== -1
+          })
+        }
+        if (matchedAliases.length > 0) {
+          var aliasesContainer = document.createElement('span')
+          aliasesContainer.className = 'app-site-search__aliases'
+          aliasesContainer.textContent = matchedAliases.join(', ')
+          elem.appendChild(aliasesContainer)
+        }
+      }
       var section = document.createElement('span')
       section.className = 'app-site-search--section'
       section.textContent = result.section

--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -3,198 +3,231 @@
 
 $icon-size: 40px;
 
-.app-site-search {
-  float: left;
-  margin-bottom: govuk-spacing(2);
-  margin-top: govuk-spacing(2);
-  max-width: calc(100% - 120px);
-  width: 100%;
-  position: relative;
-
-  @include govuk-media-query($from: tablet) {
-    max-width: 100%;
-    width: 300px;
-    float: none;
-  }
-
-  @include govuk-media-query($from: desktop) {
-    float: right;
-    margin: 0;
-    margin-top: -6px; //negative margin to vertically align search in header
-  }
-
-  .no-js & {
-    display: none;
+@include govuk-not-ie8 {
+  .app-site-search {
+    float: left;
+    margin-bottom: govuk-spacing(2);
+    margin-top: govuk-spacing(2);
+    max-width: calc(100% - 120px);
+    width: 100%;
+    position: relative;
 
     @include govuk-media-query($from: tablet) {
-      display: block;
+      max-width: 100%;
+      width: 300px;
+      float: none;
     }
 
     @include govuk-media-query($from: desktop) {
-      text-align: right;
+      float: right;
+      margin: 0;
+      margin-top: -6px; //negative margin to vertically align search in header
     }
-  }
-}
 
-.app-site-search__wrapper {
-  position: relative;
-  display: block;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='white'%3E%3C/path%3E%3C/svg%3E") govuk-colour("blue") no-repeat top left;
-  background-size: $icon-size $icon-size;
-  height: $icon-size;
-}
+    .no-js & {
+      display: none;
 
-.app-site-search__hint,
-.app-site-search__input {
-  min-height: $icon-size;
-  box-sizing: border-box;
-  width: 100%;
-  margin-bottom: 0; // BUG: Safari 10 on macOS seems to add an implicit margin.
-  border: 2px solid govuk-colour("white");
-  border-radius: 0; // Safari 10 on iOS adds implicit border rounding.
-  -webkit-appearance: none;
-}
+      @include govuk-media-query($from: tablet) {
+        display: block;
+      }
 
-.app-site-search__hint {
-  position: absolute;
-  color: govuk-colour("grey-2");
-}
-
-.app-site-search__input {
-  margin-left: $icon-size;
-  width: calc(100% - #{$icon-size});
-  height: $icon-size;
-  position: relative;
-  background-color: govuk-colour("white");
-}
-
-.app-site-search__input--default {
-  padding: 9px govuk-spacing(2) govuk-spacing(1);
-}
-
-.app-site-search__input--focused {
-  outline: 3px solid $govuk-focus-colour;
-  outline-offset: 0;
-  margin-left: 0;
-  width: 100%;
-}
-
-.app-site-search__input--show-all-values {
-  padding: govuk-spacing(1) 34px govuk-spacing(1) govuk-spacing(1);
-  cursor: pointer;
-}
-
-.app-site-search__dropdown-arrow-down {
-  display: inline-block;
-  position: absolute;
-  z-index: -1;
-  top: govuk-spacing(2);
-  right: 8px;
-  width: 24px;
-  height: 24px;
-}
-
-.app-site-search__menu {
-  width: 100%;
-  max-height: 342px;
-  margin: 0;
-  padding: 0;
-  overflow-x: hidden;
-  border-top: 0;
-  color: govuk-colour("black");
-  background-color: govuk-colour("white");
-}
-
-.app-site-search__menu--visible {
-  display: block;
-}
-
-.app-site-search__menu--hidden {
-  display: none;
-}
-
-.app-site-search__menu--overlay {
-  position: absolute;
-  z-index: 100;
-  top: 100%;
-  left: 0;
-  box-shadow: rgba(govuk-colour("black"), .256863) 0 2px 6px;
-}
-
-.app-site-search__menu--inline {
-  position: relative;
-}
-
-.app-site-search__option {
-  display: block;
-  position: relative;
-  border-bottom: solid govuk-colour("grey-2");
-  border-width: 1px 0;
-  cursor: pointer;
-}
-
-.app-site-search__option > * {
-  pointer-events: none;
-}
-
-.app-site-search__option:first-of-type {
-  border-top-width: 0;
-}
-
-.app-site-search__option:last-of-type {
-  border-bottom-width: 0;
-}
-
-.app-site-search__option--odd {
-  background-color: #FAFAFA;
-}
-
-.app-site-search__option--focused,
-.app-site-search__option:hover {
-  border-color: govuk-colour("blue");
-  outline: none;
-  color: govuk-colour("white");
-  background-color: govuk-colour("blue");
-
-  .app-site-search--section {
-    color: inherit;
-  }
-}
-
-.app-site-search__option--no-results {
-  background-color: govuk-colour("white");
-  color: govuk-colour("grey-1");
-  cursor: not-allowed;
-}
-
-.app-site-search__hint,
-.app-site-search__option {
-  padding: govuk-spacing(2);
-}
-
-.app-site-search__hint,
-.app-site-search__input,
-.app-site-search__option {
-  @include govuk-font($size: 19);
-}
-
-.app-site-search__link {
-  display: none;
-
-  .no-js & {
-    @include govuk-media-query($from: tablet) {
-      color: govuk-colour("white");
-      margin-top: 10px;
-      display: inline-block;
-      &:focus {
-        color: govuk-colour("black");
+      @include govuk-media-query($from: desktop) {
+        text-align: right;
       }
     }
   }
+
+  .app-site-search__wrapper {
+    position: relative;
+    display: block;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='white'%3E%3C/path%3E%3C/svg%3E") govuk-colour("blue") no-repeat top left;
+    background-size: $icon-size $icon-size;
+    height: $icon-size;
+  }
+
+  .app-site-search__hint,
+  .app-site-search__input {
+    min-height: $icon-size;
+    box-sizing: border-box;
+    width: 100%;
+    margin-bottom: 0; // BUG: Safari 10 on macOS seems to add an implicit margin.
+    border: 2px solid govuk-colour("white");
+    border-radius: 0; // Safari 10 on iOS adds implicit border rounding.
+    -webkit-appearance: none;
+  }
+
+  .app-site-search__hint {
+    position: absolute;
+    color: govuk-colour("grey-2");
+  }
+
+  .app-site-search__input {
+    margin-left: $icon-size;
+    width: calc(100% - #{$icon-size});
+    height: $icon-size;
+    position: relative;
+    background-color: govuk-colour("white");
+  }
+
+  .app-site-search__input--default {
+    padding: 9px govuk-spacing(2) govuk-spacing(1);
+  }
+
+  .app-site-search__input--focused {
+    outline: 3px solid $govuk-focus-colour;
+    outline-offset: 0;
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .app-site-search__input--show-all-values {
+    padding: govuk-spacing(1) 34px govuk-spacing(1) govuk-spacing(1);
+    cursor: pointer;
+  }
+
+  .app-site-search__dropdown-arrow-down {
+    display: inline-block;
+    position: absolute;
+    z-index: -1;
+    top: govuk-spacing(2);
+    right: 8px;
+    width: 24px;
+    height: 24px;
+  }
+
+  .app-site-search__menu {
+    width: 100%;
+    max-height: 342px;
+    margin: 0;
+    padding: 0;
+    overflow-x: hidden;
+    border-top: 0;
+    color: govuk-colour("black");
+    background-color: govuk-colour("white");
+  }
+
+  .app-site-search__menu--visible {
+    display: block;
+  }
+
+  .app-site-search__menu--hidden {
+    display: none;
+  }
+
+  .app-site-search__menu--overlay {
+    position: absolute;
+    z-index: 100;
+    top: 100%;
+    left: 0;
+    box-shadow: rgba(govuk-colour("black"), .256863) 0 2px 6px;
+  }
+
+  .app-site-search__menu--inline {
+    position: relative;
+  }
+
+  .app-site-search__option {
+    display: block;
+    position: relative;
+    border-bottom: solid govuk-colour("grey-2");
+    border-width: 1px 0;
+    cursor: pointer;
+  }
+
+  .app-site-search__option > * {
+    pointer-events: none;
+  }
+
+  .app-site-search__option:first-of-type {
+    border-top-width: 0;
+  }
+
+  .app-site-search__option:last-of-type {
+    border-bottom-width: 0;
+  }
+
+  .app-site-search__option--odd {
+    background-color: #FAFAFA;
+  }
+
+  .app-site-search__option--focused,
+  .app-site-search__option:hover {
+    border-color: govuk-colour("blue");
+    outline: none;
+    color: govuk-colour("white");
+    background-color: govuk-colour("blue");
+
+    .app-site-search--section {
+      color: inherit;
+    }
+  }
+
+  .app-site-search__option--no-results {
+    background-color: govuk-colour("white");
+    color: govuk-colour("grey-1");
+    cursor: not-allowed;
+  }
+
+  .app-site-search__hint,
+  .app-site-search__option {
+    padding: govuk-spacing(2);
+  }
+
+  .app-site-search__hint,
+  .app-site-search__input,
+  .app-site-search__option {
+    @include govuk-font($size: 19);
+  }
+
+  .app-site-search__link {
+    display: none;
+
+    .no-js & {
+      @include govuk-media-query($from: tablet) {
+        color: govuk-colour("white");
+        margin-top: 10px;
+        display: inline-block;
+        &:focus {
+          color: govuk-colour("black");
+        }
+      }
+    }
+  }
+
+  .app-site-search--section {
+    display: block;
+    @include govuk-font($size: 16);
+    color: $govuk-secondary-text-colour;
+  }
+
+  .app-site-search__aliases {
+    margin-left: govuk-spacing(1);
+    &::before {
+      content: '(';
+    }
+    &::after {
+      content: ')';
+    }
+  }
 }
 
-.app-site-search--section {
-  display: block;
-  @include govuk-font($size: 16);
-  color: $govuk-secondary-text-colour;
+// on IE8 we show the sitemap link as Accessible autocomplete
+// doesn't support it
+@include govuk-if-ie8 {
+  .app-site-search {
+    float: right;
+    width: 300px;
+    margin: 0;
+    margin-top: -6px;
+    text-align: right;
+  }
+
+  .app-site-search__link:link {
+    color: govuk-colour("white");
+    margin-top: 10px;
+    display: inline-block;
+    &:focus {
+      color: govuk-colour("black");
+    }
+  }
 }


### PR DESCRIPTION
Include aliases ('reveal' for details) and common alternative spellings ('color' instead of colour) when searching.

We know that different users refer to the same component or pattern using different names. Allowing them to search for the component or pattern with other names increases the likelihood that they will find it.

Trello ticket: https://trello.com/c/1qzrKg00/1276-3-include-aliases-and-common-alternative-spellings-when-searching

## Current implementation

Matches against the title carry a 10 times greater weight that matches agains the aliases.
When adding more characters to the query, if there are no matches in the title, results will contain matches in any of the item's aliases and show those aliases until there are no more matches.

Matches titles first, then aliases (for the select) and shows aliases that contain the match
<img width="321" alt="screen shot 2018-08-22 at 09 35 00" src="https://user-images.githubusercontent.com/3758555/44452480-8d867980-a5ee-11e8-97c4-cc8d481fc143.png">

Matches the title, so no aliases shown
<img width="323" alt="screen shot 2018-08-22 at 09 35 10" src="https://user-images.githubusercontent.com/3758555/44452488-90816a00-a5ee-11e8-8771-a3be0ff4b914.png">

No matches in title, only in aliases, so show aliases
<img width="328" alt="screen shot 2018-08-22 at 09 35 21" src="https://user-images.githubusercontent.com/3758555/44452497-937c5a80-a5ee-11e8-98f4-4003995717e5.png">

needs design input from @dashouse 
run locally with SEARCH=true npm start

This increases the search index size to 20KB (non gzipped, local) at the time of writing, and aliases are not present on all pages.