### PR TITLE
Update metalsmith-layouts to v2.1.0

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -246,10 +246,12 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
 
   // apply layouts to source files
   .use(layouts({
-    engine: 'nunjucks',
     default: 'layout.njk',
     directory: '../' + paths.layouts,
-    pattern: '**/*.html'
+    pattern: '**/*.html',
+    engineOptions: {
+      path: views
+    }
   }))
 
   // generate a sitemap.xml in public/ folder

--- a/package-lock.json
+++ b/package-lock.json
@@ -2110,15 +2110,6 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
-    "consolidate": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.5.tgz",
-      "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.5.1"
-      }
-    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -8262,12 +8253,6 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
       "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
     },
-    "lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
-      "dev": true
-    },
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
@@ -8671,7 +8656,7 @@
           "integrity": "sha1-l4/EFV0fwwuLWPw/AgECstoC8qQ=",
           "dev": true,
           "requires": {
-            "lodash": "4.13.1"
+            "lodash": "^4.8.0"
           }
         },
         "balanced-match": {
@@ -8686,7 +8671,7 @@
           "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.1",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -8702,11 +8687,11 @@
           "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.5",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.0",
-            "once": "1.3.3",
-            "path-is-absolute": "1.0.0"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "inflight": {
@@ -8715,8 +8700,8 @@
           "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
           "dev": true,
           "requires": {
-            "once": "1.3.3",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -8737,7 +8722,7 @@
           "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.4"
+            "brace-expansion": "^1.0.0"
           }
         },
         "once": {
@@ -8746,7 +8731,7 @@
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "path-is-absolute": {
@@ -8828,19 +8813,27 @@
       }
     },
     "metalsmith-layouts": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/metalsmith-layouts/-/metalsmith-layouts-1.8.1.tgz",
-      "integrity": "sha1-o2XTmTnZFGzf5R+t7n2HVXP8y9w=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/metalsmith-layouts/-/metalsmith-layouts-2.1.0.tgz",
+      "integrity": "sha512-saRKs8tvvD2Wq0Ff0yoqDmWxQNn14rJRK9ayUBo02fG9Kpf6cEEgRbwsE5//zZ52JhadBMM33w5N5wjeKDSvLg==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "consolidate": "0.14.5",
-        "debug": "2.6.9",
-        "extend": "3.0.1",
-        "fs-readdir-recursive": "1.1.0",
-        "is-utf8": "0.2.1",
-        "lodash.omit": "4.5.0",
-        "multimatch": "2.1.0"
+        "debug": "^3.1.0",
+        "inputformat-to-jstransformer": "^1.2.1",
+        "is-utf8": "^0.2.1",
+        "jstransformer": "^1.0.0",
+        "multimatch": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "metalsmith-markdown": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "metalsmith-env": "^2.1.1",
     "metalsmith-fingerprint-ignore": "^2.0.0",
     "metalsmith-in-place": "^3.0.1",
-    "metalsmith-layouts": "^1.8.1",
+    "metalsmith-layouts": "^2.1.0",
     "metalsmith-markdown": "^0.2.2",
     "metalsmith-metallic": "^2.0.2",
     "metalsmith-permalinks": "^0.5.0",


### PR DESCRIPTION
metalsmith-layouts v2.0.0 started using jstransformers under the hood. This means we no longer need to specify the engine, as it will be inferred from the .njk file extension. We do however now need to pass the `views` array so that the layouts knows where to look to resolve templates from other places (partials, the template in Frontend) [1] – I have no idea how this worked before…

[1] This took WAY too long to debug – the error it was giving because it could not resolve the templates was “Error: Invalid result object from transform.” 🤦‍♂️ On the plus side, I learnt a lot about using Developer Tools to debug Node apps!