### PR TITLE
Use helper to lookup fingerprinted files

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -54,6 +54,20 @@ exports.getFrontmatter = path => {
   return parsedFile.data
 }
 
+exports.getFingerprint = function (file, isRelative = false) {
+  // Grab fingerprint array from the template context
+  const fingerprints = this.lookup('fingerprint')
+
+  if (!fingerprints.hasOwnProperty(file)) {
+    // The thrown error will stop the build, but not provide any useful output,
+    // so we have to console.log as well.
+    console.log(`Could not find fingerprint for file ${file}`)
+    throw new Error(`Could not find fingerprint for file ${file}`)
+  }
+
+  return '/' + fingerprints[file]
+}
+
 // This helper function takes a path of a *.md.njk file and
 // returns the HTML rendered by Nunjucks without markdown data
 exports.getHTMLCode = path => {

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -204,7 +204,8 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
       globals: {
         getFrontmatter: fileHelper.getFrontmatter,
         getNunjucksCode: fileHelper.getNunjucksCode,
-        getHTMLCode: fileHelper.getHTMLCode
+        getHTMLCode: fileHelper.getHTMLCode,
+        getFingerprint: fileHelper.getFingerprint
       }
     }
   }))
@@ -250,7 +251,11 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     directory: '../' + paths.layouts,
     pattern: '**/*.html',
     engineOptions: {
-      path: views
+      path: views,
+      globals: {
+        joinPaths: fileHelper.joinPaths,
+        getFingerprint: fileHelper.getFingerprint
+      }
     }
   }))
 

--- a/src/styles/page-template/block-areas/index.njk
+++ b/src/styles/page-template/block-areas/index.njk
@@ -15,11 +15,11 @@ stylesheets:
   <meta name="robots" content="noindex, nofollow">
 
   <!--[if !IE 8]><!-->
-    <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
   <!--<![endif]-->
   <!--[if lt IE 9]>
-    <link href="/{{ fingerprint['stylesheets/main-ie8.css'] }}" rel="stylesheet" media="all" />
-    <script src="/{{ fingerprint['javascripts/ie.js'] }}"></script>
+    <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all" />
+    <script src="{{ getFingerprint('javascripts/ie.js') }}"></script>
   <![endif]-->
   <script src="/javascripts/vendor/modernizr.js"></script>
 
@@ -92,6 +92,6 @@ stylesheets:
     {{ super() }}
     {# Since we’re not extending the Design System layout we need to add this manually #}
     <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
-    <script src="/{{ fingerprint['javascripts/govuk-frontend.js'] }}"></script>
+    <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
   </div>
 {%- endblock %}

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -29,11 +29,11 @@ ignore_in_sitemap: true
 {% block head %}
   <meta name="robots" content="noindex, nofollow">
   <!--[if !IE 8]><!-->
-    <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
   <!--<![endif]-->
   <!--[if lt IE 9]>
-    <link href="/{{ fingerprint['stylesheets/main-ie8.css'] }}" rel="stylesheet" media="all" />
-    <script src="/{{ fingerprint['javascripts/ie.js'] }}"></script>
+    <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all" />
+    <script src="{{ getFingerprint('javascripts/ie.js') }}"></script>
   <![endif]-->
   <script src="/javascripts/vendor/modernizr.js"></script>
 {% endblock %}
@@ -122,5 +122,5 @@ ignore_in_sitemap: true
 
 {% block bodyEnd %}
   <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
-  <script src="/{{ fingerprint['javascripts/govuk-frontend.js'] }}"></script>
+  <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
 {% endblock %}

--- a/src/styles/page-template/default/index.njk
+++ b/src/styles/page-template/default/index.njk
@@ -7,11 +7,11 @@ layout: false
 {% block head %}
   <meta name="robots" content="noindex, nofollow">
   <!--[if !IE 8]><!-->
-    <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
   <!--<![endif]-->
   <!--[if lt IE 9]>
-    <link href="/{{ fingerprint['stylesheets/main-ie8.css'] }}" rel="stylesheet" media="all" />
-    <script src="/{{ fingerprint['javascripts/ie.js'] }}"></script>
+    <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all" />
+    <script src="{{ getFingerprint('javascripts/ie.js') }}"></script>
   <![endif]-->
   <script src="/javascripts/vendor/modernizr.js"></script>
 {% endblock %}
@@ -22,5 +22,5 @@ layout: false
 
 {% block bodyEnd %}
   <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
-  <script src="/{{ fingerprint['javascripts/govuk-frontend.js'] }}"></script>
+  <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
 {% endblock %}

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -11,11 +11,11 @@
 {% endif %}
 <meta name="description" content="{{description}}">
   <!--[if !IE 8]><!-->
-    <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
   <!--<![endif]-->
   <!--[if lt IE 9]>
-    <link href="/{{ fingerprint['stylesheets/main-ie8.css'] }}" rel="stylesheet" media="all" />
-    <script src="/{{ fingerprint['javascripts/ie.js'] }}"></script>
+    <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all" />
+    <script src="{{ getFingerprint('javascripts/ie.js') }}"></script>
   <![endif]-->
   <link rel="canonical" href="{{ canonical }}" />
   <script src="/javascripts/vendor/modernizr.js"></script>
@@ -46,5 +46,5 @@
 {% block footer %}{% endblock %}
 
 {% block bodyEnd %}
-<script src="/{{ fingerprint['javascripts/application.js'] }}"></script>
+<script src="{{ getFingerprint('javascripts/application.js') }}"></script>
 {% endblock %}

--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -2,7 +2,7 @@
 {% set bodyClasses = 'app-example-page' %}
 {% block pageTitle %}{{ title }} – Example – GOV.UK Design System{% endblock %}
 {% block head %}
-  <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
+  <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
   {#- Include any additional stylesheets specified in the example frontmatter #}
   {% for stylesheet in stylesheets %}
   <link href="{{ stylesheet }}" rel="stylesheet" media="all" />
@@ -17,5 +17,5 @@
 {% endblock %}
 {% block bodyEnd %}
   <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
-  <script src="/{{ fingerprint['javascripts/govuk-frontend.js'] }}"></script>
+  <script src="/{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
 {% endblock %}

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -5,7 +5,7 @@
     <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ title }} – Example – GOV.UK Design System</title>
-    <link href="/{{ fingerprint['stylesheets/main.css'] }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
     {#- Include any additional stylesheets specified in the example frontmatter #}
     {% for stylesheet in stylesheets %}
     <link href="{{ stylesheet }}" rel="stylesheet" media="all" />
@@ -22,6 +22,6 @@
       {{ contents | safe }}
     {% endblock %}
     <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
-    <script src="/{{ fingerprint['javascripts/govuk-frontend.js'] }}"></script>
+    <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
   </body>
 </html>


### PR DESCRIPTION
Using a helper allows us to throw an error if the file is not found in the fingerprint array, making it harder to break the build without realising.