### PR TITLE
Fingerprint all CSS files

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -54,18 +54,35 @@ exports.getFrontmatter = path => {
   return parsedFile.data
 }
 
-exports.getFingerprint = function (file, isRelative = false) {
+// Get 'fingerprinted' version of a given asset file.
+exports.getFingerprint = function (file) {
   // Grab fingerprint array from the template context
+  const filePath = this.lookup('path')
   const fingerprints = this.lookup('fingerprint')
 
-  if (!fingerprints.hasOwnProperty(file)) {
-    // The thrown error will stop the build, but not provide any useful output,
-    // so we have to console.log as well.
-    console.log(`Could not find fingerprint for file ${file}`)
-    throw new Error(`Could not find fingerprint for file ${file}`)
+  // If that fails, and we know the path of the current file, look for a
+  // fingerprinted asset relative to the current file (e.g. `../foo.css`)
+  //
+  // We only know the path of the current file when we're compiling the layout –
+  // calls to this function with a relative path will fail if made from the
+  // source files themselves.
+  if (filePath) {
+    const relativeFile = path.join(filePath, file)
+
+    if (fingerprints.hasOwnProperty(relativeFile)) {
+      return '/' + fingerprints[relativeFile]
+    }
   }
 
-  return '/' + fingerprints[file]
+  // Look for a fingerprinted asset at this path relative to the site root
+  if (fingerprints.hasOwnProperty(file)) {
+    return '/' + fingerprints[file]
+  }
+
+  // The thrown error will stop the build, but not provide any useful output,
+  // so we have to console.log as well.
+  console.log(`Could not find fingerprint for file ${file}`)
+  throw new Error(`Could not find fingerprint for file ${file}`)
 }
 
 // This helper function takes a path of a *.md.njk file and

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -181,8 +181,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
   // add hash to files
   .use(hashAssets({
     pattern: [
-      'stylesheets/main.css',
-      'stylesheets/main-ie8.css',
+      '**/*.css',
       'javascripts/application.js',
       'javascripts/ie.js',
       'javascripts/govuk-frontend.js'

--- a/src/styles/page-template/block-areas/index.njk
+++ b/src/styles/page-template/block-areas/index.njk
@@ -3,7 +3,7 @@ title: Block areas – Page template
 layout: false
 ignore_in_sitemap: true
 stylesheets:
-- ./block-areas-annotate.css
+- styles/page-template/block-areas/block-areas-annotate.css
 ---
 
 {% extends "template.njk" %}
@@ -22,9 +22,8 @@ stylesheets:
     <script src="{{ getFingerprint('javascripts/ie.js') }}"></script>
   <![endif]-->
   <script src="/javascripts/vendor/modernizr.js"></script>
-
   {% for stylesheet in stylesheets %}
-    <link href="{{ stylesheet }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all" />
   {%- endfor %}
 {%- endblock %}
 

--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -5,7 +5,7 @@
   <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
   {#- Include any additional stylesheets specified in the example frontmatter #}
   {% for stylesheet in stylesheets %}
-  <link href="{{ stylesheet }}" rel="stylesheet" media="all" />
+  <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all" />
   {%- endfor %}
   <!--[if lt IE 9]>
     <script src="/javascripts/ie.js"></script>

--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -8,7 +8,7 @@
   <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all" />
   {%- endfor %}
   <!--[if lt IE 9]>
-    <script src="/javascripts/ie.js"></script>
+    <script src="{{ getFingerprint('javascripts/ie.js') }}"></script>
   <![endif]-->
   <script src="/javascripts/vendor/modernizr.js"></script>
 {% endblock %}

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -12,7 +12,7 @@
     {%- endfor %}
 
     <!--[if lt IE 9]>
-      <script src="/javascripts/ie.js"></script>
+      <script src="{{ getFingerprint('javascripts/ie.js') }}"></script>
     <![endif]-->
     <script src="/javascripts/vendor/modernizr.js"></script>
   </head>

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -8,7 +8,7 @@
     <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
     {#- Include any additional stylesheets specified in the example frontmatter #}
     {% for stylesheet in stylesheets %}
-    <link href="{{ stylesheet }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all" />
     {%- endfor %}
 
     <!--[if lt IE 9]>


### PR DESCRIPTION
Update the config to fingerprint all CSS files, and use the fingerprint helper to include them.

Because we specify some asset paths using relative URLs (e.g. `../grid-nested-annotate.css`), but the fingerprint object has everything relative to the root, we need to ‘normalise’ all URLs using the path. Unfortunately that means we need to know the path of the page including the asset, and we don’t know that within metalsmith-in-place (because metalsmith-in-place runs before metalsmith-permalinks). This means we can call getFingerprint with relative URLs in layouts, but not in the source files themselves.

For that reason, the ‘block areas’ example has been updated to specify a path relative to the root.

https://trello.com/c/EHg1iVP5/1354-extra-css-for-examples-is-not-fingerprinted-but-is-cached-indefinitely