### PR TITLE
Use the correct 'alt text' instead of 'alt tag' wording

### DIFF
--- a/src/styles/images/index.md.njk
+++ b/src/styles/images/index.md.njk
@@ -27,8 +27,8 @@ If your image represents something physical, such as a letter, document or credi
 
 ## Alt text
 
-All images must have an alt tag. You should include a description of the image inside the tag to help users who are unable to see it.
+All images must have an alt text. You should include a description of the image inside the tag to help users who are unable to see it.
 
 {{ example({group: "styles", item: "images", example: "alt-text", html: true, open: true, size: "l"}) }}
 
-If your image is purely decorative and a description would be confusing you should still include the alt tag, but leave it empty so it will be ignored by screen readers.
+If your image is purely decorative and a description would be confusing you should still include the alt text, but leave it empty so it will be ignored by screen readers.


### PR DESCRIPTION
Update images guidance with correct wording.
Fixes: #507 