### PR TITLE
Use simpler default example for text inputs

### DIFF
--- a/src/components/text-input/default/index.njk
+++ b/src/components/text-input/default/index.njk
@@ -7,11 +7,8 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    text: "Email address"
+    text: "Full name"
   },
-  hint: {
-    text: "We’ll only use this to send you a receipt"
-  },
-  id: "email",
-  name: "email"
+  id: "name",
+  name: "name"
 }) }}


### PR DESCRIPTION
Change the default example for the text input component from an input asking for an email address to an example asking for someone’s full name.

As [raised in the backlog](https://github.com/alphagov/govuk-design-system-backlog/issues/51#issuecomment-414986345), we are not currently using the correct `type=“email”`. We could fix this, but as users are likely to take this ‘default’ example and modify it to ask different questions, it makes sense to make it as generic as possible, avoiding using a type specific to a particular type of input.

Therefore changing to a more ‘generic’ question, such as full name, which does not require specific input types, makes more sense.