### PR TITLE
Rewrite 'copy' functionality to remove jQuery dependency and follow GOV.UK Frontend conventions

### DIFF
--- a/src/javascripts/application.js
+++ b/src/javascripts/application.js
@@ -1,9 +1,12 @@
+import common from 'govuk-frontend/common'
 import CookieBanner from './components/cookie-banner.js'
 import Example from './components/example.js'
 import Tabs from './components/tabs.js'
 import Copy from './components/copy.js'
 import MobileNav from './components/mobile-navigation.js'
 import Search from './components/search.js'
+
+var nodeListForEach = common.nodeListForEach
 
 // Add cookie message
 CookieBanner.addCookieMessage()
@@ -15,7 +18,10 @@ Example.init('.js-example__frame')
 Tabs.init('.js-example')
 
 // Add copy to clipboard to code blocks inside tab containers
-Copy.init('.app-tabs__container pre')
+var $codeBlocks = document.querySelectorAll('[data-module="app-copy"]')
+nodeListForEach($codeBlocks, function ($codeBlock) {
+  new Copy($codeBlock).init()
+})
 
 // Initialise mobile navigation
 MobileNav.init()

--- a/src/javascripts/components/copy.js
+++ b/src/javascripts/components/copy.js
@@ -1,26 +1,41 @@
-import $ from 'jquery'
+import 'govuk-frontend/vendor/polyfills/Event'
 import ClipboardJS from 'clipboard'
 
-var Copy = {
-  init: function (selector) {
-    $(selector).parent().prepend('<button class="app-copy-button js-copy-button" aria-live="assertive">Copy</button>')
-    // Copy to clipboard
-    try {
-      new ClipboardJS('.js-copy-button', {
-        target: function (trigger) {
-          return trigger.nextElementSibling
-        }
-      }).on('success', function (e) {
-        e.trigger.textContent = 'Copied'
-        e.clearSelection()
-        setTimeout(function () {
-          e.trigger.textContent = 'Copy'
-        }, 5000)
-      })
-    } catch (err) {
-      if (err) {
-        console.log(err.message)
+function Copy ($module) {
+  this.$module = $module
+}
+
+Copy.prototype.init = function () {
+  var $module = this.$module
+  if (!$module) {
+    return
+  }
+  var $button = document.createElement('button')
+  $button.className = 'app-copy-button js-copy-button'
+  $button.setAttribute('aria-live', 'assertive')
+  $button.textContent = 'Copy'
+
+  var $parent = $module.parentNode
+  $parent.insertBefore($button, $parent.firstChild)
+  this.copyAction()
+}
+Copy.prototype.copyAction = function () {
+  // Copy to clipboard
+  try {
+    new ClipboardJS('.js-copy-button', {
+      target: function (trigger) {
+        return trigger.nextElementSibling
       }
+    }).on('success', function (e) {
+      e.trigger.textContent = 'Copied'
+      e.clearSelection()
+      setTimeout(function () {
+        e.trigger.textContent = 'Copy'
+      }, 5000)
+    })
+  } catch (err) {
+    if (err) {
+      console.log(err.message)
     }
   }
 }

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -39,7 +39,7 @@
   <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
   {% endif %}
   <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
-    <pre><code class="hljs html">
+    <pre data-module="app-copy"><code class="hljs html">
       {{- getHTMLCode(examplePath) | highlight('html') | safe -}}
     </code></pre>
   </div>
@@ -50,7 +50,7 @@
   <div class="app-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
   {% endif %}
   <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
-    <pre><code class="hljs js">
+    <pre data-module="app-copy"><code class="hljs js">
       {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
     </code></pre>
 


### PR DESCRIPTION
- Removes jQuery dependency
- Followes GOV.UK Frontend convevtions
- Works in IE9+ (plugin does not support IE8)

Trello ticket: https://trello.com/c/J02wN45k/1326-update-copyjs-to-follow-frontend-conventions-and-remove-dependency-on-jquery

Ticket to build an ie8 bundle is here: https://trello.com/c/B6N3G2fS/1325-ensure-copy-to-clipboard-functionality-does-not-break-ie8-experience