### PR TITLE
Rewrite 'example' functionality to follow GOV.UK Frontend conventions

### DIFF
--- a/src/javascripts/application.js
+++ b/src/javascripts/application.js
@@ -1,3 +1,4 @@
+import common from 'govuk-frontend/common'
 import CookieBanner from './components/cookie-banner.js'
 import Example from './components/example.js'
 import Tabs from './components/tabs.js'
@@ -5,11 +6,16 @@ import Copy from './components/copy.js'
 import MobileNav from './components/mobile-navigation.js'
 import Search from './components/search.js'
 
+var nodeListForEach = common.nodeListForEach
+
 // Add cookie message
 CookieBanner.addCookieMessage()
 
 // Initialise example frames
-Example.init('.js-example__frame')
+var $examples = document.querySelectorAll('[data-module="app-example-frame"]')
+nodeListForEach($examples, function ($example) {
+  new Example($example).init()
+})
 
 // Initialise tabs
 Tabs.init('.js-example')

--- a/src/javascripts/components/example.js
+++ b/src/javascripts/components/example.js
@@ -2,15 +2,26 @@
 // So we use an underscore here.
 import _ from 'iframe-resizer'
 
-var Example = {
-  init: function (selector) {
-    try {
-      // Example iframe; set the height equal to the body height
-      _.iframeResizer({ scrolling: 'auto', autoResize: true }, selector)
-    } catch (err) {
-      if (err) {
-        console.error(err.message)
-      }
+function Example ($module) {
+  this.$module = $module
+}
+
+Example.prototype.init = function () {
+  var $module = this.$module
+  if (!$module) {
+    return
+  }
+  this.resize()
+}
+Example.prototype.resize = function () {
+  var $module = this.$module
+
+  try {
+    // Example iframe; set the height equal to the body height
+    _.iframeResizer({ scrolling: 'auto', autoResize: true }, $module)
+  } catch (err) {
+    if (err) {
+      console.error(err.message)
     }
   }
 }

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -24,7 +24,7 @@
         example in a new window
       </a>
     </span>
-    <iframe title="{{ exampleTitle }}" class="app-example__frame app-example__frame--resizable js-example__frame{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0"></iframe>
+    <iframe title="{{ exampleTitle }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0"></iframe>
   </div>
 
   {%- if (multipleTabs) %}


### PR DESCRIPTION
- Rewrite example.js
- Rewrite initialisation in application.js
- Initialise iframe with data-module attribute instead of a css class 