### PR TITLE
Remove "Browser testing" and "Testing with assistive technologies" from Tabs component page

### DIFF
--- a/src/components/tabs/index.md.njk
+++ b/src/components/tabs/index.md.njk
@@ -90,27 +90,7 @@ The design, code and guidance here are based on recommendations from [Inclusive 
 - Judiciary UI internal systems (HMCTS)
 - Rural Payments (Defra)
 
-### Browser testing
-
-The tabs component has been tested with the following browsers and devices:
-
-- Google Chrome 66
-- Firefox 59 (including tests with custom colors)
-- Safari 11.1
-- Internet Explorer 11
-- Internet Explorer 10
-- Internet Explorer 9 (no support for matchMedia and degrades gracefully)
-
-### Testing with assistive technologies
-
-- The tabs component has been tested with the following assistive technologies:
-- JAWS 16, 17 and 18 on Internet Explorer 11
-- NVDA on Firefox 54
-- VoiceOver on Safari 11.1
-- ZoomText 10 on Internet Explorer 11
-- Dragon NaturallySpeaking on Internet Explorer 11
-
-### <a name="next-steps"></a>Next steps
+### Next steps
 
 User research is needed to confirm:
 


### PR DESCRIPTION
We don't know if listing the devices/AT in the current manner on the Tabs page is the right approach.
We would like to research this with users but meanwhile we'll remove the "Browser testing" and "Testing with assistive technologies" sections to make Tabs consistent with the other component pages.