### PR TITLE
Removed lead paragraphs from examples

### DIFF
--- a/src/patterns/service-unavailable-pages/after-service-closes/index.njk
+++ b/src/patterns/service-unavailable-pages/after-service-closes/index.njk
@@ -11,7 +11,7 @@ ignore_in_sitemap: true
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Service unavailable</h1>
-    <p class="govuk-body-l">
+    <p class="govuk-body">
       You cannot use the online service to renew your tax credits.
     </p>
     <p class="govuk-body">

--- a/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
+++ b/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
@@ -11,7 +11,7 @@ ignore_in_sitemap: true
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Service unavailable</h1>
-    <p class="govuk-body-l">
+    <p class="govuk-body">
       You will be able to use the service on Monday 19&nbsp;November&nbsp;2018.
     </p>
     <p class="govuk-body">

--- a/src/patterns/service-unavailable-pages/before-service-opens/index.njk
+++ b/src/patterns/service-unavailable-pages/before-service-opens/index.njk
@@ -11,7 +11,7 @@ ignore_in_sitemap: true
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Service unavailable</h1>
-    <p class="govuk-body-l">
+    <p class="govuk-body">
       You will be able renew your tax credits from Tuesday 24&nbsp;April&nbsp;2018.
     </p>
     <p class="govuk-body"><a class="govuk-link" href="#">

--- a/src/patterns/service-unavailable-pages/default/index.njk
+++ b/src/patterns/service-unavailable-pages/default/index.njk
@@ -11,7 +11,7 @@ ignore_in_sitemap: true
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Service unavailable</h1>
-      <p class="govuk-body-l">
+      <p class="govuk-body">
         You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.
       </p>
       <p class="govuk-body">

--- a/src/patterns/service-unavailable-pages/general/index.njk
+++ b/src/patterns/service-unavailable-pages/general/index.njk
@@ -11,7 +11,7 @@ ignore_in_sitemap: true
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Service unavailable</h1>
-      <p class="govuk-body-l">
+      <p class="govuk-body">
         You will be able to use the service later.
       </p>
       <p class="govuk-body">

--- a/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
+++ b/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
@@ -11,7 +11,7 @@ ignore_in_sitemap: true
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Service unavailable</h1>
-    <p class="govuk-body-l">
+    <p class="govuk-body">
       You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.
     </p>
     <p class="govuk-body">

--- a/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
+++ b/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
@@ -11,7 +11,7 @@ ignore_in_sitemap: true
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Service unavailable</h1>
-    <p class="govuk-body-l">
+    <p class="govuk-body">
       The submit an employment intermediary report service has closed.
     </p>
     <p class="govuk-body">

--- a/src/patterns/service-unavailable-pages/service-replaced/index.njk
+++ b/src/patterns/service-unavailable-pages/service-replaced/index.njk
@@ -11,7 +11,7 @@ ignore_in_sitemap: true
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Service unavailable</h1>
-    <p class="govuk-body-l">Universal Credit has replaced tax credits.</p>
+    <p class="govuk-body">Universal Credit has replaced tax credits.</p>
     <p class="govuk-body"><a class="govuk-link" href="#">
       Contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits.
     </p>


### PR DESCRIPTION
This makes the examples meet what was discussed in the working group meeting. A couple of members questioned the use of lead paragraphs and these should have been removed sooner.