### PR TITLE
Rewrite "search" functionality to follow GOV.UK Frontend conventions

### DIFF
--- a/src/javascripts/application.js
+++ b/src/javascripts/application.js
@@ -30,4 +30,5 @@ nodeListForEach($codeBlocks, function ($codeBlock) {
 MobileNav.init()
 
 // Initialise search
-Search.init('.app-site-search', 'app-site-search__input')
+var $searchContainer = document.querySelector('[data-module="app-search"]')
+new Search($searchContainer).init()

--- a/src/javascripts/components/search.js
+++ b/src/javascripts/components/search.js
@@ -14,128 +14,139 @@ var statusMessage = null
 var searchQuery = ''
 var searchCallback = function () {}
 
-var AppSearch = {
-  fetchSearchIndex: function (indexUrl, callback) {
-    var request = new XMLHttpRequest()
-    request.open('GET', indexUrl, true)
-    request.timeout = TIMEOUT * 1000
-    statusMessage = 'Loading search index'
-    request.onreadystatechange = function () {
-      if (request.readyState === STATE_DONE) {
-        if (request.status === 200) {
-          var response = request.responseText
-          var json = JSON.parse(response)
-          statusMessage = 'No results found'
-          searchIndex = lunr.Index.load(json.index)
-          documentStore = json.store
-          callback(json)
-        } else {
-          statusMessage = 'Failed to load the search index'
-          // Log to analytics?
-        }
-      }
-    }
-    request.send()
-  },
-  renderResults: function () {
-    var matchedResults = []
-    if (!searchIndex || !documentStore) {
-      return searchCallback(matchedResults)
-    }
-    var searchResults = searchIndex.query(function (q) {
-      q.term(lunr.tokenizer(searchQuery), {
-        wildcard: lunr.Query.wildcard.TRAILING
-      })
-    })
-    matchedResults = searchResults.map(function (result) {
-      return documentStore[result.ref]
-    })
-    searchCallback(matchedResults)
-  },
-  handleSearchQuery: function (query, callback) {
-    searchQuery = query
-    searchCallback = callback
-    this.renderResults()
-  },
-  handleOnConfirm: function (result) {
-    var path = result.path
-    if (path) {
-      window.location.pathname = path
-    }
-  },
-  inputValueTemplate: function (result) {
-    if (result) {
-      return result.title
-    }
-  },
-  resultTemplate: function (result) {
-    // add rest of the data here to build the item
-    if (result) {
-      var elem = document.createElement('span')
-      var resultTitle = result.title
-      elem.textContent = resultTitle
-      if (result.aliases) {
-        var aliases = result.aliases.split(',').map(function (item) {
-          return item.trim()
-        })
-        var matchedAliases = []
-        // only show a matching alias if there are no matches in the title
-        if (resultTitle.toLowerCase().indexOf(searchQuery) === -1) {
-          // it would be confusing to show the user
-          // aliases that don't match the typed query
-          matchedAliases = aliases.filter(function (alias) {
-            return alias.indexOf(searchQuery) !== -1
-          })
-        }
-        if (matchedAliases.length > 0) {
-          var aliasesContainer = document.createElement('span')
-          aliasesContainer.className = 'app-site-search__aliases'
-          aliasesContainer.textContent = matchedAliases.join(', ')
-          elem.appendChild(aliasesContainer)
-        }
-      }
-      var section = document.createElement('span')
-      section.className = 'app-site-search--section'
-      section.textContent = result.section
+function Search ($module) {
+  this.$module = $module
+}
 
-      elem.appendChild(section)
-      return elem.innerHTML
-    }
-  },
-  init: function (selector, input) {
-    var $container = document.querySelector(selector)
-    if (!$container) {
-      return
-    }
-    accessibleAutocomplete({
-      element: $container,
-      id: input,
-      cssNamespace: 'app-site-search',
-      displayMenu: 'overlay',
-      placeholder: 'Search Design System',
-      confirmOnBlur: false,
-      autoselect: true,
-      source: this.handleSearchQuery.bind(this),
-      onConfirm: this.handleOnConfirm,
-      templates: {
-        inputValue: this.inputValueTemplate,
-        suggestion: this.resultTemplate
-      },
-      tNoResults: function () { return statusMessage }
-    })
-    // Ensure the Button (which is a background image of the wrapper) focuses the input when clicked.
-    var $wrapper = $container.querySelector('.app-site-search__wrapper')
-    $wrapper.addEventListener('click', function (event) {
-      // Only focus the input if the user clicks the wrapper and not the input.
-      if (event.target === $wrapper) {
-        $container.querySelector('.app-site-search__input').focus()
+Search.prototype.fetchSearchIndex = function (indexUrl, callback) {
+  var request = new XMLHttpRequest()
+  request.open('GET', indexUrl, true)
+  request.timeout = TIMEOUT * 1000
+  statusMessage = 'Loading search index'
+  request.onreadystatechange = function () {
+    if (request.readyState === STATE_DONE) {
+      if (request.status === 200) {
+        var response = request.responseText
+        var json = JSON.parse(response)
+        statusMessage = 'No results found'
+        searchIndex = lunr.Index.load(json.index)
+        documentStore = json.store
+        callback(json)
+      } else {
+        statusMessage = 'Failed to load the search index'
+        // Log to analytics?
       }
-    })
+    }
+  }
+  request.send()
+}
 
-    var searchIndexUrl = $container.getAttribute('data-search-index')
-    this.fetchSearchIndex(searchIndexUrl, function () {
-      this.renderResults()
-    }.bind(this))
+Search.prototype.renderResults = function () {
+  var matchedResults = []
+  if (!searchIndex || !documentStore) {
+    return searchCallback(matchedResults)
+  }
+  var searchResults = searchIndex.query(function (q) {
+    q.term(lunr.tokenizer(searchQuery), {
+      wildcard: lunr.Query.wildcard.TRAILING
+    })
+  })
+  matchedResults = searchResults.map(function (result) {
+    return documentStore[result.ref]
+  })
+  searchCallback(matchedResults)
+}
+
+Search.prototype.handleSearchQuery = function (query, callback) {
+  searchQuery = query
+  searchCallback = callback
+  this.renderResults()
+}
+
+Search.prototype.handleOnConfirm = function (result) {
+  var path = result.path
+  if (path) {
+    window.location.pathname = path
   }
 }
-export default AppSearch
+
+Search.prototype.inputValueTemplate = function (result) {
+  if (result) {
+    return result.title
+  }
+}
+
+Search.prototype.resultTemplate = function (result) {
+  // add rest of the data here to build the item
+  if (result) {
+    var elem = document.createElement('span')
+    var resultTitle = result.title
+    elem.textContent = resultTitle
+    if (result.aliases) {
+      var aliases = result.aliases.split(',').map(function (item) {
+        return item.trim()
+      })
+      var matchedAliases = []
+      // only show a matching alias if there are no matches in the title
+      if (resultTitle.toLowerCase().indexOf(searchQuery) === -1) {
+        // it would be confusing to show the user
+        // aliases that don't match the typed query
+        matchedAliases = aliases.filter(function (alias) {
+          return alias.indexOf(searchQuery) !== -1
+        })
+      }
+      if (matchedAliases.length > 0) {
+        var aliasesContainer = document.createElement('span')
+        aliasesContainer.className = 'app-site-search__aliases'
+        aliasesContainer.textContent = matchedAliases.join(', ')
+        elem.appendChild(aliasesContainer)
+      }
+    }
+    var section = document.createElement('span')
+    section.className = 'app-site-search--section'
+    section.textContent = result.section
+
+    elem.appendChild(section)
+    return elem.innerHTML
+  }
+}
+
+Search.prototype.init = function () {
+  var $module = this.$module
+  if (!$module) {
+    return
+  }
+
+  accessibleAutocomplete({
+    element: $module,
+    id: 'app-site-search__input',
+    cssNamespace: 'app-site-search',
+    displayMenu: 'overlay',
+    placeholder: 'Search Design System',
+    confirmOnBlur: false,
+    autoselect: true,
+    source: this.handleSearchQuery.bind(this),
+    onConfirm: this.handleOnConfirm,
+    templates: {
+      inputValue: this.inputValueTemplate,
+      suggestion: this.resultTemplate
+    },
+    tNoResults: function () { return statusMessage }
+  })
+
+  // Ensure the Button (which is a background image of the wrapper) focuses the input when clicked.
+  var $wrapper = $module.querySelector('.app-site-search__wrapper')
+  $wrapper.addEventListener('click', function (event) {
+    // Only focus the input if the user clicks the wrapper and not the input.
+    if (event.target === $wrapper) {
+      $module.querySelector('.app-site-search__input').focus()
+    }
+  })
+
+  var searchIndexUrl = $module.getAttribute('data-search-index')
+  this.fetchSearchIndex(searchIndexUrl, function () {
+    this.renderResults()
+  }.bind(this))
+}
+
+export default Search

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -37,7 +37,7 @@
       Design System
     </span>
   </a>
-  <div class="app-site-search" data-search-index="/{{ fingerprint['search-index.json'] }}">
+  <div class="app-site-search" data-module="app-search" data-search-index="/{{ fingerprint['search-index.json'] }}">
     <label class="govuk-visually-hidden" for="app-site-search__input">Search Design system</label>
     <a class="app-site-search__link govuk-link" href="/sitemap">Sitemap</a>
   </div>


### PR DESCRIPTION
This PR modernises search javascript to follow GOV.UK Frontend conventions
- Use of data-module attribute to initialise the script
- Rewrite functions to match they way they're written in GOV.UK Frontend

Easier to review without whitespace: https://github.com/alphagov/govuk-design-system/pull/516/files?utf8=%E2%9C%93&diff=split&w=1