### PR TITLE
Render component options as tables

### DIFF
--- a/__tests__/component-options.test.js
+++ b/__tests__/component-options.test.js
@@ -1,0 +1,66 @@
+/* eslint-env jest */
+const configPaths = require('../config/paths.json')
+const PORT = configPaths.testPort
+
+let browser
+let page
+let baseUrl = 'http://localhost:' + PORT
+
+beforeAll(async (done) => {
+  browser = global.browser
+  page = await browser.newPage()
+  done()
+})
+
+afterAll(async (done) => {
+  await page.close()
+  done()
+})
+
+describe('Component page', () => {
+  it('should contain a "Nunjucks" tab heading', async () => {
+    await page.goto(baseUrl + '/components/back-link/', { waitUntil: 'load' })
+
+    const nunjucksTabHeadings = await page.evaluate(() => Array.from(document.querySelectorAll('.js-tabs__item a'))
+      .filter(element => element.textContent === 'Nunjucks'))
+
+    expect(nunjucksTabHeadings[0]).toBeTruthy()
+  })
+
+  it('"Nunjucks" tab content should contain a details summary with "Nunjucks macro options" text', async () => {
+    await page.goto(baseUrl + '/components/back-link/', { waitUntil: 'load' })
+
+     // Get "aria-controls" attributes from "Nunjucks" tab headings
+    const nunjucksTabHeadingControls = await page.evaluateHandle(() => Array.from(document.querySelectorAll('.js-tabs__item a'))
+      .filter(element => element.textContent === 'Nunjucks')
+      .map(element => element.getAttribute('aria-controls')))
+
+    const tabContentIds = await nunjucksTabHeadingControls.jsonValue() // Returns Puppeteer JSONHandle
+
+    const id = tabContentIds[0]
+
+    // Get summary text of details element in "Nunjucks" tab
+    const nunjucksTabHeadings = await page.evaluate(id => Array.from(document.getElementById(id).querySelectorAll('.govuk-details__summary-text'))
+      .map(element => element.textContent.trim()), id)
+
+    expect(nunjucksTabHeadings).toContain('Nunjucks macro options')
+  })
+
+  it('"Nunjucks" tab content should contain a details element that has a table with "Name", "Type" and "Description" column headings', async () => {
+    await page.goto(baseUrl + '/components/back-link/', { waitUntil: 'load' })
+
+    // Get "aria-controls" attributes from "Nunjucks" tab headings
+    const nunjucksTabHeadingControls = await page.evaluateHandle(() => Array.from(document.querySelectorAll('.js-tabs__item a'))
+      .filter(element => element.textContent === 'Nunjucks')
+      .map(element => element.getAttribute('aria-controls')))
+
+    const tabContentIds = await nunjucksTabHeadingControls.jsonValue() // Returns Puppeteer JSONHandle
+    const id = tabContentIds[0]
+
+    // Get table headings of table inside details element in "Nunjucks" tab
+    const nunjucksTableHeadings = await page.evaluate(id => Array.from(document.getElementById(id).querySelector('.govuk-details__text .govuk-table .govuk-table__head').querySelectorAll('.govuk-table__header'))
+      .map(element => element.textContent.trim()), id)
+
+    expect(nunjucksTableHeadings.sort()).toEqual(['Name', 'Type', 'Description'].sort())
+  })
+})

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -9,6 +9,8 @@ const matter = require('gray-matter')
 
 const beautify = require('js-beautify').html
 
+const markdownRenderer = require('marked')
+
 nunjucks.configure(paths.layouts)
 
 // This helper function takes a path of a file and
@@ -43,6 +45,117 @@ exports.getNunjucksCode = path => {
   )
 
   return content
+}
+
+// This helper function takes a path of a macro options file and
+// returns the options data grouped by tables to output in markup
+exports.getMacroOptions = (componentName, exampleId) => {
+  let options = []
+  let processedOptions = []
+  let primaryTable = {
+    'name': 'Primary options',
+    'id': 'primary',
+    'options': []
+  }
+  processedOptions.push(primaryTable)
+
+  if (componentName === 'text-input') {
+    componentName = 'input'
+  }
+
+  try {
+    let optionsFilePath = path.join(paths.govukfrontendcomponents, componentName, 'macro-options.json')
+    options = JSON.parse(fs.readFileSync(optionsFilePath, 'utf8'))
+  } catch (err) {
+    console.error(err)
+    process.exit(1) // Exit with a failure mode
+  }
+
+  for (let option of options) {
+    // Example of an option
+    // {
+    //    name: "errorMessage",
+    //    type: "string",
+    //    required: false,
+    //    description: "Options for the errorMessage component"
+    //    isComponent: true
+    // }
+    if (option.isComponent) {
+      // Create separate table data for components that are hidden in the
+      // Design System
+      if (option.name === 'hint' || option.name === 'label') {
+        let otherComponentOptions
+        try {
+          let otherComponentPath = path.join(paths.govukfrontendcomponents, option.name, 'macro-options.json')
+          otherComponentOptions = JSON.parse(fs.readFileSync(otherComponentPath, 'utf8'))
+        } catch (err) {
+          console.error(err)
+          process.exit(1) // Exit with a failure mode
+        }
+
+        if (otherComponentOptions) {
+          processedOptions.push({
+            'name': 'Options for ' + option.name,
+            'id': option.name,
+            'options': otherComponentOptions
+          })
+          option.description += ` See [${option.name}](#options-${exampleId}--${option.name}).`
+        }
+      // Otherwise just link to that component
+      } else {
+        let optionName = (option.name).replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase() // camelCase into kebab-case
+        let otherComponentPath = '/components/' + optionName + '/#options-example-default'
+        option.description += ` See [${option.name}](${otherComponentPath}).`
+      }
+    }
+
+    // If option contains nested options, add those as a separate table and link to it
+    if (option.params) {
+      processedOptions.push({
+        'name': 'Options for ' + option.name,
+        'id': option.name,
+        'options': option.params
+      })
+      option.description += ` See [${option.name}](#options-${exampleId}--${option.name}).`
+    }
+
+    if (option.required === true) {
+      option.description = '__Required__. ' + option.description
+    }
+
+    primaryTable.options.push(option)
+  }
+
+  // Get reference to marked.js
+  let renderer = new markdownRenderer.Renderer()
+  // Override marking up paragraphs
+  renderer.paragraph = text => text
+
+  // This will recursively loop through the options data and call itself when
+  // encountering a nested item. Any 'description' fields are marked up using
+  // marked.js
+  let markUpDescriptions = (options) => {
+    for (var key in options) {
+      if (options.hasOwnProperty(key)) {
+        if (typeof options[key] === 'object') {
+          markUpDescriptions(options[key])
+        } else if (key === 'description') {
+          try {
+            options[key] = markdownRenderer(options[key], { renderer: (renderer) })
+          } catch (e) {
+            console.error(e)
+            process.exit(1) // Exit with a failure mode
+          }
+        }
+      }
+    }
+    return options
+  }
+
+  // Mark up 'description' values in options
+  let markedUpOptions = processedOptions.map(markUpDescriptions)
+
+  return markedUpOptions
 }
 
 // This helper function takes a path of a *.md.njk file and

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -195,7 +195,8 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
         getFrontmatter: fileHelper.getFrontmatter,
         getNunjucksCode: fileHelper.getNunjucksCode,
         getHTMLCode: fileHelper.getHTMLCode,
-        getFingerprint: fileHelper.getFingerprint
+        getFingerprint: fileHelper.getFingerprint,
+        getMacroOptions: fileHelper.getMacroOptions
       },
       filters: {
         highlight: highlighter

--- a/package-lock.json
+++ b/package-lock.json
@@ -7368,7 +7368,15 @@
       "integrity": "sha1-B86EnZWjxOOY8t/ZDZS+O4hFPxY=",
       "dev": true,
       "requires": {
-        "marked": "0.3.17"
+        "marked": "^0.3.9"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "0.3.19",
+          "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+          "dev": true
+        }
       }
     },
     "jstransformer-nunjucks": {
@@ -7946,9 +7954,9 @@
       }
     },
     "marked": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.17.tgz",
-      "integrity": "sha512-+AKbNsjZl6jFfLPwHhWmGTqE009wTKn3RTmn9K8oUKHrX/abPJjtcRtXpYB/FFrwPJRUA86LX/de3T0knkPCmQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.5.1.tgz",
+      "integrity": "sha512-iUkBZegCZou4AdwbKTwSW/lNDcz5OuRSl3qdcl31Ia0B2QPG0Jn+tKblh/9/eP9/6+4h27vpoh8wel/vQOV0vw==",
       "dev": true
     },
     "mem": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "js-beautify": "^1.7.5",
     "jstransformer-marked": "^1.0.3",
     "jstransformer-nunjucks": "^0.5.0",
+    "marked": "^0.5.1",
     "metalsmith": "^2.3.0",
     "metalsmith-assets": "^0.1.0",
     "metalsmith-broken-link-checker": "^1.0.1",

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ## When to use this component
 
@@ -23,7 +23,7 @@ Don’t use the text input component if you need to let users enter longer answe
 
 There are 2 ways to use the text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "default", html: true, nunjucks: true, open: dalse, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: dalse, size: "s", id: "default-2"}) }}
 
 ### Label text inputs
 
@@ -49,7 +49,7 @@ Use fixed width inputs for content that has a specific, known length. Postcode i
 
 On fixed width inputs, the width will remain fixed on all screens unless it is wider than the viewport, in which case it will shrink to fit.
 
-{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "input-fixed-width", html: true, nunjucks: true, open: false, size: "l"}) }}
+{{ example({group: "components", item: "text-input", example: "input-fixed-width", html: true, nunjucks: true, open: false, size: "l"}) }}
 
 #### Fluid width inputs
 
@@ -57,13 +57,13 @@ Use the width override classes to reduce the width of an input in relation to it
 
 Fluid width inputs will resize with the viewport.
 
-{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "input-fluid-width", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({group: "components", item: "text-input", example: "input-fluid-width", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 ### Using hint text
 
 Use hint for help that’s relevant to the majority of users - like how their information will be used, or where to find it.
 
-{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({group: "components", item: "text-input", example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ### Don’t disable copy and paste
 
@@ -73,7 +73,7 @@ Users often need to copy and paste information into a text input, so you shouldn
 
 Error messages should be styled like this:
 
-{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "error", html: true, nunjucks: true, closed: true, size: "s"}) }}
+{{ example({group: "components", item: "text-input", example: "error", html: true, nunjucks: true, closed: true, size: "s"}) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -54,7 +54,7 @@ If there’s a good reason to limit the number of characters users can enter, yo
 
 Error messages should be styled like this:
 
-{{ example({group: "components", item: "textarea", frontendComponentName: "input", example: "error", html: true, nunjucks: true, open: false, size: "l"}) }}
+{{ example({group: "components", item: "textarea", example: "error", html: true, nunjucks: true, open: false, size: "l"}) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/javascripts/application-ie8.js
+++ b/src/javascripts/application-ie8.js
@@ -2,6 +2,7 @@ import common from 'govuk-frontend/common'
 import CookieBanner from './components/cookie-banner.js'
 import Example from './components/example.js'
 import AppTabs from './components/tabs.js'
+import OptionsTable from './components/options-table.js'
 
 var nodeListForEach = common.nodeListForEach
 
@@ -19,3 +20,7 @@ var $tabs = document.querySelectorAll('[data-module="app-tabs"]')
 nodeListForEach($tabs, function ($tabs) {
   new AppTabs($tabs).init()
 })
+
+// Open options table when detected in URL hash
+// Do this after initialising tabs
+OptionsTable.init()

--- a/src/javascripts/application.js
+++ b/src/javascripts/application.js
@@ -5,6 +5,7 @@ import AppTabs from './components/tabs.js'
 import Copy from './components/copy.js'
 import MobileNav from './components/mobile-navigation.js'
 import Search from './components/search.js'
+import OptionsTable from './components/options-table.js'
 
 var nodeListForEach = common.nodeListForEach
 
@@ -22,6 +23,9 @@ var $tabs = document.querySelectorAll('[data-module="app-tabs"]')
 nodeListForEach($tabs, function ($tabs) {
   new AppTabs($tabs).init()
 })
+
+// Do this after initialising tabs
+OptionsTable.init()
 
 // Add copy to clipboard to code blocks inside tab containers
 var $codeBlocks = document.querySelectorAll('[data-module="app-copy"]')

--- a/src/javascripts/components/copy.js
+++ b/src/javascripts/components/copy.js
@@ -15,8 +15,7 @@ Copy.prototype.init = function () {
   $button.setAttribute('aria-live', 'assertive')
   $button.textContent = 'Copy'
 
-  var $parent = $module.parentNode
-  $parent.insertBefore($button, $parent.firstChild)
+  $module.insertBefore($button, $module.firstChild)
   this.copyAction()
 }
 Copy.prototype.copyAction = function () {

--- a/src/javascripts/components/options-table.js
+++ b/src/javascripts/components/options-table.js
@@ -1,0 +1,51 @@
+import 'govuk-frontend/vendor/polyfills/Element/prototype/classList'
+
+var OptionsTable = {
+  init: function () {
+    OptionsTable.expandMacroOptions()
+  },
+  // Open Nunjucks tab and expand macro options details when URL hash is '#options-[exampleName]'
+  expandMacroOptions: function () {
+    var hash = window.location.hash
+
+    if (hash.match('^#options-')) {
+      var exampleName = hash.split('#options-')[1]
+
+      // Is hash for a specific options table? eg. #options-example-default--hint
+      var isLinkToTable = hash.indexOf('--') > -1
+      if (isLinkToTable) {
+        exampleName = exampleName.split('--')[0]
+      }
+
+      if (exampleName) {
+        var tabLink = document.querySelector('a[href="#' + exampleName + '-nunjucks"]')
+        var tabHeading = tabLink ? tabLink.parentNode : null
+        var optionsDetailsElement = document.getElementById('options-' + exampleName + '-details')
+
+        if (tabHeading && optionsDetailsElement) {
+          var tabsElement = optionsDetailsElement.parentNode
+          var detailsSummary = optionsDetailsElement.querySelector('.govuk-details__summary')
+          var detailsText = optionsDetailsElement.querySelector('.govuk-details__text')
+
+          if (detailsSummary && detailsText) {
+            tabLink.setAttribute('aria-expanded', true)
+            tabHeading.className += ' app-tabs__item--current'
+            tabsElement.classList.remove('app-tabs__container--hidden')
+            tabsElement.setAttribute('aria-hidden', false)
+
+            optionsDetailsElement.setAttribute('open', 'open')
+            detailsSummary.setAttribute('aria-expanded', true)
+            detailsText.setAttribute('aria-hidden', false)
+            detailsText.style.display = ''
+            window.setTimeout(function () {
+              tabLink.focus()
+              if (isLinkToTable) document.querySelector(hash).scrollIntoView()
+            }, 0)
+          }
+        }
+      }
+    }
+  }
+}
+
+export default OptionsTable

--- a/src/stylesheets/components/_options.scss
+++ b/src/stylesheets/components/_options.scss
@@ -1,0 +1,29 @@
+.app-options {
+  max-width: 38em;
+  margin-bottom: govuk-spacing(1);
+  padding: govuk-spacing(2) govuk-spacing(2) 0 govuk-spacing(2);
+  background-color: govuk-colour("white");
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(4);
+    padding: govuk-spacing(5) govuk-spacing(5) 0 govuk-spacing(5);
+  }
+}
+
+.app-options__table {
+  @include govuk-media-query(mobile) {
+    table-layout: fixed;
+
+    .govuk-table__header,
+    .govuk-table__cell {
+      padding-right: govuk-spacing(2);
+      word-break: break-word;
+    }
+  }
+}
+
+.app-options__limit-table-cell {
+  @include govuk-media-query(mobile) {
+    width: 29%;
+  }
+}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -15,6 +15,7 @@ $app-code-color: #dd1144;
 @import "components/masthead";
 @import "components/mobile-navigation";
 @import "components/navigation";
+@import "components/options";
 @import "components/page-navigation";
 @import "components/pane";
 @import "components/site-search";

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -46,6 +46,7 @@
 {% block footer %}{% endblock %}
 
 {% block bodyEnd %}
+<script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
   <!--[if !IE 8]><!-->
     <script src="{{ getFingerprint('javascripts/application.js') }}"></script>
   <!--<![endif]-->

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -28,6 +28,7 @@
   </div>
 
   {%- if (multipleTabs) %}
+  <span id="options-{{ exampleId }}"></span>
   <ul class="app-tabs" role="tablist">
     <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></li>
     <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></li>
@@ -59,13 +60,61 @@
 	<div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
   {% endif %}
   <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-nunjucks" role="tabpanel">
+    {%- if (params.group == 'components') %}
+      {% set macroOptions = getMacroOptions(params.item, exampleId) %}
+
+      {% set macroOptionsHTML %}
+
+        <p>
+        Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
+        </p>
+        <p>
+        Some options are required for the macro to work; these are marked as "Required" in the option description.
+        </p>
+        <p>
+        If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must sanitise the HTML to protect against  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting exploits</a>.
+        </p>
+
+        {% for table in macroOptions %}
+          <table class="govuk-table app-options__table" id="options-{{ exampleId }}--{{ table.id }}">
+            <caption class="govuk-table__caption govuk-heading-m {% if table.id == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name }}</caption>
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header app-options__limit-table-cell" scope="col">Name</th>
+                <th class="govuk-table__header app-options__limit-table-cell" scope="col">Type</th>
+                <th class="govuk-table__header" scope="col">Description</th>
+              </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+
+              {% for option in table.options %}
+                <tr class="govuk-table__row">
+                  <th class="govuk-table__header" scope="row">{{option.name}}</th>
+                  <td class="govuk-table__cell ">{{option.type}}</td>
+                  <td class="govuk-table__cell ">{{option.description | safe}}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        {% endfor %}
+
+      {% endset %}
+
+      {% from "details/macro.njk" import govukDetails %}
+
+      {{ govukDetails({
+        summaryText: "Nunjucks macro options",
+        html: macroOptionsHTML,
+        classes: "app-options",
+        attributes:{
+          id: "options-" + exampleId + "-details",
+          "data-components": "github-component-arguments"
+        }
+      })}}
+    {% endif %}
     <pre data-module="app-copy"><code class="hljs js">
       {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
     </code></pre>
-
-  {%- if (params.group == 'components') %}
-    <p class="app-tabs__text">You can configure this component using the <a href="https://github.com/alphagov/govuk-frontend/tree/master/package/components/{{frontendComponentName}}/README.md#component-arguments" class="govuk-link"  target="_blank" data-components="github-component-arguments" rel="noopener">Nunjucks macro arguments</a>.</p>
-  {% endif %}
   </div>
   {% endif %}
 </div>

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -8,7 +8,6 @@
 {% set exampleURL = "/" + params.group + "/" + params.item + "/" + params.example + "/index.html" %}
 {% set exampleId = params.id | default("example-" + params.example) %}
 {% set exampleTitle = getFrontmatter(examplePath).title %}
-{% set frontendComponentName = params.frontendComponentName | default(params.item) %}
 {% if params.open %}
   {% set exampleId = exampleId + '-open' %}
 {% endif %}


### PR DESCRIPTION
Co-authored with @hannalaakso 

This PR:
- Formats `macro-options.json` for rendering within component pages by grouping it by tables, adding heading data and linking to other components.
- Places the tables markup inside a Details component within each Nunjucks tab.
- Renders any nested items within options as their own table and links to the table from the primary options.
- Renders Hint and Label component options as their own tables in the options of the component using them.
- Marks up any markdown in `description` fields using marked.js
- Adds the warning about using HTML with Nunjucks macros in production from the component README's above the table (we have a separate card to look at how we talk about HTML and Nunjucks).
- Visually hides the "Primary options" table caption as the details as the details heading "Nunjucks macro options" is visually just above it. It is exposed to screen readers to aid navigation.
- Adds tests to check that the table is being rendered correctly by checking for the existence of Nunjucks tab, whether it contains a "Nunjucks macro options" details summary and options table with expected attributes ("Name", "Type", "Description").
- Constructs a unique ID for each of the collection of options on a component page with the name of the example eg. `nunjucks-options-example-start-open` (where `nunjucks-options-` is the prefix and the name is `example-start-open`).
- Adds some app styling for mobile to adjust padding and column widths - longer option names are forced to wrap due to lack of space, this might be okay for now and we can look into responsive tables in the future. Interestingly there's currently a conversation about responsive tables in cross-government Slack too so we should look into getting something about it in the Design System soon.
- Moves the `data-components="github-component-arguments"` we use for GTM tracking to the `details` element

More:
- The separate tables approach we use here to present options in separate tables, with [header cells in the top row and first column](https://www.w3.org/WAI/tutorials/tables/two-headers/#table-with-header-cells-in-the-top-row-and-first-column), is supported by W3C docs that [suggest separate tables are easier to navigate](https://www.w3.org/WAI/tutorials/tables/multi-level/#split-up-multi-level-tables) than [multi-level ones](https://www.w3.org/WAI/tutorials/tables/multi-level) that require each table cell to link to three different cells within the table.
- The template doesn't use our table macro but HTML. We should consider adding a "caller" to the table macro so that larger chunks of code generated in the template could be passed to `rows`.
- We now refer to the component "arguments" as “options” as calling them “arguments” is technically incorrect and “parameters” was felt to be less clear than “options”. We need to adjust our docs accordingly (will do this in a separate PR).

Tested in:
✅ Chrome 69
✅ Firefox 63 (high contrast colours)
✅ Safari 11.1 (desktop)
✅ Samsung Galaxy S9 with Chrome 
✅ iPhone 6S Plus with Safari
✅ Edge 17
✅ IE11
✅ IE10
✅ IE9
✅ IE8
✅ Jaws 18.0 with IE11
✅ NVDA 2018 with Firefox 63

Still to do:
* [x] Needs a design review
* [x] Needs a content review
* [x] Testing with assistive tech - will do this when back in the office
* [x] Should work with new tabs code - awaiting https://github.com/alphagov/govuk-design-system/pull/596 to be merged in
* [x] Rebase commits

https://trello.com/c/RHSsURyV/1322-add-table-of-options-to-components-in-the-design-system