### PR TITLE
Add in page navigation 

### DIFF
--- a/lib/extract-page-headings.js
+++ b/lib/extract-page-headings.js
@@ -1,0 +1,29 @@
+const marked = require('marked')
+
+const plugin = () => {
+  return function (files, metalsmith, done) {
+    Object.keys(files).forEach(function (file) {
+      if (!file.endsWith('njk')) {
+        return
+      }
+      var data = files[file]
+      var contents = data.contents.toString()
+      const lexer = new marked.Lexer()
+      let tokens = lexer.lex(contents)
+      let headingsArray = []
+      tokens.forEach(token => {
+        if (token.type === 'heading') {
+          let heading = {
+            depth: token.depth,
+            text: token.text,
+            url: token.text.toLowerCase().replace(/[^\w]+/g, '-')
+          }
+          headingsArray.push(heading)
+        }
+      })
+      data.headings = headingsArray
+    })
+    done()
+  }
+}
+module.exports = plugin

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -24,6 +24,7 @@ const navigation = require('./navigation.js')                // navigation plugi
 const modernizrBuild = require('./modernizr-build.js')       // modernizr build plugin
 const generateSitemap = require('./generate-sitemap.js')     // generate sitemap
 const lunr = require('./metalsmith-lunr-index')              // generate search index
+const extractPageHeadings = require('../lib/extract-page-headings.js') // extract page headings into file meta data
 
 const colours = require('../lib/colours.js')                 // get colours data
 const fileHelper = require('../lib/file-helper.js')          // helper function to operate on files
@@ -47,6 +48,9 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     title: '[TITLE NOT SET]',
     colours: colours
   })
+
+// extract page headings
+.use(extractPageHeadings())
 
   // source directory
   .source('../' + paths.source)

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -38,6 +38,11 @@ module.exports = function () {
                 'url': url,
                 'label': frontmatter.title
               }
+
+              if (frontmatter.headings) {
+                subitem.headings = frontmatter.headings
+              }
+
               // if frontmatter contains `theme` data, attach it to navigation item for grouping
               if (frontmatter.theme) {
                 subitem.theme = frontmatter.theme

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -39,7 +39,7 @@ module.exports = function () {
                 'label': frontmatter.title
               }
 
-              if (frontmatter.headings) {
+              if (frontmatter.headings && frontmatter.show_page_nav) {
                 subitem.headings = frontmatter.headings
               }
 

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -5,6 +5,7 @@ section: Styles
 aliases: grid
 backlog_issue_id:
 layout: layout-pane.njk
+show_page_nav: true
 ---
 
 {% from "_example.njk" import example %}

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -61,7 +61,7 @@ If you’re not using the [breadcrumbs](../../components/breadcrumbs), [back lin
 
 {{ example({group: "styles", item: "layout", example: "layout-wrappers-l", html: true, open: true, size: "l"}) }}
 
-## <a name="grid-system"></a>Grid system
+## Grid system
 
 Use the grid system to lay out the content on your service’s pages.
 

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -5,6 +5,7 @@ section: Styles
 aliases:
 backlog_issue_id:
 layout: layout-pane.njk
+show_page_nav: true
 ---
 
 {% from "_example.njk" import example %}

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -4,6 +4,7 @@ description: If your service is on the service.gov.uk subdomain you must use the
 section: Styles
 backlog_issue_id: 64
 layout: layout-pane.njk
+show_page_nav: true
 ---
 
 {% from "_example.njk" import example %}
@@ -82,7 +83,7 @@ You can use bold to emphasise particular words in a transaction. Use it to highl
 
 For example, "Your reference number is **ABC12345678**. Use this to track your application. Updates will be sent to **this.person<i></i>@email.com**"
 
-Use bold sparingly. Overuse will make it difficult for users to know which parts of your content they need to pay the most attention to. 
+Use bold sparingly. Overuse will make it difficult for users to know which parts of your content they need to pay the most attention to.
 
 ## Links
 

--- a/src/stylesheets/components/_page-navigation.scss
+++ b/src/stylesheets/components/_page-navigation.scss
@@ -1,0 +1,19 @@
+.app-page-navigation {
+    padding-left: govuk-spacing(4);
+    list-style: none;
+}
+
+.app-page-navigation__item {
+    @include govuk-font(19);
+    margin-bottom: govuk-spacing(2);
+
+    @include govuk-media-query($from:tablet) {
+        display: none;
+    }
+}
+
+.app-page-navigation__item::before {
+    content: "—";
+    margin-left: -(govuk-spacing(4));
+    padding-right: govuk-spacing(1);
+}

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -9,31 +9,42 @@
     margin: 0 0 govuk-spacing(4);
     padding: 0;
     list-style-type: none;
+  }
 
-    a,
-    a:link,
-    a:visited {
-      display: block;
-      padding: 8px govuk-spacing(6) 8px govuk-spacing(2);
-      border-left: 4px solid transparent;
-      color: $govuk-link-colour;
+  .app-subnav__link {
+    display: block;
+    padding: 8px govuk-spacing(6) 8px govuk-spacing(2);
+    border-left: 4px solid transparent;
+    text-decoration: none;
+
+    &:focus {
       background: inherit;
-      text-decoration: none;
     }
 
-    a:hover {
+    &:hover,
+    &:active,
+    &:visited {
+      color: $govuk-link-colour;
+    }
+
+    &:hover {
       border-left-color: $govuk-link-hover-colour;
     }
   }
 
-  .app-subnav__section-item--current {
-    a,
-    a:link,
-    a:visited {
-      border-left-color: $govuk-link-colour;
-      background: $app-light-grey;
-      font-weight: bold;
-    }
+  .app-subnav__section-item--current .app-subnav__link {
+    border-left-color: $govuk-link-colour;
+    background: $app-light-grey;
+    font-weight: bold;
+  }
+
+  .app-subnav__section--nested {
+    margin-bottom: 0;
+  }
+
+  .app-subnav__section--nested .app-subnav__link {
+    font-weight: 400;
+    padding-left: govuk-spacing(4);
   }
 
   .app-subnav__theme {

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -15,6 +15,7 @@ $app-code-color: #dd1144;
 @import "components/masthead";
 @import "components/mobile-navigation";
 @import "components/navigation";
+@import "components/page-navigation";
 @import "components/pane";
 @import "components/site-search";
 @import "components/subnav";

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -36,6 +36,17 @@
           {% endif %}
         </h1>
       </div>
+      <ul class="app-page-navigation">
+        {% for heading in headings %}
+          {% if heading.depth == 2 %}
+            <li class="app-page-navigation__item">
+              <a class="govuk-link" href="#{{ heading.url}}">
+                {{ heading.text }}
+              </a>
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
       <div class="app-prose-scope">
         {{ contents | safe }}
       </div>

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -36,17 +36,21 @@
           {% endif %}
         </h1>
       </div>
-      <ul class="app-page-navigation">
-        {% for heading in headings %}
-          {% if heading.depth == 2 %}
-            <li class="app-page-navigation__item">
-              <a class="govuk-link" href="#{{ heading.url}}">
-                {{ heading.text }}
-              </a>
-            </li>
-          {% endif %}
-        {% endfor %}
-      </ul>
+
+      {% if show_page_nav %}
+        <ul class="app-page-navigation">
+          {% for heading in headings %}
+            {% if heading.depth == 2 %}
+              <li class="app-page-navigation__item">
+                <a class="govuk-link" href="#{{ heading.url}}">
+                  {{ heading.text }}
+                </a>
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      {% endif %}
+
       <div class="app-prose-scope">
         {{ contents | safe }}
       </div>

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -9,7 +9,20 @@
           <ul class="app-subnav__section">
           {% for subitem in items %}
             <li class="app-subnav__section-item{% if subitem.url == path %} app-subnav__section-item--current{% endif %}">
-              <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
+              <a class="app-subnav__link govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
+              {% if (subitem.headings) and (subitem.url == path) %}
+                <ul class="app-subnav__section app-subnav__section--nested">
+                  {% for link in subitem.headings %}
+                    {% if link.depth == 2 %}
+                      <li class="app-subnav__section-item">
+                        <a class="app-subnav__link govuk-link" href="/{{ subitem.url }}/#{{ link.url }}" >
+                          {{ link.text }}
+                        </a>
+                      </li>
+                    {% endif %}
+                  {% endfor %}
+                </ul>
+              {% endif %}
             </li>
           {% endfor %}
           </ul>


### PR DESCRIPTION
We have a plugin that extracts page headings from the markdown file and creates an array of heading objects in page metadata. Each heading object contains text, depth level (h1,h2,h3) and a generated url (which is the same as markedjs-generated heading id). 
We use this metadata to generate in-page and sidebar navigation.

In navigation.js I created a variable `subitem.link` which reads the url of the page and puts the label from the metadata at the end. If the url has that label the I ask it to show the contents of the json file, which are links that you to the appropriate place in the page. I added a loop in _subnav.njk that is looping through the metadata.headings array. Added styles for those links at _subnav.scss

https://trello.com/c/EOkrfNkF


**In page navigation Mobile view**

<img width="401" alt="screen shot 2018-08-21 at 13 49 53" src="https://user-images.githubusercontent.com/31342138/44402261-206cd880-a549-11e8-8cb9-56897c1cbc70.png">
I have added sub-links to the Layout, Spacing and Typography pages as unordered lists in index.md.njk in src/styles/layout, spacing and typography folders as well as Scss partials for additional styles.

**In page navigation Desktop/Tablet view**

<img width="1090" alt="screen shot 2018-08-21 at 13 47 35" src="https://user-images.githubusercontent.com/31342138/44402513-ee0fab00-a549-11e8-845b-234beb20a525.png">