### PR TITLE
Fix broken script include on full-page examples

### DIFF
--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -17,5 +17,5 @@
 {% endblock %}
 {% block bodyEnd %}
   <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
-  <script src="/{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
+  <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
The getFingerprint function returns a path that includes the leading slash already, so this currently evaluates to `//javascripts/govuk-frontend-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.js` which means the browser treats the URL as a protocol-less but absolute URL and tries to load `https://javascripts/govuk-frontend-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.js`.