### PR TITLE
Disable browser form validation in examples

### DIFF
--- a/src/patterns/question-pages/default/index.njk
+++ b/src/patterns/question-pages/default/index.njk
@@ -18,7 +18,7 @@ layout: layout-example-full-page.njk
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="/form-handler" method="post">
+      <form action="/form-handler" method="post" novalidate>
         {{ govukDateInput({
           id: "dob",
           name: "dob",

--- a/src/patterns/question-pages/passport/index.njk
+++ b/src/patterns/question-pages/passport/index.njk
@@ -22,7 +22,7 @@ ignore_in_sitemap: true
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Passport details</h1>
 
-      <form action="/form-handler" method="post">
+      <form action="/form-handler" method="post" novalidate>
 
         {{ govukInput({
           label: {

--- a/src/patterns/question-pages/postcode/index.njk
+++ b/src/patterns/question-pages/postcode/index.njk
@@ -19,7 +19,7 @@ ignore_in_sitemap: true
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <form action="/form-handler" method="post">
+    <form action="/form-handler" method="post" novalidate>
       {{ govukInput({
         label: {
           text: "What is your home postcode?",

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -18,9 +18,12 @@
   </head>
   <body class="app-example-page">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
-    {% block body %}
-      {{ contents | safe }}
-    {% endblock %}
+    <!-- Disable browser validation for any examples that include form elements -->
+    <form novalidate>
+      {% block body %}
+        {{ contents | safe }}
+      {% endblock %}
+    </form>
     <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
     <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
   </body>


### PR DESCRIPTION
Most modern browsers provide some sort of validation for fields that have explicit types (such as email, or telephone) or when a field is marked as required. The way that this validation works is inconsistent across browsers, and we have little control over the content or the style of the error messages that are used. This means that there are multiple ‘stages’ of validation going on, and there is no consistency between them.

<img width="1392" alt="screen shot 2018-08-31 at 16 49 57bst" src="https://user-images.githubusercontent.com/121939/44922680-f03dea80-ad3d-11e8-9d61-3e0533f6e0a8.png">

_An example of browser validation kicking in in Firefox. Note the pink outline around the input and the tooltip._

For this reason, we have previously recommended disabling the browser’s native validation (though this doesn’t seem to be written down anywhere, yet) so we should do this in our own examples.

For full page examples that already have forms, it’s as simple as adding the novalidate attribute to that form. For other examples, they don’t currently have a form tag, so we have to add one to the example layout. This does mean that all examples, including examples that don’t use any form elements, will be wrapped in a form, but I can’t currently think of any problems this would cause. Because the form tag is part of the layout, it won’t appear in the code blocks in the Design System.

https://trello.com/c/3662jBJf/1368-disable-built-in-browser-form-validation-on-examples