### PR TITLE
Add error message examples to components and patterns

### DIFF
--- a/src/components/checkboxes/error/index.njk
+++ b/src/components/checkboxes/error/index.njk
@@ -1,0 +1,41 @@
+---
+title: Checkbox items with error
+layout: layout-example.njk
+---
+
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  idPrefix: "nationality",
+  name: "nationality",
+  fieldset: {
+    legend: {
+      text: "What is your nationality?",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--xl"
+    }
+  },
+  hint: {
+    text: "If you have dual nationality, select all options that are relevant to you."
+  },
+  errorMessage: {
+    text: "Select if you are British, Irish or a citizen of a different country"
+  },
+  items: [
+    {
+      value: "british",
+      text: "British",
+      hint: {
+        text: "including English, Scottish, Welsh and Northern Irish"
+      }
+    },
+    {
+      value: "irish",
+      text: "Irish"
+    },
+    {
+      value: "other",
+      text: "Citizen of another country"
+    }
+  ]
+}) }}

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -50,6 +50,27 @@ You can add conditionally revealing content to checkboxes, so users only see con
 
 Keep it simple - if you need to add a lot of content, consider showing it on the next page in the process instead.
 
+### Error messages
+
+Error messages should be styled like this:
+
+{{ example({group: "components", item: "checkboxes", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
+
+
+Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
+
+#### If nothing is selected and the question has options in it
+
+Say "Select if [whatever it is]".<br>
+For example, "Select if you are British, Irish or a citizen of a different country"
+
+
+#### If nothing is selected and the question does not have options in it
+
+Say "Select [whatever it is]".<br>
+For example, "Select your nationality or nationalities"
+
+
 ## Research on this component
 
 Read a blog post about [updates to the radios and checkboxes components](https://designnotes.blog.gov.uk/2016/11/30/weve-updated-the-radios-and-checkboxes-on-gov-uk/).

--- a/src/components/date-input/error/index.njk
+++ b/src/components/date-input/error/index.njk
@@ -33,7 +33,8 @@ ignore_in_sitemap: true
     },
     {
       name: "year",
-      value: "2076"
+      value: "2076",
+      classes: "govuk-input--error"
     }
   ]
 }) }}

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -39,11 +39,103 @@ There are 2 ways to use the date input component. You can use HTML or, if you’
 
 Don’t automatically tab users between the fields of the Date input because this can be confusing and may clash with normal keyboard controls.
 
-### Error states
+### Error messages
 
 Check that a valid date is entered by the user. Invalid dates should be reported to the user like this:
 
 {{ example({group: "components", item: "date-input", example: "error", html: true, nunjucks: true, open: false, size: "m"}) }}
+
+
+Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
+
+Check the entire date, not the day, month and year separately.
+
+Avoid assuming what is wrong with the date. For example, if a user enters ‘31 2 2016’, the day may be right and the month may be wrong. An error message that mentions February may be confusing if they meant to enter ‘1’. 
+
+
+#### If nothing is entered
+
+Say "Enter [whatever it is]".
+
+For example, "Enter your date of birth".
+
+
+#### If an incomplete date is entered
+
+Say "Enter [whatever it is] and include a day, month and year".
+
+For example, "Enter your date of birth and include a day, month and year".
+
+
+#### If the date entered is not a real one
+
+Say "Enter a real [whatever it is]".
+
+For example, "Enter a real date of birth".
+
+
+#### If the date is in the future when it needs to be in the past
+
+Say "[whatever it is] must be in the past".
+
+For example, "Date of birth must be in the past".
+
+
+#### If the date is in the future when it needs to be today or in the past
+
+Say "[whatever it is] must be today or in the past".
+
+For example, "Date of birth must be today or in the past".
+
+
+#### If the date is in the past when it needs to be in the future
+
+Say "[whatever it is] must be in the future".
+
+For example, "The date your course ends must be in the future".
+
+
+#### If the date is in the past when it needs to be today or in the future
+
+Say "[whatever it is] must be today or in the future".
+
+For example, "The date your course ends must be today or in the future".
+
+
+#### If the date must be the same as or after another date
+
+Say "[whatever it is] must be the same as or after [date and optional description]".
+
+For example, "The date your course ends must be the same as or after 1 September 2017 when you started the course".
+
+
+#### If the date must be after another date
+
+Say "[whatever it is] must be after [date and optional description]".
+
+For example, "The day your course ends must be after 1 September 2017".
+
+
+#### If the date must be the same as or before another date
+
+Say "[whatever it is] must be  the same as or before [date and optional description]".
+
+For example, "The date of Gordon’s last exam must be the same as or before 31 August 2017 when they left school".
+
+
+#### If the date must be before another date
+
+Say "[whatever it is] must be before [date and optional description]".
+
+For example, "The date of Gordon’s last exam must be the same as or before 31 August 2017".
+
+
+#### If the date must be between two dates
+
+Say "[whatever it is] must be between [date] and [date and optional description]".
+
+For example, "The date your contract started must be between 1 September 2017 and 30 September  2017 when you were self-employed".
+
 
 ## Research on this component
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -55,85 +55,73 @@ Avoid assuming what is wrong with the date. For example, if a user enters ‘31 
 
 #### If nothing is entered
 
-Say "Enter [whatever it is]".
-
+Say "Enter [whatever it is]".<br>
 For example, "Enter your date of birth".
 
 
 #### If an incomplete date is entered
 
-Say "Enter [whatever it is] and include a day, month and year".
-
+Say "Enter [whatever it is] and include a day, month and year".<br>
 For example, "Enter your date of birth and include a day, month and year".
 
 
 #### If the date entered is not a real one
 
-Say "Enter a real [whatever it is]".
-
+Say "Enter a real [whatever it is]".<br>
 For example, "Enter a real date of birth".
 
 
 #### If the date is in the future when it needs to be in the past
 
-Say "[whatever it is] must be in the past".
-
+Say "[whatever it is] must be in the past".<br>
 For example, "Date of birth must be in the past".
 
 
 #### If the date is in the future when it needs to be today or in the past
 
-Say "[whatever it is] must be today or in the past".
-
+Say "[whatever it is] must be today or in the past".<br>
 For example, "Date of birth must be today or in the past".
 
 
 #### If the date is in the past when it needs to be in the future
 
-Say "[whatever it is] must be in the future".
-
+Say "[whatever it is] must be in the future".<br>
 For example, "The date your course ends must be in the future".
 
 
 #### If the date is in the past when it needs to be today or in the future
 
-Say "[whatever it is] must be today or in the future".
-
+Say "[whatever it is] must be today or in the future".<br>
 For example, "The date your course ends must be today or in the future".
 
 
 #### If the date must be the same as or after another date
 
-Say "[whatever it is] must be the same as or after [date and optional description]".
-
+Say "[whatever it is] must be the same as or after [date and optional description]".<br>
 For example, "The date your course ends must be the same as or after 1 September 2017 when you started the course".
 
 
 #### If the date must be after another date
 
-Say "[whatever it is] must be after [date and optional description]".
-
+Say "[whatever it is] must be after [date and optional description]".<br>
 For example, "The day your course ends must be after 1 September 2017".
 
 
 #### If the date must be the same as or before another date
 
-Say "[whatever it is] must be  the same as or before [date and optional description]".
-
+Say "[whatever it is] must be  the same as or before [date and optional description]".<br>
 For example, "The date of Gordon’s last exam must be the same as or before 31 August 2017 when they left school".
 
 
 #### If the date must be before another date
 
-Say "[whatever it is] must be before [date and optional description]".
-
+Say "[whatever it is] must be before [date and optional description]".<br>
 For example, "The date of Gordon’s last exam must be the same as or before 31 August 2017".
 
 
 #### If the date must be between two dates
 
-Say "[whatever it is] must be between [date] and [date and optional description]".
-
+Say "[whatever it is] must be between [date] and [date and optional description]".<br>
 For example, "The date your contract started must be between 1 September 2017 and 30 September  2017 when you were self-employed".
 
 

--- a/src/components/error-message/default/index.njk
+++ b/src/components/error-message/default/index.njk
@@ -32,7 +32,8 @@ layout: layout-example.njk
     },
     {
       name: "year",
-      value: "2076"
+      value: "2076",
+      classes: "govuk-input--error"
     }
   ]
 }) }}

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -68,9 +68,12 @@ Do not use:
 - ‘valid’ and ‘invalid’ because they do not add anything to the message
 - humourous, informal language like ‘oops’
 
+Do not give an example in the error message if there is an example on the screen. For example, if you are asking for a National Insurance number and include ‘QQ 12 34 56 C’ as hint text, do not include an example in the error message.
+
 Above all, aim for clarity.
 
 Read the message out loud to see if it sounds like something you would say.
+
 
 ### Be consistent
 
@@ -111,6 +114,23 @@ Some errors work better as instructions and some work better as descriptions. Fo
 - ‘Enter a date after 31 August 2017 for when you started the course’ is wordier, less direct and natural than ‘Date you started the course must be after 31 August 2017’
 
 Use both instructions and descriptions, but use them consistently. For example, use an instruction for empty fields like ‘Enter your name’, but a description like ‘Name must be 35 characters or less’ for entries that are too long.
+
+
+### Use error message templates
+
+Use template messages for common errors on:
+
+- [addresses](/patterns/addresses/#error-messages)
+- [checkboxes](/components/checkboxes/#error-messages)
+- [date input](/components/date-input/#error-messages)
+- [dates](/patterns/dates/#error-messages)
+- [names](/patterns/names/#error-messages)
+- [National Insurance numbers](/patterns/national-insurance-numbers/#error-messages)
+- [radios](/components/radios/#error-messages)
+- [telephone numbers](/patterns/telephone-numbers/#error-messages)
+- [text input](/components/text-input/#error-messages)
+- [textarea](/components/textarea/#error-messages)
+
 
 ### Track errors
 

--- a/src/components/radios/error/index.njk
+++ b/src/components/radios/error/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Inline radios with error
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "radios/macro.njk" import govukRadios %}

--- a/src/components/radios/error/index.njk
+++ b/src/components/radios/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Inline radios
+title: Inline radios with error
 layout: layout-example.njk
 ---
 

--- a/src/components/radios/error/index.njk
+++ b/src/components/radios/error/index.njk
@@ -1,0 +1,35 @@
+---
+title: Inline radios
+layout: layout-example.njk
+---
+
+{% from "radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  classes: "govuk-radios--inline",
+  idPrefix: "changed-name",
+  name: "changed-name",
+  fieldset: {
+    legend: {
+      text: "Have you changed your name?",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--xl"
+    }
+  },
+  hint: {
+    text: "This includes changing your last name or spelling your name differently."
+  },
+  errorMessage: {
+    text: "Select yes if you have changed your name"
+  },
+  items: [
+    {
+      value: "yes",
+      text: "Yes"
+    },
+    {
+      value: "no",
+      text: "No"
+    }
+  ]
+}) }}

--- a/src/components/radios/hint/index.njk
+++ b/src/components/radios/hint/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Radio items with hint
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "radios/macro.njk" import govukRadios %}

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -61,6 +61,33 @@ You can add conditionally revealing content to radios, so users only see content
 
 Keep it simple - if you need to add a lot of content, consider showing it on the next page in the process instead.
 
+### Error messages
+
+Error messages should be styled like this:
+
+{{ example({group: "components", item: "radios", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
+
+
+Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
+
+#### If nothing is selected and the options are ‘yes’ and ‘no’
+
+Say "Select yes if [whatever it is is true]".<br>
+For example, "Select yes if Sarah normally lives with you"
+
+
+#### If nothing is selected and the question has options in it
+
+Say "Select if [whatever it is]".<br>
+For example, "Select if you are employed or self-employed"
+
+
+#### If nothing is selected and the question does not have options in it
+
+Say "Select [whatever it is]".<br>
+For example, "Select the day of the week you pay your rent"
+
+
 ## Research on this component
 
 Read a blog post about [updates to the radios and checkboxes components](https://designnotes.blog.gov.uk/2016/11/30/weve-updated-the-radios-and-checkboxes-on-gov-uk/).

--- a/src/components/text-input/error/index.njk
+++ b/src/components/text-input/error/index.njk
@@ -1,0 +1,18 @@
+---
+title: Text input with errors
+layout: layout-example.njk
+ignore_in_sitemap: true
+---
+
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "First name"
+  },
+  id: "full-name",
+  name: "full-name",
+  errorMessage: {
+    text: "Enter your first name"
+  }
+}) }}

--- a/src/components/text-input/error/index.njk
+++ b/src/components/text-input/error/index.njk
@@ -10,8 +10,8 @@ ignore_in_sitemap: true
   label: {
     text: "First name"
   },
-  id: "full-name",
-  name: "full-name",
+  id: "first-name",
+  name: "first-name",
   errorMessage: {
     text: "Enter your first name"
   }

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -69,6 +69,94 @@ Use hint for help that’s relevant to the majority of users - like how their in
 
 Users often need to copy and paste information into a text input, so you shouldn’t prevent them from doing this.
 
+
+### Error messages
+
+Error messages should be styled like this:
+
+{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "error", html: true, nunjucks: true, closed: true, size: "s"}) }}
+
+Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
+
+
+#### If the input is empty
+
+Say "Enter [whatever it is]".<br>
+For example, "Enter your first name".
+
+#### If the input is too long
+
+Say "[whatever it is] must be [number] characters or less".<br>
+For example, "Address line 1 must be 35 characters or less".
+
+#### If the input is too short
+
+Say "[whatever it is] must be [number] characters or more".<br>
+For example, "Full name must be 2 characters or more".
+
+#### If the input is too long or too short
+
+Say "[whatever it is] must be between [number] and [number] characters".<br>
+For example, "Last name must be between 2 and 35 characters".
+
+#### If the input uses characters that are not allowed and you know what the characters are
+
+Say "[whatever it is] must not include [characters]".<br>
+For example, "Town or city must not include è and £".
+
+#### If the input uses characters that are not allowed and you do not know what the characters are 
+
+Say "[whatever it is] must only include [list of allowed characters]".<br>
+For example, "Full name must only include letters a to z, hyphens, spaces and apostrophes".
+
+#### If the input is not a number
+
+Say "[whatever it is] must be a number [optional example]".<br>
+For example, "Hours worked a week must be a number, like 30".
+
+#### If the input is not a whole number
+
+Say "[whatever it is] must be a whole number [optional example]".<br>
+For example, "Hours worked a week must be a whole number, like 30".
+
+#### If the number is too low
+
+Say "[whatever it is] must be [lowest] or more".<br>
+For example, "Hours worked a week must be 16 or more".
+
+#### If the number is too high
+
+Say "[whatever it is] must be [highest] or less".<br>
+For example, "Hours worked a week must be 99 or less".
+
+#### If the input must be between 2 numbers 
+
+Say "[whatever it is] must be between [lowest] and [highest]".<br>
+For example, "Hours worked a week must be between 16 and 99".
+
+#### If the input is not an amount of money and the field allows decimals
+
+Say "[whatever it is] must be an amount of money [optional example that includes decimals and non-decimals]".<br>
+For example, "How much you earn an hour must be an amount of money, like 7.50 or 8".
+
+#### If the input is not an amount of money and the field needs decimals
+
+Say "[whatever it is] must be an amount of money [optional example that includes decimals]".<br>
+For example, "How much you earn an hour must be an amount of money, like 7.50 or 8.00".
+
+#### If the input is an amount of money that needs decimals
+
+Say "[whatever it is] must include pence, like 123.45 or 156.00".<br>
+For example, "How much you earn a week must include pence, like 123,,56 or 156.00".
+
+#### If the input is an amount of money that must not have decimals
+
+Say "[whatever it is] must not include pence, like 123 or 156".<br>
+For example, "How much you earn a week must not include pence, like 123 or 156".
+
+
+
+
 ## Research on this component
 
 If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -147,7 +147,7 @@ For example, "How much you earn an hour must be an amount of money, like 7.50 or
 #### If the input is an amount of money that needs decimals
 
 Say "[whatever it is] must include pence, like 123.45 or 156.00".<br>
-For example, "How much you earn a week must include pence, like 123,,56 or 156.00".
+For example, "How much you earn a week must include pence, like 123.45 or 156.00".
 
 #### If the input is an amount of money that must not have decimals
 

--- a/src/components/textarea/error/index.njk
+++ b/src/components/textarea/error/index.njk
@@ -1,0 +1,19 @@
+---
+title: Textarea with error
+layout: layout-example.njk
+---
+{% from "textarea/macro.njk" import govukTextarea %}
+
+{{ govukTextarea({
+  name: "more-detail",
+  id: "more-detail",
+  label: {
+    text: "Can you provide more detail?"
+  },
+  hint: {
+    text: "Don’t include personal or financial information, eg your National Insurance number or credit card details."
+  },
+  errorMessage: {
+    text: "Enter more detail"
+  }
+}) }}

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -41,6 +41,47 @@ Make the height of a textarea proportional to the amount of text you expect user
 
 Users will often need to copy and paste information into a textarea, so you shouldn’t prevent them from doing this.
 
+### Error messages
+
+Error messages should be styled like this:
+
+{{ example({group: "components", item: "textarea", frontendComponentName: "input", example: "error", html: true, nunjucks: true, closed: true, size: "l"}) }}
+
+Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
+
+
+#### If the input is empty
+
+Say "Enter [whatever it is]".<br>
+For example, "Enter your first name".
+
+#### If the input is too long
+
+Say "[whatever it is] must be [number] characters or less".<br>
+For example, "Address line 1 must be 35 characters or less".
+
+#### If the input is too short
+
+Say "[whatever it is] must be [number] characters or more".<br>
+For example, "Full name must be 2 characters or more".
+
+#### If the input is too long or too short
+
+Say "[whatever it is] must be between [number] and [number] characters".<br>
+For example, "Last name must be between 2 and 35 characters".
+
+#### If the input uses characters that are not allowed and you know what the characters are
+
+
+Say "[whatever it is] must not include [characters]".<br>
+For example, "Town or city must not include è and £".
+
+#### If the input uses characters that are not allowed and you do not know what the characters are 
+
+Say "[whatever it is] must only include [list of allowed characters]".<br>
+For example, "Full name must only include letters a to z, hyphens, spaces and apostrophes".
+
+
 ## Research on this component
 
 If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -53,33 +53,33 @@ Make sure errors follow the guidance in [error message](/components/error-messag
 #### If the input is empty
 
 Say "Enter [whatever it is]".<br>
-For example, "Enter your first name".
+For example, "Enter summary".
 
 #### If the input is too long
 
 Say "[whatever it is] must be [number] characters or less".<br>
-For example, "Address line 1 must be 35 characters or less".
+For example, "Summary must be 400 characters or less".
 
 #### If the input is too short
 
 Say "[whatever it is] must be [number] characters or more".<br>
-For example, "Full name must be 2 characters or more".
+For example, "Summary must be 10 characters or more".
 
 #### If the input is too long or too short
 
 Say "[whatever it is] must be between [number] and [number] characters".<br>
-For example, "Last name must be between 2 and 35 characters".
+For example, "Summary must be between 10 and 400 characters".
 
 #### If the input uses characters that are not allowed and you know what the characters are
 
 
 Say "[whatever it is] must not include [characters]".<br>
-For example, "Town or city must not include è and £".
+For example, "Summary must not include è and £".
 
 #### If the input uses characters that are not allowed and you do not know what the characters are 
 
 Say "[whatever it is] must only include [list of allowed characters]".<br>
-For example, "Full name must only include letters a to z, hyphens, spaces and apostrophes".
+For example, "Summary must only include letters a to z, hyphens, spaces and apostrophes".
 
 
 ## Research on this component

--- a/src/patterns/addresses/error/index.njk
+++ b/src/patterns/addresses/error/index.njk
@@ -1,0 +1,20 @@
+---
+title: Postcode error
+layout: layout-example.njk
+ignore_in_sitemap: true
+---
+
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "Postcode"
+  },
+  classes: "govuk-input--width-10",
+  id: "address-postcode",
+  name: "address-postcode",
+  value: "Not a postcode",
+  errorMessage: {
+    text: "Enter a real postcode"
+  }
+}) }}

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -73,6 +73,14 @@ Make sure there are enough text inputs to accommodate longer addresses if you kn
 
 Royal Mail doesn’t need a county as long as the town and postcode are included. You should include an optional county text input so that people who don’t know their postcode can give a valid address.
 
+#### Error messages
+
+Error messages should be styled like this:
+
+{{ example({group: "patterns", item: "addresses", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
+
+Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
+
 ## Textarea
 
 {{ example({group: "patterns", item: "addresses", example: "textarea", html: true, nunjucks: true, open: true, size: "s"}) }}
@@ -91,15 +99,6 @@ You shouldn’t use a textarea if you:
 ### How a textarea works
 
 Textareas let users enter an address in any format and make it easy to copy and paste addresses from their clipboard.
-
-
-### Error messages
-
-Error messages should be styled like this:
-
-{{ example({group: "patterns", item: "addresses", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
-
-Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
 
 ## Research on this pattern

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -92,6 +92,16 @@ You shouldn’t use a textarea if you:
 
 Textareas let users enter an address in any format and make it easy to copy and paste addresses from their clipboard.
 
+
+### Error messages
+
+Error messages should be styled like this:
+
+{{ example({group: "patterns", item: "addresses", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
+
+Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
+
+
 ## Research on this pattern
 
 If you’ve used this pattern, get in touch to share your user research findings.

--- a/src/patterns/dates/error/index.njk
+++ b/src/patterns/dates/error/index.njk
@@ -33,7 +33,8 @@ ignore_in_sitemap: true
     },
     {
       name: "year",
-      value: "2076"
+      value: "2076",
+      classes: "govuk-input--error"
     }
   ]
 }) }}

--- a/src/patterns/dates/error/index.njk
+++ b/src/patterns/dates/error/index.njk
@@ -1,0 +1,39 @@
+---
+title: Date input with errors
+layout: layout-example.njk
+ignore_in_sitemap: true
+---
+
+{% from "date-input/macro.njk" import govukDateInput %}
+
+{{ govukDateInput({
+  id: "dob",
+  name: "dob",
+  fieldset: {
+    legend: {
+      text: "What is your date of birth?",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--xl"
+    }
+  },
+  hint: {
+    text: "For example, 31 3 1980"
+  },
+  errorMessage: {
+    text: "Date of birth must be in the past"
+  },
+  items: [
+    {
+      name: "day",
+      value: "6"
+    },
+    {
+      name: "month",
+      value: "3"
+    },
+    {
+      name: "year",
+      value: "2076"
+    }
+  ]
+}) }}

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -77,6 +77,15 @@ To check that the dates users give you are valid, make sure that:
 
 See the [GOV.UK style for writing dates](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates) and [date ranges]( https://www.gov.uk/guidance/content-design/writing-for-gov-uk#date-ranges).
 
+### Error messages
+
+Error messages should be styled like this:
+
+{{ example({group: "patterns", item: "dates", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
+
+Make sure errors follow the guidance in [date input](/components/date-input/#error-messages) and have specific error messages for specific error states.
+
+
 ## Research on this pattern
 
 If you’ve used this pattern, get in touch to share your user research findings.

--- a/src/patterns/email-addresses/error/index.njk
+++ b/src/patterns/email-addresses/error/index.njk
@@ -1,0 +1,23 @@
+---
+title: Email input with errors
+layout: layout-example.njk
+ignore_in_sitemap: true
+---
+
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "Email address"
+  },
+  hint: {
+    text: "We’ll only use this to send you a receipt"
+  },
+  id: "email",
+  name: "email",
+  type: "email",
+  value: "Not an email address",
+  errorMessage: {
+    text: "Enter an email address in the right format, like name@example.com"
+  }
+}) }}

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -62,6 +62,27 @@ If email is an essential part of your service - for example to send a password r
 
 However, these are disruptive and should be avoided as far as possible.
 
+### Error messages
+
+Error messages should be styled like this:
+
+{{ example({group: "patterns", item: "email-addresses", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
+
+Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
+
+
+#### If the email address is not in the right format and there is no example
+
+Say "Enter an email address in the right format, like name@example.com".
+
+
+#### If the email address is not in the right format and there is an example
+
+Say "Enter an email address in the right format".
+
+
+
+
 ## Research on this pattern
 
 If you’ve used this pattern, get in touch to share your user research findings.

--- a/src/patterns/names/error/index.njk
+++ b/src/patterns/names/error/index.njk
@@ -1,0 +1,18 @@
+---
+title: Name input with errors
+layout: layout-example.njk
+ignore_in_sitemap: true
+---
+
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "Full name"
+  },
+  id: "full-name",
+  name: "full-name",
+  errorMessage: {
+    text: "Enter your full name"
+  }
+}) }}

--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -63,6 +63,16 @@ It’s also hard to predict the range of titles your users will have. If you hav
 
 Remember to correctly use people’s names in any resulting correspondence.
 
+
+### Error messages
+
+Error messages should be styled like this:
+
+{{ example({group: "patterns", item: "names", example: "error", html: true, nunjucks: true, open: true}) }}
+
+Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
+
+
 ## Research on this pattern
 
 If you’ve used this pattern, get in touch to share your user research findings.

--- a/src/patterns/national-insurance-numbers/error/index.njk
+++ b/src/patterns/national-insurance-numbers/error/index.njk
@@ -1,0 +1,23 @@
+---
+title: National insurance number input with errors
+layout: layout-example.njk
+ignore_in_sitemap: true
+---
+
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "National Insurance number"
+  },
+  hint: {
+    text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+  },
+  classes: "govuk-input--width-10",
+  id: "national-insurance-number",
+  name: "national-insurance-number",
+  value: "Not a National Insurance number",
+  errorMessage: {
+    text: "Enter a National Insurance number in the right format"
+  }
+}) }}

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -36,6 +36,40 @@ You should:
 
 {{ example({group: "patterns", item: "national-insurance-numbers", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
 
+### Error messages
+
+Error messages should be styled like this:
+
+{{ example({group: "patterns", item: "national-insurance-numbers", example: "error", html: true, nunjucks: true, open: true, size: "s"}) }}
+
+Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
+
+#### If the National Insurance number is not in the right format and there is no example
+
+Say "Enter a National Insurance number that is 2 letters, 6 numbers, then A, B, C or D, like QQ123456C".
+
+
+#### If the National Insurance number is not in the right format and there is an example
+
+Say "Enter a National Insurance number in the right format".
+
+#### If National Insurance number is not real because it starts with BG, GB, NK, KN, TN, NT or ZZ
+
+Enter a real National Insurance number that does not start with BG, GB, NK, KN, TN, NT or ZZ
+
+#### If National Insurance number is not real because the first or second letter is D, F, I Q, U or V
+
+Enter a real National Insurance number that does not have D, F, I, Q, U or V as the first or second letter
+
+#### If National Insurance number is not real because the second letter is O
+
+Enter a real National Insurance number that does not have O as the second letter
+
+#### If National Insurance number is not real because the last letter is not A, B, C or D
+
+Enter a real National Insurance number that ends with A, B, C or D
+
+
 ## Research on this pattern
 
 If you’ve used this pattern, get in touch to share your user research findings.

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -53,22 +53,6 @@ Say "Enter a National Insurance number that is 2 letters, 6 numbers, then A, B, 
 
 Say "Enter a National Insurance number in the right format".
 
-#### If National Insurance number is not real because it starts with BG, GB, NK, KN, TN, NT or ZZ
-
-Enter a real National Insurance number that does not start with BG, GB, NK, KN, TN, NT or ZZ
-
-#### If National Insurance number is not real because the first or second letter is D, F, I Q, U or V
-
-Enter a real National Insurance number that does not have D, F, I, Q, U or V as the first or second letter
-
-#### If National Insurance number is not real because the second letter is O
-
-Enter a real National Insurance number that does not have O as the second letter
-
-#### If National Insurance number is not real because the last letter is not A, B, C or D
-
-Enter a real National Insurance number that ends with A, B, C or D
-
 
 ## Research on this pattern
 

--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -27,17 +27,24 @@ Users should be allowed to enter telephone numbers in whatever format is familia
 ### Validate telephone numbers
 You should validate telephone numbers so you can let users know if they have entered one incorrectly. Google’s [libphonenumber](https://github.com/googlei18n/libphonenumber) library can validate telephone numbers from most countries.
 
-Validation errors should be styled like this:
+
+### Error messages
+
+Error messages should be styled like this:
 
 {{ example({group: "patterns", item: "telephone-numbers", example: "error-empty-field", html: true, nunjucks: true, open: false, size: "s"}) }}
 
-Some examples of common error messages are:
+Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
-- empty field: Enter a telephone number
-- not a real number: Enter a telephone number in the correct format, like examples
-- too short: Telephone number must have at least x numbers
-- too long: Telephone number cannot have more than x numbers
-- not a UK mobile phone number: Enter a UK mobile telephone number
+#### If the telephone number is not in the right format and there is no example
+
+Say "Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192".
+
+
+#### If the telephone number is not in the right format and there is an example
+
+Say "Enter a telephone number in the correct format".
+
 
 ### Make it clear what type of telephone number you need
 Use the form label or hint text to tell users if you specifically need a UK, international or mobile telephone number.
@@ -80,6 +87,7 @@ Avoid [input masking](https://css-tricks.com/input-masking/) because it makes it
 ### Avoid reformatting telephone numbers
 
 The GOV.UK Notify team have observed some users becoming confused when presented with a reformatted version of a telephone number that they provided, for example, with the +44 country code added.
+
 
 ## Research on this pattern
 


### PR DESCRIPTION
This pull request adds the error message examples and templates contributed by @stevenaproctor and [reviewed here by the Design System working group](https://github.com/alphagov/govuk-design-system-backlog/issues/47#issuecomment-418156705).

The following pages have had error message examples and templates added to them:

- src/components/checkboxes/index.md.njk
- src/components/date-input/index.md.njk
- src/components/error-message/index.md.njk
- src/components/radios/index.md.njk
- src/components/text-input/index.md.njk
- src/components/textarea/index.md.njk
- src/patterns/addresses/index.md.njk
- src/patterns/dates/index.md.njk
- src/patterns/email-addresses/index.md.njk
- src/patterns/names/index.md.njk
- src/patterns/national-insurance-numbers/index.md.njk
- src/patterns/telephone-numbers/index.md.njk

Additionally, the 'error message' component now links out to the relevant section of the the above pages.