### PR TITLE
Update focus styles, navigation font size

### DIFF
--- a/src/stylesheets/components/_contact-panel.scss
+++ b/src/stylesheets/components/_contact-panel.scss
@@ -25,6 +25,6 @@
 }
 
 .app-contact-panel__body {
-  @include govuk-font(19)
+  @include govuk-font(19);
   margin: 0;
 }

--- a/src/stylesheets/components/_contact-panel.scss
+++ b/src/stylesheets/components/_contact-panel.scss
@@ -16,7 +16,7 @@
   }
 
   .app-contact-panel__link:focus {
-    color: govuk-colour("blue");
+    color: $govuk-focus-text-colour;
   }
 }
 

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -64,7 +64,7 @@
     }
 
     &:focus {
-      color: govuk-colour("black");
+      color: $govuk-focus-text-colour;
     }
   }
 

--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -27,6 +27,7 @@
     @include govuk-typography-common;
     @include govuk-typography-weight-bold;
     font-size: 19px; // We don't have a font mixin that produces 19px on mobile
+    font-size: govuk-px-to-rem(19px);
 
     & > a {
       @include govuk-typography-weight-bold; // Override .govuk-link weight
@@ -83,6 +84,7 @@
   // Font is defined as a hard 19px so
   // it doesn't re-size on mobile viewport
   font-size: 19px;
+  font-size: govuk-px-to-rem(19px);
   font-weight: 400;
 }
 

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -34,6 +34,7 @@
     text-decoration: none;
 
     .app-prose-scope &:focus { // A specific selector to reset .app-prose-scope a:focus
+      color: $govuk-link-colour;
       background: inherit;
     }
   }
@@ -169,6 +170,10 @@
 
   &:hover {
     color: $govuk-link-hover-colour;
+  }
+
+  &:focus {
+    color: $govuk-focus-text-colour;
   }
 
   @include govuk-media-query($from: 1080px) {


### PR DESCRIPTION
Updates various focus styles in the design system website to be consistent with regular link styles.

Also ensure the navigation scales based on font size updates.

Fixes a regression due to prose scope styles leaking into the application specific tabs component.

## Screenshots

### Before contact panel
<img width="648" alt="screen shot 2018-09-10 at 15 19 30" src="https://user-images.githubusercontent.com/2445413/45303708-54b33380-b50e-11e8-8294-344532e05945.png">

### After contact panel
<img width="630" alt="screen shot 2018-09-10 at 15 19 37" src="https://user-images.githubusercontent.com/2445413/45303702-541a9d00-b50e-11e8-9cb5-979c29c3cae1.png">

---

### Before navigation items with font size updated
<img width="451" alt="screen shot 2018-09-10 at 15 16 47" src="https://user-images.githubusercontent.com/2445413/45303703-541a9d00-b50e-11e8-959e-7a743518da04.png">
### After navigation items with font size updated
<img width="354" alt="screen shot 2018-09-10 at 15 16 56" src="https://user-images.githubusercontent.com/2445413/45303705-54b33380-b50e-11e8-929e-29b675106fad.png">

---

### Before close button focus styles
<img width="107" alt="screen shot 2018-09-10 at 15 19 24" src="https://user-images.githubusercontent.com/2445413/45303707-54b33380-b50e-11e8-898a-992827506229.png">

### After close button focus styles
<img width="113" alt="screen shot 2018-09-10 at 15 19 17" src="https://user-images.githubusercontent.com/2445413/45303706-54b33380-b50e-11e8-9467-b0846805c58c.png">

---

### Before tab focus style (regression)
<img width="155" alt="screen shot 2018-09-10 at 15 30 31" src="https://user-images.githubusercontent.com/2445413/45303775-7c0a0080-b50e-11e8-8c6e-2a52b907ad08.png">

### After tab focus style
<img width="156" alt="screen shot 2018-09-10 at 15 30 17" src="https://user-images.githubusercontent.com/2445413/45303776-7c0a0080-b50e-11e8-9d16-d0634494af17.png">
