### PR TITLE
Fix year field widths

### DIFF
--- a/src/components/date-input/error/index.njk
+++ b/src/components/date-input/error/index.njk
@@ -34,10 +34,9 @@ ignore_in_sitemap: true
       value: "3"
     },
     {
-      classes: "govuk-input--width-4",
+      classes: "govuk-input--width-4 govuk-input--error",
       name: "year",
-      value: "2076",
-      classes: "govuk-input--error"
+      value: "2076"
     }
   ]
 }) }}

--- a/src/components/error-message/default/index.njk
+++ b/src/components/error-message/default/index.njk
@@ -33,10 +33,9 @@ layout: layout-example.njk
       value: "3"
     },
     {
-      classes: "govuk-input--width-4",
+      classes: "govuk-input--width-4 govuk-input--error",
       name: "year",
-      value: "2076",
-      classes: "govuk-input--error"
+      value: "2076"
     }
   ]
 }) }}

--- a/src/patterns/dates/error/index.njk
+++ b/src/patterns/dates/error/index.njk
@@ -8,7 +8,7 @@ ignore_in_sitemap: true
 
 {{ govukDateInput({
   id: "dob",
-  name: "dob",
+  namePrefix: "dob",
   fieldset: {
     legend: {
       text: "What is your date of birth?",
@@ -24,17 +24,19 @@ ignore_in_sitemap: true
   },
   items: [
     {
+      classes: "govuk-input--width-2",
       name: "day",
       value: "6"
     },
     {
+      classes: "govuk-input--width-2",
       name: "month",
       value: "3"
     },
     {
+      classes: "govuk-input--width-4 govuk-input--error",
       name: "year",
-      value: "2076",
-      classes: "govuk-input--error"
+      value: "2076"
     }
   ]
 }) }}


### PR DESCRIPTION
Add explicit width classes to date fields to support the 2.0 release of GOV.UK Frontend