### PR TITLE
Fix monospace font size

### DIFF
--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -118,6 +118,23 @@ $app-breakpoint-widescreen: 1200px;
       display: none;
     }
   }
+
+  // Fix monospace font size when used with relative typography
+  //
+  // Browsers automatically reduce monospace font size 
+  //
+  // [1] restores the normal text size in Mozilla Firefox, Google Chrome, 
+  // and Safari; this unusual style rule should also be used anywhere where 
+  // you would otherwise set the font-family property to ‘monospace’. 
+  // [2] restores the normal text size in Internet Explorer and Opera.
+  //
+  // source: 
+  // http://code.iamkate.com/html-and-css/fixing-browsers-broken-monospace-font-handling/
+  pre,
+  code {
+    font-family: monospace, monospace; // [1]
+    font-size: 1em; // [2]
+  }
 }
 
 .app-content__header {


### PR DESCRIPTION
From https://github.com/necolas/normalize.css/issues/519#issuecomment-197131966

Major web browsers reduce the text size of elements whose `font-family` property is explicitly set to `monospace` to account for the greater width of many monospace typefaces in comparison to other fonts at the same text height ([citation](http://code.stephenmorley.org/html-and-css/fixing-browsers-broken-monospace-font-handling/)).

Browsers using **Blink**, **Gecko**, and **WebKit** reduce the size of `monospace`. Therefore, the `monospace,monospace` fix applies to **Android ≤ 6**, **Chrome ≤ 49**, **Firefox ≤ 45**, **iOS ≤ 9**, **Opera 15-35**, and **Safari 5-9**. The fix does not work for **Safari ≤ 4**.

Browsers using **Presto** and **Trident** treat `monospace` normally. Therefore, the `monospace,monospace` fix is not required for **Edge 12-13**, **Internet Explorer 8-11**, **Opera ≤ 12.15**, and **Windows Phone ≤ 8.1**.

Since they are checking explicitly for a computed value of `monospace`, other fixes may be applied, such as `monospace,serif` or `_,monospace`, if we feel one of those or something similar would be more readable.

Fixes #531

**Before:**
<img width="724" alt="screen shot 2018-09-11 at 14 17 36" src="https://user-images.githubusercontent.com/3758555/45362819-c2726480-b5cd-11e8-80a8-78535f70a199.png">
<img width="484" alt="screen shot 2018-09-11 at 14 16 42" src="https://user-images.githubusercontent.com/3758555/45362839-d1f1ad80-b5cd-11e8-924c-aec68002fbff.png">

**After:** 
<img width="716" alt="screen shot 2018-09-11 at 14 17 58" src="https://user-images.githubusercontent.com/3758555/45362812-bdadb080-b5cd-11e8-8bd8-632c2563568b.png">
<img width="626" alt="screen shot 2018-09-11 at 14 16 04" src="https://user-images.githubusercontent.com/3758555/45362840-d1f1ad80-b5cd-11e8-8cd5-769eab15430a.png">