### PR TITLE
In-page navigation - Remove default ul margin, add margin-bottom

### DIFF
--- a/src/stylesheets/components/_page-navigation.scss
+++ b/src/stylesheets/components/_page-navigation.scss
@@ -1,4 +1,6 @@
 .app-page-navigation {
+    margin-top: 0;
+    margin-bottom: govuk-spacing(6);
     padding-left: govuk-spacing(4);
     list-style: none;
 }


### PR DESCRIPTION
Somewhere in the refactoring this code this spacing was removed.

Removes the browser default `<ul>` margin-top and adds margin-bottom so the list is equally spaced.

**CURRENT LIVE**
<img width="518" alt="screen shot 2018-09-13 at 08 38 17" src="https://user-images.githubusercontent.com/23356842/45473991-6aa03e80-b730-11e8-9f3a-265ebc895c06.png">

**AFTER**
<img width="520" alt="screen shot 2018-09-13 at 08 37 42" src="https://user-images.githubusercontent.com/23356842/45474000-755ad380-b730-11e8-9fa0-6bf4e4880533.png">

