### PR TITLE
Make search test more robust

### DIFF
--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -30,18 +30,20 @@ describe('Site search', () => {
 
     expect(optionResult).toBe('No results found')
   })
-  it('returns results that begin with a letter "d"', async () => {
+  it('returns results where a word in the title begins with the letter "d"', async () => {
     await page.goto(baseUrl, { waitUntil: 'load' })
 
     await page.waitForSelector('.app-site-search__input')
     await page.type('.app-site-search__input', 'd')
     const resultsArray = await page.evaluate(
       () => [...document.querySelectorAll('.app-site-search__option')]
-      .map(elem => elem.innerText.toLowerCase())
-      .filter(elem => elem.startsWith('d'))
+      // ignore any results where a match was found in the alias
+      .filter(elem => !elem.querySelector('.app-site-search__aliases'))
+      // only get text, ignore child nodes
+      .map(elem => elem.firstChild.textContent.toLowerCase())
     )
-
-    expect(resultsArray.every(item => item.startsWith('d'))).toBeTruthy()
+    // regex with word boundry, in our case words that begin with 'd'
+    expect(resultsArray.every(item => (/\b[d]\w*/).test(item))).toBeTruthy()
   })
   it('returns results that contain aliases that start with the letter "d"', async () => {
     await page.goto(baseUrl, { waitUntil: 'load' })
@@ -51,10 +53,12 @@ describe('Site search', () => {
 
     const resultsArray = await page.evaluate(
       () => [...document.querySelectorAll('.app-site-search__option')]
-      .filter(elem => !elem.textContent.toLowerCase().startsWith('d'))
+      // only get results where a match was found in the alias
+      .filter(elem => elem.querySelector('.app-site-search__aliases'))
       .map(elem => elem.querySelector('.app-site-search__aliases').textContent)
     )
-    expect(resultsArray.every(item => item.startsWith('d'))).toBeTruthy()
+    // regex with word boundry, in our case words that begin with 'd'
+    expect(resultsArray.every(item => (/\b[d]\w*/).test(item))).toBeTruthy()
   })
   it('doesn\'t show any aliases if it finds any matches in the title', async () => {
     await page.goto(baseUrl, { waitUntil: 'load' })


### PR DESCRIPTION
When adding different content that feeds search it flagged that tests were not set up correctly to match how the search matching logic works.

Updated tests in now test for words beginning with the query in the title (words) and then separately in the aliases, correctly accounting for the fact that there may not be aliases present.

Fault was identified in #476 and a temp fix was added there which needs to be removed once this is merged in