### PR TITLE
Add notes clarifying use of focus colour

### DIFF
--- a/data/colours.json
+++ b/data/colours.json
@@ -26,7 +26,8 @@
     ],
     "Focus": [
       {
-        "name": "$govuk-focus-colour"
+        "name": "$govuk-focus-colour",
+        "notes": "Only use this colour to indicate which element is focussed on. For example, when a user tabs to an element with their keyboard."
       }
     ],
     "Status":[


### PR DESCRIPTION
I have spoken to teams who have used focus colour for an active state since it stands out.

This updates the colours page to explicitly mention what it should be used for.

Tried to avoid using the technical terminology even though I think calling out ':focus' would be useful...

Closes #150