### PR TITLE
Update contribution guidance

### DIFF
--- a/src/community/contribution-criteria/index.md.njk
+++ b/src/community/contribution-criteria/index.md.njk
@@ -98,7 +98,7 @@ The working group reviews the implementation to make sure it is usable, consiste
         text: "Versatile"
       },
       {
-        html: "<p>The implementation is versatile enough that component or pattern can be used in a range of different services that may need it.</p>
+        html: "<p>The implementation is versatile enough that the component or pattern can be used in a range of different services that may need it.</p>
 
         <p>For example, a versatile date input component could be set up to ask for a year only, a month and year only, a precise date, or any other combination you may need.</p>
 

--- a/src/community/develop-a-component-or-pattern/index.md.njk
+++ b/src/community/develop-a-component-or-pattern/index.md.njk
@@ -52,11 +52,10 @@ All components and patterns must meet the [contribution criteria](/community/con
 
 To arrange a review, tell the Design System team your contribution is ready. The team will check your work before letting the working group know it’s ready to review. 
 
-The working group will vote if it can be published:
+The working group will vote if your contribution:
 
-- as it is with no recommendations
-- as it is with some recommendations to consider when possible
-- only after you have addressed certain recommendations
+- can be published as it is
+- cannot be published until certain recommendations have been addressed
 
 The Design System team will invite you to meet with them and discuss the decision.
 

--- a/src/community/propose-a-component-or-pattern/index.md.njk
+++ b/src/community/propose-a-component-or-pattern/index.md.njk
@@ -30,7 +30,7 @@ At this stage, you just need to present your idea and evidence of the user needs
 
 The Design System team will help you prepare your proposal and share it with the [Design System working group](/community/design-system-working-group) to review.
 
-When your proposal is ready, the Design System team will send it to the working group one week before their next monthly meeting.
+When your proposal is ready, the Design System team will send it to the working group 2 weeks before their next monthly meeting.
 
 At the meeting, the working group will review your proposal and decide if it is useful and unique. This review helps people avoid spending time and effort on something that’s not needed.
 


### PR DESCRIPTION
This PR:

- fixes a typo in the contribution criteria 
- updates the timings for proposing a new component or pattern in line with process iteration
- updates working group decision options in line with process iteration