### PR TITLE
Example code block updates

### DIFF
--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -31,7 +31,7 @@ Make sure the link takes users to the previous page and that it works even when 
 
 There are 2 ways to use the back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
 
 ## Research on this component
 

--- a/src/components/breadcrumbs/index.md.njk
+++ b/src/components/breadcrumbs/index.md.njk
@@ -12,6 +12,7 @@ layout: layout-pane.njk
 The breadcrumbs component helps users to understand where they are within a website’s structure and move between levels.
 
 {{ example({group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false}) }}
+
 ## When to use this component
 
 Use the breadcrumbs component when you need to help users understand and move between the multiple levels of a website.
@@ -28,7 +29,7 @@ The breadcrumbs component should include the user’s current page, which should
 
 There are 2 ways to use the breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
 
 ## Research on this component
 

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -29,13 +29,13 @@ Disabled buttons have poor contrast and can confuse some users, so avoid them if
 
 Only use disabled buttons if research shows it makes the user interface easier to&nbsp;understand.
 
-{{ example({group: "components", item: "button", example: "disabled", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "button", example: "disabled", html: true, nunjucks: true, open: false}) }}
 
 ### Start buttons
 
 Use a start button as the main call to action on your service’s start page.
 
-{{ example({group: "components", item: "button", example: "start", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "button", example: "start", html: true, nunjucks: true, open: false}) }}
 
 ## Research on this component
 

--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -50,7 +50,7 @@ ignore_in_sitemap: true
     legend: {
       text: "How would you like to be contacted?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--m"
+      classes: "govuk-fieldset__legend--xl"
     },
     hint: {
       text: "Select all options that are relevant to you."

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -34,13 +34,13 @@ Read more about [why and how to set legends as headings](../../get-started/label
 
 There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: true, size: "m"}) }}
+{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", id: "default-2"}) }}
 
 ### Checkbox items with hints
 
 You can add hints to checkbox items to provide additional information about the options.
 
-{{ example({group: "components", item: "checkboxes", example: "hint", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({group: "components", item: "checkboxes", example: "hint", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ### Conditionally revealing content
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -35,7 +35,7 @@ Read more about [why and how to set legends as headings](../../get-started/label
 
 There are 2 ways to use the date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
 
 Don’t automatically tab users between the fields of the Date input because this can be confusing and may clash with normal keyboard controls.
 

--- a/src/components/details/index.md.njk
+++ b/src/components/details/index.md.njk
@@ -27,7 +27,7 @@ The details component is a short link that expands into more detailed help text 
 
 There are 2 ways to use the details component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
 
 ### Write clear link text
 

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -49,11 +49,11 @@ There are 2 ways to use the error message component. You can use HTML or, if you
 
 ### Legend
 
-{{ example({group: "components", item: "error-message", example: "legend", html: true, nunjucks: true, open: true, size: "m"}) }}
+{{ example({group: "components", item: "error-message", example: "legend", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ### Label
 
-{{ example({group: "components", item: "error-message", example: "label", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({group: "components", item: "error-message", example: "label", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ### Be clear and concise
 

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -34,7 +34,7 @@ Read guidance on [writing good error messages](../error-message#be-clear-and-con
 
 There are 2 ways to use the error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
 
 ## Research on this component
 

--- a/src/components/fieldset/default/index.njk
+++ b/src/components/fieldset/default/index.njk
@@ -7,7 +7,7 @@ layout: layout-example.njk
 
 {{ govukFieldset({
   legend: {
-    text: "Legend text goes here",
+    text: "Legend as page heading",
     classes: "govuk-fieldset__legend--xl",
     isPageHeading: true
   }

--- a/src/components/fieldset/index.md.njk
+++ b/src/components/fieldset/index.md.njk
@@ -11,13 +11,11 @@ layout: layout-pane.njk
 
 Use the fieldset component to group related form inputs.
 
-{{ example({group: "components", item: "fieldset", example: "default", html: true, nunjucks: true, open: false}) }}
-
 ## When to use this component
 
 Use the fieldset component when you need to show a relationship between multiple form inputs. For example, you may need to group a set of text inputs into a single fieldset when [asking for an address](../../patterns/addresses).
 
-{{ example({group: "components", item: "fieldset", example: "address-group", html: true, nunjucks: true, open: true, size: "xl"}) }}
+{{ example({group: "components", item: "fieldset", example: "address-group", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 If you’re using the examples or macros for [radios](../radios), [checkboxes](../checkboxes) or [date input](../date-input), the fieldset will already be included.
 
@@ -29,7 +27,7 @@ If you’re asking just [one question per page](../../patterns/question-pages/#s
 
 Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings).
 
-{{ example({group: "components", item: "fieldset", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "fieldset", example: "default", html: true, nunjucks: true, open: false}) }}
 
 On [question pages](../../patterns/question-pages) containing a group of inputs, including the question as the legend helps users of screenreaders to understand that the inputs are all related to that&nbsp;question.
 

--- a/src/components/file-upload/index.md.njk
+++ b/src/components/file-upload/index.md.njk
@@ -21,7 +21,7 @@ You should only ask users to upload something if it’s critical to the delivery
 
 There are 2 ways to use the file upload component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
 
 ## Research on this component
 

--- a/src/components/inset-text/index.md.njk
+++ b/src/components/inset-text/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "components", item: "inset-text", example: "default", size: "s"}) }}
+{{ example({group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, size: "s"}) }}
 
 ## When to use this component
 
@@ -31,7 +31,7 @@ Use inset text very sparingly - it’s less effective if it’s overused.
 
 There are 2 ways to use the inset text component. You can use HTML or, if you’re using Nunjucks or the GOV.UK Prototype Kit, you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
 
 ## Research on this component
 

--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -29,7 +29,7 @@ If you add extra content to the panel, to meet colour contrast ratio requirement
 
 There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: true, size: "m"}) }}
+{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", id: "default-2"}) }}
 
 ## Research on this component
 

--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -24,7 +24,7 @@ Your banner must be directly under the black GOV.UK header and colour bar.
 
 There are 2 ways to use the phase banner component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
 
 {{ example({group: "components", item: "phase-banner", example: "beta", html: true, nunjucks: true, open: false}) }}
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -33,31 +33,31 @@ There are 2 ways to use the radios component. You can use HTML or, if you are us
 
 When there are more than 2 options, radios should be stacked, like so:
 
-{{ example({group: "components", item: "radios", example: "stacked", html: true, nunjucks: true, open: true, size: "m"}) }}
+{{ example({group: "components", item: "radios", example: "stacked", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ### Inline radios
 
 If there are only 2 options, you can either stack the radios or display them inline, like so:
 
-{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
 
 ### Radio items with hints
 
 You can add hints to radio items to provide additional information about the options.
 
-{{ example({group: "components", item: "radios", example: "hint", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({group: "components", item: "radios", example: "hint", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ### Radio items with a text divider
 
 If one or more of your radio options is different from the others, it can help users if you separate them using a text divider. The text is usually the word ‘or’.
 
-{{ example({group: "components", item: "radios", example: "divider", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({group: "components", item: "radios", example: "divider", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ### Conditionally revealing content
 
 You can add conditionally revealing content to radios, so users only see content when it’s relevant to them. For example, you could reveal an email address input only when a user chooses to be contacted by email.
 
-{{ example({group: "components", item: "radios", example: "conditional-reveal", html: true, nunjucks: true, open: true, size: "xl"}) }}
+{{ example({group: "components", item: "radios", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 Keep it simple. If you need to add a lot of content, consider showing it on the next page in the process instead.
 

--- a/src/components/select/index.md.njk
+++ b/src/components/select/index.md.njk
@@ -23,7 +23,7 @@ Asking questions means you’re less likely to need to use the select component,
 
 There are 2 ways to use the select component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com),  you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "select", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
 
 ## Research on this component
 

--- a/src/components/skip-link/index.md.njk
+++ b/src/components/skip-link/index.md.njk
@@ -27,7 +27,7 @@ The skip link component is visually hidden until a keyboard press activates it.
 
 There are 2 ways to use the skip link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
 
 ## Research on this component
 

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -33,13 +33,13 @@ Use table headers to tell users what the rows and columns represent. Use the `sc
 
 There are 2 ways to use the table component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: true, size: "m"}) }}
+{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m", id: "default-2"}) }}
 
 ## Numbers in a table
 
 When comparing columns of numbers, align the numbers to the right in table cells.
 
-{{ example({group: "components", item: "table", example: "numbers", html: true, nunjucks: true, open: true, size: "m"}) }}
+{{ example({group: "components", item: "table", example: "numbers", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ## Research on this component
 

--- a/src/components/tabs/index.md.njk
+++ b/src/components/tabs/index.md.njk
@@ -47,7 +47,7 @@ Test your content without tabs first. Consider if it’s better to:
 
 There are 2 ways to use the tabs component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: true, size: "xl"}) }}
+{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false, size: "xl", id: "default-2"}) }}
 
 More research is needed on the best way to display the tabs component on small screen sizes.
 

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -19,7 +19,7 @@ Use the tag component to indicate the status of something, such as an item on a 
 
 There are 2 ways to use the tag component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
 
 ## Research on this component
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -23,7 +23,7 @@ Don’t use the text input component if you need to let users enter longer answe
 
 There are 2 ways to use the text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({group: "components", item: "text-input", frontendComponentName: "input", example: "default", html: true, nunjucks: true, open: dalse, size: "s", id: "default-2"}) }}
 
 ### Label text inputs
 

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -23,7 +23,7 @@ Don’t use the textarea component if you need to let users enter shorter answer
 
 There are 2 ways to use the textarea component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: true, size: "m"}) }}
+{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", id: "default-2"}) }}
 
 ### Label textareas
 
@@ -35,7 +35,7 @@ Labels must be aligned above the textarea they refer to. They should be short, d
 
 Make the height of a textarea proportional to the amount of text you expect users to enter. You can set the height of a textarea by by specifying the `rows` attribute.
 
-{{ example({group: "components", item: "textarea", example: "specifying-rows", html: true, nunjucks: true, open: true, size: "l"}) }}
+{{ example({group: "components", item: "textarea", example: "specifying-rows", html: true, nunjucks: true, open: false, size: "l"}) }}
 
 ### Don’t disable copy and paste
 
@@ -45,7 +45,7 @@ Users will often need to copy and paste information into a textarea, so you shou
 
 Error messages should be styled like this:
 
-{{ example({group: "components", item: "textarea", frontendComponentName: "input", example: "error", html: true, nunjucks: true, closed: true, size: "l"}) }}
+{{ example({group: "components", item: "textarea", frontendComponentName: "input", example: "error", html: true, nunjucks: true, open: false, size: "l"}) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/components/warning-text/index.md.njk
+++ b/src/components/warning-text/index.md.njk
@@ -19,7 +19,7 @@ Use the warning text component when you need to warn users about something impor
 
 There are 2 ways to use the warning text component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
 
 You might need to rewrite the hidden text (‘Warning’ in the example) to make it appropriate for your context.
 

--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -33,7 +33,7 @@ Your confirmation page must include:
 
 If you add extra content to the panel, to meet colour contrast ratio requirements use a font size of <code>govuk-body-l</code> for normal weight and <code>govuk-body</code> for bold.
 
-{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: true, size: "xl"}) }}
+{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, id: "default-2", size: "xl"}) }}
 
 ### Help users who bookmark the page
 

--- a/src/patterns/page-not-found-pages/index.md.njk
+++ b/src/patterns/page-not-found-pages/index.md.njk
@@ -14,7 +14,7 @@ statusMessage: This pattern is currently experimental because <a class="govuk-li
 
 A page not found tells someone we cannot find the page they were trying to view. They are also known as 404 pages.
 
-{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true, size: "xl"}) }}
+{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true, nunjucks: true, size: "xl"}) }}
 
 ## When to use this pattern
 
@@ -50,7 +50,7 @@ Do not use:
 - informal or humourous words like oops
 - red text to warn people
 
-{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true, size: "xl"}) }}
+{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true, nunjucks: true, id: "default-2", size: "xl"}) }}
 
 ## Research on this pattern
 

--- a/src/patterns/problem-with-the-service-pages/index.md.njk
+++ b/src/patterns/problem-with-the-service-pages/index.md.njk
@@ -13,7 +13,7 @@ statusMessage: This pattern is currently experimental because <a class="govuk-li
 
 This is a page that tells someone there is something wrong with the service. They are also known as 500 and internal server error pages.
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, open: false, size: "l"}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 ## When to use this pattern
 
@@ -48,15 +48,15 @@ Have clear and concise content and do not use:
 
 ### Service has a specific page that includes numbers and opening times
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, open: false, size: "l"}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, nunjucks: true, open: false, id: "default-2", size: "xl"}) }}
 
 ### Service has offline support but no specific page that includes numbers and opening times
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "offline-support", html: true, open: false, size: "xl"}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "offline-support", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 ### A link to another service
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "link-to-another-service", html: true, open: false, size: "l"}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "link-to-another-service", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 ## Research on this pattern
 

--- a/src/patterns/question-pages/date-of-birth/index.njk
+++ b/src/patterns/question-pages/date-of-birth/index.njk
@@ -6,7 +6,7 @@ layout: layout-example-full-page.njk
 {% extends "example-wrappers/full-page.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
-{% from "radios/macro.njk" import govukRadios %}
+{% from "date-input/macro.njk" import govukDateInput %}
 {% from "button/macro.njk" import govukButton %}
 
 {% block beforeContent %}
@@ -19,35 +19,19 @@ layout: layout-example-full-page.njk
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form action="/form-handler" method="post" novalidate>
-
-        {{ govukRadios({
-          idPrefix: "where-do-you-live",
-          name: "where-do-you-live",
+        {{ govukDateInput({
+          id: "dob",
+          namePrefix: "dob",
           fieldset: {
             legend: {
-              text: "Where do you live?",
+              text: "What is your date of birth?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--xl"
             }
           },
-          items: [
-            {
-              value: "england",
-              text: "England"
-            },
-            {
-              value: "scotland",
-              text: "Scotland"
-            },
-            {
-              value: "wales",
-              text: "Wales"
-            },
-            {
-              value: "northern-ireland",
-              text: "Northern Ireland"
-            }
-          ]
+          hint: {
+            text: "For example, 31 3 1980"
+          }
         }) }}
 
         {{ govukButton({

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -46,13 +46,19 @@ If you’re only asking for one piece of information on a page, make the questio
 
 For example:
 
-{{ example({group: "patterns", item: "question-pages", example: "postcode", html: true, nunjucks: true, open: true}) }}
+#### Legend as page heading
+
+{{ example({group: "patterns", item: "question-pages", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+
+#### Label as a page heading
+
+{{ example({group: "patterns", item: "question-pages", example: "postcode", html: true, nunjucks: true, open: false}) }}
 
 If you need to ask for multiple related things on a page, use a statement as the heading.
 
 For example:
 
-{{ example({group: "patterns", item: "question-pages", example: "passport", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "question-pages", example: "passport", html: true, nunjucks: true, open: false}) }}
 
 Don’t duplicate the same page heading across multiple pages.
 
@@ -77,7 +83,7 @@ Start by testing your form without a progress indicator to see if it’s simple 
 
 Try improving the order, type or number of questions before adding a progress indicator. If people still have difficulty, try adding a simple step or question indicator like this one.
 
-{{ example({group: "patterns", item: "question-pages", example: "progress", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "question-pages", example: "progress", html: true, nunjucks: true, open: false}) }}
 
 Only include the total number of questions if you can do so reliably. As the user moves through the form, make sure the indicator updates to tell them which question they are on and the total number remaining.
 

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -48,7 +48,7 @@ For example:
 
 #### Legend as page heading
 
-{{ example({group: "patterns", item: "question-pages", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "patterns", item: "question-pages", example: "date-of-birth", html: true, nunjucks: true, open: false}) }}
 
 #### Label as a page heading
 

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -42,9 +42,15 @@ Make sure the back link takes users to the previous page and that it still works
 
 Page headings can be statements or questions.
 
-If you’re only asking for one piece of information on a page, make the question the page heading.
+If you need to ask for multiple related things on a page, use a statement as the heading.
 
-For example:
+{{ example({group: "patterns", item: "question-pages", example: "passport", html: true, nunjucks: true, open: false}) }}
+
+If you only asking for one piece of information per page, you can set the contents of the `<label>` or `<legend>` as the page heading.
+
+This is good practice as it means that users of screen readers will only hear the contents once.
+
+Read more about why and [how to set legends and labels as page headings](https://design-system.service.gov.uk/get-started/labels-legends-headings/) or see examples below.
 
 #### Legend as page heading
 
@@ -54,19 +60,13 @@ For example:
 
 {{ example({group: "patterns", item: "question-pages", example: "postcode", html: true, nunjucks: true, open: false}) }}
 
-If you need to ask for multiple related things on a page, use a statement as the heading.
-
-For example:
-
-{{ example({group: "patterns", item: "question-pages", example: "passport", html: true, nunjucks: true, open: false}) }}
-
 Don’t duplicate the same page heading across multiple pages.
 
 The page heading should relate specifically to the information being asked for on the current page, not any higher-level section the page is part of.
 
 If you need to show the high-level section, you can use the `govuk-caption` style.
 
-For example, ‘About you’:
+For example, ‘About you’
 
 {{ example({group: "patterns", item: "question-pages", example: "section-headings", html: true, open: true}) }}
 

--- a/src/patterns/service-unavailable-pages/index.md.njk
+++ b/src/patterns/service-unavailable-pages/index.md.njk
@@ -13,7 +13,7 @@ statusMessage: This pattern is currently experimental because <a class="govuk-li
 
 This is a page that tells someone a service is unavailable on purpose. These are also known as 503 and shutter pages.
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "default", html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
 
@@ -47,15 +47,15 @@ Have clear and concise content and do not use:
 
 ### General page
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "general", html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "general", html: true, nunjucks: true, open: false}) }}
 
 ### When you know when a service will be available
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "available-at-known-date", html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "available-at-known-date", html: true, nunjucks: true, open: false}) }}
 
 ### A link to another service
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "link-to-another-service", html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "link-to-another-service", html: true, nunjucks: true, open: false}) }}
 
 ### Service is closed for part of the year
 
@@ -63,23 +63,23 @@ This is for a service like tax credit renewals.
 
 #### After a service closes
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "after-service-closes", html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "after-service-closes", html: true, nunjucks: true, open: false}) }}
 
 #### Before a service opens
 
 Do not include any contact information.
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "before-service-opens", html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "before-service-opens", html: true, nunjucks: true, open: false}) }}
 
 ### Service is closed forever
 
 #### Nothing has replaced the service
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "no-replacement-service", html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "no-replacement-service", html: true, nunjucks: true, open: false}) }}
 
 #### Something has replaced the service
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "service-replaced", html: true, open: false}) }}
+{{ example({group: "patterns", item: "service-unavailable-pages", example: "service-replaced", html: true, nunjucks: true, open: false}) }}
 
 ## Research on this pattern
 

--- a/src/patterns/start-pages/index.md.njk
+++ b/src/patterns/start-pages/index.md.njk
@@ -38,7 +38,7 @@ This is a set pattern, so you won’t be able to customise it.
 
 Read guidance on [what information should go on a start page](https://www.gov.uk/service-manual/design/govuk-content-transactions) in the Service Manual.
 
-{{ example({group: "patterns", item: "start-pages", example: "default", html: true, nunjucks: true, open: true}) }}
+{{ example({group: "patterns", item: "start-pages", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
 
 ## Research on this pattern
 


### PR DESCRIPTION
Part 1 of https://trello.com/c/v2I1ZSAo/1342-standardise-examples-in-the-design-system

Closes codeblocks inside Patterns and Components section (There are one or two small exceptions)

It does this by:

- Adding Nunjucks examples that didn't have them
- Adding an id to duplicated default examples 

This PR Also contains some minor content updates
