### PR TITLE
Remove grid alias

### DIFF
--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -2,7 +2,6 @@
 title: Layout
 description: Organise the layout of the page into blocks
 section: Styles
-aliases: grid
 backlog_issue_id:
 layout: layout-pane.njk
 show_page_nav: true


### PR DESCRIPTION
This is no longer needed as search will now return a result for 'grid' based on the page headings on the 'layout' page