### PR TITLE
Updated service unavailable page examples and documentation

### DIFF
--- a/src/patterns/service-unavailable-pages/after-service-closes/index.njk
+++ b/src/patterns/service-unavailable-pages/after-service-closes/index.njk
@@ -10,7 +10,7 @@ ignore_in_sitemap: true
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Service unavailable</h1>
+    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
     <p class="govuk-body">
       You cannot use the online service to renew your tax credits.
     </p>

--- a/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
+++ b/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
@@ -10,7 +10,7 @@ ignore_in_sitemap: true
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Service unavailable</h1>
+    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
     <p class="govuk-body">
       You will be able to use the service on Monday 19&nbsp;November&nbsp;2018.
     </p>

--- a/src/patterns/service-unavailable-pages/before-service-opens/index.njk
+++ b/src/patterns/service-unavailable-pages/before-service-opens/index.njk
@@ -10,7 +10,7 @@ ignore_in_sitemap: true
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Service unavailable</h1>
+    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
     <p class="govuk-body">
       You will be able renew your tax credits from Tuesday 24&nbsp;April&nbsp;2018.
     </p>

--- a/src/patterns/service-unavailable-pages/default/index.njk
+++ b/src/patterns/service-unavailable-pages/default/index.njk
@@ -10,7 +10,7 @@ ignore_in_sitemap: true
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Service unavailable</h1>
+      <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
       <p class="govuk-body">
         You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.
       </p>

--- a/src/patterns/service-unavailable-pages/general/index.njk
+++ b/src/patterns/service-unavailable-pages/general/index.njk
@@ -10,7 +10,7 @@ ignore_in_sitemap: true
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Service unavailable</h1>
+      <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
       <p class="govuk-body">
         You will be able to use the service later.
       </p>

--- a/src/patterns/service-unavailable-pages/index.md.njk
+++ b/src/patterns/service-unavailable-pages/index.md.njk
@@ -27,8 +27,8 @@ Have a general page in case you need to close a service and do not have time to 
 
 The page should have:
 
-- “Service unavailable – service name – GOV.UK” as the page title
-- “Service unavailable” as the H1
+- “Sorry, the service is unavailable – service name – GOV.UK” as the page title
+- “Sorry, the service is unavailable” as the H1
 - the day, date and time it is going to be available or what to do if it is permanently closed
 - information about what has happened to their answers if they are in the middle of a transaction
 - contact information, if it exists and helps meet a user need

--- a/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
+++ b/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
@@ -10,7 +10,7 @@ ignore_in_sitemap: true
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Service unavailable</h1>
+    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
     <p class="govuk-body">
       You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.
     </p>
@@ -18,7 +18,7 @@ ignore_in_sitemap: true
       You can <a class="govuk-link" href="#">change other VAT details</a>.
     </p>
     <p class="govuk-body">
-      <a class="govuk-link" href="#">Contact the Income Tax Helpline</a> if you need to speak to someone about your tax calculation.
+      <a class="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
     </p>
   </div>
 </div>

--- a/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
+++ b/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
@@ -10,7 +10,7 @@ ignore_in_sitemap: true
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Service unavailable</h1>
+    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
     <p class="govuk-body">
       The submit an employment intermediary report service has closed.
     </p>
@@ -18,7 +18,7 @@ ignore_in_sitemap: true
       Contact us if you need to speak to someone about the service and your reports.
     </p>
     <p class="govuk-body">Telephone:<br>
-      <strong class="govuk-!-font-weight-bold">0808 157 3900</span>
+      <strong class="govuk-!-font-weight-bold">0808 157 3900</strong>
     </p>
     <p class="govuk-body">Opening times:<br>
       <strong class="govuk-!-font-weight-bold">Monday to Friday: 8:30am to 4:30pm</strong>

--- a/src/patterns/service-unavailable-pages/service-replaced/index.njk
+++ b/src/patterns/service-unavailable-pages/service-replaced/index.njk
@@ -10,7 +10,7 @@ ignore_in_sitemap: true
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Service unavailable</h1>
+    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
     <p class="govuk-body">Universal Credit has replaced tax credits.</p>
     <p class="govuk-body"><a class="govuk-link" href="#">
       Contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits.


### PR DESCRIPTION
Updated the documentation and examples to include "sorry" in the `<title>` and `<h1>`.

This makes the examples meet the ['tone' section of Writing for user interfaces](https://www.gov.uk/service-manual/design/writing-for-user-interfaces#tone). From a user's point of view, "something serious has gone wrong" when a service is unavailable, even though it is unavailable on purpose.