### PR TITLE
 Update tabs component to allow for a single tab that can be toggled

### DIFF
--- a/__tests__/tabs.test.js
+++ b/__tests__/tabs.test.js
@@ -39,12 +39,12 @@ describe('Component page', () => {
         expect(toggleButtonIsOpen).toBeTruthy()
       })
 
-      it('should indicate the selected state of the tab using aria-selected', async () => {
+      it('should indicate the selected state of the tab using aria-expanded', async () => {
         await page.goto(baseUrl + '/components/back-link/', { waitUntil: 'load' })
 
         await page.click('.js-tabs__item a')
 
-        const toggleButtonAriaExpanded = await page.evaluate(() => document.body.querySelector('.js-tabs__item a').getAttribute('aria-selected'))
+        const toggleButtonAriaExpanded = await page.evaluate(() => document.body.querySelector('.js-tabs__item a').getAttribute('aria-expanded'))
         expect(toggleButtonAriaExpanded).toBe('true')
       })
     })
@@ -60,15 +60,46 @@ describe('Component page', () => {
         const toggleButtonIsOpen = await page.evaluate(() => document.body.querySelector('.app-tabs__item').classList.contains('app-tabs__item--current'))
         expect(toggleButtonIsOpen).toBeFalsy()
       })
+    })
 
-      it('should not indicate the selected state of the tab using aria-selected', async () => {
+    describe('when the tab closed and clicked twice', () => {
+      it('should indicate the closed state of the tab', async () => {
+        await page.setJavaScriptEnabled(true)
         await page.goto(baseUrl + '/components/back-link/', { waitUntil: 'load' })
 
         await page.click('.js-tabs__item a')
-        await page.click('.js-tabs__close')
+        await page.click('.js-tabs__item a')
 
-        const toggleButtonAriaExpanded = await page.evaluate(() => document.body.querySelector('.js-tabs__item a').getAttribute('aria-selected'))
-        expect(toggleButtonAriaExpanded).toBeFalsy()
+        const toggleButtonIsOpen = await page.evaluate(() => document.body.querySelector('.app-tabs__item').classList.contains('app-tabs__item--current'))
+        expect(toggleButtonIsOpen).toBeFalsy()
+      })
+
+      it('should indicate the closed state by setting aria-expanded attribute to false', async () => {
+        await page.goto(baseUrl + '/components/back-link/', { waitUntil: 'load' })
+
+        await page.click('.js-tabs__item a')
+        await page.click('.js-tabs__item a')
+
+        const toggleButtonAriaExpanded = await page.evaluate(() => document.body.querySelector('.js-tabs__item a').getAttribute('aria-expanded'))
+        expect(toggleButtonAriaExpanded).toBe('false')
+      })
+    })
+  })
+})
+
+describe('Patterns page', () => {
+  describe('when JavaScript is available', () => {
+    describe('when "hideTab" parameter is set to true', () => {
+      it('the tab list is not rendered', async () => {
+        await page.goto(baseUrl + '/patterns/question-pages/', { waitUntil: 'load' })
+        const expandedTabContentWithNoTab = await page.evaluate(() => document.body.querySelector('#example-section-headings-open .app-tabs'))
+        expect(expandedTabContentWithNoTab).toBeFalsy()
+      })
+
+      it('close button is not shown on the code block', async () => {
+        await page.goto(baseUrl + '/patterns/question-pages/', { waitUntil: 'load' })
+        const expandedTabContentWithNoTabCloseButton = await page.evaluate(() => document.body.querySelector('.js-tabs__container--no-tabs .js-tabs__close'))
+        expect(expandedTabContentWithNoTabCloseButton).toBeFalsy()
       })
     })
   })

--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -15,34 +15,48 @@ var Tabs = {
     // Reset state
     $example.find('.js-tabs__item').removeClass('app-tabs__item--current')
     $example.find('.js-tabs__heading').removeClass('app-tabs__heading--current')
-    $example.find('.js-tabs__item a').removeAttr('aria-selected')
+    $example.find('.js-tabs__item a').attr('aria-expanded', 'false')
     $example.find('.js-tabs__container').hide().attr('aria-hidden', 'true')
   },
 
   // Activate current tab
-  activateCurrentTab: function (id) {
+  activateAndToggleCurrentTab: function (id) {
     // Check if we have an id
     if (!id) {
       console.error('id is undefined')
       return
     }
 
-    // Reset tabs
-    Tabs.resetTabs(id)
+    var $target = $('[href="' + id + '"]')
+    var isTargetOpen = $target.attr('aria-expanded') === 'true'
+    var $targetParent = $target.parent()
 
-    // Set current active tab for both tabs and accordion links
-    $('[href="' + id + '"]').attr('aria-selected', 'true')
-    var $parents = $('[href="' + id + '"]').parent()
-    $.each($parents, function (key, obj) {
-      if ($(obj).hasClass('app-tabs__item')) {
-        $(obj).addClass('app-tabs__item--current')
-      } else if ($(obj).hasClass('app-tabs__heading')) {
-        $(obj).addClass('app-tabs__heading--current')
+    if (isTargetOpen) {
+      $target.attr('aria-expanded', 'false')
+      $(id).hide().attr('aria-hidden', 'true')
+
+      if ($targetParent.hasClass('app-tabs__item--current')) {
+        $targetParent.removeClass('app-tabs__item--current')
+      } else if ($targetParent.hasClass('app-tabs__heading--current')) {
+        $targetParent.removeClass('app-tabs__heading--current')
       }
-    })
+    } else {
+      // Reset tabs
+      Tabs.resetTabs(id)
 
-    // Set current container
-    $(id).show().removeAttr('aria-hidden')
+      // Set current active tab for both tabs and accordion links
+      $target.attr('aria-expanded', 'true')
+      $.each($targetParent, function (key, obj) {
+        if ($(obj).hasClass('app-tabs__item')) {
+          $(obj).addClass('app-tabs__item--current')
+        } else if ($(obj).hasClass('app-tabs__heading')) {
+          $(obj).addClass('app-tabs__heading--current')
+        }
+      })
+
+      // Set current container
+      $(id).show().attr('aria-hidden', 'false')
+    }
   },
 
   // Tabs mode
@@ -53,7 +67,7 @@ var Tabs = {
     var id = $(this).attr('href')
 
     // Activate current tab
-    Tabs.activateCurrentTab(id)
+    Tabs.activateAndToggleCurrentTab(id)
   },
 
   // Close current container on click
@@ -71,13 +85,14 @@ var Tabs = {
     // If more than one container
     var $examples = $(selector)
     $.each($examples, function (key, obj) {
-      if ($(obj).find('.js-tabs__container').length > 1) {
+      var tabsContainer = $(obj).find('.js-tabs__container')
+      if (tabsContainer.length > 0 && !tabsContainer.hasClass('js-tabs__container--no-tabs')) {
         // Hide all containers
-        $(obj).find('.js-tabs__container').hide()
+        tabsContainer.hide()
 
         // Add close button to each container
-        $(obj).find('.js-tabs__container').append('<button class="app-tabs__close js-tabs__close">Close</button>')
-        $(obj).find('.js-tabs__container').addClass('app-tabs__container--with-close-button')
+        tabsContainer.append('<button class="app-tabs__close js-tabs__close">Close</button>')
+        tabsContainer.addClass('app-tabs__container--with-close-button')
       }
     })
 

--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -19,6 +19,26 @@ var Tabs = {
     $example.find('.js-tabs__container').hide().attr('aria-hidden', 'true')
   },
 
+  // Attach aria attributes on load based on whether tabs have been set to open or closed
+  attachAriaAttributes: function (container) {
+    // Check if we have an id
+    if (!container) {
+      console.error('container is undefined')
+      return
+    }
+
+    var $example = $(container).parent()
+    var isTabOpen = $example.find('.js-tabs__item a').attr('aria-expanded')
+
+    if (!isTabOpen) {
+      $example.find('.js-tabs__item a').attr('aria-expanded', 'false')
+      $example.find('.js-tabs__container').hide().attr('aria-hidden', 'true')
+    } else {
+      $example.find('.js-tabs__item a').attr('aria-expanded', 'true')
+      $example.find('.js-tabs__container').hide().attr('aria-hidden', 'false')
+    }
+  },
+
   // Activate current tab
   activateAndToggleCurrentTab: function (id) {
     // Check if we have an id
@@ -89,7 +109,7 @@ var Tabs = {
       if (tabsContainer.length > 0 && !tabsContainer.hasClass('js-tabs__container--no-tabs')) {
         // Hide all containers
         tabsContainer.hide()
-
+        Tabs.attachAriaAttributes(tabsContainer)
         // Add close button to each container
         tabsContainer.append('<button class="app-tabs__close js-tabs__close">Close</button>')
         tabsContainer.addClass('app-tabs__container--with-close-button')

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -68,7 +68,7 @@ If you need to show the high-level section, you can use the `govuk-caption` styl
 
 For example, ‘About you’
 
-{{ example({group: "patterns", item: "question-pages", example: "section-headings", html: true, open: true}) }}
+{{ example({group: "patterns", item: "question-pages", example: "section-headings", html: true, open: true, hideTab:true}) }}
 
 ### Continue button
 

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -32,13 +32,20 @@
     <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></li>
     <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></li>
   </ul>
+  {% elif not (params.hideTab) %}
+  {% set tabType = "html" if params.html else ("nunjucks" if params.nunjucks ) %}
+  <ul class="app-tabs" role="tablist">
+    <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation">
+      <a href="#{{ exampleId }}-{{ tabType }}" role="tab" aria-controls="{{ exampleId }}-{{ tabType }}" data-track="tab-{{ tabType }}">{{ "HTML" if params.html else ("Nunjucks" if params.nunjucks )}}</a>
+    </li>
+  </ul>
   {% endif %}
 
   {%- if (params.html) %}
-  {%- if (multipleTabs) %}
+  {%- if (multipleTabs) or (not params.hideTab) %}
   <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
   {% endif %}
-  <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
+  <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-html" role="tabpanel">
     <pre data-module="app-copy"><code class="hljs html">
       {{- getHTMLCode(examplePath) | highlight('html') | safe -}}
     </code></pre>
@@ -48,8 +55,10 @@
   {%- if (params.nunjucks) %}
   {%- if (multipleTabs) %}
   <div class="app-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
+  {% elif not (params.hideTab) %}
+	<div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
   {% endif %}
-  <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
+  <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-nunjucks" role="tabpanel">
     <pre data-module="app-copy"><code class="hljs js">
       {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
     </code></pre>


### PR DESCRIPTION
Allows for a single tab to be present and toggle-able, depending on the parameters.

Also introduces a `hideTab` parameter.
When we have a single tab, want to have is expanded but not show the tab list item, set it to `true`

This page has the most diverse examples: https://deploy-preview-557--govuk-design-system-preview.netlify.com/patterns/question-pages/

To announce to screenreaders that the tab is expanded / collapsed we toggle `aria-expanded` on the trigger and `aria-hidden` on the content container.

Trello ticket: https://trello.com/c/wF6tmFc1/1321-iterate-example-code-block-tabs-2

