### PR TITLE
Add GA preconnect recommendation for GA from latest lighthouse tests

### DIFF
--- a/views/partials/_tracking-head.njk
+++ b/views/partials/_tracking-head.njk
@@ -1,4 +1,6 @@
 {% if GTM_TAG %}
+<link rel="preconnect" href="https://www.google-analytics.com" />
+
 <script>
 // Normalize doNotTrack implementations, see https://caniuse.com/#feat=do-not-track
 var DO_NOT_TRACK_ENABLED = (


### PR DESCRIPTION
After running Lighthouse over the design system it recommends adding a preconnect link for Google Analytics.

<img width="817" alt="screen shot 2018-09-20 at 16 02 07" src="https://user-images.githubusercontent.com/1223960/45827926-5b506080-bcef-11e8-88d9-cf7fa6024248.png">

Potentially saving 210ms on an emulated Nexus 5X, Simulated Fast 3G network. Full results can be seen [here](https://builder-dot-lighthouse-ci.appspot.com/report.1537453089452.html).