### PR TITLE
Add full width override

### DIFF
--- a/src/styles/spacing/input-width/index.njk
+++ b/src/styles/spacing/input-width/index.njk
@@ -6,6 +6,18 @@ ignore_in_sitemap: true
 
 {% from "input/macro.njk" import govukInput %}
 
+<h3 class="govuk-heading-m">Full</h3>
+
+{{ govukInput({
+  label: {
+    text: "Full name",
+    classes: "govuk-!-width-full"
+  },
+  classes: "govuk-!-width-full",
+  id: "full-name",
+  name: "full-name"
+}) }}
+
 <h3 class="govuk-heading-m">Three-quarters</h3>
 
 {{ govukInput({


### PR DESCRIPTION
Full width override class was added in Frontend 2.0 but wasn't added to the spacing section of the design system