### PR TITLE
[Don't Merge] Lighthouse GA preconnect v2

### DIFF
--- a/views/partials/_tracking-head.njk
+++ b/views/partials/_tracking-head.njk
@@ -1,4 +1,6 @@
 {% if GTM_TAG %}
+<link rel="preconnect" href="https://www.google-analytics.com" />
+
 <script>
 // Normalize doNotTrack implementations, see https://caniuse.com/#feat=do-not-track
 var DO_NOT_TRACK_ENABLED = (

--- a/views/partials/_tracking-head.njk
+++ b/views/partials/_tracking-head.njk
@@ -1,5 +1,5 @@
 {% if GTM_TAG %}
-<link rel="preconnect" href="https://www.google-analytics.com" />
+<link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
 
 <script>
 // Normalize doNotTrack implementations, see https://caniuse.com/#feat=do-not-track


### PR DESCRIPTION
This is an extension of the work on [PR 558](https://github.com/alphagov/govuk-design-system/pull/558). I'm re-examining this since reading the [specification](https://w3c.github.io/resource-hints/#preconnect) more closely and also noticing that the BBC News website use both `preconnect` and `dns-prefetch`:

```html
<link href="//static.bbc.co.uk" rel="preconnect" crossorigin>
<link href="//m.files.bbci.co.uk" rel="preconnect" crossorigin>
<link href="//nav.files.bbci.co.uk" rel="preconnect" crossorigin>
<link href="//ichef.bbci.co.uk" rel="preconnect" crossorigin>
<link rel="dns-prefetch" href="//mybbc.files.bbci.co.uk">
<link rel="dns-prefetch" href="//ssl.bbc.co.uk/">
<link rel="dns-prefetch" href="//sa.bbc.co.uk/">
<link rel="dns-prefetch" href="//ichef.bbci.co.uk">
```

I'm checking to see if the addition of the `crossorigin` attribute makes any difference to the performance data. It is also a good opportunity to confirm / oppose the results from the previous test.