### PR TITLE
Add data attributes to track contact links

### DIFF
--- a/src/get-in-touch.njk
+++ b/src/get-in-touch.njk
@@ -12,9 +12,10 @@ layout: layout-single-page.njk
 
      <h2 class="govuk-heading-l">Slack</h2>
 
-     <p class="govuk-body">Use <a class="govuk-link" class="govuk-link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a>, on cross-government Slack (<a class="govuk-link" class="govuk-link" href="slack://channel?team=T04V6EBTR&id=C6DMEH5R6">open in app</a>)</a></p>
+     <p class="govuk-body">Use <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system" data-hsupport="slack">#govuk-design-system</a>, on cross-government Slack (<a class="govuk-link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6" data-hsupport="slackapp">open in app</a>)</a></p>
 
      <h2 class="govuk-heading-l">Email</h2>
-     <p class="govuk-body">Email the Design System team on <a class="govuk-link" class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">govuk-design-system-support@digital.cabinet-office.gov.uk</a></p>
+
+     <p class="govuk-body">Email the Design System team on <a class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">govuk-design-system-support@digital.cabinet-office.gov.uk</a></p>
   </div>
 </div>

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -1,4 +1,5 @@
 <div class="app-contact-panel">
   <h2 class="app-contact-panel__heading">Get in touch</h2>
-  <p class="app-contact-panel__body">If you’ve got a question, idea or suggestion share it in <a class="govuk-link app-contact-panel__link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system">#govuk-design-system</a> on cross-government Slack (<a class="govuk-link app-contact-panel__link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6">open in app</a>) or email the Design System team on <a class="govuk-link app-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">govuk-design-system-support@digital.cabinet-office.gov.uk</a></p>
+  <p class="app-contact-panel__body">
+    If you’ve got a question, idea or suggestion share it in <a class="govuk-link app-contact-panel__link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system" data-hsupport="slack">#govuk-design-system</a> on cross-government Slack (<a class="govuk-link app-contact-panel__link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6" data-hsupport="slackapp">open in app</a>) or email the Design System team on <a class="govuk-link app-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">govuk-design-system-support@digital.cabinet-office.gov.uk</a></p>
 </div>


### PR DESCRIPTION
We already track the equivalent links on the homepage, this just applies the same data attributes to support links in the panel at the bottom of most pages and on the ‘Get in touch’ page.

This will help us to understand what channels users go to for support.

Also removes duplicated class attributes from links on the get in touch page.

https://trello.com/c/2lrSoUGg/1459-add-data-attributes-to-all-support-links