### PR TITLE
Update GOV.UK Frontend dependency to v2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4736,9 +4736,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.0.0.tgz",
-      "integrity": "sha512-F0rChMqBumqphM2ourIfFgc+BIoqQcLIV3Jz/oUmx/yeiRrl799Q1DN7Q/JDB/+nbS3ZaoDLX++Qv6RtIp08/w=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.1.0.tgz",
+      "integrity": "sha512-6wYIANvYAi3aLdJQXBbvgtEeZG6KOvLlul2uwpA4Ow5BdgmSyDVUAB0PLR5MVFaiqlyvMhGTAMa38AiFHwVqgA=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "autoprefixer": "^9.1.0",
     "clipboard": "^2.0.1",
-    "govuk-frontend": "^2.0.0",
+    "govuk-frontend": "^2.1.0",
     "gray-matter": "^4.0.1",
     "highlight.js": "^9.12.0",
     "html5shiv": "^3.7.3",


### PR DESCRIPTION
Inline with the latest release of GOV.UK Frontend