### PR TITLE
Move colophon in footer example out of meta links

### DIFF
--- a/src/components/footer/full/index.njk
+++ b/src/components/footer/full/index.njk
@@ -129,11 +129,8 @@ ignore_in_sitemap: true
       {
         href: "#",
         text: "Rhestr o Wasanaethau Cymraeg"
-      },
-      {
-        href: "#",
-        text: "Government Digital Service"
       }
-    ]
+    ],
+    html: 'Built by the <a href="#" class="govuk-footer__link">Government Digital Service</a>'
   }
 }) }}


### PR DESCRIPTION
This relies on a change in GOV.UK Frontend 2.1.0 that introduced a new footer ‘meta’ area, designed for things like the ‘Built by GDS’ colophon. This aligns the footer example with the current design on GOV.UK.

## Before

<img width="1392" alt="screenshot 2018-09-26 at 14 52 45bst" src="https://user-images.githubusercontent.com/121939/46084608-f936a600-c19b-11e8-8aa5-83d22e3d00b4.png">


## After

<img width="1392" alt="screenshot 2018-09-26 at 14 52 18bst" src="https://user-images.githubusercontent.com/121939/46084612-fc319680-c19b-11e8-8450-a423fc56229b.png">
