### PR TITLE
Changed capitalisation in example

### DIFF
--- a/src/components/text-input/input-hint-text/index.njk
+++ b/src/components/text-input/input-hint-text/index.njk
@@ -8,7 +8,7 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "National insurance number"
+    text: "National Insurance number"
   },
   hint: {
     text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."


### PR DESCRIPTION
'National Insurance' instead of 'National insurance'.