### PR TITLE
Link to service manual designing questions guide from question pages

### DIFF
--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -132,6 +132,8 @@ On every question page you should:
 - make sure it’s clear to users why you’re asking each question
 - allow users to answer ‘I don’t know’ or ‘I’m not sure’ if they are valid responses
 
+Read more about [designing good questions](https://www.gov.uk/service-manual/design/designing-good-questions) in the GOV.UK Service Manual. 
+
 ## Research on this pattern
 
 If you’ve used this pattern, get in touch to share your user research findings.


### PR DESCRIPTION
This PR adds a link from the How it works section of the Question pages pattern to the Service Manual guide on Designing good questions