### PR TITLE
Add events for search tracking

### DIFF
--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -20,10 +20,6 @@ afterEach(async (done) => {
   done()
 })
 
-function timeout (ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
-
 describe('Site search', () => {
   it('does not return any results when searching for something that does not exist', async () => {
     await page.goto(baseUrl, { waitUntil: 'load' })
@@ -145,14 +141,14 @@ describe('Site search', () => {
   })
 
   describe('tracking', () => {
-    const SEARCH_TRACKING_TIMEOUT = 2000
     it('should track if there are no results', async () => {
       await page.goto(baseUrl, { waitUntil: 'load' })
+
+      await page.evaluate(() => { window.__SITE_SEARCH_TRACKING_TIMEOUT = 0 })
 
       await page.waitForSelector('.app-site-search__input')
       await page.focus('.app-site-search__input')
       await page.type('.app-site-search__input', 'lorem ipsum')
-      await timeout(SEARCH_TRACKING_TIMEOUT)
       const GoogleTagManagerDataLayer = await page.evaluate(() => window.dataLayer)
 
       expect(GoogleTagManagerDataLayer).toEqual(
@@ -174,10 +170,11 @@ describe('Site search', () => {
     it('should track if there are results', async () => {
       await page.goto(baseUrl, { waitUntil: 'load' })
 
+      await page.evaluate(() => { window.__SITE_SEARCH_TRACKING_TIMEOUT = 0 })
+
       await page.waitForSelector('.app-site-search__input')
       await page.focus('.app-site-search__input')
       await page.type('.app-site-search__input', 'g')
-      await timeout(SEARCH_TRACKING_TIMEOUT)
       const optionResults = await page.$$('.app-site-search__option')
       const GoogleTagManagerDataLayer = await page.evaluate(() => window.dataLayer)
 
@@ -261,10 +258,11 @@ describe('Site search', () => {
     it('should block personally identifable information emails', async () => {
       await page.goto(baseUrl, { waitUntil: 'load' })
 
+      await page.evaluate(() => { window.__SITE_SEARCH_TRACKING_TIMEOUT = 0 })
+
       await page.waitForSelector('.app-site-search__input')
       await page.focus('.app-site-search__input')
       await page.type('.app-site-search__input', 'user@example.com')
-      await timeout(SEARCH_TRACKING_TIMEOUT)
       const GoogleTagManagerDataLayer = await page.evaluate(() => window.dataLayer)
 
       expect(GoogleTagManagerDataLayer).toEqual(
@@ -280,10 +278,11 @@ describe('Site search', () => {
     it('should block personally identifable information numbers', async () => {
       await page.goto(baseUrl, { waitUntil: 'load' })
 
+      await page.evaluate(() => { window.__SITE_SEARCH_TRACKING_TIMEOUT = 0 })
+
       await page.waitForSelector('.app-site-search__input')
       await page.focus('.app-site-search__input')
       await page.type('.app-site-search__input', '079460999')
-      await timeout(SEARCH_TRACKING_TIMEOUT)
       const GoogleTagManagerDataLayer = await page.evaluate(() => window.dataLayer)
 
       expect(GoogleTagManagerDataLayer).toEqual(

--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -212,6 +212,8 @@ describe('Site search', () => {
       await page.goto(baseUrl, { waitUntil: 'load' })
 
       // Prevent page from unloading so we can check what was tracked.
+      // By setting onbeforeunload it forces a dialog to appear that allows a user
+      // to cancel leaving the page, so we detect the dialog opening and dismiss it to stop the navigation.
       await page.evaluate(() => {
         window.onbeforeunload = () => true
       })

--- a/src/javascripts/components/search.js
+++ b/src/javascripts/components/search.js
@@ -24,7 +24,10 @@ var inputDebounceTimer = null
 // We want to wait a bit before firing events to indicate that
 // someone is looking at a result and not that it's come up in passing.
 var DEBOUNCE_TIME_TO_WAIT = function () {
-  return 2000 // milliseconds
+  // We want to be able to reduce this timeout in order to make sure
+  // our tests do not run very slowly.
+  var timeout = window.__SITE_SEARCH_TRACKING_TIMEOUT
+  return (typeof timeout !== 'undefined') ? timeout : 2000 // milliseconds
 }
 
 function Search ($module) {

--- a/src/javascripts/components/search.js
+++ b/src/javascripts/components/search.js
@@ -117,6 +117,18 @@ Search.prototype.init = function () {
     return
   }
 
+  // The Accessible Autocomplete only works in IE9+ so we can use newer JavaScript features here
+  // but need to check for browsers that do not have these features and force the fallback by returning early.
+  // http://responsivenews.co.uk/post/18948466399/cutting-the-mustard
+  var cutsTheMustard = (
+    'querySelector' in document &&
+    !!(Array.prototype && Array.prototype.forEach)
+  )
+
+  if (!cutsTheMustard) {
+    return
+  }
+
   accessibleAutocomplete({
     element: $module,
     id: 'app-site-search__input',

--- a/src/javascripts/components/search.tracking.js
+++ b/src/javascripts/components/search.tracking.js
@@ -1,0 +1,82 @@
+function addToDataLayer (payload) {
+  window.dataLayer = window.dataLayer || []
+  window.dataLayer.push(payload)
+}
+
+function stripPossiblePII (string) {
+    // Try to detect emails and redact it.
+  string = string.replace(/\S*@\S*\s?/g, '[blocked]')
+    // If someone has typed in a number it's likely not related so redact it
+  string = string.replace(/0|1|2|3|4|5|6|7|8|9/g, '[blocked]')
+  return string
+}
+
+function trackConfirm (searchQuery, searchResults, result) {
+  if (window.DO_NOT_TRACK_ENABLED) {
+    return
+  }
+
+  var searchTerm = stripPossiblePII(searchQuery)
+  var products =
+    searchResults
+      .map(function (result, key) {
+        return {
+          name: result.title,
+          category: result.section,
+          list: searchTerm, // Used to match an searchTerm with results
+          position: (key + 1)
+        }
+      })
+      .filter(function (product) {
+        // Only return the product that matches what was clicked
+        return product.name === result.title
+      })
+
+  addToDataLayer({
+    event: 'site-search',
+    eventDetails: {
+      category: 'site search',
+      action: 'click',
+      label: searchTerm + ' | ' + result.title
+    },
+    ecommerce: {
+      click: {
+        actionField: { list: searchTerm },
+        products: products
+      }
+    }
+  })
+}
+
+function trackSearchResults (searchQuery, searchResults) {
+  if (window.DO_NOT_TRACK_ENABLED) {
+    return
+  }
+
+  var searchTerm = stripPossiblePII(searchQuery)
+
+  var hasResults = (searchResults.length > 0)
+  // Impressions is Google Analytics lingo for what people have seen.
+  var impressions = searchResults.map(function (result, key) {
+    return {
+      name: result.title,
+      category: result.section,
+      list: searchTerm, // Used to match an searchTerm with results
+      position: (key + 1)
+    }
+  })
+
+  addToDataLayer({
+    event: 'site-search',
+    eventDetails: {
+      category: 'site search',
+      action: hasResults ? 'results' : 'no result',
+      label: searchTerm
+    },
+    ecommerce: {
+      impressions: impressions
+    }
+  })
+}
+
+export { trackConfirm, trackSearchResults }


### PR DESCRIPTION
This implements events fired to Google Tag Manager via the data layer.

This article was really useful to set this up: https://www.analyticsmania.com/post/google-tag-manager-custom-event-trigger/

1. Set up a 'trigger' that matches the 'event' property in our data layer events.
<img width="1195" alt="screen shot 2018-10-12 at 15 35 48" src="https://user-images.githubusercontent.com/2445413/46875771-83396c80-ce34-11e8-8559-9b35cf0d0f6f.png">

2. Setup three new variables that can reference the eventDetails properties, (this screenshot shows one example) (This wont need to be done again if a similar approach is taken in the future)
<img width="1000" alt="screen shot 2018-10-12 at 15 37 29" src="https://user-images.githubusercontent.com/2445413/46875876-cabff880-ce34-11e8-805a-6093417ddb5d.png">

2. Setup a 'tag' that references the variables set.
<img width="1173" alt="screen shot 2018-10-12 at 15 36 48" src="https://user-images.githubusercontent.com/2445413/46875835-afed8400-ce34-11e8-8e2a-108e1d7f92d9.png">



-  mocks the normal timeout for the tracking functionality to avoid very slow tests
- includes an explicit cut off point to stop any search JavaScript executing in browsers that can not run the Accessible Autocomplete, this allows us to use any features available in IE9+
