### PR TITLE
Remove published items from backlog

### DIFF
--- a/src/community/backlog/index.md.njk
+++ b/src/community/backlog/index.md.njk
@@ -136,14 +136,6 @@ Here is a list of the components, patterns and updates currently on the Design S
     </tr>
     <tr>
       <td class="govuk-table__cell">
-        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/67">Character count</a>
-      </td>
-      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
-        To do
-      </td>
-    </tr>
-    <tr>
-      <td class="govuk-table__cell">
         <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/8">Code block</a>
       </td>
       <td class="govuk-table__cell govuk-body-s" style="text-align: right">
@@ -449,14 +441,6 @@ Here is a list of the components, patterns and updates currently on the Design S
     <tr>
       <td class="govuk-table__cell">
         <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/79">Pay for something</a>
-      </td>
-      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
-        To do
-      </td>
-    </tr>
-    <tr>
-      <td class="govuk-table__cell">
-        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/80">Payment details</a>
       </td>
       <td class="govuk-table__cell govuk-body-s" style="text-align: right">
         To do


### PR DESCRIPTION
Remove 'Character count' and 'Payment details' from backlog as these have now been published.