### PR TITLE
update-radios-and-checkboxes-guidance-with-dropbox-info

### DIFF
--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -51,10 +51,10 @@ ignore_in_sitemap: true
       text: "How would you like to be contacted?",
       isPageHeading: true,
       classes: "govuk-fieldset__legend--xl"
-    },
-    hint: {
-      text: "Select all options that are relevant to you."
     }
+  },  
+  hint: {
+    text: "Select all options that are relevant to you."
   },
   items: [
     {

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -22,7 +22,7 @@ Use the checkboxes component when you need to help users:
 
 ## When not to use this component
 
-Don’t use the checkboxes component if users can only choose one option from a selection. In this case, use the [radios component](../radios/).
+Do not use the checkboxes component if users can only choose one option from a selection. In this case, use the [radios component](../radios/).
 
 ## How it works
 
@@ -31,6 +31,10 @@ Checkboxes are grouped together in a `<fieldset>` with a `<legend>` that describ
 If you are asking just [one question per page](../../patterns/question-pages/#start-by-asking-one-question-per-page) as recommended, you can set the contents of the `<legend>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
 
 Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings).
+
+Unlike with radios, users can select multiple options from a list of checkboxes. Do not assume that users will know how many options they can select based on the visual difference between radios and checkboxes alone. 
+
+If needed, add a hint explaining this, for example, 'Select all that apply'.
 
 There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -48,10 +48,13 @@ ignore_in_sitemap: true
   name: "how-contacted",
   fieldset: {
     legend: {
-      text: "How do you want to be contacted?",
+      text: "How would you prefer to be contacted?",
       isPageHeading: true,
       classes: "govuk-fieldset__legend--xl"
     }
+  },
+  hint: {
+    text: "Select one option."
   },
   items: [
     {

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -17,7 +17,7 @@ Use the radios component when users can only select one option from a list.
 
 ## When not to use this component
 
-Don’t use the radios component if users might need to select more than one option. In this case, you should use the [checkboxes](/components/checkboxes/) component instead.
+Do not use the radios component if users might need to select more than one option. In this case, you should use the [checkboxes](/components/checkboxes/) component instead.
 
 ## How it works
 
@@ -26,6 +26,23 @@ Radios are grouped together in a `<fieldset>` with a `<legend>` that describes t
 If you are asking just [one question per page](../../patterns/question-pages/#start-by-asking-one-question-per-page) as recommended, you can set the contents of the `<legend>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
 
 Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings).
+
+Users can only select one option from a list of radios. Do not assume that users will know how many options they can select based on the visual difference between radios and checkboxes alone. 
+
+If needed, add a hint explaining this, for example, 'Select one option'.
+
+Do not pre-select radio options as this makes it more likely that users will:
+
+- not realise they've missed a question
+- submit the wrong answer
+
+Unlike with checkboxes, users cannot return to an unselected group of radios once they have selected one, without refreshing their browser window. Therefore, you should include 'None of the above' if it's a valid option. 
+
+Order radio options alphabetically by default. 
+
+In some cases, it can be helpful to order them from most-to-least common options, for example, you could order options for 'Where do you live?' based on population size.
+
+However you should do this with extreme caution as it can reinforce bias in your service. If in doubt, order alphabetically. 
 
 There are 2 ways to use the radios component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -27,7 +27,7 @@ If you are asking just [one question per page](../../patterns/question-pages/#st
 
 Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings).
 
-Users can only select one option from a list of radios. Do not assume that users will know how many options they can select based on the visual difference between radios and checkboxes alone. 
+Unlike with radios, users can only select one option from a list of radios. Do not assume that users will know how many options they can select based on the visual difference between radios and checkboxes alone. 
 
 If needed, add a hint explaining this, for example, 'Select one option'.
 
@@ -36,7 +36,7 @@ Do not pre-select radio options as this makes it more likely that users will:
 - not realise they've missed a question
 - submit the wrong answer
 
-Unlike with checkboxes, users cannot return to an unselected group of radios once they have selected one, without refreshing their browser window. Therefore, you should include 'None of the above' if it's a valid option. 
+Users cannot go back to having no option selected once they have selected one, without refreshing their browser window. Therefore, you should include 'None of the above' or 'I do not know' if they are valid options. 
 
 Order radio options alphabetically by default. 
 


### PR DESCRIPTION
This PR:

- updates radios and checkboxes guidance
- updates radios and checkboxes examples

These changes are based on a review of the content in the Dropbox Paper file for Radios, there is more information here:

https://github.com/alphagov/govuk-design-system-backlog/issues/59#issuecomment-429818508