### PR TITLE
Add guidance on asking for names

### DIFF
--- a/src/patterns/payment-card-details/index.md.njk
+++ b/src/patterns/payment-card-details/index.md.njk
@@ -42,6 +42,8 @@ When you validate the card number, the card security code information should upd
 
 Do not use CVV or other acronyms for the card security code.
 
+If you need to ask for a user's name elsewhere in your service, do not assume that the name on their card will be the same. 
+
 ## Research on this pattern
 
 This pattern is based on the one used in [GOV.UK Pay](https://www.payments.service.gov.uk/), which has been live since November 2016.


### PR DESCRIPTION
This PR adds guidance to the Payment card details pattern saying not to assume that the name on a user's card will be the same as they enter elsewhere in the service.

This addition came from the Credit card details file on Dropbox Paper which has been archived as part of the migration work.