### PR TITLE
Fix javascript errors in ie8

### DIFF
--- a/config/paths.json
+++ b/config/paths.json
@@ -7,8 +7,6 @@
     "govukfrontendcomponents": "node_modules/govuk-frontend/components/",
     "iframeresizer": "node_modules/iframe-resizer/",
     "clipboard": "node_modules/clipboard/dist/",
-    "html5shiv": "node_modules/html5shiv/dist/",
-    "jquery": "node_modules/jquery/dist/",
   "source": "src/",
     "components": "src/components/",
     "images": "src/images/",

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -87,12 +87,6 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     destination: 'javascripts/vendor'
   }))
 
-  // copy static assets from node_modules/html5shiv/dist
-  .use(assets({
-    source: '../' + paths.html5shiv,
-    destination: 'javascripts/vendor'
-  }))
-
   // build custom modernizr.js file
   .use(modernizrBuild({
     config: '../config/modernizr.json',

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -131,6 +131,21 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     ]
   }))
 
+  // build the entrypoint for application IE8 specific JavaScript
+  .use(rollup({
+    input: 'src/javascripts/application-ie8.js',
+    output: {
+      legacy: true,
+      format: 'iife',
+      file: 'javascripts/application-ie8.js'
+    },
+    plugins: [
+      // TODO: Since we're not exporting ES6 Modules to NPM we need to import these as commonjs
+      resolve(),
+      commonjs()
+    ]
+  }))
+
   // build GOV.UK Frontend JavaScript
   .use(rollup({
     input: 'src/javascripts/govuk-frontend.js',
@@ -153,6 +168,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     },
     sameName: true, // overwrite the original files, with the minified ones.
     files: [
+      'javascripts/application-ie8.js',
       'javascripts/application.js',
       'javascripts/head-ie8.js',
       'javascripts/govuk-frontend.js'
@@ -163,6 +179,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
   .use(hashAssets({
     pattern: [
       '**/*.css',
+      'javascripts/application-ie8.js',
       'javascripts/application.js',
       'javascripts/head-ie8.js',
       'javascripts/govuk-frontend.js'

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -2,7 +2,6 @@ const metalsmith = require('metalsmith')                     // static site gene
 const assets = require('metalsmith-assets')                  // copy static assets
 const brokenLinkChecker = require('metalsmith-broken-link-checker')
 const titleChecker = require('./metalsmith-title-checker.js')
-const concat = require('metalsmith-concat')                  // concatenate files
 const env = require('metalsmith-env')                        // environment vars plugin
 const hashAssets = require('metalsmith-fingerprint-ignore')  // add hash to specified files and ignores files that match a pattern
 const inplace = require('metalsmith-in-place')               // render templating syntax in your source files

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -143,6 +143,9 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
 
   // minify the JavaScript assets to reduce time it takes to download
   .use(uglify({
+    uglify: {
+      ie8: true
+    },
     sameName: true, // overwrite the original files, with the minified ones.
     files: [
       'javascripts/application.js',

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -98,8 +98,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
   .use(concat({
     files: [
       'javascripts/vendor/html5shiv-printshiv.js',
-      'javascripts/vendor/ie8.polyfils.min.js', // from iframeresizer
-      'javascripts/ie-only.js'
+      'javascripts/vendor/ie8.polyfils.min.js' // from iframeresizer
     ],
     output: 'javascripts/ie.js'
   }))

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -94,20 +94,26 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     destination: 'javascripts/vendor'
   }))
 
-  // concatenate IE only javascript files
-  .use(concat({
-    files: [
-      'javascripts/vendor/html5shiv-printshiv.js',
-      'javascripts/vendor/ie8.polyfils.min.js' // from iframeresizer
-    ],
-    output: 'javascripts/ie.js'
-  }))
-
   // build custom modernizr.js file
   .use(modernizrBuild({
     config: '../config/modernizr.json',
     destination: 'javascripts/vendor/',
     filename: 'modernizr.js'
+  }))
+
+  // build the entrypoint for the IE8 JavaScript that goes in the <head>
+  .use(rollup({
+    input: 'src/javascripts/head-ie8.js',
+    output: {
+      legacy: true,
+      format: 'iife',
+      file: 'javascripts/head-ie8.js'
+    },
+    plugins: [
+      // TODO: Since we're not exporting ES6 Modules to NPM we need to import these as commonjs
+      resolve(),
+      commonjs()
+    ]
   }))
 
   // build the entrypoint for application specific JavaScript
@@ -148,7 +154,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     sameName: true, // overwrite the original files, with the minified ones.
     files: [
       'javascripts/application.js',
-      'javascripts/ie.js',
+      'javascripts/head-ie8.js',
       'javascripts/govuk-frontend.js'
     ]
   }))
@@ -158,7 +164,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     pattern: [
       '**/*.css',
       'javascripts/application.js',
-      'javascripts/ie.js',
+      'javascripts/head-ie8.js',
       'javascripts/govuk-frontend.js'
     ]
   }))

--- a/package-lock.json
+++ b/package-lock.json
@@ -954,9 +954,9 @@
           "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
           "dev": true,
           "requires": {
-            "debug": "~2.2.0",
+            "debug": "2.2.0",
             "finalhandler": "0.5.0",
-            "parseurl": "~1.3.1",
+            "parseurl": "1.3.2",
             "utils-merge": "1.0.0"
           }
         },
@@ -975,11 +975,11 @@
           "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
           "dev": true,
           "requires": {
-            "debug": "~2.2.0",
-            "escape-html": "~1.0.3",
-            "on-finished": "~2.3.0",
-            "statuses": "~1.3.0",
-            "unpipe": "~1.0.0"
+            "debug": "2.2.0",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
           }
         },
         "fs-extra": {
@@ -999,10 +999,10 @@
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
+            "statuses": "1.5.0"
           },
           "dependencies": {
             "statuses": {
@@ -1047,18 +1047,18 @@
           "dev": true,
           "requires": {
             "debug": "2.6.4",
-            "depd": "~1.1.0",
-            "destroy": "~1.0.4",
-            "encodeurl": "~1.0.1",
-            "escape-html": "~1.0.3",
-            "etag": "~1.8.0",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
             "fresh": "0.5.0",
-            "http-errors": "~1.6.1",
+            "http-errors": "1.6.3",
             "mime": "1.3.4",
             "ms": "1.0.0",
-            "on-finished": "~2.3.0",
-            "range-parser": "~1.2.0",
-            "statuses": "~1.3.1"
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.3.1"
           },
           "dependencies": {
             "debug": {
@@ -1098,9 +1098,9 @@
           "integrity": "sha1-5UbicmCBuBtLzsjpCAjrzdMjr7o=",
           "dev": true,
           "requires": {
-            "encodeurl": "~1.0.1",
-            "escape-html": "~1.0.3",
-            "parseurl": "~1.3.1",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.2",
             "send": "0.15.2"
           }
         },
@@ -1678,7 +1678,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "~1.3.2",
+        "parseurl": "1.3.2",
         "utils-merge": "1.0.1"
       }
     },
@@ -3044,12 +3044,12 @@
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.3.1",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
       }
     },
     "find-file-up": {
@@ -8176,115 +8176,6 @@
         }
       }
     },
-    "metalsmith-concat": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-concat/-/metalsmith-concat-6.0.0.tgz",
-      "integrity": "sha1-BUfZmJ8MRD545ay5DBpvr0oMLbI=",
-      "dev": true,
-      "requires": {
-        "async": "2.0.0-rc.6",
-        "glob": "7.0.3",
-        "minimatch": "3.0.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.0.0-rc.6",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.0.0-rc.6.tgz",
-          "integrity": "sha1-l4/EFV0fwwuLWPw/AgECstoC8qQ=",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.8.0"
-          }
-        },
-        "balanced-match": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-          "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-          "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^0.4.1",
-            "concat-map": "0.0.1"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-          "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-          "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
-          "dev": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.13.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
-          "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-          "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
-          "dev": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        }
-      }
-    },
     "metalsmith-env": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/metalsmith-env/-/metalsmith-env-2.1.1.tgz",
@@ -11401,18 +11292,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "http-errors": {
@@ -11420,10 +11311,10 @@
           "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
+            "statuses": "1.4.0"
           }
         },
         "setprototypeof": {
@@ -11481,9 +11372,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "metalsmith-broken-link-checker": "^1.0.1",
     "metalsmith-browser-sync": "^1.1.1",
     "metalsmith-canonical": "^1.1.2",
-    "metalsmith-concat": "^6.0.0",
     "metalsmith-env": "^2.1.1",
     "metalsmith-fingerprint-ignore": "^2.0.0",
     "metalsmith-in-place": "^4.2.0",

--- a/src/javascripts/application-ie8.js
+++ b/src/javascripts/application-ie8.js
@@ -1,6 +1,7 @@
 import common from 'govuk-frontend/common'
 import CookieBanner from './components/cookie-banner.js'
 import Example from './components/example.js'
+import Tabs from './components/tabs.js'
 
 var nodeListForEach = common.nodeListForEach
 
@@ -12,3 +13,6 @@ var $examples = document.querySelectorAll('[data-module="app-example-frame"]')
 nodeListForEach($examples, function ($example) {
   new Example($example).init()
 })
+
+// Initialise tabs
+Tabs.init('.js-example')

--- a/src/javascripts/application-ie8.js
+++ b/src/javascripts/application-ie8.js
@@ -1,0 +1,14 @@
+import common from 'govuk-frontend/common'
+import CookieBanner from './components/cookie-banner.js'
+import Example from './components/example.js'
+
+var nodeListForEach = common.nodeListForEach
+
+// // Add cookie message
+CookieBanner.addCookieMessage()
+
+// Initialise example frames
+var $examples = document.querySelectorAll('[data-module="app-example-frame"]')
+nodeListForEach($examples, function ($example) {
+  new Example($example).init()
+})

--- a/src/javascripts/head-ie8.js
+++ b/src/javascripts/head-ie8.js
@@ -1,0 +1,5 @@
+// JavaScript that blocks render before the rest of the page.
+
+// Ensure that HTML5 elements can be styled
+import 'html5shiv/dist/html5shiv-printshiv.js'
+import 'iframe-resizer/js/ie8.polyfils.min.js'

--- a/src/styles/page-template/block-areas/index.njk
+++ b/src/styles/page-template/block-areas/index.njk
@@ -19,7 +19,7 @@ stylesheets:
   <!--<![endif]-->
   <!--[if lt IE 9]>
     <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all" />
-    <script src="{{ getFingerprint('javascripts/ie.js') }}"></script>
+    <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
   <script src="/javascripts/vendor/modernizr.js"></script>
   {% for stylesheet in stylesheets %}

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -33,7 +33,7 @@ ignore_in_sitemap: true
   <!--<![endif]-->
   <!--[if lt IE 9]>
     <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all" />
-    <script src="{{ getFingerprint('javascripts/ie.js') }}"></script>
+    <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
   <script src="/javascripts/vendor/modernizr.js"></script>
 {% endblock %}

--- a/src/styles/page-template/default/index.njk
+++ b/src/styles/page-template/default/index.njk
@@ -11,7 +11,7 @@ layout: false
   <!--<![endif]-->
   <!--[if lt IE 9]>
     <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all" />
-    <script src="{{ getFingerprint('javascripts/ie.js') }}"></script>
+    <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
   <script src="/javascripts/vendor/modernizr.js"></script>
 {% endblock %}

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -15,7 +15,7 @@
   <!--<![endif]-->
   <!--[if lt IE 9]>
     <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all" />
-    <script src="{{ getFingerprint('javascripts/ie.js') }}"></script>
+    <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
   <link rel="canonical" href="{{ canonical }}" />
   <script src="/javascripts/vendor/modernizr.js"></script>

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -46,5 +46,10 @@
 {% block footer %}{% endblock %}
 
 {% block bodyEnd %}
-<script src="{{ getFingerprint('javascripts/application.js') }}"></script>
+  <!--[if !IE 8]><!-->
+    <script src="{{ getFingerprint('javascripts/application.js') }}"></script>
+  <!--<![endif]-->
+  <!--[if lt IE 9]>
+    <script src="{{ getFingerprint('javascripts/application-ie8.js') }}"></script>
+  <![endif]-->
 {% endblock %}

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -6,20 +6,20 @@
 {% block pageTitle %}{{ title }} – GOV.UK Design System{% endblock %}
 
 {% block head %}
-{% if not TRAVIS_BRANCH or TRAVIS_BRANCH != 'master' %}
-  <meta name="robots" content="noindex, nofollow">
-{% endif %}
-<meta name="description" content="{{description}}">
-  <!--[if !IE 8]><!-->
-    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
-  <!--<![endif]-->
+  {% if not TRAVIS_BRANCH or TRAVIS_BRANCH != 'master' %}
+    <meta name="robots" content="noindex, nofollow">
+  {% endif %}
+  <meta name="description" content="{{description}}">
+  <link rel="canonical" href="{{ canonical }}" />
   <!--[if lt IE 9]>
     <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all" />
     <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
-  <link rel="canonical" href="{{ canonical }}" />
-  <script src="/javascripts/vendor/modernizr.js"></script>
-  {% include "_tracking-head.njk" %}
+  <!--[if !IE 8]><!-->
+    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
+    <script src="/javascripts/vendor/modernizr.js"></script>
+    {% include "_tracking-head.njk" %}
+  <!--<![endif]-->
 {% endblock %}
 
 {# We provide our own header, so blank the one provided by the template #}

--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -8,7 +8,7 @@
   <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all" />
   {%- endfor %}
   <!--[if lt IE 9]>
-    <script src="{{ getFingerprint('javascripts/ie.js') }}"></script>
+    <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
   <script src="/javascripts/vendor/modernizr.js"></script>
 {% endblock %}

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -12,7 +12,7 @@
     {%- endfor %}
 
     <!--[if lt IE 9]>
-      <script src="{{ getFingerprint('javascripts/ie.js') }}"></script>
+      <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
     <![endif]-->
     <script src="/javascripts/vendor/modernizr.js"></script>
   </head>


### PR DESCRIPTION
Fixes issues that stopped the Design System JavaScript behaviour from working in IE8.

- Google Tag Manager fails in IE8
- Uglify needs to be configured to work in IE8
- Copy and Search both rely on dependencies that fail on runtime

Clipboard.js and Accessible Autocomplete cannot bypassed by runtime feature detection and must not be loaded instead, this is why I have opted for a separate IE8 bundle.

I have raised an issue on the accessible autocomplete to make this easier for others: https://github.com/alphagov/accessible-autocomplete/issues/306

https://trello.com/c/B6N3G2fS/1325-ensure-copy-to-clipboard-functionality-does-not-break-ie8-experience