### PR TITLE
Showcase custom classes on tables

### DIFF
--- a/src/components/table/column-widths-custom-classes/column-width-custom-classes.scss
+++ b/src/components/table/column-widths-custom-classes/column-width-custom-classes.scss
@@ -1,0 +1,7 @@
+@import "example-init";
+
+// This is a separate stylesheet for the `my-custom-class` example
+
+.my-custom-class {
+  width: 20%;
+}

--- a/src/components/table/column-widths-custom-classes/index.njk
+++ b/src/components/table/column-widths-custom-classes/index.njk
@@ -1,0 +1,62 @@
+---
+title: Table
+layout: layout-example.njk
+stylesheets:
+- column-width-custom-classes.css
+---
+
+{% from "table/macro.njk" import govukTable %}
+
+{{ govukTable({
+  caption: "Month you apply",
+  firstCellIsHeader: true,
+  head: [
+    {
+      text: "Date",
+      classes: 'my-custom-class'
+    },
+    {
+      text: "Rate for vehicles",
+      classes: 'my-custom-class'
+    },
+    {
+      text: "Rate for bicycles",
+      classes: 'my-custom-class'
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "First 6 weeks"
+      },
+      {
+        text: "£109.80 per week"
+      },
+      {
+        text: "59.10 per week"
+      }
+    ],
+    [
+      {
+        text: "Next 33 weeks"
+      },
+      {
+        text: "£159.80 per week"
+      },
+      {
+        text: "£89.10 per week"
+      }
+    ],
+    [
+      {
+        text: "Total estimated pay"
+      },
+      {
+        text: "£4,282.20"
+      },
+      {
+        text: "£2,182.20"
+      }
+    ]
+  ]
+}) }}

--- a/src/components/table/column-widths/index.njk
+++ b/src/components/table/column-widths/index.njk
@@ -1,0 +1,60 @@
+---
+title: Table
+layout: layout-example.njk
+---
+
+{% from "table/macro.njk" import govukTable %}
+
+{{ govukTable({
+  caption: "Month you apply",
+  firstCellIsHeader: true,
+  head: [
+    {
+      text: "Date",
+      classes: 'govuk-!-width-one-half'
+    },
+    {
+      text: "Rate for vehicles",
+      classes: 'govuk-!-width-one-quarter'
+    },
+    {
+      text: "Rate for bicycles",
+      classes: 'govuk-!-width-one-quarter'
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "First 6 weeks"
+      },
+      {
+        text: "£109.80 per week"
+      },
+      {
+        text: "59.10 per week"
+      }
+    ],
+    [
+      {
+        text: "Next 33 weeks"
+      },
+      {
+        text: "£159.80 per week"
+      },
+      {
+        text: "£89.10 per week"
+      }
+    ],
+    [
+      {
+        text: "Total estimated pay"
+      },
+      {
+        text: "£4,282.20"
+      },
+      {
+        text: "£2,182.20"
+      }
+    ]
+  ]
+}) }}

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -43,11 +43,13 @@ When comparing columns of numbers, align the numbers to the right in table cells
 
 ## Custom column widths
 
-You can use the [width override classes](../../styles/spacing#width-override-classes) to set the width of table columns. 
-
-If these do not meet your needs you can set your own by by providing the `classes` option to the Nunjucks macro as shown in the example or applying CSS classes to cells in the table head.
+You can use the [width override classes](../../styles/spacing#width-override-classes) to set the width of table columns.
 
 {{ example({group: "components", item: "table", example: "column-widths", html: true, nunjucks: true, open: false, size: "m"}) }}
+
+If the [width override classes](../../styles/spacing#width-override-classes) do not meet your needs you can create your own width classes and apply them to the cells in the table head. These can be added using the `classes` option in the Nunjucks macro or adding the class directly to the individual cells within `govuk-table__head` as below.
+
+{{ example({group: "components", item: "table", example: "column-widths-custom-classes", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ## Research on this component
 

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -41,6 +41,14 @@ When comparing columns of numbers, align the numbers to the right in table cells
 
 {{ example({group: "components", item: "table", example: "numbers", html: true, nunjucks: true, open: false, size: "m"}) }}
 
+## Custom column widths
+
+You can use the [width override classes](../../styles/spacing#width-override-classes) to set the width of table columns. 
+
+If these do not meet your needs you can set your own by by providing the `classes` option to the Nunjucks macro as shown in the example or applying CSS classes to cells in the table head.
+
+{{ example({group: "components", item: "table", example: "column-widths", html: true, nunjucks: true, open: false, size: "m"}) }}
+
 ## Research on this component
 
 If you’ve used this component, get in touch to share your user research findings.


### PR DESCRIPTION
Provide an example of how table column widths can be set using the available 'classes' parameter in the Nunjucks macro.

Addresses https://github.com/alphagov/govuk-frontend/issues/887 with an example  here.
Also part of https://trello.com/c/2A9eFRgu/1546-add-missing-documentation-to-the-design-system