### PR TITLE
Change right format to correct format

### DIFF
--- a/src/components/error-message/label/index.njk
+++ b/src/components/error-message/label/index.njk
@@ -16,6 +16,6 @@ ignore_in_sitemap: true
   id: "national-insurance-number",
   name: "national-insurance-number",
   errorMessage: {
-    text: "Enter a National Insurance number in the right format"
+    text: "Enter a National Insurance number in the correct format"
   }
 }) }}

--- a/src/patterns/email-addresses/error/index.njk
+++ b/src/patterns/email-addresses/error/index.njk
@@ -18,6 +18,6 @@ ignore_in_sitemap: true
   type: "email",
   value: "Not an email address",
   errorMessage: {
-    text: "Enter an email address in the right format, like name@example.com"
+    text: "Enter an email address in the correct format, like name@example.com"
   }
 }) }}

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -70,18 +70,13 @@ Error messages should be styled like this:
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
+#### If the email address is not in the correct format and there is no example
 
-#### If the email address is not in the right format and there is no example
+Say "Enter an email address in the correct format, like name@example.com".
 
-Say "Enter an email address in the right format, like name@example.com".
+#### If the email address is not in the correct format and there is an example
 
-
-#### If the email address is not in the right format and there is an example
-
-Say "Enter an email address in the right format".
-
-
-
+Say "Enter an email address in the correct format".
 
 ## Research on this pattern
 

--- a/src/patterns/national-insurance-numbers/error/index.njk
+++ b/src/patterns/national-insurance-numbers/error/index.njk
@@ -18,6 +18,6 @@ ignore_in_sitemap: true
   name: "national-insurance-number",
   value: "Not a National Insurance number",
   errorMessage: {
-    text: "Enter a National Insurance number in the right format"
+    text: "Enter a National Insurance number in the correct format"
   }
 }) }}

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -44,13 +44,13 @@ Error messages should be styled like this:
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
-#### If the National Insurance number is not in the right format and there is no example
+#### If the National Insurance number is not in the correct format and there is no example
 
 Say ‘Enter a National Insurance number that is 2 letters, 6 numbers, then A, B, C or D, like QQ123456C’.
 
-#### If the National Insurance number is not in the right format and there is an example
+#### If the National Insurance number is not in the correct format and there is an example
 
-Say ‘Enter a National Insurance number in the right format’.
+Say ‘Enter a National Insurance number in the correct format’.
 
 ## Research on this pattern
 

--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -35,11 +35,11 @@ Error messages should be styled like this:
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
-#### If the telephone number is not in the right format and there is no example
+#### If the telephone number is not in the correct format and there is no example
 
 Say ‘Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192’.
 
-#### If the telephone number is not in the right format and there is an example
+#### If the telephone number is not in the correct format and there is an example
 
 Say ‘Enter a telephone number in the correct format’.
 


### PR DESCRIPTION
After a discussion with other designers, we thought "right format" maybe misinterpreted by some users and thought saying "correct format" was more accessible.