### PR TITLE
Remove jquery from mobile navigation

### DIFF
--- a/src/javascripts/application.js
+++ b/src/javascripts/application.js
@@ -27,7 +27,7 @@ nodeListForEach($codeBlocks, function ($codeBlock) {
 })
 
 // Initialise mobile navigation
-MobileNav.init()
+new MobileNav().init()
 
 // Initialise search
 var $searchContainer = document.querySelector('[data-module="app-search"]')

--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -3,38 +3,38 @@ import 'govuk-frontend/vendor/polyfills/Element/prototype/classList'
 import common from 'govuk-frontend/common'
 var nodeListForEach = common.nodeListForEach
 
-var mobileNavActiveClass = 'app-mobile-nav--active'
-var mobileNavTogglerActiveClass = 'app-header-mobile-nav-toggler--active'
+var navActiveClass = 'app-mobile-nav--active'
+var navTogglerActiveClass = 'app-header-mobile-nav-toggler--active'
 var subNavActiveClass = 'app-mobile-nav__subnav--active'
 var subNavTogglerActiveClass = 'app-mobile-nav__subnav-toggler--active'
 
 function MobileNav ($module) {
   this.$module = $module || document
-  this.$mobileNav = this.$module.querySelector('.js-app-mobile-nav')
-  this.$mobileNavToggler = this.$module.querySelector('.js-app-mobile-nav-toggler')
+  this.$nav = this.$module.querySelector('.js-app-mobile-nav')
+  this.$navToggler = this.$module.querySelector('.js-app-mobile-nav-toggler')
 }
 
 MobileNav.prototype.bindUIEvents = function () {
-  var $mobileNav = this.$mobileNav
-  var $mobileNavToggler = this.$mobileNavToggler
+  var $nav = this.$nav
+  var $navToggler = this.$navToggler
 
-  $mobileNavToggler.addEventListener('click', function (e) {
-    if ($mobileNav.classList.contains(mobileNavActiveClass)) {
-      $mobileNav.classList.remove(mobileNavActiveClass)
-      $mobileNav.setAttribute('aria-hidden', 'true')
+  $navToggler.addEventListener('click', function (e) {
+    if ($nav.classList.contains(navActiveClass)) {
+      $nav.classList.remove(navActiveClass)
+      $nav.setAttribute('aria-hidden', 'true')
 
-      $mobileNavToggler.classList.remove(mobileNavTogglerActiveClass)
-      $mobileNavToggler.setAttribute('aria-expanded', 'false')
+      $navToggler.classList.remove(navTogglerActiveClass)
+      $navToggler.setAttribute('aria-expanded', 'false')
     } else {
-      $mobileNav.classList.add(mobileNavActiveClass)
-      $mobileNav.setAttribute('aria-hidden', 'false')
+      $nav.classList.add(navActiveClass)
+      $nav.setAttribute('aria-hidden', 'false')
 
-      $mobileNavToggler.setAttribute('aria-expanded', 'true')
-      $mobileNavToggler.classList.add(mobileNavTogglerActiveClass)
+      $navToggler.setAttribute('aria-expanded', 'true')
+      $navToggler.classList.add(navTogglerActiveClass)
     }
   })
 
-  $mobileNav.addEventListener('click', function (event) {
+  $nav.addEventListener('click', function (event) {
     var $toggler = event.target
     if (!$toggler.classList.contains('js-mobile-nav-subnav-toggler')) {
       return
@@ -61,13 +61,13 @@ MobileNav.prototype.bindUIEvents = function () {
 }
 
 MobileNav.prototype.includeAria = function () {
-  this.$mobileNav.setAttribute('aria-hidden', 'true')
-  this.$mobileNav.setAttribute('aria-labelledby', 'app-header-mobile-nav-toggler')
+  this.$nav.setAttribute('aria-hidden', 'true')
+  this.$nav.setAttribute('aria-labelledby', 'app-header-mobile-nav-toggler')
 
-  var $mobileNavToggler = this.$mobileNavToggler
-  $mobileNavToggler.setAttribute('aria-label', 'Toggle mobile menu')
-  $mobileNavToggler.setAttribute('aria-expanded', 'false')
-  $mobileNavToggler.setAttribute('aria-controls', 'app-mobile-nav')
+  var $navToggler = this.$navToggler
+  $navToggler.setAttribute('aria-label', 'Toggle mobile menu')
+  $navToggler.setAttribute('aria-expanded', 'false')
+  $navToggler.setAttribute('aria-controls', 'app-mobile-nav')
 
   var $subNavTogglers = this.$module.querySelectorAll('.js-mobile-nav-subnav-toggler')
 

--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -1,4 +1,8 @@
-import $ from 'jquery'
+import 'govuk-frontend/vendor/polyfills/Event'
+import 'govuk-frontend/vendor/polyfills/Element/prototype/classList'
+
+import common from 'govuk-frontend/common'
+var nodeListForEach = common.nodeListForEach
 
 var mobileNavActiveClass = 'app-mobile-nav--active'
 var mobileNavTogglerActiveClass = 'app-header-mobile-nav-toggler--active'
@@ -6,85 +10,89 @@ var subNavActiveClass = 'app-mobile-nav__subnav--active'
 var subNavTogglerActiveClass = 'app-mobile-nav__subnav-toggler--active'
 
 function MobileNav ($module) {
-  this.$module = $module
-  this.$mobileNav = $('.js-app-mobile-nav')
-  this.$mobileNavToggler = $('.js-app-mobile-nav-toggler')
-  this.$subNav = $('.js-app-mobile-nav-subnav')
-  this.$subNavToggler = $('.js-mobile-nav-subnav-toggler')
+  this.$module = $module || document
+  this.$mobileNav = this.$module.querySelector('.js-app-mobile-nav')
+  this.$mobileNavToggler = this.$module.querySelector('.js-app-mobile-nav-toggler')
+  this.$subNavTogglers = this.$module.querySelectorAll('.js-mobile-nav-subnav-toggler')
 }
 
 MobileNav.prototype.bindUIEvents = function () {
-  var self = this
-  self.$mobileNavToggler.on('click', function (e) {
-    if (self.$mobileNav.hasClass(mobileNavActiveClass)) {
-      self.$mobileNav.removeClass(mobileNavActiveClass)
-      self.$mobileNav.attr('aria-hidden', 'true')
+  var $mobileNav = this.$mobileNav
+  var $mobileNavToggler = this.$mobileNavToggler
+  var $subNavTogglers = this.$subNavTogglers
 
-      self.$mobileNavToggler.removeClass(mobileNavTogglerActiveClass)
-      self.$mobileNavToggler.attr('aria-expanded', 'false')
+  $mobileNavToggler.addEventListener('click', function (e) {
+    if ($mobileNav.classList.contains(mobileNavActiveClass)) {
+      $mobileNav.classList.remove(mobileNavActiveClass)
+      $mobileNav.setAttribute('aria-hidden', 'true')
+
+      $mobileNavToggler.classList.remove(mobileNavTogglerActiveClass)
+      $mobileNavToggler.setAttribute('aria-expanded', 'false')
     } else {
-      self.$mobileNav.addClass(mobileNavActiveClass)
-      self.$mobileNav.attr('aria-hidden', 'false')
+      $mobileNav.classList.add(mobileNavActiveClass)
+      $mobileNav.setAttribute('aria-hidden', 'false')
 
-      self.$mobileNavToggler.attr('aria-expanded', 'true')
-      self.$mobileNavToggler.addClass(mobileNavTogglerActiveClass)
+      $mobileNavToggler.setAttribute('aria-expanded', 'true')
+      $mobileNavToggler.classList.add(mobileNavTogglerActiveClass)
     }
   })
 
-  self.$subNavToggler.on('click', function () {
-    var $toggler = $(this)
-    var $nextSubNav = $(this).next(self.$subNav)
+  nodeListForEach($subNavTogglers, function ($toggler) {
+    $toggler.addEventListener('click', function (event) {
+      var $toggler = event.target
+      var $nextSubNav = $toggler.parentNode.querySelector('.js-app-mobile-nav-subnav')
 
-    if ($nextSubNav.length > 0) {
-      if ($nextSubNav.hasClass(subNavActiveClass)) {
-        $nextSubNav.removeClass(subNavActiveClass)
-        $toggler.removeClass(subNavTogglerActiveClass)
+      if ($nextSubNav) {
+        if ($nextSubNav.classList.contains(subNavActiveClass)) {
+          $nextSubNav.classList.remove(subNavActiveClass)
+          $toggler.classList.remove(subNavTogglerActiveClass)
 
-        $nextSubNav.attr('aria-hidden', 'true')
-        $toggler.attr('aria-expanded', 'false')
-      } else {
-        $nextSubNav.addClass(subNavActiveClass)
-        $toggler.addClass(subNavTogglerActiveClass)
+          $nextSubNav.setAttribute('aria-hidden', 'true')
+          $toggler.setAttribute('aria-expanded', 'false')
+        } else {
+          $nextSubNav.classList.add(subNavActiveClass)
+          $toggler.classList.add(subNavTogglerActiveClass)
 
-        $nextSubNav.attr('aria-hidden', 'false')
-        $toggler.attr('aria-expanded', 'true')
+          $nextSubNav.setAttribute('aria-hidden', 'false')
+          $toggler.setAttribute('aria-expanded', 'true')
+        }
+        event.preventDefault()
       }
-      return false
-    } else {
-      return true // Go to anchor link URL
-    }
+    })
   })
 }
 
 MobileNav.prototype.includeAria = function () {
-  var self = this
-  self.$mobileNav.attr('aria-hidden', 'true')
-  self.$mobileNav.attr('aria-labelledby', 'app-header-mobile-nav-toggler')
+  this.$mobileNav.setAttribute('aria-hidden', 'true')
+  this.$mobileNav.setAttribute('aria-labelledby', 'app-header-mobile-nav-toggler')
 
-  self.$mobileNavToggler.attr('aria-label', 'Toggle mobile menu')
-  self.$mobileNavToggler.attr('aria-expanded', 'false')
-  self.$mobileNavToggler.attr('aria-controls', 'app-mobile-nav')
+  var $mobileNavToggler = this.$mobileNavToggler
+  $mobileNavToggler.setAttribute('aria-label', 'Toggle mobile menu')
+  $mobileNavToggler.setAttribute('aria-expanded', 'false')
+  $mobileNavToggler.setAttribute('aria-controls', 'app-mobile-nav')
 
-  self.$subNavToggler.each(function (index) {
-    var $toggler = $(this)
-    var $nextSubNav = $toggler.next(self.$subNav)
+  var $subNavTogglers = this.$subNavTogglers
 
-    if ($nextSubNav.length > 0) {
-      var navIsOpen = $nextSubNav.hasClass(subNavActiveClass)
+  nodeListForEach($subNavTogglers, function ($toggler, index) {
+    var $nextSubNav = $toggler.parentNode.querySelector('.js-app-mobile-nav-subnav')
+
+    if ($nextSubNav) {
+      var navIsOpen = $nextSubNav.classList.contains(subNavActiveClass)
       var subNavTogglerId = 'js-mobile-nav-subnav-toggler-' + index
       var nextSubNavId = 'js-mobile-nav__subnav-' + index
 
-      $nextSubNav.attr('id', nextSubNavId)
-      $nextSubNav.attr('aria-hidden', navIsOpen ? 'false' : 'true')
-      $nextSubNav.attr('aria-labelledby', subNavTogglerId)
+      $nextSubNav.setAttribute('id', nextSubNavId)
+      $nextSubNav.setAttribute('aria-hidden', navIsOpen ? 'false' : 'true')
+      $nextSubNav.setAttribute('aria-labelledby', subNavTogglerId)
 
-      $toggler.attr('id', subNavTogglerId)
-      $toggler.attr('aria-label', 'Toggle subnavigation for ' + $toggler.text())
-      $toggler.attr('aria-expanded', navIsOpen ? 'true' : 'false')
-      $toggler.attr('aria-controls', nextSubNavId)
+      $toggler.setAttribute('id', subNavTogglerId)
+      $toggler.setAttribute('aria-label', 'Toggle subnavigation for ' + $toggler.innerText)
+      $toggler.setAttribute('aria-expanded', navIsOpen ? 'true' : 'false')
+      $toggler.setAttribute('aria-controls', nextSubNavId)
     }
   })
 }
+
 MobileNav.prototype.init = function () {
   this.includeAria()
   this.bindUIEvents()

--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -12,13 +12,11 @@ function MobileNav ($module) {
   this.$module = $module || document
   this.$mobileNav = this.$module.querySelector('.js-app-mobile-nav')
   this.$mobileNavToggler = this.$module.querySelector('.js-app-mobile-nav-toggler')
-  this.$subNavTogglers = this.$module.querySelectorAll('.js-mobile-nav-subnav-toggler')
 }
 
 MobileNav.prototype.bindUIEvents = function () {
   var $mobileNav = this.$mobileNav
   var $mobileNavToggler = this.$mobileNavToggler
-  var $subNavTogglers = this.$subNavTogglers
 
   $mobileNavToggler.addEventListener('click', function (e) {
     if ($mobileNav.classList.contains(mobileNavActiveClass)) {
@@ -36,28 +34,29 @@ MobileNav.prototype.bindUIEvents = function () {
     }
   })
 
-  nodeListForEach($subNavTogglers, function ($toggler) {
-    $toggler.addEventListener('click', function (event) {
-      var $toggler = event.target
-      var $nextSubNav = $toggler.parentNode.querySelector('.js-app-mobile-nav-subnav')
+  $mobileNav.addEventListener('click', function (event) {
+    var $toggler = event.target
+    if (!$toggler.classList.contains('js-mobile-nav-subnav-toggler')) {
+      return
+    }
+    var $nextSubNav = $toggler.parentNode.querySelector('.js-app-mobile-nav-subnav')
 
-      if ($nextSubNav) {
-        if ($nextSubNav.classList.contains(subNavActiveClass)) {
-          $nextSubNav.classList.remove(subNavActiveClass)
-          $toggler.classList.remove(subNavTogglerActiveClass)
+    if ($nextSubNav) {
+      if ($nextSubNav.classList.contains(subNavActiveClass)) {
+        $nextSubNav.classList.remove(subNavActiveClass)
+        $toggler.classList.remove(subNavTogglerActiveClass)
 
-          $nextSubNav.setAttribute('aria-hidden', 'true')
-          $toggler.setAttribute('aria-expanded', 'false')
-        } else {
-          $nextSubNav.classList.add(subNavActiveClass)
-          $toggler.classList.add(subNavTogglerActiveClass)
+        $nextSubNav.setAttribute('aria-hidden', 'true')
+        $toggler.setAttribute('aria-expanded', 'false')
+      } else {
+        $nextSubNav.classList.add(subNavActiveClass)
+        $toggler.classList.add(subNavTogglerActiveClass)
 
-          $nextSubNav.setAttribute('aria-hidden', 'false')
-          $toggler.setAttribute('aria-expanded', 'true')
-        }
-        event.preventDefault()
+        $nextSubNav.setAttribute('aria-hidden', 'false')
+        $toggler.setAttribute('aria-expanded', 'true')
       }
-    })
+      event.preventDefault()
+    }
   })
 }
 
@@ -70,7 +69,7 @@ MobileNav.prototype.includeAria = function () {
   $mobileNavToggler.setAttribute('aria-expanded', 'false')
   $mobileNavToggler.setAttribute('aria-controls', 'app-mobile-nav')
 
-  var $subNavTogglers = this.$subNavTogglers
+  var $subNavTogglers = this.$module.querySelectorAll('.js-mobile-nav-subnav-toggler')
 
   nodeListForEach($subNavTogglers, function ($toggler, index) {
     var $nextSubNav = $toggler.parentNode.querySelector('.js-app-mobile-nav-subnav')

--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -1,4 +1,3 @@
-import 'govuk-frontend/vendor/polyfills/Event'
 import 'govuk-frontend/vendor/polyfills/Element/prototype/classList'
 
 import common from 'govuk-frontend/common'
@@ -94,6 +93,18 @@ MobileNav.prototype.includeAria = function () {
 }
 
 MobileNav.prototype.init = function () {
+  // Since the Mobile navigation is not included in IE8
+  // We detect features we need to use only available in IE9+ https://caniuse.com/#feat=addeventlistener
+  // http://responsivenews.co.uk/post/18948466399/cutting-the-mustard
+  var featuresNeeded = (
+    'querySelector' in document &&
+    'addEventListener' in window
+  )
+
+  if (!featuresNeeded) {
+    return
+  }
+
   this.includeAria()
   this.bindUIEvents()
 }

--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -1,89 +1,93 @@
 import $ from 'jquery'
 
-var MobileNav = {
-  $mobileNav: $('.js-app-mobile-nav'),
-  $mobileNavToggler: $('.js-app-mobile-nav-toggler'),
-  mobileNavActiveClass: 'app-mobile-nav--active',
-  mobileNavTogglerActiveClass: 'app-header-mobile-nav-toggler--active',
-  $subNav: $('.js-app-mobile-nav-subnav'),
-  $subNavToggler: $('.js-mobile-nav-subnav-toggler'),
-  subNavActiveClass: 'app-mobile-nav__subnav--active',
-  subNavTogglerActiveClass: 'app-mobile-nav__subnav-toggler--active',
+var mobileNavActiveClass = 'app-mobile-nav--active'
+var mobileNavTogglerActiveClass = 'app-header-mobile-nav-toggler--active'
+var subNavActiveClass = 'app-mobile-nav__subnav--active'
+var subNavTogglerActiveClass = 'app-mobile-nav__subnav-toggler--active'
 
-  bindUIEvents: function () {
-    MobileNav.$mobileNavToggler.on('click', function (e) {
-      if (MobileNav.$mobileNav.hasClass(MobileNav.mobileNavActiveClass)) {
-        MobileNav.$mobileNav.removeClass(MobileNav.mobileNavActiveClass)
-        MobileNav.$mobileNav.attr('aria-hidden', 'true')
+function MobileNav ($module) {
+  this.$module = $module
+  this.$mobileNav = $('.js-app-mobile-nav')
+  this.$mobileNavToggler = $('.js-app-mobile-nav-toggler')
+  this.$subNav = $('.js-app-mobile-nav-subnav')
+  this.$subNavToggler = $('.js-mobile-nav-subnav-toggler')
+}
 
-        MobileNav.$mobileNavToggler.removeClass(MobileNav.mobileNavTogglerActiveClass)
-        MobileNav.$mobileNavToggler.attr('aria-expanded', 'false')
+MobileNav.prototype.bindUIEvents = function () {
+  var self = this
+  self.$mobileNavToggler.on('click', function (e) {
+    if (self.$mobileNav.hasClass(mobileNavActiveClass)) {
+      self.$mobileNav.removeClass(mobileNavActiveClass)
+      self.$mobileNav.attr('aria-hidden', 'true')
+
+      self.$mobileNavToggler.removeClass(mobileNavTogglerActiveClass)
+      self.$mobileNavToggler.attr('aria-expanded', 'false')
+    } else {
+      self.$mobileNav.addClass(mobileNavActiveClass)
+      self.$mobileNav.attr('aria-hidden', 'false')
+
+      self.$mobileNavToggler.attr('aria-expanded', 'true')
+      self.$mobileNavToggler.addClass(mobileNavTogglerActiveClass)
+    }
+  })
+
+  self.$subNavToggler.on('click', function () {
+    var $toggler = $(this)
+    var $nextSubNav = $(this).next(self.$subNav)
+
+    if ($nextSubNav.length > 0) {
+      if ($nextSubNav.hasClass(subNavActiveClass)) {
+        $nextSubNav.removeClass(subNavActiveClass)
+        $toggler.removeClass(subNavTogglerActiveClass)
+
+        $nextSubNav.attr('aria-hidden', 'true')
+        $toggler.attr('aria-expanded', 'false')
       } else {
-        MobileNav.$mobileNav.addClass(MobileNav.mobileNavActiveClass)
-        MobileNav.$mobileNav.attr('aria-hidden', 'false')
+        $nextSubNav.addClass(subNavActiveClass)
+        $toggler.addClass(subNavTogglerActiveClass)
 
-        MobileNav.$mobileNavToggler.attr('aria-expanded', 'true')
-        MobileNav.$mobileNavToggler.addClass(MobileNav.mobileNavTogglerActiveClass)
+        $nextSubNav.attr('aria-hidden', 'false')
+        $toggler.attr('aria-expanded', 'true')
       }
-    })
+      return false
+    } else {
+      return true // Go to anchor link URL
+    }
+  })
+}
 
-    MobileNav.$subNavToggler.on('click', function () {
-      var $toggler = $(this)
-      var $nextSubNav = $(this).next(MobileNav.$subNav)
+MobileNav.prototype.includeAria = function () {
+  var self = this
+  self.$mobileNav.attr('aria-hidden', 'true')
+  self.$mobileNav.attr('aria-labelledby', 'app-header-mobile-nav-toggler')
 
-      if ($nextSubNav.length > 0) {
-        if ($nextSubNav.hasClass(MobileNav.subNavActiveClass)) {
-          $nextSubNav.removeClass(MobileNav.subNavActiveClass)
-          $toggler.removeClass(MobileNav.subNavTogglerActiveClass)
+  self.$mobileNavToggler.attr('aria-label', 'Toggle mobile menu')
+  self.$mobileNavToggler.attr('aria-expanded', 'false')
+  self.$mobileNavToggler.attr('aria-controls', 'app-mobile-nav')
 
-          $nextSubNav.attr('aria-hidden', 'true')
-          $toggler.attr('aria-expanded', 'false')
-        } else {
-          $nextSubNav.addClass(MobileNav.subNavActiveClass)
-          $toggler.addClass(MobileNav.subNavTogglerActiveClass)
+  self.$subNavToggler.each(function (index) {
+    var $toggler = $(this)
+    var $nextSubNav = $toggler.next(self.$subNav)
 
-          $nextSubNav.attr('aria-hidden', 'false')
-          $toggler.attr('aria-expanded', 'true')
-        }
-        return false
-      } else {
-        return true // Go to anchor link URL
-      }
-    })
-  },
+    if ($nextSubNav.length > 0) {
+      var navIsOpen = $nextSubNav.hasClass(subNavActiveClass)
+      var subNavTogglerId = 'js-mobile-nav-subnav-toggler-' + index
+      var nextSubNavId = 'js-mobile-nav__subnav-' + index
 
-  includeAria: function () {
-    MobileNav.$mobileNav.attr('aria-hidden', 'true')
-    MobileNav.$mobileNav.attr('aria-labelledby', 'app-header-mobile-nav-toggler')
+      $nextSubNav.attr('id', nextSubNavId)
+      $nextSubNav.attr('aria-hidden', navIsOpen ? 'false' : 'true')
+      $nextSubNav.attr('aria-labelledby', subNavTogglerId)
 
-    MobileNav.$mobileNavToggler.attr('aria-label', 'Toggle mobile menu')
-    MobileNav.$mobileNavToggler.attr('aria-expanded', 'false')
-    MobileNav.$mobileNavToggler.attr('aria-controls', 'app-mobile-nav')
-
-    MobileNav.$subNavToggler.each(function (index) {
-      var $toggler = $(this)
-      var $nextSubNav = $toggler.next(MobileNav.$subNav) //
-
-      if ($nextSubNav.length > 0) {
-        var navIsOpen = $nextSubNav.hasClass(MobileNav.subNavActiveClass)
-        var subNavTogglerId = 'js-mobile-nav-subnav-toggler-' + index
-        var nextSubNavId = 'js-mobile-nav__subnav-' + index
-
-        $nextSubNav.attr('id', nextSubNavId)
-        $nextSubNav.attr('aria-hidden', navIsOpen ? 'false' : 'true')
-        $nextSubNav.attr('aria-labelledby', subNavTogglerId)
-
-        $toggler.attr('id', subNavTogglerId)
-        $toggler.attr('aria-label', 'Toggle subnavigation for ' + $toggler.text())
-        $toggler.attr('aria-expanded', navIsOpen ? 'true' : 'false')
-        $toggler.attr('aria-controls', nextSubNavId)
-      }
-    })
-  },
-  init: function () {
-    MobileNav.includeAria()
-    MobileNav.bindUIEvents()
-  }
+      $toggler.attr('id', subNavTogglerId)
+      $toggler.attr('aria-label', 'Toggle subnavigation for ' + $toggler.text())
+      $toggler.attr('aria-expanded', navIsOpen ? 'true' : 'false')
+      $toggler.attr('aria-controls', nextSubNavId)
+    }
+  })
+}
+MobileNav.prototype.init = function () {
+  this.includeAria()
+  this.bindUIEvents()
 }
 
 export default MobileNav

--- a/src/javascripts/components/search.js
+++ b/src/javascripts/components/search.js
@@ -143,13 +143,13 @@ Search.prototype.init = function () {
   // The Accessible Autocomplete only works in IE9+ so we can use newer JavaScript features here
   // but need to check for browsers that do not have these features and force the fallback by returning early.
   // http://responsivenews.co.uk/post/18948466399/cutting-the-mustard
-  var cutsTheMustard = (
+  var featuresNeeded = (
     'querySelector' in document &&
     'addEventListener' in window &&
     !!(Array.prototype && Array.prototype.forEach)
   )
 
-  if (!cutsTheMustard) {
+  if (!featuresNeeded) {
     return
   }
 

--- a/src/javascripts/components/search.js
+++ b/src/javascripts/components/search.js
@@ -145,6 +145,7 @@ Search.prototype.init = function () {
   // http://responsivenews.co.uk/post/18948466399/cutting-the-mustard
   var cutsTheMustard = (
     'querySelector' in document &&
+    'addEventListener' in window &&
     !!(Array.prototype && Array.prototype.forEach)
   )
 


### PR DESCRIPTION
Rewrites the mobile navigation JavaScript to avoid using jQuery

Worth reading this commit by commit since I needed to refactor the structure of this before rewriting it to jQuery.

## Todo

- [x] Test on mobile
- [x] Double check IE8-IE11 
- [x] Test cross browser
- [x] Check ARIA behaviour is consistent with previous implementation

https://trello.com/c/IqK2orrv/1328-update-mobile-navigationjs-to-follow-frontend-conventions-and-remove-dependency-on-jquery