### PR TITLE
Remove jQuery from Tabs

### DIFF
--- a/src/javascripts/application-ie8.js
+++ b/src/javascripts/application-ie8.js
@@ -1,7 +1,7 @@
 import common from 'govuk-frontend/common'
 import CookieBanner from './components/cookie-banner.js'
 import Example from './components/example.js'
-import Tabs from './components/tabs.js'
+import AppTabs from './components/tabs.js'
 
 var nodeListForEach = common.nodeListForEach
 
@@ -15,4 +15,7 @@ nodeListForEach($examples, function ($example) {
 })
 
 // Initialise tabs
-Tabs.init('.js-example')
+var $tabs = document.querySelectorAll('[data-module="app-tabs"]')
+nodeListForEach($tabs, function ($tabs) {
+  new AppTabs($tabs).init()
+})

--- a/src/javascripts/application.js
+++ b/src/javascripts/application.js
@@ -1,7 +1,7 @@
 import common from 'govuk-frontend/common'
 import CookieBanner from './components/cookie-banner.js'
 import Example from './components/example.js'
-import Tabs from './components/tabs.js'
+import AppTabs from './components/tabs.js'
 import Copy from './components/copy.js'
 import MobileNav from './components/mobile-navigation.js'
 import Search from './components/search.js'
@@ -18,7 +18,10 @@ nodeListForEach($examples, function ($example) {
 })
 
 // Initialise tabs
-Tabs.init('.js-example')
+var $tabs = document.querySelectorAll('[data-module="app-tabs"]')
+nodeListForEach($tabs, function ($tabs) {
+  new AppTabs($tabs).init()
+})
 
 // Add copy to clipboard to code blocks inside tab containers
 var $codeBlocks = document.querySelectorAll('[data-module="app-copy"]')

--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -1,133 +1,126 @@
-import $ from 'jquery'
+import 'govuk-frontend/vendor/polyfills/Function/prototype/bind'
+import 'govuk-frontend/vendor/polyfills/Element'
+import 'govuk-frontend/vendor/polyfills/Element/prototype/classList'
+import 'govuk-frontend/vendor/polyfills/Event'
+import common from 'govuk-frontend/common'
 
-var Tabs = {
+var nodeListForEach = common.nodeListForEach
 
-  // Reset tabs and containers
-  resetTabs: function (id) {
-    // Check if we have an id
-    if (!id) {
-      console.error('id is undefined')
-      return
+var tabsItemClass = 'app-tabs__item'
+var tabsItemCurrentClass = tabsItemClass + '--current'
+var tabsItemJsClass = 'js-tabs__item'
+var headingItemClass = 'app-tabs__heading'
+var headingItemCurrentClass = headingItemClass + '--current'
+var headingItemJsClass = 'js-tabs__heading'
+var tabContainerHiddenClass = 'app-tabs__container--hidden'
+var tabContainerJsClass = '.js-tabs__container'
+var tabContainerNoTabsJsClass = 'js-tabs__container--no-tabs'
+var tabContainerWithCloseBtnClass = 'app-tabs__container--with-close-button'
+var allTabTogglers = '.' + tabsItemJsClass + ' a, ' + '.' + headingItemJsClass + ' a'
+var tabTogglersMarkedOpenClass = '.js-tabs__item--open a'
+var closeButtonClass = 'js-tabs__close'
+
+function AppTabs ($module) {
+  this.$module = $module
+  this.$allTabContainers = this.$module.querySelectorAll(tabContainerJsClass)
+  this.$allTabTogglers = this.$module.querySelectorAll(allTabTogglers)
+  this.$allTabTogglersMarkedOpen = this.$module.querySelectorAll(tabTogglersMarkedOpenClass)
+}
+
+AppTabs.prototype.init = function () {
+  if (!this.$module) {
+    return
+  }
+  // reset all tabs
+  this.resetTabs()
+  // add close buttons to each tab
+  this.addCloseBtn()
+  this.$module.addEventListener('click', this.handleClick.bind(this))
+
+  nodeListForEach(this.$allTabTogglersMarkedOpen, function ($tabToggler) {
+    $tabToggler.click()
+  })
+}
+
+AppTabs.prototype.addCloseBtn = function () {
+  // add close button to each tab container except open one with no tab items
+  nodeListForEach(this.$allTabContainers, function ($tabContainer) {
+    if (!($tabContainer.classList.contains(tabContainerNoTabsJsClass))) {
+      var $closeButton = document.createElement('button')
+      $closeButton.className = 'app-tabs__close ' + closeButtonClass
+      $closeButton.innerText = 'Close'
+      $tabContainer.appendChild($closeButton)
+      $tabContainer.classList.add(tabContainerWithCloseBtnClass)
     }
+  })
+}
+// expand and collapse functionality
+AppTabs.prototype.activateAndToggle = function (event) {
+  event.preventDefault()
+  var $currentToggler = event.target
+  var $currentTogglerSiblings = this.$module.querySelectorAll('[href="' + $currentToggler.hash + '"]')
+  var $tabContainer = this.$module.querySelector($currentToggler.hash)
+  var isTabAlreadyOpen = $currentToggler.getAttribute('aria-expanded') === 'true'
 
-    var $example = $(id).parent()
-
-    // Reset state
-    $example.find('.js-tabs__item').removeClass('app-tabs__item--current')
-    $example.find('.js-tabs__heading').removeClass('app-tabs__heading--current')
-    $example.find('.js-tabs__item a').attr('aria-expanded', 'false')
-    $example.find('.js-tabs__container').hide().attr('aria-hidden', 'true')
-  },
-
-  // Attach aria attributes on load based on whether tabs have been set to open or closed
-  attachAriaAttributes: function (container) {
-    // Check if we have an id
-    if (!container) {
-      console.error('container is undefined')
-      return
-    }
-
-    var $example = $(container).parent()
-    var isTabOpen = $example.find('.js-tabs__item a').attr('aria-expanded')
-
-    if (!isTabOpen) {
-      $example.find('.js-tabs__item a').attr('aria-expanded', 'false')
-      $example.find('.js-tabs__container').hide().attr('aria-hidden', 'true')
-    } else {
-      $example.find('.js-tabs__item a').attr('aria-expanded', 'true')
-      $example.find('.js-tabs__container').hide().attr('aria-hidden', 'false')
-    }
-  },
-
-  // Activate current tab
-  activateAndToggleCurrentTab: function (id) {
-    // Check if we have an id
-    if (!id) {
-      console.error('id is undefined')
-      return
-    }
-
-    var $target = $('[href="' + id + '"]')
-    var isTargetOpen = $target.attr('aria-expanded') === 'true'
-    var $targetParent = $target.parent()
-
-    if (isTargetOpen) {
-      $target.attr('aria-expanded', 'false')
-      $(id).hide().attr('aria-hidden', 'true')
-
-      if ($targetParent.hasClass('app-tabs__item--current')) {
-        $targetParent.removeClass('app-tabs__item--current')
-      } else if ($targetParent.hasClass('app-tabs__heading--current')) {
-        $targetParent.removeClass('app-tabs__heading--current')
-      }
-    } else {
-      // Reset tabs
-      Tabs.resetTabs(id)
-
-      // Set current active tab for both tabs and accordion links
-      $target.attr('aria-expanded', 'true')
-      $.each($targetParent, function (key, obj) {
-        if ($(obj).hasClass('app-tabs__item')) {
-          $(obj).addClass('app-tabs__item--current')
-        } else if ($(obj).hasClass('app-tabs__heading')) {
-          $(obj).addClass('app-tabs__heading--current')
-        }
-      })
-
-      // Set current container
-      $(id).show().attr('aria-hidden', 'false')
-    }
-  },
-
-  // Tabs mode
-  clickTabItem: function (e) {
-    e.preventDefault()
-
-    // Get tab container ID
-    var id = $(this).attr('href')
-
-    // Activate current tab
-    Tabs.activateAndToggleCurrentTab(id)
-  },
-
-  // Close current container on click
-  clickCloseContainer: function (e) {
-    e.preventDefault()
-
-    // Get tab container ID and save example object
-    var id = $(this).parent().attr('id')
-
+  if (isTabAlreadyOpen) {
+    $tabContainer.classList.add(tabContainerHiddenClass)
+    $tabContainer.setAttribute('aria-hidden', 'true')
+    nodeListForEach($currentTogglerSiblings, function ($tabToggler) {
+      $tabToggler.setAttribute('aria-expanded', 'false')
+      // desktop and mobile
+      $tabToggler.parentNode.classList.remove(tabsItemCurrentClass, headingItemCurrentClass)
+    })
+  } else {
     // Reset tabs
-    Tabs.resetTabs('#' + id)
-  },
+    this.resetTabs()
+    // make current active
+    $tabContainer.classList.remove(tabContainerHiddenClass)
+    $tabContainer.setAttribute('aria-hidden', 'false')
 
-  init: function (selector) {
-    // If more than one container
-    var $examples = $(selector)
-    $.each($examples, function (key, obj) {
-      var tabsContainer = $(obj).find('.js-tabs__container')
-      if (tabsContainer.length > 0 && !tabsContainer.hasClass('js-tabs__container--no-tabs')) {
-        // Hide all containers
-        tabsContainer.hide()
-        Tabs.attachAriaAttributes(tabsContainer)
-        // Add close button to each container
-        tabsContainer.append('<button class="app-tabs__close js-tabs__close">Close</button>')
-        tabsContainer.addClass('app-tabs__container--with-close-button')
+    nodeListForEach($currentTogglerSiblings, function ($tabToggler) {
+      $tabToggler.setAttribute('aria-expanded', 'true')
+      if ($tabToggler.parentNode.classList.contains(tabsItemClass)) {
+        $tabToggler.parentNode.classList.add(tabsItemCurrentClass)
+      } else if ($tabToggler.parentNode.classList.contains(headingItemClass)) {
+        $tabToggler.parentNode.classList.add(headingItemCurrentClass)
       }
     })
+  }
+}
+// reset aria attributes to default and close the tab content container
+AppTabs.prototype.resetTabs = function () {
+  nodeListForEach(this.$allTabContainers, function ($tabContainer) {
+    // unless the tab content has not tabs and it's been set as open
+    if (!$tabContainer.classList.contains(tabContainerNoTabsJsClass)) {
+      $tabContainer.classList.add(tabContainerHiddenClass)
+      $tabContainer.setAttribute('aria-hidden', 'true')
+    }
+  })
 
-    // Bind tab item click
-    $('.js-tabs__item a').click(Tabs.clickTabItem)
+  nodeListForEach(this.$allTabTogglers, function ($tabToggler) {
+    $tabToggler.setAttribute('aria-expanded', 'false')
+    // desktop and mobile
+    $tabToggler.parentNode.classList.remove(tabsItemCurrentClass, headingItemCurrentClass)
+  })
+}
 
-    // Bind accordion item click
-    $('.js-tabs__heading a').click(Tabs.clickTabItem)
+// Close current container on click
+AppTabs.prototype.clickCloseContainer = function (event) {
+  event.preventDefault()
+  this.resetTabs()
+}
 
-    // Bind close container link
-    $('.js-tabs__close').click(Tabs.clickCloseContainer)
+AppTabs.prototype.handleClick = function (event) {
+  // toggle and active selected tab and heading (on mobile)
+  if (event.target.parentNode.classList.contains(tabsItemJsClass) ||
+    event.target.parentNode.classList.contains(headingItemJsClass)) {
+    this.activateAndToggle(event)
+  }
 
-    // Show open containers
-    $('.js-tabs__heading--open a').click()
+  // close button behavior
+  if (event.target.classList.contains(closeButtonClass)) {
+    this.clickCloseContainer(event)
   }
 }
 
-export default Tabs
+export default AppTabs

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -87,6 +87,10 @@
   border: 1px solid $govuk-border-colour;
 }
 
+.app-tabs__container--hidden {
+  display: none;
+}
+
 .app-tabs__container pre {
   max-width: inherit;
   margin-bottom: 0;

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -15,7 +15,7 @@
 
 {% set multipleTabs = params.html and params.nunjucks %}
 
-<div class="app-example-wrapper js-example" id="{{ exampleId }}">
+<div class="app-example-wrapper" id="{{ exampleId }}" data-module="app-tabs">
   <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
     <span class="app-example__new-window">
       <a href="{{ exampleURL }}" target="_blank">


### PR DESCRIPTION
Rewrites the Tabs JavaScript to avoid using jQuery

- [x] Aria attributes are correctly assigned to tab items and tab content container
- [x] works on mobile devices
- [x] works in evergreen browsers (Chrome, Firefox, Safari, Edge)
- [x] works in legacy browsers
    - [x] IE 11
    - [x] IE 10
    - [x] IE 9
    - [x] IE 8

Trello ticket: https://trello.com/c/kUIcctm7/1352-update-tabsjs-to-avoid-using-jquery-3