### PR TITLE
Prevent Google Tag Manager from updating the dataLayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prestart": "node bin/check-nvmrc.js",
     "build": "node tasks/build.js",
     "start": "node tasks/serve.js",
-    "test": "npm run lint && jest",
+    "test": "GTM_TAG=false npm run lint && jest",
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "standard",
     "lint:scss": "gulp scss:lint"

--- a/views/partials/_tracking-head.njk
+++ b/views/partials/_tracking-head.njk
@@ -1,4 +1,4 @@
-{% if GTM_TAG %}
+{% if GTM_TAG and GTM_TAG != 'false' %}
 <script>
 // Normalize doNotTrack implementations, see https://caniuse.com/#feat=do-not-track
 var DO_NOT_TRACK_ENABLED = (


### PR DESCRIPTION
I think this started failing when we published the Google Tag Manager updates.

Since we are only testing that our events are added to the data layer, and the data layer is a simple object on the window, we can force Google Tag Manager not to load which'll ensure our tests won't get polluted.