### PR TITLE
Prevent google tag manager running in tests

### DIFF
--- a/__tests__/mobile-navigation.test.js
+++ b/__tests__/mobile-navigation.test.js
@@ -11,6 +11,9 @@ let baseUrl = 'http://localhost:' + PORT
 beforeAll(async (done) => {
   browser = global.browser
   page = await browser.newPage()
+  await page.evaluateOnNewDocument(() => {
+    window.__TESTS_RUNNING = true
+  })
   await page.emulate(iPhone)
   done()
 })

--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -12,6 +12,9 @@ let baseUrl = 'http://localhost:' + PORT
 beforeEach(async (done) => {
   browser = global.browser
   page = await browser.newPage()
+  await page.evaluateOnNewDocument(() => {
+    window.__TESTS_RUNNING = true
+  })
   done()
 })
 

--- a/__tests__/tabs.test.js
+++ b/__tests__/tabs.test.js
@@ -9,6 +9,9 @@ let baseUrl = 'http://localhost:' + PORT
 beforeAll(async (done) => {
   browser = global.browser
   page = await browser.newPage()
+  await page.evaluateOnNewDocument(() => {
+    window.__TESTS_RUNNING = true
+  })
   done()
 })
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prestart": "node bin/check-nvmrc.js",
     "build": "node tasks/build.js",
     "start": "node tasks/serve.js",
-    "test": "GTM_TAG=false npm run lint && jest",
+    "test": "npm run lint && jest",
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "standard",
     "lint:scss": "gulp scss:lint"

--- a/views/partials/_tracking-head.njk
+++ b/views/partials/_tracking-head.njk
@@ -9,7 +9,7 @@ var DO_NOT_TRACK_ENABLED = (
 )
 
 // If the user has enabled 'DoNotTrack', we should not load Google Tag Manager (and therefore, Google Analytics.)
-if (!DO_NOT_TRACK_ENABLED) {
+if (!DO_NOT_TRACK_ENABLED && !window.__TESTS_RUNNING) {
   // Google Tag Manager
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/views/partials/_tracking-head.njk
+++ b/views/partials/_tracking-head.njk
@@ -1,4 +1,4 @@
-{% if GTM_TAG and GTM_TAG != 'false' %}
+{% if GTM_TAG %}
 <script>
 // Normalize doNotTrack implementations, see https://caniuse.com/#feat=do-not-track
 var DO_NOT_TRACK_ENABLED = (


### PR DESCRIPTION
We need to inject a global variable at runtime since we do not want to create additional builds as this would cause our tests to run too slowly.

Uses [evalutateOnNewDocument](https://github.com/GoogleChrome/puppeteer/blob/v1.9.0/docs/api.md#pageevaluateonnewdocumentpagefunction-args) to ensure we inject this variable before any of our code is run.

> The function is invoked after the document was created but before any of its scripts were run. This is useful to amend the JavaScript environment, e.g. to seed Math.random.

Reverts the previous attempt since while it could be useful it might confuse someone in the future since it does not actually do anything in our build pipeline.