### PR TITLE
Show scrollbars for Edge / IE11 when page is interacted with

### DIFF
--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -42,7 +42,7 @@
       > * {
         overflow-x: scroll;
         -webkit-overflow-scrolling: touch;
-        -ms-overflow-style: none;
+        -ms-overflow-style: -ms-autohiding-scrollbar;
       }
     }
   }


### PR DESCRIPTION
Until we do proper 3-pane scrollable layout we can address the scrollbar issue for Edge / IE11 when scrollbar is invisible when scrolling.

This work makes the scrollbar appear when hovered over the section or section is in focus.
Otherwise scrollbar disappears, same as it does in other browsers.

Addresses: #468

Before:
![current](https://user-images.githubusercontent.com/3758555/47847617-aae07c80-ddc3-11e8-98c0-7fe4995542cc.gif)


After:
![ie11](https://user-images.githubusercontent.com/3758555/47847546-78cf1a80-ddc3-11e8-86a2-7706d977f7e5.gif)