### PR TITLE
Update GOV.UK Frontend to v2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4836,9 +4836,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.2.0.tgz",
-      "integrity": "sha512-vNiUIp8EQACARNTyOwmE110HcQd+zJvkgbKv+gmY28QxqQGGd2DEJ35nblnjElsRJpSgbxwa85iqlNtbR3Q5tA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.3.0.tgz",
+      "integrity": "sha512-LRg8HH4657V+pDWO6wyKQLPcdsU0RJmkFHkKjj72MP5CQAg4VSWU9I5IdemHwmCcnaTAgk+ygS5e9+jd5Iz+mQ=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "autoprefixer": "^9.1.0",
     "clipboard": "^2.0.1",
     "connect": "^3.6.6",
-    "govuk-frontend": "^2.2.0",
+    "govuk-frontend": "^2.3.0",
     "gray-matter": "^4.0.1",
     "highlight.js": "^9.12.0",
     "html5shiv": "^3.7.3",


### PR DESCRIPTION
Latest released version. 
Release notes here: https://github.com/alphagov/govuk-frontend/releases/tag/v2.3.0