### PR TITLE
Fix 'Discuss' link so it points to new 'step by step' issue

### DIFF
--- a/src/patterns/step-by-step-navigation/index.md.njk
+++ b/src/patterns/step-by-step-navigation/index.md.njk
@@ -4,7 +4,7 @@ description: A starting point for your digital service on GOV.UK
 section: Patterns
 theme: Pages
 aliases:
-backlog_issue_id: 111
+backlog_issue_id: 171
 layout: layout-pane.njk
 ---
 


### PR DESCRIPTION
It was pointing to the start page issue