### PR TITLE
Prevent forms in examples from submitting

### DIFF
--- a/__tests__/example.test.js
+++ b/__tests__/example.test.js
@@ -1,0 +1,35 @@
+/* eslint-env jest */
+const configPaths = require('../config/paths.json')
+const PORT = configPaths.testPort
+
+let browser
+let page
+let baseUrl = 'http://localhost:' + PORT
+
+beforeAll(async (done) => {
+  browser = global.browser
+  page = await browser.newPage()
+  await page.evaluateOnNewDocument(() => {
+    window.__TESTS_RUNNING = true
+  })
+  done()
+})
+
+afterAll(async (done) => {
+  await page.close()
+  done()
+})
+
+describe('Example page', () => {
+  describe('that has a form', () => {
+    it('does not submit the form / reload the page', async () => {
+      const defaultExampleUrl = baseUrl + '/patterns/question-pages/default/'
+      await page.goto(defaultExampleUrl, { waitUntil: 'load' })
+      await page.waitForSelector('form[action="/form-handler"]')
+      await page.click('.govuk-button')
+      let url = await page.url()
+      // url should stay the same as the form shouldn't submit
+      expect(url).toBe(defaultExampleUrl)
+    })
+  })
+})

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -154,6 +154,21 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     ]
   }))
 
+  // build the entrypoint for example specific JavaScript
+  .use(rollup({
+    input: 'src/javascripts/example.js',
+    output: {
+      legacy: true,
+      format: 'iife',
+      file: 'javascripts/example.js'
+    },
+    plugins: [
+      // TODO: Since we're not exporting ES6 Modules to NPM we need to import these as commonjs
+      resolve(),
+      commonjs()
+    ]
+  }))
+
   // minify the JavaScript assets to reduce time it takes to download
   .use(uglify({
     uglify: {
@@ -164,7 +179,8 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
       'javascripts/application-ie8.js',
       'javascripts/application.js',
       'javascripts/head-ie8.js',
-      'javascripts/govuk-frontend.js'
+      'javascripts/govuk-frontend.js',
+      'javascripts/example.js'
     ]
   }))
 
@@ -175,7 +191,8 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
       'javascripts/application-ie8.js',
       'javascripts/application.js',
       'javascripts/head-ie8.js',
-      'javascripts/govuk-frontend.js'
+      'javascripts/govuk-frontend.js',
+      'javascripts/example.js'
     ]
   }))
 

--- a/src/javascripts/example.js
+++ b/src/javascripts/example.js
@@ -1,0 +1,25 @@
+import 'govuk-frontend/vendor/polyfills/Event'
+
+function ExamplePage ($module) {
+  this.$module = $module
+}
+ExamplePage.prototype.init = function () {
+  var $module = this.$module
+  if (!$module) {
+    return
+  }
+  var $form = $module.querySelector('form[action="/form-handler"]')
+  this.preventFormSubmission($form)
+}
+ExamplePage.prototype.preventFormSubmission = function ($form) {
+  // we should only have one form per example
+  if (!$form) {
+    return false
+  }
+  $form.addEventListener('submit', function (e) {
+    e.preventDefault()
+  })
+}
+
+var $examplePageContainer = document.querySelector('.app-example-page')
+new ExamplePage($examplePageContainer).init()

--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -18,4 +18,5 @@
 {% block bodyEnd %}
   <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
   <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
+  <script src="{{ getFingerprint('javascripts/example.js') }}"></script>
 {% endblock %}

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -26,5 +26,6 @@
     </form>
     <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
     <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
+    <script src="{{ getFingerprint('javascripts/example.js') }}"></script>
   </body>
 </html>


### PR DESCRIPTION
This work creates a new `example.js` file entry point that is imported in example layout views and it includes a function that prevents form submission.

This is needed as users can either view the example in an iframe or a separate page. On those pages we don't import `application.js`, only 'frontend.js`.

`Example.js` is rolled-up, hashed and minified in the metalsmith build process.

Example page: https://deploy-preview-621--govuk-design-system-preview.netlify.com/patterns/question-pages/

Tested in:

- [x] Modern browsers (Chrome, Firefox, Safari, Edge)
- [x] IE 9 - 11
- [x] IE 8

Trello ticket: https://trello.com/c/i3DlCyU3/1369-form-examples-in-the-design-system-load-the-system-into-the-iframe-on-submission-timebox-05-days