### PR TITLE
Proposal: Make better use of space in Nunjucks options tables

### DIFF
--- a/src/stylesheets/components/_options.scss
+++ b/src/stylesheets/components/_options.scss
@@ -13,11 +13,8 @@
   max-width: 38em;
 
   @include govuk-media-query(mobile) {
-    table-layout: fixed;
-
     .govuk-table__header,
     .govuk-table__cell {
-      padding-right: govuk-spacing(2);
       word-break: break-word;
     }
   }

--- a/src/stylesheets/components/_options.scss
+++ b/src/stylesheets/components/_options.scss
@@ -19,9 +19,3 @@
     }
   }
 }
-
-.app-options__limit-table-cell {
-  @include govuk-media-query(mobile) {
-    width: 29%;
-  }
-}

--- a/src/stylesheets/components/_options.scss
+++ b/src/stylesheets/components/_options.scss
@@ -20,15 +20,19 @@
       padding-right: govuk-spacing(2);
       word-break: break-word;
     }
+  }
+}
 
-    .govuk-table__head {
-      .govuk-table__header:first-child {
-        width: var(--app-macro-options-name-width);
-      }
+@include govuk-media-query(mobile) {
+  .app-options__limit-table-cell {
+    width: 29%;
 
-      .govuk-table__header:nth-child(2) {
-        width: var(--app-macro-options-type-width);
-      }
+    &:nth-child(1) {
+      width: var(--app-macro-options-name-width);
+    }
+
+    &:nth-child(2) {
+      width: var(--app-macro-options-type-width);
     }
   }
 }

--- a/src/stylesheets/components/_options.scss
+++ b/src/stylesheets/components/_options.scss
@@ -13,9 +13,22 @@
   max-width: 38em;
 
   @include govuk-media-query(mobile) {
+    table-layout: fixed;
+
     .govuk-table__header,
     .govuk-table__cell {
+      padding-right: govuk-spacing(2);
       word-break: break-word;
+    }
+
+    .govuk-table__head {
+      .govuk-table__header:first-child {
+        width: var(--app-macro-options-name-width);
+      }
+
+      .govuk-table__header:nth-child(2) {
+        width: var(--app-macro-options-type-width);
+      }
     }
   }
 }

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -118,8 +118,8 @@
               {% for option in table.options %}
                 <tr class="govuk-table__row">
                   <th class="govuk-table__header" scope="row">{{option.name}}</th>
-                  <td class="govuk-table__cell ">{{option.type}}</td>
-                  <td class="govuk-table__cell ">
+                  <td class="govuk-table__cell">{{option.type}}</td>
+                  <td class="govuk-table__cell">
                     {% if (option.required === true) %}
                       <strong>Required.</strong>
                     {% endif %}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -65,6 +65,32 @@
     {%- if (params.group == 'components') %}
       {% set macroOptions = getMacroOptions(params.item) %}
 
+      {% set nameCellWidth = 0 %}
+      {% set typeCellWidth = 0 %}
+      {#
+      Iterate over all the tables to find the biggest names.
+      Use that for the width of the table so that users can scan in columns between tables.
+      #}
+      {% for table in macroOptions %}
+        {% for option in table.options %}
+          {% set nameLength = (option.name | length) %}
+          {% set typeLength = (option.type | length) %}
+          {% if (nameLength) > nameCellWidth %}
+            {% set nameCellWidth = (nameLength) %}
+          {% endif %}
+          {% if (typeLength) > typeCellWidth %}
+            {% set typeCellWidth = (typeLength) %}
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
+
+      <style>
+        [id="{{ exampleId }}-nunjucks"] {
+          --app-macro-options-name-width: {{ nameCellWidth }}ch;
+          --app-macro-options-type-width: {{ typeCellWidth }}ch;
+        }
+      </style>
+
       {% set macroOptionsHTML %}
 
         <p>
@@ -77,44 +103,13 @@
         If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must sanitise the HTML to protect against  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting exploits</a>.
         </p>
 
-        {% set nameCellWidth = 0 %}
-        {% set typeCellWidth = 0 %}
-        {#
-        Iterate over all the tables to find the biggest names.
-        Use that for the width of the table so that users can scan in columns between tables.
-        #}
-        {% for table in macroOptions %}
-          {% for option in table.options %}
-            {% set nameLength = (option.name | length) %}
-            {% set typeLength = (option.type | length) %}
-            {% if (nameLength) > nameCellWidth %}
-              {% set nameCellWidth = (nameLength) %}
-            {% endif %}
-            {% if (typeLength) > typeCellWidth %}
-              {% set typeCellWidth = (typeLength) %}
-            {% endif %}
-          {% endfor %}
-        {% endfor %}
-
         {% for table in macroOptions %}
           <table class="govuk-table app-options__table" id="options-{{ exampleId }}--{{ table.id }}">
             <caption class="govuk-table__caption govuk-heading-m {% if table.id == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name }}</caption>
             <thead class="govuk-table__head">
               <tr class="govuk-table__row">
-                <th
-                  class="govuk-table__header"
-                  scope="col"
-                  {% if (nameCellWidth > 0)  %}
-                    style="width: {{ nameCellWidth }}ch"
-                  {% endif %}
-                >Name</th>
-                <th
-                  class="govuk-table__header"
-                  scope="col"
-                  {% if (typeCellWidth > 0)  %}
-                    style="width: {{ typeCellWidth }}ch"
-                  {% endif %}
-                >Type</th>
+                <th class="govuk-table__header" scope="col">Name</th>
+                <th class="govuk-table__header" scope="col">Type</th>
                 <th class="govuk-table__header" scope="col">Description</th>
               </tr>
             </thead>

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -108,8 +108,8 @@
             <caption class="govuk-table__caption govuk-heading-m {% if table.id == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name }}</caption>
             <thead class="govuk-table__head">
               <tr class="govuk-table__row">
-                <th class="govuk-table__header" scope="col">Name</th>
-                <th class="govuk-table__header" scope="col">Type</th>
+                <th class="govuk-table__header app-options__limit-table-cell" scope="col">Name</th>
+                <th class="govuk-table__header app-options__limit-table-cell" scope="col">Type</th>
                 <th class="govuk-table__header" scope="col">Description</th>
               </tr>
             </thead>

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -71,7 +71,7 @@
         Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
         </p>
         <p>
-        Some options are required for the macro to work; these are marked as "Required" in the option description.
+        Some options are required for the macro to work; these are marked as <strong>Required</strong> in the option description.
         </p>
         <p>
         If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must sanitise the HTML to protect against  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting exploits</a>.

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -77,13 +77,44 @@
         If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must sanitise the HTML to protect against  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting exploits</a>.
         </p>
 
+        {% set nameCellWidth = 0 %}
+        {% set typeCellWidth = 0 %}
+        {#
+        Iterate over all the tables to find the biggest names.
+        Use that for the width of the table so that users can scan in columns between tables.
+        #}
+        {% for table in macroOptions %}
+          {% for option in table.options %}
+            {% set nameLength = (option.name | length) %}
+            {% set typeLength = (option.type | length) %}
+            {% if (nameLength) > nameCellWidth %}
+              {% set nameCellWidth = (nameLength) %}
+            {% endif %}
+            {% if (typeLength) > typeCellWidth %}
+              {% set typeCellWidth = (typeLength) %}
+            {% endif %}
+          {% endfor %}
+        {% endfor %}
+
         {% for table in macroOptions %}
           <table class="govuk-table app-options__table" id="options-{{ exampleId }}--{{ table.id }}">
             <caption class="govuk-table__caption govuk-heading-m {% if table.id == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name }}</caption>
             <thead class="govuk-table__head">
               <tr class="govuk-table__row">
-                <th class="govuk-table__header app-options__limit-table-cell" scope="col">Name</th>
-                <th class="govuk-table__header app-options__limit-table-cell" scope="col">Type</th>
+                <th
+                  class="govuk-table__header app-options__limit-table-cell"
+                  scope="col"
+                  {% if (nameCellWidth > 0)  %}
+                    style="width: {{ nameCellWidth }}ch"
+                  {% endif %}
+                >Name</th>
+                <th
+                  class="govuk-table__header app-options__limit-table-cell"
+                  scope="col"
+                  {% if (typeCellWidth > 0)  %}
+                    style="width: {{ typeCellWidth }}ch"
+                  {% endif %}
+                >Type</th>
                 <th class="govuk-table__header" scope="col">Description</th>
               </tr>
             </thead>

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -102,14 +102,14 @@
             <thead class="govuk-table__head">
               <tr class="govuk-table__row">
                 <th
-                  class="govuk-table__header app-options__limit-table-cell"
+                  class="govuk-table__header"
                   scope="col"
                   {% if (nameCellWidth > 0)  %}
                     style="width: {{ nameCellWidth }}ch"
                   {% endif %}
                 >Name</th>
                 <th
-                  class="govuk-table__header app-options__limit-table-cell"
+                  class="govuk-table__header"
                   scope="col"
                   {% if (typeCellWidth > 0)  %}
                     style="width: {{ typeCellWidth }}ch"


### PR DESCRIPTION
The line lengths on the Nunjucks descriptions are small which I find difficult to read.

My assumption is we have fixed columns that are not based on the content since otherwise scanning between columns would be difficult.

By measuring the length of the words we can dynamically set this width giving us the best of both worlds.

With the extra space we can add in the required attribute as it's own column.

To make the descriptions even easier to read I would suggest we update GOV.UK Frontend to have them multiline.

For example:

```yaml
description: |
  First line
  Second line
```

Some of this logic might be better placed in the application rather than the view, so consider this a proposal than final code.


## Screenshots

### Back link (simple options)
#### Before
![image](https://user-images.githubusercontent.com/2445413/48020460-dd74d700-e12d-11e8-84b3-87df766c7139.png)

#### After
![image](https://user-images.githubusercontent.com/2445413/48020418-c7671680-e12d-11e8-9477-413f7e1d3dd9.png)


### Radios (complex options)
#### Before
![image](https://user-images.githubusercontent.com/2445413/48020139-09dc2380-e12d-11e8-8e5f-3a3e6b0175cc.png)

#### After
![image](https://user-images.githubusercontent.com/2445413/48020150-12345e80-e12d-11e8-9845-18d4c3b63a69.png)

