### PR TITLE
Conditional render of tab list items

### DIFF
--- a/__tests__/tabs.test.js
+++ b/__tests__/tabs.test.js
@@ -107,3 +107,19 @@ describe('Patterns page', () => {
     })
   })
 })
+
+describe('Styles -> Images page', () => {
+  describe('when both nunjucks and html parameters are set to "false"', () => {
+    it('the tab list items are not rendered', async () => {
+      await page.goto(baseUrl + '/styles/images/', { waitUntil: 'load' })
+      const tabListItems = await page.evaluate(() => document.body.querySelector('#example-default .app-tabs'))
+      expect(tabListItems).toBeFalsy()
+    })
+
+    it('the tab heading items are not rendered', async () => {
+      await page.goto(baseUrl + '/styles/images/', { waitUntil: 'load' })
+      const tabHeadingItems = await page.evaluate(() => document.body.querySelector('#example-default .app-tabs__heading'))
+      expect(tabHeadingItems).toBeFalsy()
+    })
+  })
+})

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -34,11 +34,14 @@
   </ul>
   {% elif not (params.hideTab) %}
   {% set tabType = "html" if params.html else ("nunjucks" if params.nunjucks ) %}
+  {#- if at least one tab is set to true show the list -#}
+  {% if tabType %}
   <ul class="app-tabs" role="tablist">
     <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation">
       <a href="#{{ exampleId }}-{{ tabType }}" role="tab" aria-controls="{{ exampleId }}-{{ tabType }}" data-track="tab-{{ tabType }}">{{ "HTML" if params.html else ("Nunjucks" if params.nunjucks )}}</a>
     </li>
   </ul>
+  {% endif %}
   {% endif %}
 
   {%- if (params.html) %}


### PR DESCRIPTION
If the example has both html and nunjucks set to false we don't want to render the tabs list items.

This fixes the current issue, where on [styles/images](https://design-system.service.gov.uk/styles/images/) there is an empty tab list item, even though html is set to false.

Fixes: #622 