### PR TITLE
Move GTM tag to innermost <span> in options <details>

### DIFF
--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -102,12 +102,11 @@
       {% from "details/macro.njk" import govukDetails %}
 
       {{ govukDetails({
-        summaryText: "Nunjucks macro options",
+        summaryHtml: "<span data-components='github-component-arguments'>Nunjucks macro options</span>",
         html: macroOptionsHTML,
         classes: "app-options",
         attributes:{
-          id: "options-" + exampleId + "-details",
-          "data-components": "github-component-arguments"
+          id: "options-" + exampleId + "-details"
         }
       })}}
     {% endif %}


### PR DESCRIPTION
This should have been in https://github.com/alphagov/govuk-design-system/pull/518.

Google Tag Manager looks for the innermost element as the source of clicks so the tag needs to be inside the summary.