### PR TITLE
Fix Safari layout display bug

### DIFF
--- a/config/modernizr.json
+++ b/config/modernizr.json
@@ -4,6 +4,7 @@
     "setClasses"
   ],
   "feature-detects": [
-    "test/css/flexbox"
+    "test/css/flexbox",
+    "test/css/flexboxtweener"
   ]
 }

--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -37,6 +37,7 @@
       display: flex;
       position: relative;
       min-height: 0;
+      overflow: hidden;
       flex: 1 1 100%;
 
       > * {
@@ -62,6 +63,7 @@
   .app-pane__content {
     @include govuk-media-query($from: tablet) {
       display: flex;
+      min-width: 0;
       margin-left: auto;
       flex: 1 1 auto;
       flex-direction: column;
@@ -74,7 +76,7 @@
     }
   }
 
-  .no-flexbox {
+  .no-flexbox.no-flexboxtweener {
     .app-pane {
       height: auto;
       overflow: visible;


### PR DESCRIPTION
Fixes: #624 

Based on ideas from
https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size

Browser visual check:

Safari
![screen shot 2018-11-14 at 08 10 54](https://user-images.githubusercontent.com/3758555/48468834-eed07a00-e7e4-11e8-86aa-c198f159999e.png)

Chrome:
<img width="1642" alt="screen shot 2018-11-14 at 08 10 23" src="https://user-images.githubusercontent.com/3758555/48468848-f7c14b80-e7e4-11e8-9f00-4e2a9b657a30.png">

Firefox:
<img width="1642" alt="screen shot 2018-11-14 at 08 11 20" src="https://user-images.githubusercontent.com/3758555/48468866-027be080-e7e5-11e8-8b97-1d14af3b59a2.png">

Edge: 
<img width="1409" alt="screen shot 2018-11-14 at 08 13 41" src="https://user-images.githubusercontent.com/3758555/48469107-baa98900-e7e5-11e8-926d-6aab6287a2f0.png">

IE 11: 
<img width="1419" alt="screen shot 2018-11-14 at 08 14 10" src="https://user-images.githubusercontent.com/3758555/48469114-c39a5a80-e7e5-11e8-99cc-38305a49cf7c.png">

IE 10: 
<img width="1422" alt="screen shot 2018-11-14 at 08 14 39" src="https://user-images.githubusercontent.com/3758555/48469120-cac16880-e7e5-11e8-93c7-9887a6b242a6.png">

IE 9: 
<img width="1417" alt="screen shot 2018-11-14 at 08 18 56" src="https://user-images.githubusercontent.com/3758555/48469182-09572300-e7e6-11e8-99b9-c27c1770a31b.png">

IE 8:
<img width="1413" alt="screen shot 2018-11-14 at 08 20 24" src="https://user-images.githubusercontent.com/3758555/48469230-31468680-e7e6-11e8-9246-096ea015e199.png">

to note: ie8 footer is still fubar is it is on live, partly issue with the use of HTML5 footer element
<img width="1544" alt="screen shot 2018-11-07 at 09 49 50" src="https://user-images.githubusercontent.com/3758555/48123751-9c3a0f80-e272-11e8-9ae3-e0558cf238bc.png">


