### PR TITLE
Updated error message template lists

### DIFF
--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -121,9 +121,11 @@ Use both instructions and descriptions, but use them consistently. For example, 
 Use template messages for common errors on:
 
 - [addresses](/patterns/addresses/#error-messages)
+- [character count](/components/character-count/#error-messages)
 - [checkboxes](/components/checkboxes/#error-messages)
 - [date input](/components/date-input/#error-messages)
 - [dates](/patterns/dates/#error-messages)
+- [email address](/patterns/email-addresses/#error-messages)
 - [names](/patterns/names/#error-messages)
 - [National Insurance numbers](/patterns/national-insurance-numbers/#error-messages)
 - [radios](/components/radios/#error-messages)


### PR DESCRIPTION
I have added links to character count and email addresses as part of the list of error message templates on the error summary component.