### PR TITLE
Add guidance on linking from the error summary

### DIFF
--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use this component at the top of a page to summarise any errors a user has made.
 
-When a user makes an error, you must show both an error summary and an [error message](../error-message/) next to each question that contains an error.
+When a user makes an error, you must show both an error summary and an [error message](../error-message/) next to each answer that contains an error.
 
 {{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
@@ -27,7 +27,7 @@ You must:
 - show an error summary at the top of a page
 - move keyboard focus to the error summary
 - include the heading ‘There is a problem’
-- link to each of the questions that have validation errors
+- link to each of the answers that have validation errors
 - show the same error messages next to the inputs with errors
 
 Read guidance on [writing good error messages](../error-message#be-clear-and-concise).
@@ -36,9 +36,9 @@ There are 2 ways to use the error summary component. You can use HTML or, if you
 
 {{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
 
-### Linking from the error summary to each question
+### Linking from the error summary to each answer
 
-You must link the errors in the error summary to the question they relate to.
+You must link the errors in the error summary to the answer they relate to.
 
 For questions that use a single field, for example the character count, file upload, select, textarea or text input components, link to the field.
 

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use this component at the top of a page to summarise any errors a user has made.
 
-When a user makes an error, you must show both an error summary and an [error message](../error-message/) next to each field that contains an error.
+When a user makes an error, you must show both an error summary and an [error message](../error-message/) next to each question that contains an error.
 
 {{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
@@ -27,7 +27,7 @@ You must:
 - show an error summary at the top of a page
 - move keyboard focus to the error summary
 - include the heading ‘There is a problem’
-- link to each of the validation errors
+- link to each of the questions that have validation errors
 - show the same error messages next to the inputs with errors
 
 Read guidance on [writing good error messages](../error-message#be-clear-and-concise).
@@ -35,6 +35,22 @@ Read guidance on [writing good error messages](../error-message#be-clear-and-con
 There are 2 ways to use the error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
+
+### Linking from the error summary to each question
+
+You must link the errors in the error summary to the question they relate to.
+
+For questions that use a single field, for example the character count, file upload, select, textarea or text input components, link to the field.
+
+{{ example({group: "components", item: "error-summary", example: "linking", html: true, nunjucks: true, open: false, size: "s"}) }}
+
+For questions that use multiple fields, for example the date input component, you should link to the first field that contains an error. If you don't know which fields contain errors, link to the first field.
+
+{{ example({group: "components", item: "error-summary", example: "linking-multiple-fields", html: true, nunjucks: true, open: false, size: "s"}) }}
+
+For questions that use multiple inputs, such as the checkboxes or radios components, link to the first checkbox or radio.
+
+{{ example({group: "components", item: "error-summary", example: "linking-checkboxes-radios", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ## Research on this component
 

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -40,15 +40,17 @@ There are 2 ways to use the error summary component. You can use HTML or, if you
 
 You must link the errors in the error summary to the answer they relate to.
 
-For questions that use a single field, for example the character count, file upload, select, textarea or text input components, link to the field.
+For questions that require a user to answer using a single field, like a file upload, select, textarea, text input or character count, link to the field.
 
 {{ example({group: "components", item: "error-summary", example: "linking", html: true, nunjucks: true, open: false, size: "s"}) }}
 
-For questions that use multiple fields, like the date input component, link to the first field that contains an error. If you do not know which fields contain errors, link to the first field.
+When a user has to enter their answer into multiple fields, such as the day, month and year fields in the date input component, link to the first field that contains an error.
+
+If you do not know which field contains an error, link to the first field.
 
 {{ example({group: "components", item: "error-summary", example: "linking-multiple-fields", html: true, nunjucks: true, open: false, size: "s"}) }}
 
-For questions that use multiple inputs, such as the checkboxes or radios components, link to the first checkbox or radio.
+For questions that require a user to select one or more options from a list using radios or checkboxes, link to the first radio or checkbox.
 
 {{ example({group: "components", item: "error-summary", example: "linking-checkboxes-radios", html: true, nunjucks: true, open: false, size: "s"}) }}
 

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -44,7 +44,7 @@ For questions that use a single field, for example the character count, file upl
 
 {{ example({group: "components", item: "error-summary", example: "linking", html: true, nunjucks: true, open: false, size: "s"}) }}
 
-For questions that use multiple fields, for example the date input component, you should link to the first field that contains an error. If you don't know which fields contain errors, link to the first field.
+For questions that use multiple fields, like the date input component, link to the first field that contains an error. If you do not know which fields contain errors, link to the first field.
 
 {{ example({group: "components", item: "error-summary", example: "linking-multiple-fields", html: true, nunjucks: true, open: false, size: "s"}) }}
 

--- a/src/components/error-summary/linking-checkboxes-radios/index.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/index.njk
@@ -1,6 +1,7 @@
 ---
-title: Error summary
+title: Linking from the error summary to checkboxes
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "error-summary/macro.njk" import govukErrorSummary %}

--- a/src/components/error-summary/linking-checkboxes-radios/index.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/index.njk
@@ -1,0 +1,54 @@
+---
+title: Error summary
+layout: layout-example.njk
+---
+
+{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukErrorSummary({
+  "titleText": "There is a problem",
+  "errorList": [
+    {
+      "text": "Select if you are British, Irish or a citizen of a different country",
+      "href": "#nationality"
+    }
+  ]
+}) }}
+
+{{ govukCheckboxes({
+  idPrefix: "nationality",
+  name: "nationality",
+  fieldset: {
+    legend: {
+      text: "What is your nationality?",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--xl"
+    }
+  },
+  hint: {
+    text: "If you have dual nationality, select all options that are relevant to you."
+  },
+  errorMessage: {
+    text: "Select if you are British, Irish or a citizen of a different country"
+  },
+  items: [
+    {
+      value: "british",
+      text: "British",
+      hint: {
+        text: "including English, Scottish, Welsh and Northern Irish"
+      },
+      id: "nationality"
+    },
+    {
+      value: "irish",
+      text: "Irish"
+    },
+    {
+      value: "other",
+      text: "Citizen of another country"
+    }
+  ]
+}) }}
+

--- a/src/components/error-summary/linking-multiple-fields/index.njk
+++ b/src/components/error-summary/linking-multiple-fields/index.njk
@@ -20,8 +20,8 @@ layout: layout-example.njk
   fieldset: {
     legend: {
       isPageHeading: true,
-      text: 'Label for date input',
-      classes: 'govuk-legend--xl'
+      text: 'What is your date of birth?',
+      classes: 'govuk-fieldset__legend--xl'
     }
   },
   id: 'dob',
@@ -32,12 +32,12 @@ layout: layout-example.njk
   items: [
     {
       name: "day",
-      classes: "govuk-input--width-2 govuk-input--error",
+      classes: "govuk-input--width-2",
       value: 5
     },
     {
       name: "month",
-      classes: "govuk-input--width-2 govuk-input--error",
+      classes: "govuk-input--width-2",
       value: 12
     },
     {

--- a/src/components/error-summary/linking-multiple-fields/index.njk
+++ b/src/components/error-summary/linking-multiple-fields/index.njk
@@ -1,6 +1,7 @@
 ---
-title: Error summary
+title: Linking from the error summary to an answer that uses multiple fields
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "date-input/macro.njk" import govukDateInput %}

--- a/src/components/error-summary/linking-multiple-fields/index.njk
+++ b/src/components/error-summary/linking-multiple-fields/index.njk
@@ -1,0 +1,50 @@
+---
+title: Error summary
+layout: layout-example.njk
+---
+
+{% from "date-input/macro.njk" import govukDateInput %}
+{% from "error-summary/macro.njk" import govukErrorSummary %}
+
+{{ govukErrorSummary({
+  "titleText": "There is a problem",
+  "errorList": [
+    {
+      "text": "Enter your date of birth and include a day, month and year",
+      "href": "#dob-year"
+    }
+  ]
+}) }}
+
+{{ govukDateInput({
+  fieldset: {
+    legend: {
+      isPageHeading: true,
+      text: 'Label for date input',
+      classes: 'govuk-legend--xl'
+    }
+  },
+  id: 'dob',
+  name: 'dob',
+  errorMessage: {
+    text: "Enter your date of birth and include a day, month and year"
+  },
+  items: [
+    {
+      name: "day",
+      classes: "govuk-input--width-2 govuk-input--error",
+      value: 5
+    },
+    {
+      name: "month",
+      classes: "govuk-input--width-2 govuk-input--error",
+      value: 12
+    },
+    {
+      name: "year",
+      classes: "govuk-input--width-4 govuk-input--error"
+    }
+  ]
+  })
+}}
+

--- a/src/components/error-summary/linking/index.njk
+++ b/src/components/error-summary/linking/index.njk
@@ -3,16 +3,8 @@ title: Error summary
 layout: layout-example.njk
 ---
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "button/macro.njk" import govukButton %}
-{% from "date-input/macro.njk" import govukDateInput %}
 {% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "file-upload/macro.njk" import govukFileUpload %}
 {% from "input/macro.njk" import govukInput %}
-{% from "select/macro.njk" import govukSelect %}
-{% from "radios/macro.njk" import govukRadios %}
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
-{% from "textarea/macro.njk" import govukTextarea %}
 
 {{ govukErrorSummary({
   "titleText": "There is a problem",

--- a/src/components/error-summary/linking/index.njk
+++ b/src/components/error-summary/linking/index.njk
@@ -1,6 +1,7 @@
 ---
-title: Error summary
+title: Linking from the error summary to an answer that uses a single field
 layout: layout-example.njk
+ignore_in_sitemap: true
 ---
 
 {% from "error-summary/macro.njk" import govukErrorSummary %}

--- a/src/components/error-summary/linking/index.njk
+++ b/src/components/error-summary/linking/index.njk
@@ -1,0 +1,39 @@
+---
+title: Error summary
+layout: layout-example.njk
+---
+
+{% from "back-link/macro.njk" import govukBackLink %}
+{% from "button/macro.njk" import govukButton %}
+{% from "date-input/macro.njk" import govukDateInput %}
+{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from "file-upload/macro.njk" import govukFileUpload %}
+{% from "input/macro.njk" import govukInput %}
+{% from "select/macro.njk" import govukSelect %}
+{% from "radios/macro.njk" import govukRadios %}
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% from "textarea/macro.njk" import govukTextarea %}
+
+{{ govukErrorSummary({
+  "titleText": "There is a problem",
+  "errorList": [
+    {
+      "text": "Enter your full name",
+      "href": "#name"
+    }
+  ]
+}) }}
+
+<h1 class="govuk-heading-xl">Your details</h1>
+
+{{ govukInput({
+  label: {
+    "text": 'Full name'
+  },
+  id: "name",
+  name: "name",
+  errorMessage: {
+    "text": "Enter your full name"
+  }
+}) }}
+


### PR DESCRIPTION
This introduces guidance to help service teams link from the error summary to the corresponding questions in an accessible way.

👉You can preview this change here: https://deploy-preview-634--govuk-design-system-preview.netlify.com/components/error-summary/

Our approach mirrors the [recommended approach from WebAIM][1], linking to the input in all cases.

This does mean that the input would natively be focussed at the top of the viewport, which means the associated label or legend would not be visible to the user. There is a [corresponding change to Frontend][2] to manually manage the focus and scroll state, allowing us to target and focus the input whilst scrolling to the label or legend.

To understand how to do this in an accessible way, we carried out research using a [simplified test case][3] and the assistive technologies we aim to support:

## Voiceover + Safari (macOS El Capitan)

The behaviour differs depending on whether you use Enter or Ctrl-Opt-Space to navigate.

When navigating using Enter:

- linking to the label or legend generally resulted in the focus moving but nothing being announced.
- linking to the input generally worked well, but the error message (associated using aria-describedby) was not announced for radios or checkboxes.

When navigating using Ctrl-Opt-Space:
- linking to a label worked but it was not clear how to interact with the related form contrl (the label would be read followed by "You are currently on a text element, inside of web content. To exit this web area, press Ctrl-Option-Shift-Up Arrow.")
- linking to the input worked OK, but the associated legend and error message were not read out for inputs within a fieldset

Overall, linking to the input worked better.

## Voiceover + Safari (iOS 11)

There doesn't seem to be any way to get Voiceover on iOS to do anything useful, regardless of where you link to. For everything except selects and file inputs (!?) linking to the input results in the focus and VO cursor moving, but nothing being announced. Linking to the label or legend caused Voiceover to repeat itself, and neither the focus nor the VO cursor moved at all.

There is no good option. 🤷‍♂️

We've filed [a number of bugs](https://github.com/alphagov/govuk-frontend/pull/1056#issuecomment-439381905) against WebKit that relate to the way VoiceOver behaves when linking to different types of input.

## TalkBack + Google Chrome (Android)

Linking to the input worked OK, but the associated legend and error message were not read out for inputs within a fieldset.

Linking to labels resulted in the page scrolling but nothing being announced. Linking to legends resulted in the legend and error message being read, but with no clear way to navigate to the corresponding control.

Overall, linking to the input worked better.

## NVDA + Firefox

Linking to the input only described the input type, without reading any of the associated context (label, legend, error message). We've filed [a bug against NVDA](https://github.com/alphagov/govuk-frontend/pull/1056#issuecomment-439381905) to try and get this fixed.

Linking to the label resulted in the label being read out, preceded by 'clickable'.

Overall, linking to the label worked better. However, the manual focus state management introduced in https://github.com/alphagov/govuk-frontend/pull/1056 means that linking to the input now works really well, announcing all expected context.

## JAWS2018 + IE11

Linking to the label resulted in the focus shifting down but then immediately returning to the top of the page and enters reading mode.

Linking to the input generally worked well, but the error message was not read in some cases (text areas, and error messages associated with fieldsets)

Overall, linking to the input worked better.

## Dragon NaturallySpeaking

Clicking links using Naturally Speaking's commands worked as expected in all cases.

---

https://trello.com/c/OHeUK8Df/1452-add-guidance-to-help-users-understand-how-to-link-from-the-error-summary-to-different-types-of-input

[1]: https://webaim.org/techniques/formvalidation/
[2]: https://github.com/alphagov/govuk-frontend/pull/1056
[3]: https://36degrees.github.io/linking-to-form-inputs/