### PR TITLE
add-guidance-for-conditional-reveal-with-horizontal-radios

### DIFF
--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -72,11 +72,15 @@ If one or more of your radio options is different from the others, it can help u
 
 ### Conditionally revealing content
 
-You can add conditionally revealing content to radios, so users only see content when it’s relevant to them. For example, you could reveal an email address input only when a user chooses to be contacted by email.
+Using this component, you can add conditionally revealing content to stacked radios, so users only see content when it’s relevant to them. 
+
+For example, you could reveal an email address input only when a user chooses to be contacted by email.
 
 {{ example({group: "components", item: "radios", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 Keep it simple. If you need to add a lot of content, consider showing it on the next page in the process instead.
+
+Do not use this component to add conditionally revealing content to inline radios.
 
 ### Error messages
 


### PR DESCRIPTION
This pull request adds guidance to the radios component page explaining that combining conditional reveals with inline radios is not recommended or supported.