### PR TITLE
Updated date input error messages and example

### DIFF
--- a/src/components/date-input/error/index.njk
+++ b/src/components/date-input/error/index.njk
@@ -24,12 +24,12 @@ ignore_in_sitemap: true
   },
   items: [
     {
-      classes: "govuk-input--width-2",
+      classes: "govuk-input--width-2 govuk-input--error",
       name: "day",
       value: "6"
     },
     {
-      classes: "govuk-input--width-2",
+      classes: "govuk-input--width-2 govuk-input--error",
       name: "month",
       value: "3"
     },

--- a/src/components/date-input/error/index.njk
+++ b/src/components/date-input/error/index.njk
@@ -24,12 +24,12 @@ ignore_in_sitemap: true
   },
   items: [
     {
-      classes: "govuk-input--width-2 govuk-input--error",
+      classes: "govuk-input--width-2",
       name: "day",
       value: "6"
     },
     {
-      classes: "govuk-input--width-2 govuk-input--error",
+      classes: "govuk-input--width-2",
       name: "month",
       value: "3"
     },

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -56,6 +56,14 @@ Avoid assuming what is wrong with the date. For example, if a user enters ‘31 
 Say ‘Enter [whatever it is]’.<br>
 For example, ‘Enter your date of birth’.
 
+#### If an incomplete date is entered and you know what is missing
+Say ‘[whatever it is] must include a [whatever is missing]’.
+For example, ‘Date of birth must include a month’ or ‘Date of birth must include a day and month’.
+
+#### If an incomplete date is entered and you do not know what is missing
+Say ‘Enter [whatever it is] and include a day, month and year’.
+For example, ‘Enter your date of birth and include a day, month and year’.
+
 #### If an incomplete date is entered
 
 Say ‘Enter [whatever it is] and include a day, month and year’.<br>

--- a/src/components/error-message/default/index.njk
+++ b/src/components/error-message/default/index.njk
@@ -23,12 +23,12 @@ layout: layout-example.njk
   namePrefix: "dob",
   items: [
     {
-      classes: "govuk-input--width-2",
+      classes: "govuk-input--width-2 govuk-input--error",
       name: "day",
       value: "6"
     },
     {
-      classes: "govuk-input--width-2",
+      classes: "govuk-input--width-2 govuk-input--error",
       name: "month",
       value: "3"
     },

--- a/src/components/error-summary/linking-multiple-fields/index.njk
+++ b/src/components/error-summary/linking-multiple-fields/index.njk
@@ -11,7 +11,7 @@ ignore_in_sitemap: true
   "titleText": "There is a problem",
   "errorList": [
     {
-      "text": "Enter your date of birth and include a day, month and year",
+      "text": "Date of birth must include a year",
       "href": "#dob-year"
     }
   ]
@@ -28,7 +28,7 @@ ignore_in_sitemap: true
   id: 'dob',
   name: 'dob',
   errorMessage: {
-    text: "Enter your date of birth and include a day, month and year"
+    text: "Date of birth must include a year"
   },
   items: [
     {
@@ -48,4 +48,3 @@ ignore_in_sitemap: true
   ]
   })
 }}
-


### PR DESCRIPTION
Added a new error message template following a conversation in Slack with Wayne from DVLA.

I added the error message border to the day and month fields in the date input error example and the date of birth example in error message. This is because the entire date is wrong, not just the year.

I have updated the example in the error summary to fit more with the new documentation too.