### PR TITLE
Update "updating your code" section

### DIFF
--- a/src/get-started/updating-your-code/index.md.njk
+++ b/src/get-started/updating-your-code/index.md.njk
@@ -1,6 +1,6 @@
 ---
 layout: layout-pane.njk
-title: Updating your code
+title: Updating from GOV.UK Elements and Frontend Toolkit
 section: Get started
 theme: How to guides
 order: 3

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -81,9 +81,18 @@ $app-breakpoint-widescreen: 1200px;
 
   @include govuk-responsive-padding(6);
 
-  h1,
-  h2,
-  h3,
+  h1 {
+    max-width: 15em;
+  }
+
+  h2 {
+    max-width: 20em;
+  }
+
+  h3 {
+    max-width: 30em;
+  }
+
   h4,
   h5,
   h6,
@@ -123,14 +132,14 @@ $app-breakpoint-widescreen: 1200px;
 
   // Fix monospace font size when used with relative typography
   //
-  // Browsers automatically reduce monospace font size 
+  // Browsers automatically reduce monospace font size
   //
-  // [1] restores the normal text size in Mozilla Firefox, Google Chrome, 
-  // and Safari; this unusual style rule should also be used anywhere where 
-  // you would otherwise set the font-family property to ‘monospace’. 
+  // [1] restores the normal text size in Mozilla Firefox, Google Chrome,
+  // and Safari; this unusual style rule should also be used anywhere where
+  // you would otherwise set the font-family property to ‘monospace’.
   // [2] restores the normal text size in Internet Explorer and Opera.
   //
-  // source: 
+  // source:
   // http://code.iamkate.com/html-and-css/fixing-browsers-broken-monospace-font-handling/
   pre,
   code {


### PR DESCRIPTION
Now we have been in public beta for some time "Updating your code" may not be as relevant as it was in the first few weeks after release.

I have changed the title of the page to be more specific "Updating from GOV.UK Elements and Frontend Toolkit"

In doing this I also noticed the max-widths, that limit the line length of the page were all set to the same em value. I have added specific em values for h1-3 so they have the same visual boundary as paragraphs. 