### PR TITLE
Update GOV.UK Frontend and enable error summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4836,9 +4836,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.3.0.tgz",
-      "integrity": "sha512-LRg8HH4657V+pDWO6wyKQLPcdsU0RJmkFHkKjj72MP5CQAg4VSWU9I5IdemHwmCcnaTAgk+ygS5e9+jd5Iz+mQ=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.4.0.tgz",
+      "integrity": "sha512-WSecWLGM1qZ48UD0YGGWOfaBqrWtwf39cOUAuC8+SMNh7kkZ6Ou2Y7+d3Bt8OEPaFNFR2N2vZO2WRnT2gaCjMg=="
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -4880,7 +4880,7 @@
     },
     "gulp": {
       "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
       "requires": {
@@ -6998,7 +6998,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
           "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
           "dev": true
         },
@@ -7368,7 +7368,7 @@
       "integrity": "sha1-B86EnZWjxOOY8t/ZDZS+O4hFPxY=",
       "dev": true,
       "requires": {
-        "marked": "^0.3.9"
+        "marked": "0.3.19"
       },
       "dependencies": {
         "marked": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "autoprefixer": "^9.1.0",
     "clipboard": "^2.0.1",
     "connect": "^3.6.6",
-    "govuk-frontend": "^2.3.0",
+    "govuk-frontend": "^2.4.0",
     "gray-matter": "^4.0.1",
     "highlight.js": "^9.12.0",
     "html5shiv": "^3.7.3",

--- a/src/javascripts/govuk-frontend.js
+++ b/src/javascripts/govuk-frontend.js
@@ -2,8 +2,7 @@ import Button from 'govuk-frontend/components/button/button'
 import Details from 'govuk-frontend/components/details/details'
 import CharacterCount from 'govuk-frontend/components/character-count/character-count'
 import Checkboxes from 'govuk-frontend/components/checkboxes/checkboxes'
-// Intentionally avoid importing ErrorSummary since it will steal focus, scrolling example pages.
-// import ErrorSummary from 'govuk-frontend/components/error-summary/error-summary'
+import ErrorSummary from 'govuk-frontend/components/error-summary/error-summary'
 import Radios from 'govuk-frontend/components/radios/radios'
 import Header from 'govuk-frontend/components/header/header'
 import Tabs from 'govuk-frontend/components/tabs/tabs'
@@ -13,6 +12,18 @@ new Button(document).init()
 var $details = document.querySelector('details')
 if ($details) {
   new Details($details).init()
+}
+
+var $errorSummary = document.querySelector('[data-module="error-summary"]')
+if ($errorSummary) {
+  var errorSummary = new ErrorSummary($errorSummary)
+  // Override the `init` method since it automatically focuses the ErrorSummary.
+  // This is not ideal when showing examples for this component
+  // TODO: Allow option for ErrorSummary to avoid this hack
+  errorSummary.init = function () {
+    this.$module.addEventListener('click', ErrorSummary.prototype.handleClick.bind(this))
+  }
+  errorSummary.init()
 }
 
 var $characterCount = document.querySelector('[data-module="character-count"]')


### PR DESCRIPTION
Overrides the init function to avoid the autofocus behaviour, we should remove this when the component has this option itself.
