### PR TITLE
Remove Element polyfill import in tabs.js

### DIFF
--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -1,5 +1,4 @@
 import 'govuk-frontend/vendor/polyfills/Function/prototype/bind'
-import 'govuk-frontend/vendor/polyfills/Element'
 import 'govuk-frontend/vendor/polyfills/Element/prototype/classList'
 import 'govuk-frontend/vendor/polyfills/Event'
 import common from 'govuk-frontend/common'


### PR DESCRIPTION
We fix the dependency import in GOV.UK Frontend in v2.4.0, so there is no more need to import it here.

Fixes: #637 

Tabs looking lovely in IE8 after removal

![bs_win7_ie_8 0](https://user-images.githubusercontent.com/3758555/48727477-36fafc80-ec2a-11e8-93b2-0c19a7ba9bc3.jpg)
