### PR TITLE
Update nginx buildpack to v1.0.3

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -14,8 +14,6 @@ daemon off;
 error_log stderr;
 events { worker_connections 1024; }
 
-pid /tmp/nginx.pid;
-
 http {
   charset utf-8;
 
@@ -117,7 +115,7 @@ http {
   # Set up a server!
 
   server {
-    listen {{.Port}} default_server;
+    listen {{port}} default_server;
 
     root public;
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,7 +9,7 @@ applications:
   # by GitHub URL
   #
   # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
-  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v0.0.5
+  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.0.3
   # Run two instances to ensure availability
   #
   # https://docs.cloud.service.gov.uk/managing_apps.html#scaling


### PR DESCRIPTION
This upgrades nginx from 1.13.11 to 1.15.6.

Relevant breaking changes in v1.0.0 of the buildpack:

- Change {{.Port}} to {{ port }} for nginx config templating
- Apps no longer need to set pid to /tmp/nginx.pid because the default now just works

Tested by deploying to CloudFoundry using `cf push`.

https://trello.com/c/DRa9ngrl/1536-update-nginx-buildpack