### PR TITLE
Remove link to hypothesis on Telephone numbers pattern

### DIFF
--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -72,7 +72,7 @@ It’s also not necessary - most modern mobile browsers automatically detect tel
 
 If you do need to mark up your telephone number as links, for example, to support a device that cannot automatically detect them, make sure they don’t display as links on devices that cannot make calls.
 ### Write telephone numbers in the GOV.UK style
-See the [GOV.UK style for writing telephone numbers](https://via.hypothes.is/https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#telephone-numbers).
+See the [GOV.UK style for writing telephone numbers](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#telephone-numbers).
 
 ### Avoid input masking
 


### PR DESCRIPTION
The link to the GOV.UK Style guide is - `https://via.hypothes.is/https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#telephone-numbers`

This PR removes hypothesis from the link