### PR TITLE
Add generic 'service name' to all full page examples

### DIFF
--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -12,6 +12,15 @@
   <![endif]-->
   <script src="/javascripts/vendor/modernizr.js"></script>
 {% endblock %}
+
+{% block header %}
+  {{ govukHeader({
+    homepageUrl: "#",
+    serviceName: "Service name",
+    serviceUrl: "#"
+  }) }}
+{% endblock %}
+
 {% block main %}
   {{ contents | safe }}
 {% endblock %}


### PR DESCRIPTION
This PR adds 'Service name' to our full page examples in the design system.

<img width="1274" alt="screen shot 2018-11-29 at 10 46 59" src="https://user-images.githubusercontent.com/23356842/49217118-aad49c00-f3c4-11e8-9cfa-92c5639c0f38.png">

This is one step related to an issue of services about to go live with no service name  https://trello.com/c/Ufu0Y7KE/1631-make-it-clear-which-template-govuk-services-should-be-using