### PR TITLE
Fix navigation height in Safari 9

### DIFF
--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -32,6 +32,14 @@
     }
   }
 
+  .app-pane__nav {
+    @include govuk-media-query($from: tablet) {
+      display: flex;
+      flex-direction: column;
+      flex: 1 0 auto;
+    }
+  }
+
   .app-pane__body {
     @include govuk-media-query($from: tablet) {
       display: flex;


### PR DESCRIPTION
Before:
<img width="1086" alt="screen shot 2018-11-29 at 14 43 20" src="https://user-images.githubusercontent.com/3758555/49238262-f5234080-f3f7-11e8-986f-daea36bb4a1a.png">


After:
<img width="1110" alt="screen shot 2018-11-29 at 16 55 28" src="https://user-images.githubusercontent.com/3758555/49238113-a675a680-f3f7-11e8-815e-58cd67cf49b0.png">

Browserstack says no changes to other flexbox-supporting browsers
