### PR TITLE
Fix label association for label examples

### DIFF
--- a/src/get-started/labels-legends-headings/label-h1/index.njk
+++ b/src/get-started/labels-legends-headings/label-h1/index.njk
@@ -28,6 +28,6 @@ ignore_in_sitemap: true
   hint: {
     text: "This example shows an <h1> around a <label> with the class of govuk-label--l"
   },
-  id: "example",
-  name: "example"
+  id: "example-2",
+  name: "example-2"
 }) }}

--- a/src/get-started/labels-legends-headings/label-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/label-m-s/index.njk
@@ -27,6 +27,6 @@ ignore_in_sitemap: true
   hint: {
     text: "This example shows a <label> with the class of govuk-label--s"
   },
-  id: "example",
-  name: "example"
+  id: "example-2",
+  name: "example-2"
 }) }}


### PR DESCRIPTION
Noticed that the checkboxes issue also applies to the label examples

https://github.com/alphagov/govuk-design-system/pull/662