### PR TITLE
Add summary list component

### DIFF
--- a/src/components/summary-list/default/index.njk
+++ b/src/components/summary-list/default/index.njk
@@ -18,7 +18,8 @@ layout: layout-example.njk
         items: [
           {
             href: "#",
-            text: "Change"
+            text: "Change",
+            visuallyHiddenText: "name"
           }
         ]
       }
@@ -34,7 +35,8 @@ layout: layout-example.njk
         items: [
           {
             href: "#",
-            text: "Change"
+            text: "Change",
+            visuallyHiddenText: "date of birth"
           }
         ]
       }
@@ -50,7 +52,8 @@ layout: layout-example.njk
         items: [
           {
             href: "#",
-            text: "Change"
+            text: "Change",
+            visuallyHiddenText: "contact information"
           }
         ]
       }
@@ -66,7 +69,8 @@ layout: layout-example.njk
         items: [
           {
             href: "#",
-            text: "Change"
+            text: "Change",
+            visuallyHiddenText: "contact details"
           }
         ]
       }

--- a/src/components/summary-list/default/index.njk
+++ b/src/components/summary-list/default/index.njk
@@ -46,7 +46,7 @@ layout: layout-example.njk
         text: "Contact information"
       },
       value: {
-        html: "72 Guild Street<br>\nLondon<br>\nSE23 6FH\n"
+        html: "72 Guild Street<br>London<br>SE23 6FH"
       },
       actions: {
         items: [
@@ -63,7 +63,7 @@ layout: layout-example.njk
         text: "Contact details"
       },
       value: {
-        html: "07700 900457<br>\nsarah.phillips@example.com\n"
+        html: '<p class="govuk-body">07700 900457</p><p class="govuk-body">sarah.phillips@example.com</p>'
       },
       actions: {
         items: [

--- a/src/components/summary-list/default/index.njk
+++ b/src/components/summary-list/default/index.njk
@@ -1,0 +1,75 @@
+---
+title: Summary list
+layout: layout-example.njk
+---
+
+{% from "summary-list/macro.njk" import govukSummaryList %}
+
+{{ govukSummaryList({
+  rows: [
+    {
+      key: {
+        text: "Name"
+      },
+      value: {
+        text: "Sarah Philips"
+      },
+      actions: {
+        items: [
+          {
+            href: "#",
+            text: "Change"
+          }
+        ]
+      }
+    },
+    {
+      key: {
+        text: "Date of birth"
+      },
+      value: {
+        text: "5 January 1978"
+      },
+      actions: {
+        items: [
+          {
+            href: "#",
+            text: "Change"
+          }
+        ]
+      }
+    },
+    {
+      key: {
+        text: "Contact information"
+      },
+      value: {
+        html: "72 Guild Street<br>\nLondon<br>\nSE23 6FH\n"
+      },
+      actions: {
+        items: [
+          {
+            href: "#",
+            text: "Change"
+          }
+        ]
+      }
+    },
+    {
+      key: {
+        text: "Contact details"
+      },
+      value: {
+        html: "07700 900457<br>\nsarah.phillips@example.com\n"
+      },
+      actions: {
+        items: [
+          {
+            href: "#",
+            text: "Change"
+          }
+        ]
+      }
+    }
+  ]
+}) }}

--- a/src/components/summary-list/index.md.njk
+++ b/src/components/summary-list/index.md.njk
@@ -3,7 +3,7 @@ title: Summary list
 description: Use the summary list to summarise information, for example, a user’s responses at the end of a form.
 section: Components
 aliases:
-backlog_issue_id:
+backlog_issue_id: 182
 layout: layout-pane.njk
 ---
 

--- a/src/components/summary-list/index.md.njk
+++ b/src/components/summary-list/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Summary list
-description: 
+description:
 section: Components
 aliases:
 backlog_issue_id:
@@ -9,20 +9,49 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-Lorem ipsum
+Use the summary list to summarise information, for example, a user’s responses at the end of a form.
 
 {{ example({group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component
 
-Lorem ipsum
+Use the summary list component to present pairs of related information, known as key-value pairs, in a list. The key is a description or label of a piece of information, like ‘Name’, and the value is the piece of information itself, like ‘John Smith’.
+
+You can use it to display metadata like ‘Last updated’ with a date like ‘22 June 2018’. Or to summarise a user’s responses at the end of a form like the [check answers](/patterns/check-answers) pattern.
+
+## When not to use this component
+
+The summary list uses the description list (`<dl>`) HTML element, so only use it to present information that has a key and at least one value.
+
+Do not use it for tabular data or a simple list of information or tasks, like a [task list](/patterns/task-list-pages). For those use a `<table>`, `<ul>` or `<ol>`.
+
 
 ## How it works
 
 There are 2 ways to use the summary list component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
+### Summary list with actions
+
+You can add actions to a summary list, like a ‘Change’ link to let users go back and edit their answer.
+
 {{ example({group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+
+### Summary list without actions
+
+{{ example({group: "components", item: "summary-list", example: "without-actions", html: true, nunjucks: true, open: false}) }}
+
+### Summary list without borders
+
+If you do not include actions in your summary list and it would be better for your design to remove the separating borders, use the `govuk-summary-list--no-border` class.
+
+{{ example({group: "components", item: "summary-list", example: "without-borders", html: true, nunjucks: true, open: false}) }}
 
 ## Research on this component
 
-Lorem ipsum
+This component was developed and tested by the Government Digital Services as part of the [check answers pattern](/patterns/check-answers).
+
+### Next steps
+
+More research is needed to find out how well this component works outside the check answers pattern, for example, to present summaries within caseworking systems.
+
+If you use this component in your service, get in touch to share your research findings.

--- a/src/components/summary-list/index.md.njk
+++ b/src/components/summary-list/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Summary list
-description:
+description: Use the summary list to summarise information, for example, a user’s responses at the end of a form.
 section: Components
 aliases:
 backlog_issue_id:

--- a/src/components/summary-list/index.md.njk
+++ b/src/components/summary-list/index.md.njk
@@ -1,0 +1,28 @@
+---
+title: Summary list
+description: 
+section: Components
+aliases:
+backlog_issue_id:
+layout: layout-pane.njk
+---
+
+{% from "_example.njk" import example %}
+
+Lorem ipsum
+
+{{ example({group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false}) }}
+
+## When to use this component
+
+Lorem ipsum
+
+## How it works
+
+There are 2 ways to use the summary list component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+
+{{ example({group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+
+## Research on this component
+
+Lorem ipsum

--- a/src/components/summary-list/without-actions/index.njk
+++ b/src/components/summary-list/without-actions/index.njk
@@ -28,7 +28,7 @@ layout: layout-example.njk
         text: "Contact information"
       },
       value: {
-        html: "72 Guild Street<br>\nLondon<br>\nSE23 6FH\n"
+        html: "72 Guild Street<br>London<br>SE23 6FH"
       }
     },
     {
@@ -36,7 +36,7 @@ layout: layout-example.njk
         text: "Contact details"
       },
       value: {
-        html: "07700 900457<br>\nsarah.phillips@example.com\n"
+        html: '<p class="govuk-body">07700 900457</p><p class="govuk-body">sarah.phillips@example.com</p>'
       }
     }
   ]

--- a/src/components/summary-list/without-actions/index.njk
+++ b/src/components/summary-list/without-actions/index.njk
@@ -1,0 +1,43 @@
+---
+title: Summary list
+layout: layout-example.njk
+---
+
+{% from "summary-list/macro.njk" import govukSummaryList %}
+
+{{ govukSummaryList({
+  rows: [
+    {
+      key: {
+        text: "Name"
+      },
+      value: {
+        text: "Sarah Philips"
+      }
+    },
+    {
+      key: {
+        text: "Date of birth"
+      },
+      value: {
+        text: "5 January 1978"
+      }
+    },
+    {
+      key: {
+        text: "Contact information"
+      },
+      value: {
+        html: "72 Guild Street<br>\nLondon<br>\nSE23 6FH\n"
+      }
+    },
+    {
+      key: {
+        text: "Contact details"
+      },
+      value: {
+        html: "07700 900457<br>\nsarah.phillips@example.com\n"
+      }
+    }
+  ]
+}) }}

--- a/src/components/summary-list/without-borders/index.njk
+++ b/src/components/summary-list/without-borders/index.njk
@@ -1,0 +1,44 @@
+---
+title: Summary list
+layout: layout-example.njk
+---
+
+{% from "summary-list/macro.njk" import govukSummaryList %}
+
+{{ govukSummaryList({
+  classes: 'govuk-summary-list--no-border',
+  rows: [
+    {
+      key: {
+        text: "Name"
+      },
+      value: {
+        text: "Sarah Philips"
+      }
+    },
+    {
+      key: {
+        text: "Date of birth"
+      },
+      value: {
+        text: "5 January 1978"
+      }
+    },
+    {
+      key: {
+        text: "Contact information"
+      },
+      value: {
+        html: "72 Guild Street<br>\nLondon<br>\nSE23 6FH\n"
+      }
+    },
+    {
+      key: {
+        text: "Contact details"
+      },
+      value: {
+        html: "07700 900457<br>\nsarah.phillips@example.com\n"
+      }
+    }
+  ]
+}) }}

--- a/src/components/summary-list/without-borders/index.njk
+++ b/src/components/summary-list/without-borders/index.njk
@@ -29,7 +29,7 @@ layout: layout-example.njk
         text: "Contact information"
       },
       value: {
-        html: "72 Guild Street<br>\nLondon<br>\nSE23 6FH\n"
+        html: "72 Guild Street<br>London<br>SE23 6FH"
       }
     },
     {
@@ -37,7 +37,7 @@ layout: layout-example.njk
         text: "Contact details"
       },
       value: {
-        html: "07700 900457<br>\nsarah.phillips@example.com\n"
+        html: '<p class="govuk-body">07700 900457</p><p class="govuk-body">sarah.phillips@example.com</p>'
       }
     }
   ]


### PR DESCRIPTION
https://github.com/alphagov/govuk-frontend/pull/1065

https://trello.com/c/kh2atSrd/1612-add-summary-list-component-to-govuk-frontend-pair

We probably should have some guidance on how to use the `visuallyHiddenText` option.

This is blocked on https://github.com/alphagov/govuk-design-system/pull/667

See https://github.com/alphagov/govuk-frontend/pull/1097 for an example of the two new features for check answers