### PR TITLE
Fixed typos

### DIFF
--- a/src/patterns/page-not-found-pages/default/index.njk
+++ b/src/patterns/page-not-found-pages/default/index.njk
@@ -17,7 +17,7 @@ layout: layout-example-full-page.njk
           If you pasted the web address, check you copied the entire address.
         </p>
         <p class="govuk-body">
-          If the web address is correct or you selected a link or button, <a href="#" class="govuk-link">contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits.
+          If the web address is correct or you selected a link or button, <a href="#" class="govuk-link">contact the Tax Credits Helpline</a> if you need to speak to someone about your tax credits.
         </p>
     </div>
   </div>

--- a/src/patterns/problem-with-the-service-pages/default/index.njk
+++ b/src/patterns/problem-with-the-service-pages/default/index.njk
@@ -13,7 +13,7 @@ layout: layout-example-full-page.njk
       <p class="govuk-body">Try again later.</p>
       <p class="govuk-body">We saved your answers. They will be available for 30 days.</p>
       <p class="govuk-body">
-        <a class="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
+        <a class="govuk-link" href="#">Contact the Tax Credits Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
       </p>
     </div>
   </div>

--- a/src/patterns/problem-with-the-service-pages/offline-support/index.njk
+++ b/src/patterns/problem-with-the-service-pages/offline-support/index.njk
@@ -16,7 +16,7 @@ ignore_in_sitemap: true
         We have not saved your answers. When the service is available, you will have to start again.
       </p>
       <p class="govuk-body">
-        Contact the Tax Credit Helpline if you have any questions.
+        Contact the Tax Credits Helpline if you have any questions.
       </p>
       <p class="govuk-body">
         Telephone:<br>

--- a/src/patterns/service-unavailable-pages/after-service-closes/index.njk
+++ b/src/patterns/service-unavailable-pages/after-service-closes/index.njk
@@ -15,7 +15,7 @@ ignore_in_sitemap: true
       You cannot use the online service to renew your tax credits.
     </p>
     <p class="govuk-body">
-      <a class="govuk-link" href="#">Contact the Tax Credit Helpline</a> to renew your tax credits by phone or letter.
+      <a class="govuk-link" href="#">Contact the Tax Credits Helpline</a> to renew your tax credits by phone or letter.
     </p>
     <p class="govuk-body">
       You can use the tax credits service to:

--- a/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
+++ b/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
@@ -18,7 +18,7 @@ ignore_in_sitemap: true
       We have not saved your answers. When the service is available, you will have to start again.
     </p>
     <p class="govuk-body">
-      <a class ="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
+      <a class ="govuk-link" href="#">Contact the Tax Credits Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
     </p>
   </div>
 </div>

--- a/src/patterns/service-unavailable-pages/before-service-opens/index.njk
+++ b/src/patterns/service-unavailable-pages/before-service-opens/index.njk
@@ -15,7 +15,7 @@ ignore_in_sitemap: true
       You will be able to renew your tax credits from Tuesday 24&nbsp;April&nbsp;2018.
     </p>
     <p class="govuk-body"><a class="govuk-link" href="#">
-      Contact the Tax Credit Helpline</a> to renew your tax credits by phone or letter.
+      Contact the Tax Credits Helpline</a> to renew your tax credits by phone or letter.
     </p>
     <p class="govuk-body">
       You can <a class="govuk-link" href="#">use the tax credits service</a> to:

--- a/src/patterns/service-unavailable-pages/default/index.njk
+++ b/src/patterns/service-unavailable-pages/default/index.njk
@@ -15,7 +15,7 @@ ignore_in_sitemap: true
         You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.
       </p>
       <p class="govuk-body">
-        <a class ="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
+        <a class ="govuk-link" href="#">Contact the Tax Credits Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
       </p>
     </div>
   </div>

--- a/src/patterns/service-unavailable-pages/general/index.njk
+++ b/src/patterns/service-unavailable-pages/general/index.njk
@@ -18,7 +18,7 @@ ignore_in_sitemap: true
         We saved your answers. They will be available for 30 days.
       </p>
       <p class="govuk-body"><a class="govuk-link" href="#">
-        Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
+        Contact the Tax Credits Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
       </p>
     </div>
   </div>

--- a/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
+++ b/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
@@ -18,7 +18,7 @@ ignore_in_sitemap: true
       You can <a class="govuk-link" href="#">change other VAT details</a>.
     </p>
     <p class="govuk-body">
-      <a class="govuk-link" href="#">Contact the Tax Credit Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
+      <a class="govuk-link" href="#">Contact the Tax Credits Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
     </p>
   </div>
 </div>

--- a/src/patterns/service-unavailable-pages/service-replaced/index.njk
+++ b/src/patterns/service-unavailable-pages/service-replaced/index.njk
@@ -13,7 +13,7 @@ ignore_in_sitemap: true
     <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
     <p class="govuk-body">Universal Credit has replaced tax credits.</p>
     <p class="govuk-body"><a class="govuk-link" href="#">
-      Contact the Tax Credit Helpline</a> if you need to speak to someone about your tax credits.
+      Contact the Tax Credits Helpline</a> if you need to speak to someone about your tax credits.
     </p>
     <p class="govuk-body">You can:</p>
     <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
Updated examples that mentioned 'Tax Credit Helpline' to say 'Tax Credits Helpline'.