### PR TITLE
Updated There is a problem with the service pages documentation

### DIFF
--- a/src/patterns/problem-with-the-service-pages/index.md.njk
+++ b/src/patterns/problem-with-the-service-pages/index.md.njk
@@ -27,8 +27,8 @@ Only display the page for a short time. If a problem cannot be fixed quickly, cl
 
 These pages should have:
 
-- ‘There is a problem with the service – [service name] – GOV.UK’ as the page title
-- ‘There is a problem with the service’ as the H1
+- ‘Sorry, there is a problem with the service – service name – GOV.UK’ as the page title
+- ‘Sorry, there is a problem with the service’ as the H1
 - ‘Try again later.’ as a normal paragraph
 - information about what has happened to their answers if they are in the middle of a transaction
 - contact information, if it exists and helps meet a user need


### PR DESCRIPTION
Updated the bullets under 'How it works' to include the correct page title and h1.