### PR TITLE
Update back link guidance

### DIFF
--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -25,9 +25,11 @@ Never use the back link component together with [breadcrumbs](../breadcrumbs). I
 
 ## How it works
 
-Back links must always go at the top of a page.
+Always place back links at the top of a page.
 
-Make sure the link takes users to the previous page and that it works even when JavaScript is not available.
+Make sure the link takes users to the previous page they were on, in the state they last saw it. Where possible, ensure it works even when JavaScript is not available.
+
+If this is not possible, you should hide the back link when JavaScript is not available. 
 
 There are 2 ways to use the back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -34,9 +34,9 @@ Some users do not trust browser back buttons when they’re entering data.
 
 Always include a [back link](../../components/back-link) at the top of question pages to reassure them it’s possible to go back and change previous answers.
 
-However, do not break the browser back button. Make sure it returns users to the screen they were previously on. Any data they entered should be retained.
+However, do not break the browser back button. Make sure it takes users to the previous page they were on, in the state they last saw it.
 
-An exception to this is when the user has just performed an action that can only be done once, like make a payment or submit an application. In these cases, the browser back button should still work but show the user a sensible message rather than letting them perform the action again.
+An exception to this is when the user has performed an action they should only do once, like make a payment or complete an application. The browser back button should still work, but show the user a sensible message rather than let them perform the action again.
 
 ### Page headings
 

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -30,13 +30,13 @@ If research shows it’s helpful for users, you can also include a [progress ind
 
 ### Back link
 
-Always include a [back link](../../components/back-link) on question pages.
+Some users do not trust browser back buttons when they’re entering data. 
 
-Some users do not trust browser ‘back’ buttons when they’re entering data. Add a back link to reassure users that it’s possible to go back and change previous answers.
+Always include a [back link](../../components/back-link) at the top of question pages to reassure them it’s possible to go back and change previous answers.
 
-The back link should be at the top of the page because users are most likely to want to go back when they first land on a page.
+However, do not break the browser back button. Make sure it returns users to the screen they were previously on. Any data they entered should be retained.
 
-Make sure the back link takes users to the previous page and that it still works when JavaScript is not available.
+An exception to this is when the user has just performed an action that can only be done once, like make a payment or submit an application. In these cases, the browser back button should still work but show the user a sensible message rather than letting them perform the action again.
 
 ### Page headings
 


### PR DESCRIPTION
Following a review of the back link guidance in Dropbox Paper (which has now been removed), this pull request:

- updates the Question pages guidance to say do not disable the browser back button.

- updates the back link guidance to say hide the back link if it relies on JavaScript and JavaScript is not available

