### PR TITLE
Updated heading level in example

### DIFF
--- a/src/patterns/confirmation-pages/default/index.njk
+++ b/src/patterns/confirmation-pages/default/index.njk
@@ -18,7 +18,7 @@ layout: layout-example-full-page.njk
 
       <p class="govuk-body">We have sent you a confirmation email.</p>
 
-      <h3 class="govuk-heading-m">What happens next</h3>
+      <h2 class="govuk-heading-m">What happens next</h2>
 
       <p class="govuk-body">
         We’ve sent your application to Hackney Electoral Register Office.


### PR DESCRIPTION
Changed h3 to h2 to avoid skipping a heading level.