### PR TITLE
Remove Accordion from backlog page as now published

### DIFF
--- a/src/community/backlog/index.md.njk
+++ b/src/community/backlog/index.md.njk
@@ -28,14 +28,6 @@ Here is a list of the components, patterns and updates currently on the Design S
     </tr>
     <tr>
       <td class="govuk-table__cell">
-        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/1">Accordion</a>
-      </td>
-      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
-        In progress
-      </td>
-    </tr>
-    <tr>
-      <td class="govuk-table__cell">
         <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/125">Additional information</a>
       </td>
       <td class="govuk-table__cell govuk-body-s" style="text-align: right">
@@ -286,7 +278,7 @@ Here is a list of the components, patterns and updates currently on the Design S
         To do
       </td>
     </tr>
-    
+
     <tr>
       <td class="govuk-table__cell">
         <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/83">Ethnicity</a>


### PR DESCRIPTION
This PR updates the Backlog page by removing the Accordion component from the list of backlog work, because it's now been published.