### PR TITLE
Update colours page

### DIFF
--- a/data/colours.json
+++ b/data/colours.json
@@ -32,7 +32,7 @@
   "Focus state": [
     {
       "name": "$govuk-focus-colour",
-      "notes": "Only use this colour to indicate which element is focussed on. For example, when a user tabs to an element with their keyboard."
+      "notes": "Only use this colour to indicate which element is focused on. For example, when a user tabs to an element with their keyboard."
     },
     {
       "name": "$govuk-focus-text-colour"

--- a/data/colours.json
+++ b/data/colours.json
@@ -30,14 +30,15 @@
         "notes": "Only use this colour to indicate which element is focussed on. For example, when a user tabs to an element with their keyboard."
       }
     ],
-    "Status":[
-      {
-        "name": "govuk-colour(\"blue\")",
-        "notes": "Use for phase banners"
-      },
+    "Error state": [
       {
         "name": "$govuk-error-colour",
         "notes": "Use for error messages"
+      }
+    ],
+    "Brand colour": [
+      {
+        "name": "$govuk-brand-colour"
       }
     ]
   },

--- a/data/colours.json
+++ b/data/colours.json
@@ -16,17 +16,26 @@
     },
     {
       "name": "$govuk-link-visited-colour"
+    },
+    {
+      "name": "$govuk-link-active-colour"
     }
   ],
   "Border": [
     {
       "name": "$govuk-border-colour"
+    },
+    {
+      "name": "$govuk-input-border-colour"
     }
   ],
-  "Focus": [
+  "Focus state": [
     {
       "name": "$govuk-focus-colour",
       "notes": "Only use this colour to indicate which element is focussed on. For example, when a user tabs to an element with their keyboard."
+    },
+    {
+      "name": "$govuk-focus-text-colour"
     }
   ],
   "Error state": [

--- a/data/colours.json
+++ b/data/colours.json
@@ -1,112 +1,43 @@
 {
-  "main":{
-    "Text": [
-      {
-        "name": "$govuk-text-colour"
-      },
-      {
-        "name": "$govuk-secondary-text-colour"
-      }
-    ],
-    "Links": [
-      {
-        "name": "$govuk-link-colour"
-      },
-      {
-        "name": "$govuk-link-hover-colour"
-      },
-      {
-        "name": "$govuk-link-visited-colour"
-      }
-    ],
-    "Border": [
-      {
-        "name": "$govuk-border-colour"
-      }
-    ],
-    "Focus": [
-      {
-        "name": "$govuk-focus-colour",
-        "notes": "Only use this colour to indicate which element is focussed on. For example, when a user tabs to an element with their keyboard."
-      }
-    ],
-    "Error state": [
-      {
-        "name": "$govuk-error-colour",
-        "notes": "Use for error messages"
-      }
-    ],
-    "Brand colour": [
-      {
-        "name": "$govuk-brand-colour"
-      }
-    ]
-  },
-  "greyscale":[
+  "Text": [
     {
-      "name": "govuk-colour(\"black\")"
+      "name": "$govuk-text-colour"
     },
     {
-      "name": "govuk-colour(\"grey-1\")"
-    },
-    {
-      "name": "govuk-colour(\"grey-2\")"
-    },
-    {
-      "name": "govuk-colour(\"grey-3\")"
-    },
-    {
-      "name": "govuk-colour(\"grey-4\")"
-    },
-    {
-      "name": "govuk-colour(\"white\")"
+      "name": "$govuk-secondary-text-colour"
     }
   ],
-  "extended":[
+  "Links": [
     {
-      "name": "govuk-colour(\"red\")"
+      "name": "$govuk-link-colour"
     },
     {
-      "name": "govuk-colour(\"bright-red\")"
+      "name": "$govuk-link-hover-colour"
     },
     {
-      "name": "govuk-colour(\"orange\")"
-    },
+      "name": "$govuk-link-visited-colour"
+    }
+  ],
+  "Border": [
     {
-      "name": "govuk-colour(\"brown\")"
-    },
+      "name": "$govuk-border-colour"
+    }
+  ],
+  "Focus": [
     {
-      "name": "govuk-colour(\"yellow\")"
-    },
+      "name": "$govuk-focus-colour",
+      "notes": "Only use this colour to indicate which element is focussed on. For example, when a user tabs to an element with their keyboard."
+    }
+  ],
+  "Error state": [
     {
-      "name": "govuk-colour(\"light-green\")"
-    },
+      "name": "$govuk-error-colour",
+      "notes": "Use for error messages"
+    }
+  ],
+  "Brand colour": [
     {
-      "name": "govuk-colour(\"green\")"
-    },
-    {
-      "name": "govuk-colour(\"turquoise\")"
-    },
-    {
-      "name": "govuk-colour(\"light-blue\")"
-    },
-    {
-      "name": "govuk-colour(\"blue\")"
-    },
-    {
-      "name": "govuk-colour(\"light-purple\")"
-    },
-    {
-      "name": "govuk-colour(\"purple\")"
-    },
-    {
-      "name": "govuk-colour(\"bright-purple\")"
-    },
-    {
-      "name": "govuk-colour(\"pink\")"
-    },
-    {
-      "name": "govuk-colour(\"light-pink\")"
+      "name": "$govuk-brand-colour"
     }
   ]
 }

--- a/lib/colours.js
+++ b/lib/colours.js
@@ -1,4 +1,3 @@
-const assert = require('assert')
 const exporter = require('sass-export').exporter
 
 function parseSCSS (filename) {
@@ -8,40 +7,67 @@ function parseSCSS (filename) {
   }).getStructured()
 }
 
-const parsedColoursApplied = parseSCSS('_colours-applied.scss')
-let coloursApplied = {}
-parsedColoursApplied.variables.forEach(colour => {
-  coloursApplied[colour.name] = colour.compiledValue
-})
+function getColourFromSass (sass, variableName) {
+  return sass.variables.find(variable => variable.name === variableName).compiledValue
+}
 
-// Since the palette is a map, we need to get them out differently
-const parsedColoursPalette = parseSCSS('_colours-palette.scss')
-let coloursPalette = {}
-parsedColoursPalette.variables[0].mapValue.forEach(colour => {
-  coloursPalette[`govuk-colour("${colour.name}")`] = colour.compiledValue
-})
+/**
+ * Get colour palette
+ *
+ * Extracts the colour palette from the $govuk-colours map defined in
+ * settings/_colours-palette.scss in GOV.UK Frontend
+ *
+ * @return Object mapping colour names to their hexidecimal values
+ */
 
-// combine both SCSS data objects - some Main colours are only in Palette
-const coloursSCSS = Object.assign(coloursApplied, coloursPalette)
+const palette = function () {
+  const paletteSass = parseSCSS('_colours-palette.scss')
+  const paletteMap = paletteSass.variables.find(variable => variable.name === '$govuk-colours').mapValue
 
-// process colours data
-let colours = require('../data/colours.json')
+  // Reduce the array of Sass map entry objects down into a single object
+  return paletteMap.reduce((accumulator, mapEntry) => {
+    accumulator[mapEntry.name] = mapEntry.compiledValue
+    return accumulator
+  }, {})
+}
 
-assert.notStrictEqual(colours.main, undefined, 'colours.main is not defined')
+/**
+ * Get applied colours
+ *
+ * Adds colour definitions to the colours data defined in data/colours.json,
+ * looking up the hexidecimal values from their definitions in
+ * settings/_colours-applied.scss in GOV.UK Frontend
+ *
+ * Example output:
+ *
+ * ```
+ * { Text: [
+ *     { name: '$govuk-text-colour', colour: '#0b0c0c', 'notes': '' },
+ *     { name: '$govuk-secondary-text-colour', colour: '#6f777b', 'notes': '' },
+ *   ],
+ *   ...
+ * }
+ * ```
+ *
+ * @return Object containing 'groups' of colours
+ */
 
-for (var groupName in colours.main) {
-  var group = colours.main[groupName]
-  for (let colour of group) {
-    colour.colour = coloursSCSS[colour.name]
+const applied = function () {
+  let data = require('../data/colours.json')
+  const sass = parseSCSS('_colours-applied.scss')
+
+  for (let group in data) {
+    data[group] = data[group].map(colour => {
+      colour.colour = getColourFromSass(sass, colour.name)
+
+      return colour
+    })
   }
+
+  return data
 }
 
-for (let colour of colours.greyscale) {
-  colour.colour = coloursSCSS[colour.name]
+module.exports = {
+  applied: applied(),
+  palette: palette()
 }
-
-for (let colour of colours.extended) {
-  colour.colour = coloursSCSS[colour.name]
-}
-
-module.exports = colours

--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -16,14 +16,17 @@ your service meets [level AA of the Web Content Accessibility Guidelines
 
 ## Main colours
 
-Use the Sass variables provided rather than copying the hexadecimal colour
-codes. This means that your service will always use the most recent colour
-palette when you update GOV.UK Frontend.
+If you are using GOV.UK Frontend or the GOV.UK Prototype Kit, use the [Sass
+variables](https://sass-lang.com/guide#topic-2) provided rather than copying the
+hexadecimal (hex) colour values. For example, use `$govuk-brand-colour` rather
+than `{{ colours.applied['Brand colour'][0]['colour'] | trim }}`.
+This means that your service will always use the most recent colour palette
+whenever you update.
 
-Avoid using these variables to re-use colours in different contexts. For
-example, if you wanted to use red to represent some data in a graph, use
-`govuk-colour("red")` to reference the [colour palette](#colour-palette)
-directly rather than reusing `$govuk-error-colour`.
+Only uses the variables in the context they're designed for. In all other cases,
+you should reference the [colour palette](#colour-palette) directly. For
+example, if you wanted to use red to represent some data in a graph you should
+use `govuk-colour("red")` rather than `$govuk-error-colour`.
 
 <table class="govuk-body app-colour-list" summary="Table of main colours">
   <tbody>
@@ -59,11 +62,12 @@ directly rather than reusing `$govuk-error-colour`.
 Use these colours for graphs and supporting material.
 
 To reference colours from the palette directly you should use the `govuk-colour`
-function.
+function. For example, `color: govuk-colour("blue")`.
 
-Avoid using the palette colours directly when there is a contextual colour that
-meets your use case. For example, if you are styling a component's error state
-you should use `$govuk-error-colour` rather than `govuk-colour("red")`.
+Avoid using the palette colours if there is a Sass variable that is designed for
+your context. For example, if you are styling the error state of a component you
+should use the `$govuk-error-colour` Sass variable rather than
+`govuk-colour("red")`.
 
 If you need to use tints of the extended palette, use either 25% or 50%.
 

--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -23,7 +23,7 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
 <table class="govuk-body app-colour-list" summary="Table of main colours">
   <tbody>
   {# colours is an object built by ./lib/colours.js based on data defined in ./data/colours.json #}
-  {% for groupName, group in colours.main %}
+  {% for groupName, group in colours.applied %}
     <tr>
       <td colspan="3">
         <h3 class="govuk-heading-m {% if not loop.first %}govuk-!-padding-top-6{% endif %}">
@@ -36,7 +36,7 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
       <tr class="app-colour-list-row">
 
         <th class="app-colour-list-column app-colour-list-column--name" scope="row">
-          <span class="app-swatch {% if colour.colour == "#fff" %}app-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
+          <span class="app-swatch {% if colour.colour == "#ffffff" %}app-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
           <code>{{colour.name}}</code>
         </th>
         <td class="app-colour-list-column app-colour-list-column--colour">
@@ -54,33 +54,6 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
   </tbody>
 </table>
 
-## Greyscale
-
-<table class="govuk-body app-colour-list" summary="Table of greyscale colours"> 
-
-  <tbody>
-  {% for colour in colours.greyscale %}
-
-    <tr class="app-colour-list-row">
-
-      <th class="app-colour-list-column app-colour-list-column--name">
-        <span class="app-swatch {% if colour.colour == "#ffffff" %}app-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
-        <code>{{colour.name}}</code>
-      </th>
-
-      <td class="app-colour-list-column app-colour-list-column--colour">
-        {{colour.colour}}
-      </td>
-      <td class="app-colour-list-column app-colour-list-column--notes">
-        {{colour.notes}}
-      </td>
-
-    </tr>
-
-  {% endfor %}
-  </tbody>
-</table>
-
 ## Extended colours
 
 Use these colours for graphs and supporting material.
@@ -92,21 +65,18 @@ You can find departmental colours in the GOV.UK Frontend [_colours-organisations
 <table class="govuk-body app-colour-list" summary="Table of extended colours">
 
   <tbody>
-  {% for colour in colours.extended %}
+  {% for name, colour in colours.palette %}
 
     <tr class="app-colour-list-row">
 
       <th class="app-colour-list-column app-colour-list-column--name">
-        <span class="app-swatch {% if colour.colour == "#fff" %}app-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
-        <code>{{colour.name}}</code>
+        <span class="app-swatch {% if colour == "#ffffff" %}app-swatch-border{% endif %}" style="background-color:{{colour}}"></span>
+        <code>govuk-colour("{{name}}")</code>
       </th>
       <td class="app-colour-list-column app-colour-list-column--colour">
-        {{colour.colour}}
+        {{colour}}
       </td>
-      <td class="app-colour-list-column app-colour-list-column--notes">
-        {{colour.notes}}
-      </td>
-
+      <td class="app-colour-list-column app-colour-list-column--notes"></td>
     </tr>
 
   {% endfor %}

--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -14,11 +14,16 @@ You must make sure that the contrast ratio of text and interactive elements in
 your service meets [level AA of the Web Content Accessibility Guidelines
 (WCAG 2.0)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
 
-## Sass variables
-Use the Sass variables listed below, so you’ll automatically get any updates to
-the GOV.UK colour palette when you update GOV.UK Frontend.
-
 ## Main colours
+
+Use the Sass variables provided rather than copying the hexadecimal colour
+codes. This means that your service will always use the most recent colour
+palette when you update GOV.UK Frontend.
+
+Avoid using these variables to re-use colours in different contexts. For
+example, if you wanted to use red to represent some data in a graph, use
+`govuk-colour("red")` to reference the [colour palette](#colour-palette)
+directly rather than reusing `$govuk-error-colour`.
 
 <table class="govuk-body app-colour-list" summary="Table of main colours">
   <tbody>
@@ -32,9 +37,7 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
       </td>
     </tr>
     {% for colour in group %}
-
       <tr class="app-colour-list-row">
-
         <th class="app-colour-list-column app-colour-list-column--name" scope="row">
           <span class="app-swatch {% if colour.colour == "#ffffff" %}app-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
           <code>{{colour.name}}</code>
@@ -45,30 +48,31 @@ the GOV.UK colour palette when you update GOV.UK Frontend.
         <td class="app-colour-list-column app-colour-list-column--notes">
           {{colour.notes}}
         </td>
-
       </tr>
     {% endfor %}
-    
-
   {% endfor %}
   </tbody>
 </table>
 
-## Extended colours
+## Colour palette
 
 Use these colours for graphs and supporting material.
+
+To reference colours from the palette directly you should use the `govuk-colour`
+function.
+
+Avoid using the palette colours directly when there is a contextual colour that
+meets your use case. For example, if you are styling a component's error state
+you should use `$govuk-error-colour` rather than `govuk-colour("red")`.
 
 If you need to use tints of the extended palette, use either 25% or 50%.
 
 You can find departmental colours in the GOV.UK Frontend [_colours-organisations](https://github.com/alphagov/govuk-frontend/blob/master/src/settings/_colours-organisations.scss) file.
 
 <table class="govuk-body app-colour-list" summary="Table of extended colours">
-
   <tbody>
   {% for name, colour in colours.palette %}
-
     <tr class="app-colour-list-row">
-
       <th class="app-colour-list-column app-colour-list-column--name">
         <span class="app-swatch {% if colour == "#ffffff" %}app-swatch-border{% endif %}" style="background-color:{{colour}}"></span>
         <code>govuk-colour("{{name}}")</code>
@@ -78,7 +82,6 @@ You can find departmental colours in the GOV.UK Frontend [_colours-organisations
       </td>
       <td class="app-colour-list-column app-colour-list-column--notes"></td>
     </tr>
-
   {% endfor %}
  </tbody>
 </table>


### PR DESCRIPTION
Replace reference to `govuk-colour("blue")` in the 'main colours' section with a reference to `$govuk-brand-colour`.

Add guidance to discourage people from using the palette when there is a variable that meets their use case, and also from using the semantic variables for unrelated purposes.

Move the guidance about using sass variables into the ‘main colours’ section.

Add undocumented colours (`$govuk-input-border-colour`, `$govuk-link-active-colour`, `$govuk-focus-text-colour`)

Refactor the colour library code – primarily to avoid having to define the palette again.

Hopefully this should help to clear up some of the confusion discussed in https://github.com/alphagov/govuk-frontend/issues/920

👉[Preview change](https://deploy-preview-717--govuk-design-system-preview.netlify.com/styles/colour/)