### PR TITLE
Add guidance and examples for `spellcheck="false"`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4631,8 +4631,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4653,14 +4652,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4675,20 +4672,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4805,8 +4799,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4818,7 +4811,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4833,7 +4825,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4841,14 +4832,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4867,7 +4856,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4948,8 +4936,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4961,7 +4948,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5047,8 +5033,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5084,7 +5069,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5104,7 +5088,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5148,14 +5131,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5232,7 +5213,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -6767,7 +6748,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },

--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -15,6 +15,9 @@ ignore_in_sitemap: true
   classes: "govuk-!-width-one-third",
   label: {
     text: "Email address"
+  },
+  attributes: {
+    spellcheck: "false"
   }
 }) }}
 {% endset -%}

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -15,6 +15,9 @@ ignore_in_sitemap: true
   classes: "govuk-!-width-one-third",
   label: {
     text: "Email address"
+  },
+  attributes: {
+    spellcheck: "false"
   }
 }) }}
 {% endset -%}

--- a/src/components/text-input/default/index.njk
+++ b/src/components/text-input/default/index.njk
@@ -7,8 +7,8 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    text: "Full name"
+    text: "Event name"
   },
-  id: "name",
-  name: "name"
+  id: "event-name",
+  name: "event-name"
 }) }}

--- a/src/components/text-input/error/index.njk
+++ b/src/components/text-input/error/index.njk
@@ -8,11 +8,14 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "First name"
+    text: "Event name"
   },
-  id: "first-name",
-  name: "first-name",
+  id: "event-name",
+  name: "event-name",
+  hint: {
+    text: "The name you'll use on promotional material."
+  },
   errorMessage: {
-    text: "Enter your first name"
+    text: "Enter an event name"
   }
 }) }}

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -81,6 +81,12 @@ You will not normally need to use the `autocomplete` attribute in prototypes, as
 
 Users often need to copy and paste information into a text input, so do not stop them from doing this.
 
+### Do not spell check user input in some cases
+
+If you ask users for data such as reference numbers or document numbers that don't contain human readable content, it is recommended to disable spell check using `spellcheck="false"` so that browsers don't [suggest or make corrections](https://github.com/alphagov/govuk-frontend/issues/1129#issuecomment-455584260) to the user input.
+
+{{ example({group: "components", item: "text-input", example: "input-spellcheck-disabled", html: true, nunjucks: true, open: false, size: "s"}) }}
+
 ### Error messages
 
 Error messages should be styled like this:

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -59,9 +59,9 @@ Fluid width inputs will resize with the viewport.
 
 {{ example({group: "components", item: "text-input", example: "input-fluid-width", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
-### Using hint text
+### Hint text
 
-Use hint for help that’s relevant to the majority of users - like how their information will be used, or where to find it.
+Use hint for help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
 {{ example({group: "components", item: "text-input", example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s"}) }}
 
@@ -81,11 +81,17 @@ You will not normally need to use the `autocomplete` attribute in prototypes, as
 
 Users often need to copy and paste information into a text input, so do not stop them from doing this.
 
-### Do not spell check user input in some cases
+### How and when to spellcheck a user’s input
 
-If you ask users for data such as reference numbers or document numbers that don't contain human readable content, it is recommended to disable spell check using `spellcheck="false"` so that browsers don't [suggest or make corrections](https://github.com/alphagov/govuk-frontend/issues/1129#issuecomment-455584260) to the user input.
+Sometimes, browsers will spellcheck the information a user puts into a text input. If a user enters something which is recognised as a spelling error, sighted users will see a red line under the word.
 
-{{ example({group: "components", item: "text-input", example: "input-spellcheck-disabled", html: true, nunjucks: true, open: false, size: "s"}) }}
+If you are asking users for information which is not appropriate to spellcheck, like a reference number, name, email address or National Insurance number, disable the spellcheck.
+
+To do this set the `spellcheck` attribute to `false` as shown in this example.
+
+{{ example({group: "components", item: "text-input", example: "input-spellcheck-disabled", html: true, nunjucks: true, displayExample: false, open: true, size: "s"}) }}
+
+Browsers do not consistently spellcheck user’s input by default. If you are asking a question where spellcheck would be useful, set the `spellcheck` attribute to `true`.
 
 ### Error messages
 

--- a/src/components/text-input/input-hint-text/index.njk
+++ b/src/components/text-input/input-hint-text/index.njk
@@ -1,5 +1,5 @@
 ---
-title: National insurance numbers
+title: Hint text
 layout: layout-example.njk
 ignore_in_sitemap: true
 ---
@@ -8,12 +8,11 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "National Insurance number"
+    text: "Event name"
   },
   hint: {
-    text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    text: "The name you'll use on promotional material."
   },
-  classes: "govuk-input--width-10",
-  id: "national-insurance-number",
-  name: "national-insurance-number"
+  id: "event-name",
+  name: "event-name"
 }) }}

--- a/src/components/text-input/input-spellcheck-disabled/index.njk
+++ b/src/components/text-input/input-spellcheck-disabled/index.njk
@@ -1,0 +1,17 @@
+---
+title: Text input with spellcheck disabled
+layout: layout-example.njk
+---
+
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "Reference number"
+  },
+  id: "name",
+  name: "name",
+  attributes: {
+    spellcheck: "false"
+  }
+}) }}

--- a/src/patterns/email-addresses/default/index.njk
+++ b/src/patterns/email-addresses/default/index.njk
@@ -15,5 +15,8 @@ layout: layout-example.njk
   id: "email",
   name: "email",
   type: "email",
-  autocomplete: "email"
+  autocomplete: "email",
+  attributes: {
+    spellcheck: "false"
+  }
 }) }}

--- a/src/patterns/email-addresses/error/index.njk
+++ b/src/patterns/email-addresses/error/index.njk
@@ -20,5 +20,8 @@ ignore_in_sitemap: true
   autocomplete: "email",
   errorMessage: {
     text: "Enter an email address in the correct format, like name@example.com"
+  },
+  attributes: {
+    spellcheck: "false"
   }
 }) }}

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -48,7 +48,7 @@ Help your users to enter a valid email address by:
 - checking they have entered the correct format
 - allowing users to paste the email address
 - setting the `type` attribute to `email` so that devices display the correct keyboard
-- using the `spellcheck="false"` attribute so that browsers do not spell check the email address
+- setting the `spellcheck` attribute to `false` so that browsers do not spellcheck the email address
 - confirming their address back to them so they can check and change it
 
 You should also set the `autocomplete` attribute to `email`. This lets browsers autofill the email address on a user's behalf if they’ve entered it previously.

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -48,6 +48,7 @@ Help your users to enter a valid email address by:
 - checking they have entered the correct format
 - allowing users to paste the email address
 - setting the `type` attribute to `email` so that devices display the correct keyboard
+- using the `spellcheck="false"` attribute so that browsers do not spell check the email address
 - confirming their address back to them so they can check and change it
 
 You should also set the `autocomplete` attribute to `email`. This lets browsers autofill the email address on a user's behalf if they’ve entered it previously.

--- a/src/patterns/names/default/index.njk
+++ b/src/patterns/names/default/index.njk
@@ -11,5 +11,8 @@ layout: layout-example.njk
   },
   id: "full-name",
   name: "full-name",
-  autocomplete: "name"
+  autocomplete: "name",
+  attributes: {
+    spellcheck: "false"
+  }
 }) }}

--- a/src/patterns/names/error/index.njk
+++ b/src/patterns/names/error/index.njk
@@ -15,5 +15,8 @@ ignore_in_sitemap: true
   autocomplete: "name",
   errorMessage: {
     text: "Enter your full name"
+  },
+   attributes: {
+    spellcheck: "false"
   }
 }) }}

--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -68,6 +68,12 @@ If you are working in production you’ll need to do this to meet [WCAG 2.1 Leve
 
 You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
 
+### Do not spellcheck user's names
+
+Sometimes, browsers will spellcheck the information a user enters into a text input. To make sure user's names will not be spellchecked, set the `spellcheck` attribute to `false` as shown in this example.
+
+{{ example({group: "patterns", item: "names", example: "default", html: true, nunjucks: true, open: true, displayExample: false}) }}
+
 ### Avoid asking for a person’s title
 
 Avoid asking users for their title.

--- a/src/patterns/national-insurance-numbers/default/index.njk
+++ b/src/patterns/national-insurance-numbers/default/index.njk
@@ -14,5 +14,8 @@ layout: layout-example.njk
   },
   classes: "govuk-input--width-10",
   id: "national-insurance-number",
-  name: "national-insurance-number"
+  name: "national-insurance-number",
+  attributes: {
+    spellcheck: "false"
+  }
 }) }}

--- a/src/patterns/national-insurance-numbers/error/index.njk
+++ b/src/patterns/national-insurance-numbers/error/index.njk
@@ -16,8 +16,11 @@ ignore_in_sitemap: true
   classes: "govuk-input--width-10",
   id: "national-insurance-number",
   name: "national-insurance-number",
-  value: "Not a National Insurance number",
+  value: "12345678",
   errorMessage: {
     text: "Enter a National Insurance number in the correct format"
+  },
+   attributes: {
+    spellcheck: "false"
   }
 }) }}

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -28,11 +28,12 @@ If you currently use National Insurance numbers to verify identity, find out how
 
 Use a single [text input](../../components/text-input) labelled ‘National Insurance number’. Write it out in full and never use abbreviations such as ‘NINO’ or ‘NI Number’.
 
-You should:
+When asking for a National Insurance number:
 
 - allow for 13 characters as National Insurance numbers are spaced in pairs followed by a single letter
 - allow upper and lower case letters and strip out spaces before validating
 - avoid using ‘AB 12 34 56 C’ as an example because it belongs to a real person and use ‘QQ 12 34 56 C’ instead
+- set the `spellcheck` attribute to `false` so that browsers do not spellcheck the National Insurance number
 
 {{ example({group: "patterns", item: "national-insurance-numbers", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
 


### PR DESCRIPTION
Add examples and guidance on disabling spell check for form inputs such as email addresses and reference numbers.

As discussed in https://github.com/alphagov/govuk-frontend/issues/1129#issuecomment-455584260, Safari can correct user input without user approval and Chrome on Android can offer "corrections" even when user types in their email address. Spell checking is also unnecessary and potentially confusing when collecting user input like reference numbers.

Fixes https://github.com/alphagov/govuk-frontend/issues/1129

We could also consider changing the text input component in GOV.UK Frontend so that when `type="email"`, `spellcheck="false"` is added.