### PR TITLE
Add examples and guidance for `autocomplete` attribute 

### DIFF
--- a/src/components/date-input/date-of-birth/index.njk
+++ b/src/components/date-input/date-of-birth/index.njk
@@ -1,0 +1,38 @@
+---
+title: Date input to ask for date of birth
+layout: layout-example.njk
+---
+
+{% from "date-input/macro.njk" import govukDateInput %}
+
+{{ govukDateInput({
+  id: "dob",
+  namePrefix: "dob",
+  fieldset: {
+    legend: {
+      text: "What is your date of birth?",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--xl"
+    }
+  },
+  hint: {
+    text: "For example, 31 3 1980"
+  },
+  items: [
+    {
+      name: "day",
+      classes: "govuk-input--width-2",
+      autocomplete: "bday-day"
+    },
+    {
+      name: "month",
+      classes: "govuk-input--width-2",
+      autocomplete: "bday-month"
+    },
+    {
+      name: "year",
+      classes: "govuk-input--width-2",
+      autocomplete: "bday-year"
+    }
+  ]
+}) }}

--- a/src/components/date-input/default/index.njk
+++ b/src/components/date-input/default/index.njk
@@ -6,16 +6,16 @@ layout: layout-example.njk
 {% from "date-input/macro.njk" import govukDateInput %}
 
 {{ govukDateInput({
-  id: "dob",
-  namePrefix: "dob",
+  id: "passport-issued",
+  namePrefix: "passport-issued",
   fieldset: {
     legend: {
-      text: "What is your date of birth?",
+      text: "When was your passport issued?",
       isPageHeading: true,
       classes: "govuk-fieldset__legend--xl"
     }
-  },
+  }, 
   hint: {
-    text: "For example, 31 3 1980"
+    text: "For example, 12 11 2007"
   }
 }) }}

--- a/src/components/date-input/error/index.njk
+++ b/src/components/date-input/error/index.njk
@@ -7,20 +7,20 @@ ignore_in_sitemap: true
 {% from "date-input/macro.njk" import govukDateInput %}
 
 {{ govukDateInput({
-  id: "dob",
-  namePrefix: "dob",
+  id: "passport-issued",
+  namePrefix: "passport-issued",
   fieldset: {
     legend: {
-      text: "What is your date of birth?",
+      text: "When was your passport issued?",
       isPageHeading: true,
       classes: "govuk-fieldset__legend--xl"
     }
   },
   hint: {
-    text: "For example, 31 3 1980"
+    text: "For example, 12 11 2007"
   },
   errorMessage: {
-    text: "Date of birth must be in the past"
+    text: "The date your passport was issued must be in the past"
   },
   items: [
     {

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-Use the date input component to help users enter a memorable date.
+Use the date input component to help users enter a memorable date or one they can easily look up.
 
 {{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
@@ -38,6 +38,18 @@ There are 2 ways to use the date input component. You can use HTML or, if you’
 {{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
 
 Never automatically tab users between the fields of the date input because this can be confusing and may clash with normal keyboard controls.
+
+### Use the autocomplete attribute for a date of birth
+
+Use the `autocomplete` attribute on the date input component when you're asking for a date of birth. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.
+
+To do this, set the `autocomplete` attribute on the 3 fields to `bday-day`, `bday-month` and `bday-year`. See how to do this in the HTML and Nunjucks tabs in the following example. 
+
+{{ example({group: "components", item: "date-input", example: "date-of-birth", html: true, nunjucks: true, open: true, size: "s", id: "default-2"}) }}
+
+If you are working in production you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
+
+You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
 
 ### Error messages
 

--- a/src/components/error-message/default/index.njk
+++ b/src/components/error-message/default/index.njk
@@ -8,19 +8,19 @@ layout: layout-example.njk
 {{ govukDateInput({
   fieldset: {
     legend: {
-      text: "What is your date of birth?",
+      text: "When was your passport issued?",
       isPageHeading: true,
       classes: "govuk-fieldset__legend--xl"
     }
   },
   hint: {
-    text: "For example, 31 3 1980"
+    text: "For example, 12 11 2007"
   },
   errorMessage: {
-    text: "Date of birth must be in the past"
+    text: "The date your passport was issued must be in the past"
   },
-  id: "dob",
-  namePrefix: "dob",
+  id: "passport-issued",
+  namePrefix: "passport-issued",
   items: [
     {
       classes: "govuk-input--width-2 govuk-input--error",

--- a/src/components/error-summary/default/index.njk
+++ b/src/components/error-summary/default/index.njk
@@ -9,8 +9,8 @@ layout: layout-example.njk
   titleText: "There is a problem",
   errorList: [
     {
-      text: "Date of birth must be in the past",
-      href: "#dob-error"
+      text: "The date your passport was issued must be in the past",
+      href: "#passport-issued-error"
     },
     {
       text: "Enter a postcode, like AA1 1AA",

--- a/src/components/error-summary/linking-multiple-fields/index.njk
+++ b/src/components/error-summary/linking-multiple-fields/index.njk
@@ -11,8 +11,8 @@ ignore_in_sitemap: true
   "titleText": "There is a problem",
   "errorList": [
     {
-      "text": "Date of birth must include a year",
-      "href": "#dob-year"
+      "text": "Passport issue date must include a year",
+      "href": "#passport-issued-year"
     }
   ]
 }) }}
@@ -21,14 +21,14 @@ ignore_in_sitemap: true
   fieldset: {
     legend: {
       isPageHeading: true,
-      text: 'What is your date of birth?',
+      text: 'When was your passport issued?',
       classes: 'govuk-fieldset__legend--xl'
     }
   },
-  id: 'dob',
-  name: 'dob',
+  id: 'passport-issued',
+  name: 'passport-issued',
   errorMessage: {
-    text: "Date of birth must include a year"
+    text: "Passport issue date must include a year"
   },
   items: [
     {

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -65,6 +65,18 @@ Use hint for help that’s relevant to the majority of users - like how their in
 
 {{ example({group: "components", item: "text-input", example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s"}) }}
 
+### Use the autocomplete attribute
+
+Use the `autocomplete` attribute on text inputs to help users complete forms more quickly. This lets you specify an input's purpose so browsers can autofill the information on a user's behalf if they’ve entered it previously.
+
+For example, to enable autofill on a postcode field, set the `autocomplete` attribute to `postal-code`. See how to do this in the HTML and Nunjucks tabs in the following example.
+
+{{ example({group: "components", item: "text-input", example: "input-autocomplete-attribute", html: true, nunjucks: true, open: true, size: "s"}) }}
+
+If you are working in production and there is a relevant [input purpose](https://www.w3.org/TR/WCAG21/#input-purposes), you'll need to use the `autocomplete` attribute to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
+
+You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
+
 ### Do not disable copy and paste
 
 Users often need to copy and paste information into a text input, so do not stop them from doing this.

--- a/src/components/text-input/input-autocomplete-attribute/index.njk
+++ b/src/components/text-input/input-autocomplete-attribute/index.njk
@@ -1,0 +1,17 @@
+---
+title: Text input with autocomplete attribute
+layout: layout-example.njk
+ignore_in_sitemap: true
+---
+
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "Postcode"
+  },
+  classes: "govuk-input--width-10",
+  id: "postcode",
+  name: "postcode",
+  autocomplete: "postal-code"
+}) }}

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -48,14 +48,12 @@ When using an address lookup, you should:
 
 Only use multiple text inputs when you know which countries the addresses will come from and can find a format that supports them all. This can be difficult to know if you’re asking for addresses outside of the UK.
 
-### How multiple text inputs work
-
 Using multiple text inputs means:
 
 - you can easily extract and use specific parts of an address
 - you can give help for individual text inputs
 - you can validate each part of the address separately
-- users can complete the form using their browser’s auto-complete function
+- users can complete the form using their browser’s autocomplete function
 
 The disadvantages of using multiple text inputs are that:
 
@@ -63,15 +61,25 @@ The disadvantages of using multiple text inputs are that:
 - there’s no guarantee that users will use the text inputs the way you think they will
 - users cannot easily paste addresses from their clipboards
 
+### How multiple text inputs work
+
 If you use multiple text inputs, you should:
 
 - only make individual text inputs mandatory if you really need the information
-- make the text inputs the appropriate length for the content - it helps people understand the form, for example, make postcode text inputs shorter than street text inputs
+- make the text inputs the appropriate length for the content – it helps people understand the form, for example, make postcode text inputs shorter than street text inputs
 - let people enter their postcodes in upper or lower case and with or without spaces
 
 Make sure there are enough text inputs to accommodate longer addresses if you know your users will need them. For example, allow users to include a company name or flat&nbsp;number.
 
 Royal Mail does not need a county as long as the town and postcode are included. You should include an optional county text input so that people who do not know their postcode can give a valid address.
+
+#### Use the autocomplete attribute on multiple address fields
+
+Use the `autocomplete` attribute on each individual address field to help users enter their address more quickly. This lets you specify each input’s purpose so browsers can autofill the information on a user’s behalf if they’ve entered it previously.
+
+[Check which input purpose to use](https://www.w3.org/TR/WCAG21/#input-purposes) for each field.
+
+In production, you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html). You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
 
 #### Error messages
 
@@ -100,6 +108,15 @@ You should not use a textarea if you:
 
 Textareas let users enter an address in any format and make it easy to copy and paste addresses from their clipboard.
 
+#### Use the autocomplete attribute on a textarea
+
+Use the `autocomplete` attribute on the textarea component when you're asking for an address. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.
+
+To do this, set the `autocomplete` attribute to `street-address` as shown in the HTML and Nunjucks tabs in the textarea example above. 
+
+If you are working in production you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
+
+You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
 
 ## Research on this pattern
 

--- a/src/patterns/addresses/textarea/index.njk
+++ b/src/patterns/addresses/textarea/index.njk
@@ -10,6 +10,7 @@ ignore_in_sitemap: true
 {{ govukTextarea({
   name: "address",
   id: "address",
+  autocomplete: "street-address",
   label: {
     text: "What is your address?"
   }

--- a/src/patterns/dates/default/index.njk
+++ b/src/patterns/dates/default/index.njk
@@ -1,21 +1,21 @@
 ---
-title: Asking for memorable dates
+title: Asking for dates from documents
 layout: layout-example.njk
 ---
 
 {% from "date-input/macro.njk" import govukDateInput %}
 
 {{ govukDateInput({
-  id: "dob",
-  namePrefix: "dob",
+  id: "passport-issued",
+  namePrefix: "passport-issued",
   fieldset: {
     legend: {
-      text: "What is your date of birth?",
+      text: "When was your passport issued?",
       isPageHeading: true,
       classes: "govuk-fieldset__legend--xl"
     }
   },
   hint: {
-    text: "For example, 31 3 1980"
+    text: "For example, 01 08 2007"
   }
 }) }}

--- a/src/patterns/dates/error/index.njk
+++ b/src/patterns/dates/error/index.njk
@@ -7,20 +7,20 @@ ignore_in_sitemap: true
 {% from "date-input/macro.njk" import govukDateInput %}
 
 {{ govukDateInput({
-  id: "dob",
-  namePrefix: "dob",
+  id: "passport-issued",
+  namePrefix: "passport-issued",
   fieldset: {
     legend: {
-      text: "What is your date of birth?",
+      text: "When was your passport issued?",
       isPageHeading: true,
       classes: "govuk-fieldset__legend--xl"
     }
   },
   hint: {
-    text: "For example, 31 3 1980"
+    text: "For example, 12 11 2007"
   },
   errorMessage: {
-    text: "Date of birth must be in the past"
+    text: "The date your passport was issued must be in the past"
   },
   items: [
     {

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -34,7 +34,17 @@ In some cases you might need users to pick a date from a given selection.
 
 Ask for memorable dates, like dates of birth, using the [date input](../../components/date-input) component.
 
-{{ example({group: "patterns", item: "dates", example: "default", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({group: "patterns", item: "dates", example: "memorable-date", html: true, nunjucks: true, open: true, size: "s"}) }}
+
+#### Use the autocomplete attribute when asking for a date of birth
+
+Use the `autocomplete` attribute when you're asking for a date of birth. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.
+
+To do this, set the `autocomplete` attribute on the 3 fields to `bday-day`, `bday-month` and `bday-year`. See how to do this in the HTML and Nunjucks tabs in the memorable date example above. 
+
+If you are working in production you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
+
+You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
 
 ### Asking for dates from documents and cards
 

--- a/src/patterns/dates/memorable-date/index.njk
+++ b/src/patterns/dates/memorable-date/index.njk
@@ -1,0 +1,38 @@
+---
+title: Asking for memorable dates
+layout: layout-example.njk
+---
+
+{% from "date-input/macro.njk" import govukDateInput %}
+
+{{ govukDateInput({
+  id: "dob",
+  namePrefix: "dob",
+  fieldset: {
+    legend: {
+      text: "What is your date of birth?",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--xl"
+    }
+  },
+  hint: {
+    text: "For example, 31 3 1980"
+  },
+  items: [
+    {
+      name: "day",
+      classes: "govuk-input--width-2",
+      autocomplete: "bday-day"
+    },
+    {
+      name: "month",
+      classes: "govuk-input--width-2",
+      autocomplete: "bday-month"
+    },
+    {
+      name: "year",
+      classes: "govuk-input--width-2",
+      autocomplete: "bday-year"
+    }
+  ]
+}) }}

--- a/src/patterns/email-addresses/default/index.njk
+++ b/src/patterns/email-addresses/default/index.njk
@@ -14,5 +14,6 @@ layout: layout-example.njk
   },
   id: "email",
   name: "email",
-  type: "email"
+  type: "email",
+  autocomplete: "email"
 }) }}

--- a/src/patterns/email-addresses/error/index.njk
+++ b/src/patterns/email-addresses/error/index.njk
@@ -17,6 +17,7 @@ ignore_in_sitemap: true
   name: "email",
   type: "email",
   value: "Not an email address",
+  autocomplete: "email",
   errorMessage: {
     text: "Enter an email address in the correct format, like name@example.com"
   }

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -47,8 +47,12 @@ Help your users to enter a valid email address by:
 
 - checking they have entered the correct format
 - allowing users to paste the email address
-- using the `type="email"` attribute so that devices display the correct keyboard
+- setting the `type` attribute to `email` so that devices display the correct keyboard
 - confirming their address back to them so they can check and change it
+
+You should also set the `autocomplete` attribute to `email`. This lets browsers autofill the email address on a user's behalf if they’ve entered it previously.
+
+If you are working in production you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html). You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
 
 The field should be wide enough for most users to see their entire email address once they have entered it. A good rule of thumb is to make sure you can see at least 30 characters at once. You can analyse your user data to refine this.
 

--- a/src/patterns/names/default/index.njk
+++ b/src/patterns/names/default/index.njk
@@ -10,5 +10,6 @@ layout: layout-example.njk
     text: "Full name"
   },
   id: "full-name",
-  name: "full-name"
+  name: "full-name",
+  autocomplete: "name"
 }) }}

--- a/src/patterns/names/error/index.njk
+++ b/src/patterns/names/error/index.njk
@@ -12,6 +12,7 @@ ignore_in_sitemap: true
   },
   id: "full-name",
   name: "full-name",
+  autocomplete: "name",
   errorMessage: {
     text: "Enter your full name"
   }

--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -53,6 +53,21 @@ Make middle names optional.
 
 Make it clear whether you need someone’s common name or their full legal name.
 
+### Use the autocomplete attribute on name fields
+
+Use the `autocomplete` attribute on the text input component when you're asking for a user's name. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.
+
+If you are asking for a user's full name in a single field, set the `autocomplete` attribute to `name`. 
+
+If you are asking users to enter their name in multiple fields, set the `autocomplete` attribute on both fields using:
+
+- `given-name` for fields labelled 'First name' or 'Given name' 
+- `family-name` for fields labelled 'Last name' or 'Family name'
+
+If you are working in production you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
+
+You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
+
 ### Avoid asking for a person’s title
 
 Avoid asking users for their title.

--- a/src/patterns/telephone-numbers/default/index.njk
+++ b/src/patterns/telephone-numbers/default/index.njk
@@ -12,5 +12,6 @@ title: Default – Telephone numbers
   id: "telephone-number",
   name: "telephone-number",
   type: "tel",
+  autocomplete: "tel",
   classes: "govuk-input--width-20"
 }) }}

--- a/src/patterns/telephone-numbers/error-empty-field/index.njk
+++ b/src/patterns/telephone-numbers/error-empty-field/index.njk
@@ -16,5 +16,6 @@ ignore_in_sitemap: true
   id: "telephone-number",
   name: "telephone-number",
   type: "tel",
+  autocomplete: "tel",
   classes: "govuk-input--width-20"
 }) }}

--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -26,6 +26,15 @@ Users should be allowed to enter telephone numbers in whatever format is familia
 ### Validate telephone numbers
 You should validate telephone numbers so you can let users know if they have entered one incorrectly. Google’s [libphonenumber](https://github.com/googlei18n/libphonenumber) library can validate telephone numbers from most countries.
 
+### Use the autocomplete attribute
+
+Use the `autocomplete` attribute on telephone number inputs. This lets browsers autofill the information on a user's behalf if they’ve entered it previously. 
+
+To do this, set the `autocomplete` attribute to `tel`, as shown in the HTML and Nunjucks tabs in the examples on this page. 
+
+If you are working in production you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
+
+You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
 
 ### Error messages
 

--- a/src/patterns/telephone-numbers/international/index.njk
+++ b/src/patterns/telephone-numbers/international/index.njk
@@ -16,5 +16,6 @@ ignore_in_sitemap: true
   id: "telephone-number",
   name: "telephone-number",
   type: "tel",
+  autocomplete: "tel",
   classes: "govuk-input--width-20"
 }) }}


### PR DESCRIPTION
We now allow textarea, input and date input components to accept an option to render `autocomplete` attribute. 

This helps to surface the new WCAG 2.1 guidelines for "Identify Input Purpose" - see https://github.com/alphagov/govuk-design-system/issues/696

This PR:
- Adds guidance and examples of using `autocomplete` for the above components.
- Changes the default examples for date-input, error-message and error-summary to use a different question (not date of birth) for their default example. This is to avoid adding `autocomplete` attributes to default examples as these could be copy pasted for use in other contexts than date of birth.
- Is doing the minimum to add guidance for the components that now explicitly accept `autocomplete`. There are probably other examples in the Design System where we could add the `autocomplete` attribute for enhanced usability, we should look at those separately.

Fixes https://github.com/alphagov/govuk-design-system/issues/696