### PR TITLE
Changed 'date input' from sentence case to lower case

### DIFF
--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -37,7 +37,7 @@ There are 2 ways to use the date input component. You can use HTML or, if you’
 
 {{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
 
-Never automatically tab users between the fields of the Date input because this can be confusing and may clash with normal keyboard controls.
+Never automatically tab users between the fields of the date input because this can be confusing and may clash with normal keyboard controls.
 
 ### Error messages
 


### PR DESCRIPTION
Line 40

CHANGED:

Never automatically tab users between the fields of the Date input because this can be confusing and may clash with normal keyboard controls.

TO:

Never automatically tab users between the fields of the date input because this can be confusing and may clash with normal keyboard controls.

REASON:

Should use lower case.