### PR TITLE
Update layouts styles page to meet our style guide

### DIFF
--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -24,7 +24,8 @@ The default maximum page width is 1020px, but you can make it wider if your cont
 
 {{ example({group: "styles", item: "layout", example: "common-two-thirds", html: true, open: true, size: "m"}) }}
 
-### Two-thirds / One-third
+- ### Two-thirds / One-third
++ ### Two-thirds / one-third
 
 {{ example({group: "styles", item: "layout", example: "common-two-thirds-one-third", html: true, open: true, size: "m"}) }}
 

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -24,8 +24,7 @@ The default maximum page width is 1020px, but you can make it wider if your cont
 
 {{ example({group: "styles", item: "layout", example: "common-two-thirds", html: true, open: true, size: "m"}) }}
 
-- ### Two-thirds / One-third
-+ ### Two-thirds / one-third
+### Two-thirds / one-third
 
 {{ example({group: "styles", item: "layout", example: "common-two-thirds-one-third", html: true, open: true, size: "m"}) }}
 


### PR DESCRIPTION
This change updates the description to meet our style guide which says that 'Two-thirds/One-third' should be written in sentence case instead of title case.