### PR TITLE
Colour contrast needs to be updated from WCAG.2.0 to WCAG 2.1

### DIFF
--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -14,6 +14,7 @@ You must make sure that the contrast ratio of text and interactive elements in
 your service meets [level AA of the Web Content Accessibility Guidelines
 - (WCAG 2.0)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
 + (WCAG 2.1)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).
+
 ## Main colours
 
 If you are using GOV.UK Frontend or the GOV.UK Prototype Kit, use the [Sass

--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -12,8 +12,8 @@ Always use the GOV.UK colour palette.
 ## Colour contrast
 You must make sure that the contrast ratio of text and interactive elements in
 your service meets [level AA of the Web Content Accessibility Guidelines
-(WCAG 2.0)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
-
+- (WCAG 2.0)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
++ (WCAG 2.1)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).
 ## Main colours
 
 If you are using GOV.UK Frontend or the GOV.UK Prototype Kit, use the [Sass

--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -12,8 +12,7 @@ Always use the GOV.UK colour palette.
 ## Colour contrast
 You must make sure that the contrast ratio of text and interactive elements in
 your service meets [level AA of the Web Content Accessibility Guidelines
-- (WCAG 2.0)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
-+ (WCAG 2.1)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).
+(WCAG 2.1)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).
 
 ## Main colours
 


### PR DESCRIPTION
Make sure that the contrast ratio of text and interactive elements in the service meets [level AA of the Web Content Accessibility Guidelines

Colour contrast needs to be updated from WCAG.2.0 to WCAG 2.1