### PR TITLE
Made bullet clearer

### DIFF
--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -14,7 +14,7 @@ This page template combines the boilerplate markup and [components](../../compon
 
 - JavaScript that adds a `.js-enabled` class, which is required by components with JavaScript behaviour
 - the [skip link](../../components/skip-link), [header](../../components/header) and [footer](../../components/footer) components
-- favicon, and other related theme icons
+- the favicon, and other related theme icons
 
 In the examples provided, we show both HTML and Nunjucks.
 


### PR DESCRIPTION
Changed bullet "favicon, and other related theme icons" to start with "the" so that the sentence is clearer.