### PR TITLE
Remove reference to modifier for width

### DIFF
--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -72,7 +72,7 @@ Your main content should always be in a two-thirds column even if you’re not u
 
 The grid is structured with a `govuk-grid-row` wrapper which acts as a row to contain your grid columns.
 
-You can add columns inside this wrapper to create your layout. To define your columns add the class beginning with `govuk-grid-column-` to a new container followed by the width "modifier", for example `govuk-grid-column-one-third` to apply your desired width.
+You can add columns inside this wrapper to create your layout. To define your columns add the class beginning with `govuk-grid-column-` to a new container followed by the width, for example `govuk-grid-column-one-third` to apply your desired width.
 
 The available widths are:
 


### PR DESCRIPTION
Remove reference to "modifier" in under Understanding the grid system, as it is not following the BEM syntax