### PR TITLE
Corrected spelling of 'humourous' to 'humorous'

### DIFF
--- a/src/patterns/page-not-found-pages/index.md.njk
+++ b/src/patterns/page-not-found-pages/index.md.njk
@@ -47,7 +47,7 @@ Do not use:
 
 - breadcrumbs
 - technical jargon like 404 or bad request
-- informal or humourous words like oops
+- informal or humorous words like oops
 - red text to warn people
 
 {{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true, nunjucks: true, id: "default-2", size: "xl"}) }}


### PR DESCRIPTION
'Humorous' is how the Guardian style guide recommends spelling it, and GDS defers to this when there's no guidance in our style guide.