### PR TITLE
Fix grammar error in when to use this component

### DIFF
--- a/src/components/summary-list/index.md.njk
+++ b/src/components/summary-list/index.md.njk
@@ -17,7 +17,7 @@ Use the summary list to summarise information, for example, a user’s responses
 
 Use the summary list component to present pairs of related information, known as key-value pairs, in a list. The key is a description or label of a piece of information, like ‘Name’, and the value is the piece of information itself, like ‘John Smith’.
 
-You can use it to display metadata like ‘Last updated’ with a date like ‘22 June 2018’. Or to summarise a user’s responses at the end of a form like the [check answers](/patterns/check-answers) pattern.
+You can use it to display metadata like ‘Last updated’ with a date like ‘22 June 2018’, or to summarise a user’s responses at the end of a form like the [check answers](/patterns/check-answers) pattern.
 
 ## When not to use this component
 


### PR DESCRIPTION
CHANGE:

You can use it to display metadata like ‘Last updated’ with a date like ‘22 June 2018’. Or to summarise a user’s responses at the end of a form like the [check answers](/patterns/check-answers) pattern.

TO:

You can use it to display metadata like ‘Last updated’ with a date like ‘22 June 2018’, or to summarise a user’s responses at the end of a form like the [check answers](/patterns/check-answers) pattern.

REASON:

Incorrect grammar.