### PR TITLE
Fix reference to service manual in phase banner

### DIFF
--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -32,7 +32,7 @@ There are 2 ways to use the phase banner component. You can use HTML or, if you 
 
 Use a ‘feedback’ link to collect on-page feedback about your service. This can open an email or take the user to a dedicated page or form. Whatever option you use, make sure that users do not lose their place in the service and can return to the page they were on.
 
-Find out what [feedback you need to collect at each phase](https://www.gov.uk/service-manual/measuring-success/measuring-user-satisfaction#user-satisfaction-through-each-service-phase) in the Service Manual.
+Find out what [feedback you need to collect at each phase](https://www.gov.uk/service-manual/measuring-success/measuring-user-satisfaction#user-satisfaction-through-each-service-phase) in the GOV.UK Service Manual.
 
 ## Research on this component
 


### PR DESCRIPTION
"Service Manual" changes to "GOV.UK Service Manual".