### PR TITLE
Update copy button content and position

### DIFF
--- a/src/javascripts/components/copy.js
+++ b/src/javascripts/components/copy.js
@@ -13,7 +13,7 @@ Copy.prototype.init = function () {
   var $button = document.createElement('button')
   $button.className = 'app-copy-button js-copy-button'
   $button.setAttribute('aria-live', 'assertive')
-  $button.textContent = 'Copy'
+  $button.textContent = 'Copy code'
 
   $module.insertBefore($button, $module.firstChild)
   this.copyAction()
@@ -26,10 +26,10 @@ Copy.prototype.copyAction = function () {
         return trigger.nextElementSibling
       }
     }).on('success', function (e) {
-      e.trigger.textContent = 'Copied'
+      e.trigger.textContent = 'Code copied'
       e.clearSelection()
       setTimeout(function () {
-        e.trigger.textContent = 'Copy'
+        e.trigger.textContent = 'Copy code'
       }, 5000)
     })
   } catch (err) {

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -108,6 +108,8 @@
 
 .app-tabs__container pre code {
   display: block;
+  // Extra 3px to compensate for border and box shadow of button
+  padding-top: govuk-spacing(7) + 3px;
   padding-right: govuk-spacing(4);
   padding-bottom: govuk-spacing(4);
   overflow-x: auto;

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -175,16 +175,20 @@ body {
   z-index: 1;
   top: govuk-spacing(4);
   right: govuk-spacing(4);
-  min-width: 80px;
-  padding: 4px 10px 0;
+  min-width: 110px;
+  padding: 4px 10px 2px 10px;
   border: 1px solid $copy-button-colour;
   color: $copy-button-colour;
   background-color: govuk-colour("white");
-  box-shadow: 0 0 0 4px govuk-colour("grey-4");
+  box-shadow: 0 2px 0 0 govuk-colour("green");
   text-align: center;
   text-decoration: none;
-  text-transform: uppercase;
   cursor: pointer;
+
+  &:active {
+    margin-top: 2px;
+    box-shadow: none;
+  }
 }
 
 $colour-list-breakpoint: 980px;


### PR DESCRIPTION
This PR adds extra space to the top of the code block to stop the copy button clashing with the code referenced in https://github.com/alphagov/govuk-design-system/issues/704

In addition I have changed the content of the button to "Copy code" and "Code copied" to add some context to the button to help with the feedback below. I have also changed the text to sentence case and adjusted the padding accordingly.

> The ‘copy’ link is not descriptive to users that rely on audio feedback and navigate out of
> the context of the page.

This does not add the context of the particular code block the user is copying but is a good start.

![button](https://user-images.githubusercontent.com/23356842/51918280-24930100-23d9-11e9-85f8-99dc2d26c749.gif)

