### PR TITLE
Revert "Colour contrast needs to be updated from WCAG.2.0 to WCAG 2.1"

### DIFF
--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -12,7 +12,7 @@ Always use the GOV.UK colour palette.
 ## Colour contrast
 You must make sure that the contrast ratio of text and interactive elements in
 your service meets [level AA of the Web Content Accessibility Guidelines
-(WCAG 2.1)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).
+(WCAG 2.0)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
 
 ## Main colours
 


### PR DESCRIPTION
We were a bit too hasty doing this.

We should complete the work in the Design System to ensure services can achieve this with our tools before recommending this.

> Services built after 23 September 2018 must meet WCAG 2.1 by 23 September 2019
> Services built before 23 September 2018 must meet by 23 September 2020