### PR TITLE
Add "feedback banner" to aliases for phase banner

### DIFF
--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -2,7 +2,7 @@
 title: Phase banner
 description: Use the phase banner component to show users your service is still being worked on
 section: Components
-aliases: alpha banner, beta banner, prototype banner, status banner
+aliases: alpha banner, beta banner, prototype banner, status banner, feedback banner
 backlog_issue_id: 57
 layout: layout-pane.njk
 ---


### PR DESCRIPTION
A user researcher got in touch with GDS to ask how to get the feedback banner at the top of their page within their service. This additional alias should help users find this component in the future.