### PR TITLE
Adds simple aXe testing to the Design System

### DIFF
--- a/__tests__/accessiblity_audit.test.js
+++ b/__tests__/accessiblity_audit.test.js
@@ -1,0 +1,103 @@
+/* eslint-env jest */
+const configPaths = require('../config/paths.json')
+const PORT = configPaths.testPort
+const { AxePuppeteer } = require('axe-puppeteer')
+
+let browser
+let page
+let baseUrl = 'http://localhost:' + PORT
+const thingsToExclude = [
+  // axe reports there is "no label associated with the text field", when there is one.
+  ['#app-site-search__input'],
+  // axe reports that the phase banner is not inside a landmark, which is intentional.
+  ['.app-phase-banner__wrapper']
+]
+beforeAll(async (done) => {
+  browser = global.browser
+  page = await browser.newPage()
+  done()
+})
+
+afterAll(async (done) => {
+  await page.close()
+  done()
+})
+
+describe('Accessibility Audit', () => {
+  describe('Home page - layout.njk', () => {
+    it('validates', async () => {
+      await page.goto(baseUrl + '/', { waitUntil: 'load' })
+      const results =
+        await new AxePuppeteer(page)
+          .include(['body'])
+          .exclude(...thingsToExclude)
+          .analyze()
+      expect(results.violations).toEqual([])
+    })
+  })
+
+  describe('Component page - layout-pane.njk', () => {
+    it('validates', async () => {
+      await page.goto(baseUrl + '/components/radios/', { waitUntil: 'load' })
+      const results =
+        await new AxePuppeteer(page)
+          .include(['body'])
+          .exclude(...thingsToExclude)
+          .analyze()
+
+      expect(results.violations).toEqual([])
+    })
+  })
+
+  describe('Patterns page - layout-pane.njk', () => {
+    it('validates', async () => {
+      await page.goto(baseUrl + '/patterns/gender-or-sex/', { waitUntil: 'load' })
+      const results =
+        await new AxePuppeteer(page)
+          .include(['body'])
+          .exclude(...thingsToExclude)
+          .analyze()
+
+      expect(results.violations).toEqual([])
+    })
+  })
+
+  describe('Cookies page - layout-single-page-prose.njk', () => {
+    it('validates', async () => {
+      await page.goto(baseUrl + '/cookies/', { waitUntil: 'load' })
+      const results =
+        await new AxePuppeteer(page)
+          .include(['body'])
+          .exclude(...thingsToExclude)
+          .analyze()
+
+      expect(results.violations).toEqual([])
+    })
+  })
+
+  describe('Get in touch page - layout-single-page.njk', () => {
+    it('validates', async () => {
+      await page.goto(baseUrl + '/get-in-touch/', { waitUntil: 'load' })
+      const results =
+        await new AxePuppeteer(page)
+          .include(['body'])
+          .exclude(...thingsToExclude)
+          .analyze()
+
+      expect(results.violations).toEqual([])
+    })
+  })
+
+  describe('Site Map page - layout-sitemap.njk', () => {
+    it('validates', async () => {
+      await page.goto(baseUrl + '/sitemap/', { waitUntil: 'load' })
+      const results =
+        await new AxePuppeteer(page)
+          .include(['body'])
+          .exclude(...thingsToExclude)
+          .analyze()
+
+      expect(results.violations).toEqual([])
+    })
+  })
+})

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -217,7 +217,8 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
         getMacroOptions: getMacroOptions
       },
       filters: {
-        highlight: highlighter
+        highlight: highlighter,
+        kebabCase: string => string.replace(/\s+/g, '-').toLowerCase()
       },
 
       // Markdown engine options

--- a/package-lock.json
+++ b/package-lock.json
@@ -801,6 +801,21 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "axe-core": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.1.2.tgz",
+      "integrity": "sha512-e1WVs0SQu3tM29J9a/mISGvlo2kdCStE+yffIAJF6eb42FS+eUFEVz9j4rgDeV2TAfPJmuOZdRetWYycIbK7Vg==",
+      "dev": true
+    },
+    "axe-puppeteer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/axe-puppeteer/-/axe-puppeteer-1.0.0.tgz",
+      "integrity": "sha512-hTF3u4mtatgTN7fsLVyVgbRdNc15ngjDcTEuqhn9A7ugqLhLCryJWp9fzqZkNlrW8awPcxugyTwLPR7mRdPZmA==",
+      "dev": true,
+      "requires": {
+        "axe-core": "3.1.2"
+      }
+    },
     "axios": {
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
@@ -3503,7 +3518,7 @@
     },
     "eslint": {
       "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "resolved": "http://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
       "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
       "dev": true,
       "requires": {
@@ -5290,7 +5305,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -8942,7 +8957,7 @@
       "dependencies": {
         "yargs": {
           "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "dev": true,
           "requires": {
@@ -11493,7 +11508,7 @@
     },
     "shelljs": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
       "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "accessible-autocomplete": "^1.6.2",
+    "axe-puppeteer": "^1.0.0",
     "fs-extra": "^7.0.1",
     "iframe-resizer": "^3.5.16",
     "jest": "^23.6.0",

--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -33,7 +33,7 @@ If this is not possible, you should hide the back link when JavaScript is not av
 
 There are 2 ways to use the back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/breadcrumbs/index.md.njk
+++ b/src/components/breadcrumbs/index.md.njk
@@ -29,7 +29,7 @@ The breadcrumbs component should include the user’s current page, which should
 
 There are 2 ways to use the breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -49,7 +49,7 @@ In some cases, it can be helpful to order them from most-to-least common options
 
 There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", id: "default-2"}) }}
+{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
 
 ### Checkbox items with hints
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -35,7 +35,7 @@ Read more about [why and how to set legends as headings](../../get-started/label
 
 There are 2 ways to use the date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 
 Never automatically tab users between the fields of the date input because this can be confusing and may clash with normal keyboard controls.
 

--- a/src/components/details/index.md.njk
+++ b/src/components/details/index.md.njk
@@ -35,7 +35,7 @@ The details component is a short link that expands into more detailed help text 
 
 There are 2 ways to use the details component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 
 ### Write clear link text
 

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -34,7 +34,7 @@ Read guidance on [writing good error messages](../error-message#be-clear-and-con
 
 There are 2 ways to use the error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 
 ### Linking from the error summary to each answer
 

--- a/src/components/file-upload/index.md.njk
+++ b/src/components/file-upload/index.md.njk
@@ -21,7 +21,7 @@ You should only ask users to upload something if it’s critical to the delivery
 
 There are 2 ways to use the file upload component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ### Error messages
 

--- a/src/components/footer/index.md.njk
+++ b/src/components/footer/index.md.njk
@@ -27,7 +27,7 @@ You can add links to:
 
 ### Default footer
 
-{{ example({group: "components", item: "footer", example: "default", id: "default-2", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({group: "components", item: "footer", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ### Footer with secondary navigation
 

--- a/src/components/header/index.md.njk
+++ b/src/components/header/index.md.njk
@@ -31,7 +31,7 @@ You must not use the GOV.UK header if your service is not being hosted on one of
 
 Use the default header if your service has 5 pages or fewer.
 
-{{ example({group: "components", item: "header", example: "default", id: "default-2", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "header", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false}) }}
 
 ### Header with service name
 

--- a/src/components/inset-text/index.md.njk
+++ b/src/components/inset-text/index.md.njk
@@ -31,7 +31,7 @@ Use inset text very sparingly - it’s less effective if it’s overused.
 
 There are 2 ways to use the inset text component. You can use HTML or, if you’re using Nunjucks or the GOV.UK Prototype Kit, you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -29,7 +29,7 @@ If you add extra content to the panel, to meet colour contrast ratio requirement
 
 There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", id: "default-2"}) }}
+{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -24,7 +24,7 @@ Your banner must be directly under the black GOV.UK header and colour bar.
 
 There are 2 ways to use the phase banner component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 {{ example({group: "components", item: "phase-banner", example: "beta", html: true, nunjucks: true, open: false}) }}
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -29,7 +29,7 @@ Read more about [why and how to set legends as headings](../../get-started/label
 
 Always position radios to the left of their labels. This makes them easier to find, especially for users of screen magnifiers.
 
-Unlike with checkboxes, users can only select one option from a list of radios. Do not assume that users will know how many options they can select based on the visual difference between radios and checkboxes alone. 
+Unlike with checkboxes, users can only select one option from a list of radios. Do not assume that users will know how many options they can select based on the visual difference between radios and checkboxes alone.
 
 If needed, add a hint explaining this, for example, 'Select one option'.
 
@@ -38,13 +38,13 @@ Do not pre-select radio options as this makes it more likely that users will:
 - not realise they've missed a question
 - submit the wrong answer
 
-Users cannot go back to having no option selected once they have selected one, without refreshing their browser window. Therefore, you should include 'None of the above' or 'I do not know' if they are valid options. 
+Users cannot go back to having no option selected once they have selected one, without refreshing their browser window. Therefore, you should include 'None of the above' or 'I do not know' if they are valid options.
 
-Order radio options alphabetically by default. 
+Order radio options alphabetically by default.
 
 In some cases, it can be helpful to order them from most-to-least common options. For example, you could order options for 'Where do you live?' based on population size.
 
-However you should do this with extreme caution as it can reinforce bias in your service. If in doubt, order alphabetically. 
+However you should do this with extreme caution as it can reinforce bias in your service. If in doubt, order alphabetically.
 
 There are 2 ways to use the radios component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
@@ -58,7 +58,7 @@ When there are more than 2 options, radios should be stacked, like so:
 
 If there are only 2 options, you can either stack the radios or display them inline, like so:
 
-{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "radios", example: "default", exampleSuffix: 'second' ,html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
 
 ### Radio items with hints
 
@@ -74,7 +74,7 @@ If one or more of your radio options is different from the others, it can help u
 
 ### Conditionally revealing content
 
-Using this component, you can add conditionally revealing content to stacked radios, so users only see content when it’s relevant to them. 
+Using this component, you can add conditionally revealing content to stacked radios, so users only see content when it’s relevant to them.
 
 For example, you could reveal an email address input only when a user chooses to be contacted by email.
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -58,7 +58,7 @@ When there are more than 2 options, radios should be stacked, like so:
 
 If there are only 2 options, you can either stack the radios or display them inline, like so:
 
-{{ example({group: "components", item: "radios", example: "default", exampleSuffix: 'second' ,html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 
 ### Radio items with hints
 

--- a/src/components/select/index.md.njk
+++ b/src/components/select/index.md.njk
@@ -23,7 +23,7 @@ Asking questions means you’re less likely to need to use the select component,
 
 There are 2 ways to use the select component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com),  you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/skip-link/index.md.njk
+++ b/src/components/skip-link/index.md.njk
@@ -27,7 +27,7 @@ The skip link component is visually hidden until a keyboard press activates it.
 
 There are 2 ways to use the skip link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/summary-list/index.md.njk
+++ b/src/components/summary-list/index.md.njk
@@ -39,7 +39,7 @@ For sighted users, the actions get their context from the other content in the r
 Assistive technology users, like those who use a screen reader, may hear the links out of context and not know what they do.
 To give more context, add visually hidden text to the links. This means a screen reader user will hear a meaningful action, like ‘Change name’ or ‘Change date of birth’.
 
-{{ example({group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ### Summary list without actions
 

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -33,7 +33,7 @@ Use table headers to tell users what the rows and columns represent. Use the `sc
 
 There are 2 ways to use the table component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m", id: "default-2"}) }}
+{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
 
 ## Numbers in a table
 

--- a/src/components/tabs/index.md.njk
+++ b/src/components/tabs/index.md.njk
@@ -64,7 +64,7 @@ The details component is less visually prominent than tabs, so tends to work bet
 
 There are 2 ways to use the tabs component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false, size: "xl", id: "default-2"}) }}
+{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false, size: "xl", titleSuffix: "second"}) }}
 
 The tabs component uses JavaScript. When JavaScript is not available, users will see the tabbed content on a single page, in order from first to last, with a table of contents that links to each of the sections.
 

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -19,7 +19,7 @@ Use the tag component to indicate the status of something, such as an item on a 
 
 There are 2 ways to use the tag component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -23,7 +23,7 @@ Do not use the text input component if you need to let users enter longer answer
 
 There are 2 ways to use the text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: dalse, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: dalse, size: "s", titleSuffix: "second"}) }}
 
 ### Label text inputs
 

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -27,7 +27,7 @@ Do not use the textarea component if you need to let users enter shorter answers
 
 There are 2 ways to use the textarea component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", id: "default-2"}) }}
+{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
 
 ### Label textareas
 

--- a/src/components/warning-text/index.md.njk
+++ b/src/components/warning-text/index.md.njk
@@ -19,7 +19,7 @@ Use the warning text component when you need to warn users about something impor
 
 There are 2 ways to use the warning text component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 You might need to rewrite the hidden text (‘Warning’ in the example) to make it appropriate for your context.
 

--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -33,7 +33,7 @@ Your confirmation page must include:
 
 If you add extra content to the panel, to meet colour contrast ratio requirements use a font size of <code>govuk-body-l</code> for normal weight and <code>govuk-body</code> for bold.
 
-{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, id: "default-2", size: "xl"}) }}
+{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second", size: "xl"}) }}
 
 ### Help users who bookmark the page
 

--- a/src/patterns/page-not-found-pages/index.md.njk
+++ b/src/patterns/page-not-found-pages/index.md.njk
@@ -50,7 +50,7 @@ Do not use:
 - informal or humorous words like oops
 - red text to warn people
 
-{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true, nunjucks: true, id: "default-2", size: "xl"}) }}
+{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true, nunjucks: true, titleSuffix: "second", size: "xl"}) }}
 
 ## Research on this pattern
 

--- a/src/patterns/problem-with-the-service-pages/index.md.njk
+++ b/src/patterns/problem-with-the-service-pages/index.md.njk
@@ -48,7 +48,7 @@ Have clear and concise content and do not use:
 
 ### Service has a specific page that includes numbers and opening times
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, nunjucks: true, open: false, id: "default-2", size: "xl"}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second", size: "xl"}) }}
 
 ### Service has offline support but no specific page that includes numbers and opening times
 

--- a/src/patterns/start-pages/index.md.njk
+++ b/src/patterns/start-pages/index.md.njk
@@ -38,7 +38,7 @@ This is a set pattern, so you will not be able to customise it.
 
 Read guidance on [what information should go on a start page](https://www.gov.uk/service-manual/design/govuk-content-transactions) in the Service Manual.
 
-{{ example({group: "patterns", item: "start-pages", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "patterns", item: "start-pages", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ## Research on this pattern
 

--- a/src/styles/layout/common-two-thirds-one-third/index.njk
+++ b/src/styles/layout/common-two-thirds-one-third/index.njk
@@ -20,7 +20,7 @@ ignore_in_sitemap: true
       </div>
 
       <div class="govuk-grid-column-one-third">
-        <h3 class="govuk-heading-m">One-third column</h3>
+        <h2 class="govuk-heading-m">One-third column</h3>
         <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
       </div>
     </div>

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -28,7 +28,7 @@
 {% block header %}{% endblock %}
 
 {% block main %}
-<div class="app-pane {% block appPaneClasses %}{% endblock %}">
+<div class="app-pane {% block appPaneClasses %}{% endblock %}" id="top">
   {% include "_cookie-banner.njk" %}
   <div class="app-pane__header">
     {% include "_header.njk" %}

--- a/views/layouts/layout.njk
+++ b/views/layouts/layout.njk
@@ -1,7 +1,6 @@
 {% extends "_generic.njk" %}
 
 {% block body %}
-<a name="top"></a>
 <div class="app-pane__content">
   <main id="main-content" role="main">
     {{ contents | safe }}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -6,8 +6,14 @@
   {% set examplePath = exampleRoot + "index.njk" %}
 {% endif %}
 {% set exampleURL = "/" + params.group + "/" + params.item + "/" + params.example + "/index.html" %}
-{% set exampleId = params.id | default("example-" + params.example) %}
+
 {% set exampleTitle = getFrontmatter(examplePath).title %}
+{% if params.titleSuffix %}
+  {% set exampleTitle = exampleTitle + " " + params.titleSuffix %}
+{% endif %}
+{% set exampleTitle = exampleTitle + " example" %}
+
+{% set exampleId = exampleTitle | kebabCase %}
 {% if params.open %}
   {% set exampleId = exampleId + '-open' %}
 {% endif %}


### PR DESCRIPTION
Instead of testing all the pages in the service, it was decided that it
would be best to check page templates instead of specific components which
should be tested in GOV.UK Frontend.

1. Home page - layout template ✅
2. Component page - layout-pane template ✅
3. Patterns - Gender and Sex page - layout-pane template ✅
4. Cookie page - layout-single-page-prose template ✅
5. Get in touch Page - layout-single-page template ✅
6. Sitemap page - layout-sitemap template ✅

fixes #620 