### PR TITLE
Remove redundant clickCloseContainer function

### DIFF
--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -88,12 +88,6 @@ AppTabs.prototype.resetTabs = function () {
   })
 }
 
-// Close current container on click
-AppTabs.prototype.clickCloseContainer = function (event) {
-  event.preventDefault()
-  this.resetTabs()
-}
-
 AppTabs.prototype.handleClick = function (event) {
   // toggle and active selected tab and heading (on mobile)
   if (event.target.parentNode.classList.contains(tabsItemJsClass) ||


### PR DESCRIPTION
As the functionality was removed in #670 this function is no longer used and can be removed