### PR TITLE
Add community principles

### DIFF
--- a/src/community/index.md.njk
+++ b/src/community/index.md.njk
@@ -14,3 +14,34 @@ Find out:
 
 Learn how the [Design System working group](/community/design-system-working-group) reviews and approves components and patterns to confirm they meet the [contribution criteria](/community/contribution-criteria).
 
+## Community principles 
+
+These principles are for the community of people that create and contribute to government components and patterns. 
+
+### 1. Start with what exists
+
+Reuse as much as possible and iterate based on user needs. 
+
+Start by checking what exists in the [GOV.UK Design System](/). 
+
+If something is not in the Design System, check the [community backlog](/community/backlog/) to see what colleagues in other departments have done before.
+
+Reach out to the community to ask questions, gather examples and learn from others’ mistakes.
+
+### 2. Contribute back and help others 
+
+The GOV.UK Design System is for everyone. Anyone can contribute evidenced-based changes. 
+
+Think beyond your service and aim to design components and patterns that are scalable, reusable and can evolve over time. 
+
+Share research findings and examples with others. Be open to feedback or changes to your work. 
+
+Above all, be kind. Encourage others to contribute by being respectful when asking questions or giving feedback.
+
+### 3. Prioritise openness and honesty
+
+Prioritise sharing components and patterns in the GOV.UK Design System and community backlog. This makes them to find and reduces duplication of effort. 
+
+Share work in progress as early as possible. Be honest about the amount and nature of your research and findings. Share what works and what does not.
+
+Promote awareness of existing work whenever possible.

--- a/src/community/index.md.njk
+++ b/src/community/index.md.njk
@@ -40,7 +40,7 @@ Above all, be kind. Encourage others to contribute by being respectful when aski
 
 ### 3. Prioritise openness and honesty
 
-Prioritise sharing components and patterns in the GOV.UK Design System and community backlog. This makes them to find and reduces duplication of effort. 
+Prioritise sharing components and patterns in the GOV.UK Design System and [community backlog](/community/backlog/). This makes them to find and reduces duplication of effort. 
 
 Share work in progress as early as possible. Be honest about the amount and nature of your research and findings. Share what works and what does not.
 


### PR DESCRIPTION
Add community principles to the landing page of the Community section.

These principles were co-created with 35 members of our community of users and contributors.