### PR TITLE
Update radios and checkboxes guidance on ordering options

### DIFF
--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -38,6 +38,15 @@ Unlike with radios, users can select multiple options from a list of checkboxes.
 
 If needed, add a hint explaining this, for example, 'Select all that apply'.
 
+Do not pre-select checkbox options as this makes it more likely that users will:
+
+- not realise they’ve missed a question
+- submit the wrong answer
+
+Order checkbox options alphabetically by default.
+
+In some cases, it can be helpful to order them from most-to-least common options. For example, you could order options for ‘What is your nationality?’ based on population size.
+
 There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", id: "default-2"}) }}

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -42,7 +42,7 @@ Users cannot go back to having no option selected once they have selected one, w
 
 Order radio options alphabetically by default. 
 
-In some cases, it can be helpful to order them from most-to-least common options, for example, you could order options for 'Where do you live?' based on population size.
+In some cases, it can be helpful to order them from most-to-least common options. For example, you could order options for 'Where do you live?' based on population size.
 
 However you should do this with extreme caution as it can reinforce bias in your service. If in doubt, order alphabetically. 
 


### PR DESCRIPTION
As part of the Dropbox Paper migration work, this PR:

- adds guidance explaining that you should order checkboxes alphabetically by default, and from most-to-least common if applicable
- makes a small change to shorten a sentence length in the radios guidance

More information about this work can be found in the [checkboxes issue in the community backlog](https://github.com/alphagov/govuk-design-system-backlog/issues/37#issuecomment-460603249)