### PR TITLE
Fix typo in community principles

### DIFF
--- a/src/community/index.md.njk
+++ b/src/community/index.md.njk
@@ -40,7 +40,7 @@ Above all, be kind. Encourage others to contribute by being respectful when aski
 
 ### 3. Prioritise openness and honesty
 
-Prioritise sharing components and patterns in the GOV.UK Design System and [community backlog](/community/backlog/). This makes them to find and reduces duplication of effort. 
+Prioritise sharing components and patterns in the GOV.UK Design System and [community backlog](/community/backlog/). This makes them easier to find and reduces duplication of effort. 
 
 Share work in progress as early as possible. Be honest about the amount and nature of your research and findings. Share what works and what does not.
 


### PR DESCRIPTION
This pull request adds a missing word to the community principles section. Thanks @rpowis for the spot!