### PR TITLE
Example component update

### DIFF
--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -71,7 +71,7 @@ Use the `autocomplete` attribute on text inputs to help users complete forms mor
 
 For example, to enable autofill on a postcode field, set the `autocomplete` attribute to `postal-code`. See how to do this in the HTML and Nunjucks tabs in the following example.
 
-{{ example({group: "components", item: "text-input", example: "input-autocomplete-attribute", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({group: "components", item: "text-input", example: "input-autocomplete-attribute", displayExample: false, html: true, nunjucks: true, open: true, size: "s"}) }}
 
 If you are working in production and there is a relevant [input purpose](https://www.w3.org/TR/WCAG21/#input-purposes), you'll need to use the `autocomplete` attribute to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
 

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -84,6 +84,12 @@
   }
 }
 
+@include govuk-media-query($until: desktop) {
+  .app-tabs__heading:nth-of-type(1) {
+    border-top: 1px solid $govuk-border-colour;
+  }
+}
+
 .app-tabs__heading--current {
   background-color: darken(govuk-colour("grey-4"), 3%);
 }

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -11,10 +11,12 @@
 {% if params.open %}
   {% set exampleId = exampleId + '-open' %}
 {% endif %}
+{% set display = params.displayExample | default(true) %}
 
 {% set multipleTabs = params.html and params.nunjucks %}
 
 <div class="app-example-wrapper" id="{{ exampleId }}" data-module="app-tabs">
+  {% if display %}
   <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
     <span class="app-example__new-window">
       <a href="{{ exampleURL }}" target="_blank">
@@ -25,6 +27,7 @@
     </span>
     <iframe title="{{ exampleTitle }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0"></iframe>
   </div>
+  {% endif %}
 
   {%- if (multipleTabs) %}
   <span id="options-{{ exampleId }}"></span>


### PR DESCRIPTION
This PR adds the option to remove the rendered example from the example / codeblock.

This means we can present both HTML / Nunjucks tabs when we want to talk specifically about the HTML / Nunjucks (e.g. attributes) and a rendered example would have no purpose.

<img width="853" alt="screen shot 2019-02-11 at 15 40 15" src="https://user-images.githubusercontent.com/23356842/52619638-201b1d80-2e9a-11e9-8874-7203e6f63f85.png">

<img width="419" alt="screen shot 2019-02-12 at 07 37 18" src="https://user-images.githubusercontent.com/23356842/52619644-27422b80-2e9a-11e9-9620-e48ab6a222f6.png">
