### PR TITLE
Add research to confirmation page from dropbox paper

### DIFF
--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -48,3 +48,7 @@ If you cannot, make sure your service responds in a helpful way when users retur
 ## Research on this pattern
 
 [Read a blog post about users who bookmark confirmation pages](https://designnotes.blog.gov.uk/2015/12/10/do-users-return-to-your-service-after-finishing/).
+
+### Known gaps
+
+Research is needed on the best way to confirm transactions that are part of a wider user task. For example, where you might need to emphasise next steps more than completion of that particular transaction.


### PR DESCRIPTION
Adds this research gathered from Dropbox paper audit

**Known gaps**
Research is needed on the best way to confirm transactions that are part of a wider user task. For example, where you might need to emphasise next steps more than completion of that particular transaction.