### PR TITLE
Make GOV.UK banner same height with/without search

### DIFF
--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -21,6 +21,7 @@ $icon-size: 40px;
     @include govuk-media-query($from: desktop) {
       margin: 0;
       margin-top: -6px; //negative margin to vertically align search in header
+      margin-bottom: -1px;
       float: right;
     }
 


### PR DESCRIPTION
When the page first loads the GOV.UK banner is 33px high. 

When Javascript kicks in and search field is rendered it takes up 1px more space than is available, causing the GOV.UK banner to increase in height to accommodate the search.

This causes a 1px jump of the whole page on every page load, because the header pushes down all content below it:

![ds-refresh](https://user-images.githubusercontent.com/355079/52721328-5a231700-2fa1-11e9-8020-2737e320fc82.gif)

This commit adds some negative margin to the search field to make it take up less space, meaning the GOV.UK banner doesn’t need to grow to accommodate it.

***

I haven’t tested this fix locally, and maybe negative margin isn’t the best way of achieving this, but I figured a PR is more useful than an issue…