### PR TITLE
Remove duplicated word

### DIFF
--- a/src/patterns/confirm-an-email-address/index.md.njk
+++ b/src/patterns/confirm-an-email-address/index.md.njk
@@ -28,7 +28,7 @@ Common problems with email confirmation include:
 - confusing users about the journey outside the service
 - assuming users have an email account and access to it
 - sending emails to spam folders so users do not see them, for example, because it goes to their spam folder
-- taking too long to send send the confirmation email
+- taking too long to send the confirmation email
 
 You must design your service to reduce these issues for users.
 


### PR DESCRIPTION
Removes a duplicated word that was reported by a member of the community.