### PR TITLE
Clarify what is meant by 'full legal name'

### DIFF
--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -51,7 +51,7 @@ If users are from outside the UK, use the labels:
 
 Make middle names optional.
 
-Make it clear whether you need someone’s common name, or if it needs to match their name as used on official documents such as a passport or driving licence.
+Make it clear whether you need someone’s common name, or their name as it's written on official documents such as a passport or driving licence.
 
 ### Use the autocomplete attribute on name fields
 

--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -51,7 +51,7 @@ If users are from outside the UK, use the labels:
 
 Make middle names optional.
 
-Make it clear whether you need someone’s common name or their full legal name.
+Make it clear whether you need someone’s common name, or if it needs to match their name as used on official documents such as a passport or driving licence.
 
 ### Use the autocomplete attribute on name fields
 


### PR DESCRIPTION
"Full legal name" doesn’t seem to have a clear and unambiguous meaning (for instance it implies that everyone has a single legal name, when they may use both a married and maiden name in different contexts).  Instead it may be better to refer to a name matching that used on government issued documents such as passports and driving licences.

It is also possibly to have an additional name noted on a passport in the observations page.

See:

* [Change your name by deed poll](https://www.gov.uk/change-name-deed-poll)
* [Recording Changes of Forename(s) and Surname(s) in Scotland
](https://www.nrscotland.gov.uk/registration/recording-change-of-forename-and-surname-in-scotland)
* [Annex A: use of names in passports](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/548220/Annex_A_passports_August_2016.pdf)