### PR TITLE
Remove label width overrides on Spacing and Text Input page

### DIFF
--- a/src/components/text-input/input-fluid-width/index.njk
+++ b/src/components/text-input/input-fluid-width/index.njk
@@ -8,8 +8,7 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "Full width",
-    classes: "govuk-!-width-full"
+    text: "Full width"
   },
   classes: "govuk-!-width-full",
   id: "full",
@@ -18,8 +17,7 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "Three-quarters width",
-    classes: "govuk-!-width-three-quarters"
+    text: "Three-quarters width"
   },
   classes: "govuk-!-width-three-quarters",
   id: "three-quarters",
@@ -28,8 +26,7 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "Two-thirds width",
-    classes: "govuk-!-width-two-thirds"
+    text: "Two-thirds width"
   },
   classes: "govuk-!-width-two-thirds",
   id: "two-thirds",
@@ -38,8 +35,7 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "One-half width",
-    classes: "govuk-!-width-one-half"
+    text: "One-half width"
   },
   classes: "govuk-!-width-one-half",
   id: "one-half",
@@ -48,8 +44,7 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "One-third width",
-    classes: "govuk-!-width-one-third"
+    text: "One-third width"
   },
   classes: "govuk-!-width-one-third",
   id: "one-third",
@@ -58,8 +53,7 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "One-quarter width",
-    classes: "govuk-!-width-one-quarter"
+    text: "One-quarter width"
   },
   classes: "govuk-!-width-one-quarter",
   id: "one-quarter",

--- a/src/styles/spacing/input-width/index.njk
+++ b/src/styles/spacing/input-width/index.njk
@@ -10,8 +10,7 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "Full name",
-    classes: "govuk-!-width-full"
+    text: "Full name"
   },
   classes: "govuk-!-width-full",
   id: "full-name",
@@ -22,8 +21,7 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "Full name",
-    classes: "govuk-!-width-three-quarters"
+    text: "Full name"
   },
   classes: "govuk-!-width-three-quarters",
   id: "full-name",
@@ -34,8 +32,7 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "Full name",
-    classes: "govuk-!-width-two-thirds"
+    text: "Full name"
   },
   classes: "govuk-!-width-two-thirds",
   id: "full-name",
@@ -46,8 +43,7 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "Full name",
-    classes: "govuk-!-width-one-half"
+    text: "Full name"
   },
   classes: "govuk-!-width-one-half",
   id: "full-name",
@@ -58,8 +54,7 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "Full name",
-    classes: "govuk-!-width-one-third"
+    text: "Full name"
   },
   classes: "govuk-!-width-one-third",
   id: "full-name",
@@ -70,8 +65,7 @@ ignore_in_sitemap: true
 
 {{ govukInput({
   label: {
-    text: "Full name",
-    classes: "govuk-!-width-one-quarter"
+    text: "Full name"
   },
   classes: "govuk-!-width-one-quarter",
   id: "full-name",


### PR DESCRIPTION
As reported by @edwardhorsford in https://github.com/alphagov/govuk-design-system/issues/804, the labels having width override classes as well as the inputs could be misleading outside of the context of the examples.

This PR removes the override classes from the labels on the Styles > Spacing page and the Text input page.

