### PR TITLE
Clarify wording for the main block in the page template

### DIFF
--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -213,7 +213,7 @@ To change the components that are included by default, set their equivalent bloc
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">main</td>
       <td class="govuk-table__cell">
-        Override the default <code>&lt;main&gt;</code> element.
+        Override the main section of the page, which by default wraps the <code>&lt;main&gt;</code> element, <code>beforeContent</code> block and <code>content</code> block.
       </td>
     </tr>
 


### PR DESCRIPTION
Clarify what the main block overrides so that it also includes 'content' and 'beforeContent' block, which aims to resolve some of the confusion around how the diagram relates to this block.

Fixes #802