### PR TITLE
Fix generating example IDs

### DIFF
--- a/__tests__/accessiblity_audit.test.js
+++ b/__tests__/accessiblity_audit.test.js
@@ -15,6 +15,12 @@ const thingsToExclude = [
 beforeAll(async (done) => {
   browser = global.browser
   page = await browser.newPage()
+
+  // Capture JavaScript errors.
+  page.on('pageerror', error => {
+    throw error
+  })
+
   done()
 })
 

--- a/__tests__/accessiblity_audit.test.js
+++ b/__tests__/accessiblity_audit.test.js
@@ -1,0 +1,103 @@
+/* eslint-env jest */
+const configPaths = require('../config/paths.json')
+const PORT = configPaths.testPort
+const { AxePuppeteer } = require('axe-puppeteer')
+
+let browser
+let page
+let baseUrl = 'http://localhost:' + PORT
+const thingsToExclude = [
+  // axe reports there is "no label associated with the text field", when there is one.
+  ['#app-site-search__input'],
+  // axe reports that the phase banner is not inside a landmark, which is intentional.
+  ['.app-phase-banner__wrapper']
+]
+beforeAll(async (done) => {
+  browser = global.browser
+  page = await browser.newPage()
+  done()
+})
+
+afterAll(async (done) => {
+  await page.close()
+  done()
+})
+
+describe('Accessibility Audit', () => {
+  describe('Home page - layout.njk', () => {
+    it('validates', async () => {
+      await page.goto(baseUrl + '/', { waitUntil: 'load' })
+      const results =
+        await new AxePuppeteer(page)
+          .include(['body'])
+          .exclude(...thingsToExclude)
+          .analyze()
+      expect(results.violations).toEqual([])
+    })
+  })
+
+  describe('Component page - layout-pane.njk', () => {
+    it('validates', async () => {
+      await page.goto(baseUrl + '/components/radios/', { waitUntil: 'load' })
+      const results =
+        await new AxePuppeteer(page)
+          .include(['body'])
+          .exclude(...thingsToExclude)
+          .analyze()
+
+      expect(results.violations).toEqual([])
+    })
+  })
+
+  describe('Patterns page - layout-pane.njk', () => {
+    it('validates', async () => {
+      await page.goto(baseUrl + '/patterns/gender-or-sex/', { waitUntil: 'load' })
+      const results =
+        await new AxePuppeteer(page)
+          .include(['body'])
+          .exclude(...thingsToExclude)
+          .analyze()
+
+      expect(results.violations).toEqual([])
+    })
+  })
+
+  describe('Cookies page - layout-single-page-prose.njk', () => {
+    it('validates', async () => {
+      await page.goto(baseUrl + '/cookies/', { waitUntil: 'load' })
+      const results =
+        await new AxePuppeteer(page)
+          .include(['body'])
+          .exclude(...thingsToExclude)
+          .analyze()
+
+      expect(results.violations).toEqual([])
+    })
+  })
+
+  describe('Get in touch page - layout-single-page.njk', () => {
+    it('validates', async () => {
+      await page.goto(baseUrl + '/get-in-touch/', { waitUntil: 'load' })
+      const results =
+        await new AxePuppeteer(page)
+          .include(['body'])
+          .exclude(...thingsToExclude)
+          .analyze()
+
+      expect(results.violations).toEqual([])
+    })
+  })
+
+  describe('Site Map page - layout-sitemap.njk', () => {
+    it('validates', async () => {
+      await page.goto(baseUrl + '/sitemap/', { waitUntil: 'load' })
+      const results =
+        await new AxePuppeteer(page)
+          .include(['body'])
+          .exclude(...thingsToExclude)
+          .analyze()
+
+      expect(results.violations).toEqual([])
+    })
+  })
+})

--- a/__tests__/back-to-top.test.js
+++ b/__tests__/back-to-top.test.js
@@ -12,6 +12,12 @@ beforeAll(async (done) => {
   await page.evaluateOnNewDocument(() => {
     window.__TESTS_RUNNING = true
   })
+
+  // Capture JavaScript errors.
+  page.on('pageerror', error => {
+    throw error
+  })
+
   done()
 })
 

--- a/__tests__/component-options.test.js
+++ b/__tests__/component-options.test.js
@@ -9,6 +9,12 @@ let baseUrl = 'http://localhost:' + PORT
 beforeAll(async (done) => {
   browser = global.browser
   page = await browser.newPage()
+
+  // Capture JavaScript errors.
+  page.on('pageerror', error => {
+    throw error
+  })
+
   done()
 })
 

--- a/__tests__/example.test.js
+++ b/__tests__/example.test.js
@@ -12,6 +12,12 @@ beforeAll(async (done) => {
   await page.evaluateOnNewDocument(() => {
     window.__TESTS_RUNNING = true
   })
+
+  // Capture JavaScript errors.
+  page.on('pageerror', error => {
+    throw error
+  })
+
   done()
 })
 

--- a/__tests__/mobile-navigation.test.js
+++ b/__tests__/mobile-navigation.test.js
@@ -15,6 +15,12 @@ beforeAll(async (done) => {
     window.__TESTS_RUNNING = true
   })
   await page.emulate(iPhone)
+
+  // Capture JavaScript errors.
+  page.on('pageerror', error => {
+    throw error
+  })
+
   done()
 })
 

--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -15,6 +15,12 @@ beforeEach(async (done) => {
   await page.evaluateOnNewDocument(() => {
     window.__TESTS_RUNNING = true
   })
+
+  // Capture JavaScript errors.
+  page.on('pageerror', error => {
+    throw error
+  })
+
   done()
 })
 

--- a/__tests__/tabs.test.js
+++ b/__tests__/tabs.test.js
@@ -12,6 +12,12 @@ beforeAll(async (done) => {
   await page.evaluateOnNewDocument(() => {
     window.__TESTS_RUNNING = true
   })
+
+  // Capture JavaScript errors.
+  page.on('pageerror', error => {
+    throw error
+  })
+
   done()
 })
 

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -24,6 +24,7 @@ const modernizrBuild = require('./modernizr-build.js') // modernizr build plugin
 const generateSitemap = require('./generate-sitemap.js') // generate sitemap
 const lunr = require('./metalsmith-lunr-index') // generate search index
 const extractPageHeadings = require('../lib/extract-page-headings/index.js') // extract page headings into file meta data
+const slugger = require('slugger') // generate slugs from titles
 
 const colours = require('../lib/colours.js') // get colours data
 const fileHelper = require('../lib/file-helper.js') // helper function to operate on files
@@ -218,7 +219,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
       },
       filters: {
         highlight: highlighter,
-        kebabCase: string => string.replace(/\s+/g, '-').toLowerCase()
+        slugger
       },
 
       // Markdown engine options

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -217,7 +217,8 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
         getMacroOptions: getMacroOptions
       },
       filters: {
-        highlight: highlighter
+        highlight: highlighter,
+        kebabCase: string => string.replace(/\s+/g, '-').toLowerCase()
       },
 
       // Markdown engine options

--- a/package-lock.json
+++ b/package-lock.json
@@ -801,6 +801,21 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "axe-core": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.1.2.tgz",
+      "integrity": "sha512-e1WVs0SQu3tM29J9a/mISGvlo2kdCStE+yffIAJF6eb42FS+eUFEVz9j4rgDeV2TAfPJmuOZdRetWYycIbK7Vg==",
+      "dev": true
+    },
+    "axe-puppeteer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/axe-puppeteer/-/axe-puppeteer-1.0.0.tgz",
+      "integrity": "sha512-hTF3u4mtatgTN7fsLVyVgbRdNc15ngjDcTEuqhn9A7ugqLhLCryJWp9fzqZkNlrW8awPcxugyTwLPR7mRdPZmA==",
+      "dev": true,
+      "requires": {
+        "axe-core": "3.1.2"
+      }
+    },
     "axios": {
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
@@ -3503,7 +3518,7 @@
     },
     "eslint": {
       "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "resolved": "http://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
       "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
       "dev": true,
       "requires": {
@@ -5213,7 +5228,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -5290,7 +5305,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -6748,7 +6763,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
@@ -8942,7 +8957,7 @@
       "dependencies": {
         "yargs": {
           "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "dev": true,
           "requires": {
@@ -11493,7 +11508,7 @@
     },
     "shelljs": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
       "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -813,7 +813,7 @@
       "integrity": "sha512-hTF3u4mtatgTN7fsLVyVgbRdNc15ngjDcTEuqhn9A7ugqLhLCryJWp9fzqZkNlrW8awPcxugyTwLPR7mRdPZmA==",
       "dev": true,
       "requires": {
-        "axe-core": "3.1.2"
+        "axe-core": "^3.1.2"
       }
     },
     "axios": {
@@ -3518,7 +3518,7 @@
     },
     "eslint": {
       "version": "2.13.1",
-      "resolved": "http://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
       "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
       "dev": true,
       "requires": {
@@ -5228,7 +5228,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -5305,7 +5305,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -6763,7 +6763,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
@@ -8957,7 +8957,7 @@
       "dependencies": {
         "yargs": {
           "version": "3.32.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "dev": true,
           "requires": {
@@ -11508,7 +11508,7 @@
     },
     "shelljs": {
       "version": "0.6.1",
-      "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
       "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
       "dev": true
     },
@@ -11576,6 +11576,11 @@
           "dev": true
         }
       }
+    },
+    "slugger": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/slugger/-/slugger-1.0.1.tgz",
+      "integrity": "sha1-eEQ2CMtuiV9+tcbARFayfI2Xc1s="
     },
     "slugify": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "accessible-autocomplete": "^1.6.2",
+    "axe-puppeteer": "^1.0.0",
     "fs-extra": "^7.0.1",
     "iframe-resizer": "^3.5.16",
     "jest": "^23.6.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "metalsmith-postcss": "^4.2.0",
     "modernizr": "^3.6.0",
     "sass-export": "^1.0.2",
-    "serve-static": "^1.13.2"
+    "serve-static": "^1.13.2",
+    "slugger": "^1.0.1"
   },
   "devDependencies": {
     "accessible-autocomplete": "^1.6.2",

--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -33,7 +33,7 @@ If this is not possible, you should hide the back link when JavaScript is not av
 
 There are 2 ways to use the back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/breadcrumbs/index.md.njk
+++ b/src/components/breadcrumbs/index.md.njk
@@ -29,7 +29,7 @@ The breadcrumbs component should include the user’s current page, which should
 
 There are 2 ways to use the breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -49,7 +49,7 @@ In some cases, it can be helpful to order them from most-to-least common options
 
 There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", id: "default-2"}) }}
+{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
 
 ### Checkbox items with hints
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -35,7 +35,7 @@ Read more about [why and how to set legends as headings](../../get-started/label
 
 There are 2 ways to use the date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 
 Never automatically tab users between the fields of the date input because this can be confusing and may clash with normal keyboard controls.
 

--- a/src/components/details/index.md.njk
+++ b/src/components/details/index.md.njk
@@ -35,7 +35,7 @@ The details component is a short link that expands into more detailed help text 
 
 There are 2 ways to use the details component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 
 ### Write clear link text
 

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -34,7 +34,7 @@ Read guidance on [writing good error messages](../error-message#be-clear-and-con
 
 There are 2 ways to use the error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 
 ### Linking from the error summary to each answer
 

--- a/src/components/file-upload/index.md.njk
+++ b/src/components/file-upload/index.md.njk
@@ -21,7 +21,7 @@ You should only ask users to upload something if it’s critical to the delivery
 
 There are 2 ways to use the file upload component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ### Error messages
 

--- a/src/components/footer/index.md.njk
+++ b/src/components/footer/index.md.njk
@@ -27,7 +27,7 @@ You can add links to:
 
 ### Default footer
 
-{{ example({group: "components", item: "footer", example: "default", id: "default-2", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({group: "components", item: "footer", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ### Footer with secondary navigation
 

--- a/src/components/header/index.md.njk
+++ b/src/components/header/index.md.njk
@@ -31,7 +31,7 @@ You must not use the GOV.UK header if your service is not being hosted on one of
 
 Use the default header if your service has 5 pages or fewer.
 
-{{ example({group: "components", item: "header", example: "default", id: "default-2", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "header", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false}) }}
 
 ### Header with service name
 

--- a/src/components/inset-text/index.md.njk
+++ b/src/components/inset-text/index.md.njk
@@ -31,7 +31,7 @@ Use inset text very sparingly - it’s less effective if it’s overused.
 
 There are 2 ways to use the inset text component. You can use HTML or, if you’re using Nunjucks or the GOV.UK Prototype Kit, you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -29,7 +29,7 @@ If you add extra content to the panel, to meet colour contrast ratio requirement
 
 There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", id: "default-2"}) }}
+{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -24,7 +24,7 @@ Your banner must be directly under the black GOV.UK header and colour bar.
 
 There are 2 ways to use the phase banner component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 {{ example({group: "components", item: "phase-banner", example: "beta", html: true, nunjucks: true, open: false}) }}
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -58,7 +58,7 @@ When there are more than 2 options, radios should be stacked, like so:
 
 If there are only 2 options, you can either stack the radios or display them inline, like so:
 
-{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 
 ### Radio items with hints
 

--- a/src/components/select/index.md.njk
+++ b/src/components/select/index.md.njk
@@ -23,7 +23,7 @@ Asking questions means you’re less likely to need to use the select component,
 
 There are 2 ways to use the select component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com),  you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/skip-link/index.md.njk
+++ b/src/components/skip-link/index.md.njk
@@ -27,7 +27,7 @@ The skip link component is visually hidden until a keyboard press activates it.
 
 There are 2 ways to use the skip link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/summary-list/index.md.njk
+++ b/src/components/summary-list/index.md.njk
@@ -39,7 +39,7 @@ For sighted users, the actions get their context from the other content in the r
 Assistive technology users, like those who use a screen reader, may hear the links out of context and not know what they do.
 To give more context, add visually hidden text to the links. This means a screen reader user will hear a meaningful action, like ‘Change name’ or ‘Change date of birth’.
 
-{{ example({group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ### Summary list without actions
 

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -33,7 +33,7 @@ Use table headers to tell users what the rows and columns represent. Use the `sc
 
 There are 2 ways to use the table component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m", id: "default-2"}) }}
+{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
 
 ## Numbers in a table
 

--- a/src/components/tabs/index.md.njk
+++ b/src/components/tabs/index.md.njk
@@ -64,7 +64,7 @@ The details component is less visually prominent than tabs, so tends to work bet
 
 There are 2 ways to use the tabs component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false, size: "xl", id: "default-2"}) }}
+{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false, size: "xl", titleSuffix: "second"}) }}
 
 The tabs component uses JavaScript. When JavaScript is not available, users will see the tabbed content on a single page, in order from first to last, with a table of contents that links to each of the sections.
 

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -19,7 +19,7 @@ Use the tag component to indicate the status of something, such as an item on a 
 
 There are 2 ways to use the tag component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ## Research on this component
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -23,7 +23,7 @@ Do not use the text input component if you need to let users enter longer answer
 
 There are 2 ways to use the text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: dalse, size: "s", id: "default-2"}) }}
+{{ example({group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: dalse, size: "s", titleSuffix: "second"}) }}
 
 ### Label text inputs
 

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -27,7 +27,7 @@ Do not use the textarea component if you need to let users enter shorter answers
 
 There are 2 ways to use the textarea component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", id: "default-2"}) }}
+{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
 
 ### Label textareas
 

--- a/src/components/warning-text/index.md.njk
+++ b/src/components/warning-text/index.md.njk
@@ -19,7 +19,7 @@ Use the warning text component when you need to warn users about something impor
 
 There are 2 ways to use the warning text component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 You might need to rewrite the hidden text (‘Warning’ in the example) to make it appropriate for your context.
 

--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -43,8 +43,18 @@ AppTabs.prototype.activateAndToggle = function (event) {
   event.preventDefault()
   var $currentToggler = event.target
   var $currentTogglerSiblings = this.$module.querySelectorAll('[href="' + $currentToggler.hash + '"]')
-  var $tabContainer = this.$module.querySelector($currentToggler.hash)
+  var $tabContainer
+
+  try {
+    $tabContainer = this.$module.querySelector($currentToggler.hash)
+  } catch (exception) {
+    throw new Error('Invalid example ID given: ' + exception)
+  }
   var isTabAlreadyOpen = $currentToggler.getAttribute('aria-expanded') === 'true'
+
+  if (!$tabContainer) {
+    return
+  }
 
   if (isTabAlreadyOpen) {
     $tabContainer.classList.add(tabContainerHiddenClass)

--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -33,7 +33,7 @@ Your confirmation page must include:
 
 If you add extra content to the panel, to meet colour contrast ratio requirements use a font size of <code>govuk-body-l</code> for normal weight and <code>govuk-body</code> for bold.
 
-{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, id: "default-2", size: "xl"}) }}
+{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second", size: "xl"}) }}
 
 ### Help users who bookmark the page
 

--- a/src/patterns/page-not-found-pages/index.md.njk
+++ b/src/patterns/page-not-found-pages/index.md.njk
@@ -50,7 +50,7 @@ Do not use:
 - informal or humorous words like oops
 - red text to warn people
 
-{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true, nunjucks: true, id: "default-2", size: "xl"}) }}
+{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true, nunjucks: true, titleSuffix: "second", size: "xl"}) }}
 
 ## Research on this pattern
 

--- a/src/patterns/problem-with-the-service-pages/index.md.njk
+++ b/src/patterns/problem-with-the-service-pages/index.md.njk
@@ -48,7 +48,7 @@ Have clear and concise content and do not use:
 
 ### Service has a specific page that includes numbers and opening times
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, nunjucks: true, open: false, id: "default-2", size: "xl"}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second", size: "xl"}) }}
 
 ### Service has offline support but no specific page that includes numbers and opening times
 

--- a/src/patterns/start-pages/index.md.njk
+++ b/src/patterns/start-pages/index.md.njk
@@ -38,7 +38,7 @@ This is a set pattern, so you will not be able to customise it.
 
 Read guidance on [what information should go on a start page](https://www.gov.uk/service-manual/design/govuk-content-transactions) in the Service Manual.
 
-{{ example({group: "patterns", item: "start-pages", example: "default", html: true, nunjucks: true, open: false, id: "default-2"}) }}
+{{ example({group: "patterns", item: "start-pages", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ## Research on this pattern
 

--- a/src/styles/layout/common-two-thirds-one-third/index.njk
+++ b/src/styles/layout/common-two-thirds-one-third/index.njk
@@ -20,7 +20,7 @@ ignore_in_sitemap: true
       </div>
 
       <div class="govuk-grid-column-one-third">
-        <h3 class="govuk-heading-m">One-third column</h3>
+        <h2 class="govuk-heading-m">One-third column</h3>
         <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
       </div>
     </div>

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -28,7 +28,7 @@
 {% block header %}{% endblock %}
 
 {% block main %}
-<div class="app-pane {% block appPaneClasses %}{% endblock %}">
+<div class="app-pane {% block appPaneClasses %}{% endblock %}" id="top">
   {% include "_cookie-banner.njk" %}
   <div class="app-pane__header">
     {% include "_header.njk" %}

--- a/views/layouts/layout.njk
+++ b/views/layouts/layout.njk
@@ -1,7 +1,6 @@
 {% extends "_generic.njk" %}
 
 {% block body %}
-<a name="top"></a>
 <div class="app-pane__content">
   <main id="main-content" role="main">
     {{ contents | safe }}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -6,9 +6,14 @@
   {% set examplePath = exampleRoot + "index.njk" %}
 {% endif %}
 {% set exampleURL = "/" + params.group + "/" + params.item + "/" + params.example + "/index.html" %}
-{% set exampleId = params.id | default("example-" + params.example) %}
-{% set exampleTitle = getFrontmatter(examplePath).title %}
 
+{% set exampleTitle = getFrontmatter(examplePath).title %}
+{% if params.titleSuffix %}
+  {% set exampleTitle = exampleTitle + " " + params.titleSuffix %}
+{% endif %}
+{% set exampleTitle = exampleTitle + " example" %}
+
+{% set exampleId = exampleTitle | kebabCase %}
 {% if params.open %}
   {% set exampleId = exampleId + '-open' %}
 {% endif %}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -13,10 +13,16 @@
 {% endif %}
 {% set exampleTitle = exampleTitle + " example" %}
 
-{% set exampleId = exampleTitle | kebabCase %}
+{% if params.id %}
+  {% set exampleId = params.id %}
+{% else %}
+  {% set exampleId = exampleTitle | slugger %}
+{% endif %}
+
 {% if params.open %}
   {% set exampleId = exampleId + '-open' %}
 {% endif %}
+
 {% set display = params.displayExample | default(true) %}
 
 {% set multipleTabs = params.html and params.nunjucks %}


### PR DESCRIPTION
This reverts a hotfix #809  that removed the changes, in favour of a fix for generating example IDs for https://github.com/alphagov/govuk-design-system/pull/784.

Generating example IDs from example titles can be brittle if there are unexpected characters in titles. This goes back to using `exampleTitle` to generate the IDs with slugger and uses the solution from #620 to fix duplicate IDs that were flagged by Axe. Alternatively we could keep the kebab casing filter and try to make sure that the Regex in it can cope with foreign characters but it seems kind of liable to breaking.

If someone adds the same example to a page several times, they'll need to specify `titleSuffix` for the example macro as `example` parameter from the macro won't be unique but this issue existed also with the previous solution. We could think about testing all the pages to catch this.

Best just to review these commits directly: 
- https://github.com/alphagov/govuk-design-system/commit/3522fc138ede0638d933e384f904e7ba59bf74e4 
- https://github.com/alphagov/govuk-design-system/pull/813/commits/ac4f3475bacdcb5c7b088a912589214afeacf99e
- https://github.com/alphagov/govuk-design-system/pull/813/commits/48fcf34db72a125a17a14d67b4f23e14832aa03a

