### PR TITLE
Avoid tests from running Google Tag Manager analytics code

### DIFF
--- a/__tests__/accessiblity_audit.test.js
+++ b/__tests__/accessiblity_audit.test.js
@@ -1,32 +1,26 @@
 /* eslint-env jest */
-const configPaths = require('../config/paths.json')
-const PORT = configPaths.testPort
+
 const { AxePuppeteer } = require('axe-puppeteer')
 
-let browser
+const { setupPage } = require('../lib/jest-utilities.js')
+const configPaths = require('../config/paths.json')
+const PORT = configPaths.testPort
+
 let page
 let baseUrl = 'http://localhost:' + PORT
+
 const thingsToExclude = [
   // axe reports there is "no label associated with the text field", when there is one.
   ['#app-site-search__input'],
   // axe reports that the phase banner is not inside a landmark, which is intentional.
   ['.app-phase-banner__wrapper']
 ]
-beforeAll(async (done) => {
-  browser = global.browser
-  page = await browser.newPage()
-
-  // Capture JavaScript errors.
-  page.on('pageerror', error => {
-    throw error
-  })
-
-  done()
+beforeAll(async () => {
+  page = await setupPage()
 })
 
-afterAll(async (done) => {
+afterAll(async () => {
   await page.close()
-  done()
 })
 
 describe('Accessibility Audit', () => {

--- a/__tests__/back-to-top.test.js
+++ b/__tests__/back-to-top.test.js
@@ -1,29 +1,18 @@
 /* eslint-env jest */
+
+const { setupPage } = require('../lib/jest-utilities.js')
 const configPaths = require('../config/paths.json')
 const PORT = configPaths.testPort
 
-let browser
 let page
 let baseUrl = 'http://localhost:' + PORT
 
-beforeAll(async (done) => {
-  browser = global.browser
-  page = await browser.newPage()
-  await page.evaluateOnNewDocument(() => {
-    window.__TESTS_RUNNING = true
-  })
-
-  // Capture JavaScript errors.
-  page.on('pageerror', error => {
-    throw error
-  })
-
-  done()
+beforeAll(async () => {
+  page = await setupPage()
 })
 
-afterAll(async (done) => {
+afterAll(async () => {
   await page.close()
-  done()
 })
 
 const BACK_TO_TOP_LINK_SELECTOR = '[data-module="app-back-to-top"] a'

--- a/__tests__/component-options.test.js
+++ b/__tests__/component-options.test.js
@@ -1,26 +1,18 @@
 /* eslint-env jest */
+
+const { setupPage } = require('../lib/jest-utilities.js')
 const configPaths = require('../config/paths.json')
 const PORT = configPaths.testPort
 
-let browser
 let page
 let baseUrl = 'http://localhost:' + PORT
 
-beforeAll(async (done) => {
-  browser = global.browser
-  page = await browser.newPage()
-
-  // Capture JavaScript errors.
-  page.on('pageerror', error => {
-    throw error
-  })
-
-  done()
+beforeAll(async () => {
+  page = await setupPage()
 })
 
-afterAll(async (done) => {
+afterAll(async () => {
   await page.close()
-  done()
 })
 
 describe('Component page', () => {

--- a/__tests__/example.test.js
+++ b/__tests__/example.test.js
@@ -1,29 +1,18 @@
 /* eslint-env jest */
+
+const { setupPage } = require('../lib/jest-utilities.js')
 const configPaths = require('../config/paths.json')
 const PORT = configPaths.testPort
 
-let browser
 let page
 let baseUrl = 'http://localhost:' + PORT
 
-beforeAll(async (done) => {
-  browser = global.browser
-  page = await browser.newPage()
-  await page.evaluateOnNewDocument(() => {
-    window.__TESTS_RUNNING = true
-  })
-
-  // Capture JavaScript errors.
-  page.on('pageerror', error => {
-    throw error
-  })
-
-  done()
+beforeAll(async () => {
+  page = await setupPage()
 })
 
-afterAll(async (done) => {
+afterAll(async () => {
   await page.close()
-  done()
 })
 
 describe('Example page', () => {

--- a/__tests__/mobile-navigation.test.js
+++ b/__tests__/mobile-navigation.test.js
@@ -1,32 +1,20 @@
 /* eslint-env jest */
 const devices = require('puppeteer/DeviceDescriptors')
 const iPhone = devices['iPhone 6']
+
+const { setupPage } = require('../lib/jest-utilities.js')
 const configPaths = require('../config/paths.json')
 const PORT = configPaths.testPort
 
-let browser
 let page
 let baseUrl = 'http://localhost:' + PORT
 
-beforeAll(async (done) => {
-  browser = global.browser
-  page = await browser.newPage()
-  await page.evaluateOnNewDocument(() => {
-    window.__TESTS_RUNNING = true
-  })
-  await page.emulate(iPhone)
-
-  // Capture JavaScript errors.
-  page.on('pageerror', error => {
-    throw error
-  })
-
-  done()
+beforeAll(async () => {
+  page = await setupPage(iPhone)
 })
 
-afterAll(async (done) => {
+afterAll(async () => {
   await page.close()
-  done()
 })
 
 describe('Homepage', () => {

--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -1,32 +1,21 @@
 /* eslint-env jest */
+
+const { setupPage } = require('../lib/jest-utilities.js')
 const configPaths = require('../config/paths.json')
 const PORT = configPaths.testPort
 
 // Regex that can be used to match on fingerprinted search index files
 const isSearchIndex = /.*\/search-index-[0-9a-f]{32}.json$/
 
-let browser
 let page
 let baseUrl = 'http://localhost:' + PORT
 
-beforeEach(async (done) => {
-  browser = global.browser
-  page = await browser.newPage()
-  await page.evaluateOnNewDocument(() => {
-    window.__TESTS_RUNNING = true
-  })
-
-  // Capture JavaScript errors.
-  page.on('pageerror', error => {
-    throw error
-  })
-
-  done()
+beforeEach(async () => {
+  page = await setupPage()
 })
 
-afterEach(async (done) => {
+afterEach(async () => {
   await page.close()
-  done()
 })
 
 describe('Site search', () => {

--- a/__tests__/tabs.test.js
+++ b/__tests__/tabs.test.js
@@ -1,29 +1,18 @@
 /* eslint-env jest */
+
+const { setupPage } = require('../lib/jest-utilities.js')
 const configPaths = require('../config/paths.json')
 const PORT = configPaths.testPort
 
-let browser
 let page
 let baseUrl = 'http://localhost:' + PORT
 
-beforeAll(async (done) => {
-  browser = global.browser
-  page = await browser.newPage()
-  await page.evaluateOnNewDocument(() => {
-    window.__TESTS_RUNNING = true
-  })
-
-  // Capture JavaScript errors.
-  page.on('pageerror', error => {
-    throw error
-  })
-
-  done()
+beforeAll(async () => {
+  page = await setupPage()
 })
 
-afterAll(async (done) => {
+afterAll(async () => {
   await page.close()
-  done()
 })
 
 describe('Component page', () => {

--- a/lib/jest-utilities.js
+++ b/lib/jest-utilities.js
@@ -1,0 +1,23 @@
+async function setupPage (emulate) {
+  let page = await global.browser.newPage()
+
+  // Inject a global flag to avoid running analytics code while the tests are running.
+  await page.evaluateOnNewDocument(() => {
+    window.__TESTS_RUNNING = true
+  })
+
+  if (emulate) {
+    await page.emulate(emulate)
+  }
+
+  // Capture JavaScript errors.
+  page.on('pageerror', error => {
+    throw error
+  })
+
+  return page
+}
+
+module.exports = {
+  setupPage
+}


### PR DESCRIPTION
This refactor tests to that they all have the same setup
so that we can't accidentally ommit the logic that ensure the analytics are not run.