### PR TITLE
Show sub nav on community and get started pages

### DIFF
--- a/src/community/index.md.njk
+++ b/src/community/index.md.njk
@@ -2,6 +2,7 @@
 layout: layout-pane.njk
 title: Community
 description:  The GOV.UK Design System brings together the latest research, design and development from across government to make it sure it’s representative and relevant for its users
+show_subnav: true
 ---
 
 The GOV.UK Design System is for everyone. It has a strong cross-government community behind it. It includes the latest research, design and development to represent and be relevant for its users.

--- a/src/get-started/index.md.njk
+++ b/src/get-started/index.md.njk
@@ -2,6 +2,7 @@
 layout: layout-pane.njk
 title: Get started
 description: The following introductory guides will help you to get set up
+show_subnav: true
 ---
 
 The examples in the GOV.UK Design System come with code to make it easy for you to use them in your project. 


### PR DESCRIPTION
We need to include a (mobile only) sub nav on these pages so that if JS has failed on a mobile device the user can still access the pages in the section (as the main menu will not be usable for accessing sub pages)