### PR TITLE
Fix broken link

### DIFF
--- a/src/get-started/extending-and-modifying-components/index.md.njk
+++ b/src/get-started/extending-and-modifying-components/index.md.njk
@@ -22,7 +22,7 @@ When you extend or modify components in the GOV.UK Design System you create pote
 You can help reduce potential risk to your code by:
 
 - using [override classes](#start-with-override-classes)
-- not [overwriting GOV.UK Design System code](#avoid-overwriting-govuk-design-system-code)
+- not [overwriting GOV.UK Design System code](#avoid-overwriting-gov-uk-design-system-code)
 - using a [unique prefix for component names][prefix]
 - creating [custom override classes for multiple components](#custom-override-classes)
 - using BEM for [small modifications to components](#small-modifications-to-components)


### PR DESCRIPTION
On `Avoid overwriting GOV.UK Design System code` the automated conversion generates a `-` between GOV and UK which is missing from a reference