### PR TITLE
Update link to NCSC password research

### DIFF
--- a/src/patterns/passwords/index.md.njk
+++ b/src/patterns/passwords/index.md.njk
@@ -108,7 +108,7 @@ You should not use password reminders because they:
 
 ## Research on this pattern
 
-[Read the National Cyber Security Centre’s guidance on passwords](https://www.ncsc.gov.uk/index/guidance?f%5B0%5D=field_topics%253Aname%3AIdentity%20and%20passwords).
+[Read the National Cyber Security Centre’s guidance on passwords](https://www.ncsc.gov.uk/collection/passwords)
 
 ### Next steps
 


### PR DESCRIPTION
The old link redirected to the new NCSC home page, so I've updated the link to point to the new home for password research. Many thanks to @joelgsamuel for the tip off.