### PR TITLE
Fix mismatched <h2> </h3> in layout example

### DIFF
--- a/src/styles/layout/common-two-thirds-one-third/index.njk
+++ b/src/styles/layout/common-two-thirds-one-third/index.njk
@@ -20,7 +20,7 @@ ignore_in_sitemap: true
       </div>
 
       <div class="govuk-grid-column-one-third">
-        <h2 class="govuk-heading-m">One-third column</h3>
+        <h2 class="govuk-heading-m">One-third column</h2>
         <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
       </div>
     </div>


### PR DESCRIPTION
Looks like this came in by mistake in #784:

https://github.com/alphagov/govuk-design-system/pull/784/files#diff-7883ebc5245f0aeaea5ee02bb00d6d56L23