### PR TITLE
Add contextual adjustment for headings after pre elements

### DIFF
--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -349,4 +349,13 @@ p code {
     @extend %govuk-section-break--visible;
     @extend %govuk-section-break--xl;
   }
+
+  pre + h2 {
+    padding-top: govuk-spacing(4);
+  }
+
+  pre + h3,
+  pre + h4 {
+    padding-top: govuk-spacing(2);
+  }
 }


### PR DESCRIPTION
This PR adds some contextual spacing adjustments to the heading when they immediately follow a `<pre>` element.

This was raised by @fofr more generally (https://github.com/alphagov/govuk-design-system/issues/838) but until we have a better idea on how we handle the spacing of non-text content within large blocks of text I have only updated the design system itself.

**Before**
<img width="695" alt="Screen Shot 2019-04-10 at 12 07 56" src="https://user-images.githubusercontent.com/23356842/55874132-65518800-5b89-11e9-8637-1af822fe45e5.png">

**After**
<img width="701" alt="Screen Shot 2019-04-10 at 12 07 46" src="https://user-images.githubusercontent.com/23356842/55874144-71d5e080-5b89-11e9-9286-2e7fb7805f3b.png">

**After (switching to an H2)**
<img width="690" alt="Screen Shot 2019-04-10 at 12 08 15" src="https://user-images.githubusercontent.com/23356842/55874168-7f8b6600-5b89-11e9-957f-70ec88f3ec95.png">
