### PR TITLE
Removed leading zero from date examples

### DIFF
--- a/src/patterns/dates/default/index.njk
+++ b/src/patterns/dates/default/index.njk
@@ -16,6 +16,6 @@ layout: layout-example.njk
     }
   },
   hint: {
-    text: "For example, 01 08 2007"
+    text: "For example, 27 3 2007"
   }
 }) }}

--- a/src/patterns/dates/error/index.njk
+++ b/src/patterns/dates/error/index.njk
@@ -17,7 +17,7 @@ ignore_in_sitemap: true
     }
   },
   hint: {
-    text: "For example, 12 11 2007"
+    text: "For example, 27 3 2007"
   },
   errorMessage: {
     text: "The date your passport was issued must be in the past"

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -86,7 +86,7 @@ To check that the dates users give you are valid, make sure that:
 
 ### How to write dates
 
-Do not use a leading zero in example dates. If you provide an example day number, use a number greater than 12. If you provide an example month number, use a number greater than 12. This will emphasise the distinction between the day field and the month field which can be a problem for some users, particularly if accustomed to other date formats.
+Do not use a leading zero in example dates. If you provide an example day number, use a number greater than 12. If you provide an example month number, use a single digit. This will emphasise the distinction between the day field and the month field which can be a problem for some users, particularly if accustomed to other date formats. It will also highlight that leading zeros aren't required.
 See the [GOV.UK style for writing dates](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates) and [date ranges]( https://www.gov.uk/guidance/content-design/writing-for-gov-uk#date-ranges).
 
 ### Error messages

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -82,12 +82,14 @@ To check that the dates users give you are valid, make sure that:
 - past dates are in the past
 - future dates are in the future
 - the first date in a date range is before the second
-- a date with or without a leading zero is accepted
+
+Make sure you accept numbers both with or without a leading zero.
 
 ### How to write dates
 
-Do not use a leading zero in example dates. If you provide an example day number, use a number greater than 12. If you provide an example month number, use a single digit. This will emphasise the distinction between the day field and the month field which can be a problem for some users, particularly if accustomed to other date formats. It will also highlight that leading zeros aren't required.
 See the [GOV.UK style for writing dates](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates) and [date ranges]( https://www.gov.uk/guidance/content-design/writing-for-gov-uk#date-ranges).
+
+If you give an example date, use 13 or more for the day and 9 or less for the month - for example ‘27 3 2007’. This helps users enter the date in the correct order and without leading zeroes.
 
 ### Error messages
 

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -82,9 +82,11 @@ To check that the dates users give you are valid, make sure that:
 - past dates are in the past
 - future dates are in the future
 - the first date in a date range is before the second
+- a date with or without a leading zero is accepted
 
 ### How to write dates
 
+Do not use a leading zero in example dates. If you provide an example day number, use a number greater than 12. If you provide an example month number, use a number greater than 12. This will emphasise the distinction between the day field and the month field which can be a problem for some users, particularly if accustomed to other date formats.
 See the [GOV.UK style for writing dates](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates) and [date ranges]( https://www.gov.uk/guidance/content-design/writing-for-gov-uk#date-ranges).
 
 ### Error messages


### PR DESCRIPTION
- Day and month fields should accept input with and without leading zeros
- The example month number should illustrate a leading zero isn't mandatory i.e in the range 1 to 9.
- The example day number should illustrate it's day before month rather then month before day i.e. in the range 13 to 31
- The examples in the guidance should be updated to reflect the above.

Relates to https://github.com/alphagov/govuk-design-system-backlog/issues/42