### PR TITLE
Dates pattern: Fix input size on year

### DIFF
--- a/src/patterns/dates/memorable-date/index.njk
+++ b/src/patterns/dates/memorable-date/index.njk
@@ -31,7 +31,7 @@ layout: layout-example.njk
     },
     {
       name: "year",
-      classes: "govuk-input--width-2",
+      classes: "govuk-input--width-4",
       autocomplete: "bday-year"
     }
   ]


### PR DESCRIPTION
Input size on the "year" for memorable dates is 2 characters, should be 4