### PR TITLE
Temporarily remove link to broken example

### DIFF
--- a/src/patterns/check-a-service-is-suitable/index.md.njk
+++ b/src/patterns/check-a-service-is-suitable/index.md.njk
@@ -16,8 +16,6 @@ It can also help reduce time and money spent processing queries from users confu
 
 ![‘Check a service is suitable’ flow diagram. Contains an introduction page followed by a series of simple questions. If at any point a user is deemed not eligible for the service they will be pointed to a page that explains why they are not eligible. Otherwise they will be presented a ‘results’ page. ](check-a-service-is-suitable-flow.png)
 
-See a complete [example of check a service is suitable](https://check-before-you-start-pattern.cloudapps.digital/)
-
 ## When to use this pattern
 
 If you have complicated eligibility requirements you should follow this pattern. This will save  users from having to read through large amounts of documentation outside of your service to work out if they can use it.


### PR DESCRIPTION
We had a discussion about this example and are not confident that it is useful so instead of resolving the issue short term we want to remove it and raise an issue to investigate it to give us more time.