### PR TITLE
Add full page example to error summary component

### DIFF
--- a/src/components/error-summary/full-page-example/index.njk
+++ b/src/components/error-summary/full-page-example/index.njk
@@ -1,0 +1,73 @@
+---
+title: Linking from the error summary to an answer that uses multiple fields
+layout: layout-example-full-page.njk
+ignore_in_sitemap: true
+---
+
+{% extends "example-wrappers/full-page.njk" %}
+
+{% from "back-link/macro.njk" import govukBackLink %}
+{% from "date-input/macro.njk" import govukDateInput %}
+{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from "button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="/form-handler" method="post" novalidate>
+        {{ govukErrorSummary({
+          "titleText": "There is a problem",
+          "errorList": [
+            {
+              "text": "Passport issue date must include a year",
+              "href": "#passport-issued-year"
+            }
+          ]
+        }) }}
+
+        {{ govukDateInput({
+          fieldset: {
+            legend: {
+              isPageHeading: true,
+              text: 'When was your passport issued?',
+              classes: 'govuk-fieldset__legend--xl'
+            }
+          },
+          id: 'passport-issued',
+          name: 'passport-issued',
+          errorMessage: {
+            text: "Passport issue date must include a year"
+          },
+          items: [
+            {
+              name: "day",
+              classes: "govuk-input--width-2",
+              value: 5
+            },
+            {
+              name: "month",
+              classes: "govuk-input--width-2",
+              value: 12
+            },
+            {
+              name: "year",
+              classes: "govuk-input--width-4 govuk-input--error"
+            }
+          ]
+          })
+        }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>  
+    </div>
+  </div>
+{% endblock %}

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -56,7 +56,7 @@ For questions that require a user to select one or more options from a list usin
 
 ### Example in context
 
-The error summary should sit at the top of the `main` container. If you page has breadcrumbs or a back link it should be below these, but before the `<h1>`.
+The error summary should sit at the top of the `main` container. If your page has breadcrumbs or a back link it should be below these, but before the `<h1>`.
 
 {{ example({group: "components", item: "error-summary", example: "full-page-example", html: true, nunjucks: true, open: false, size: "s"}) }}
 

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -54,7 +54,7 @@ For questions that require a user to select one or more options from a list usin
 
 {{ example({group: "components", item: "error-summary", example: "linking-checkboxes-radios", html: true, nunjucks: true, open: false, size: "s"}) }}
 
-### Example in context
+### Where to put the error summary
 
 The error summary should sit at the top of the `main` container. If your page has breadcrumbs or a back link it should be below these, but before the `<h1>`.
 

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -54,6 +54,12 @@ For questions that require a user to select one or more options from a list usin
 
 {{ example({group: "components", item: "error-summary", example: "linking-checkboxes-radios", html: true, nunjucks: true, open: false, size: "s"}) }}
 
+### Example in context
+
+The error summary should sit at the top of the `main` container. If you page has breadcrumbs or a back link it should be below these, but before the `<h1>`.
+
+{{ example({group: "components", item: "error-summary", example: "full-page-example", html: true, nunjucks: true, open: false, size: "s"}) }}
+
 ## Research on this component
 
 If you’ve used this component, get in touch to share your user research findings.

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -56,7 +56,7 @@ For questions that require a user to select one or more options from a list usin
 
 ### Where to put the error summary
 
-The error summary should sit at the top of the `main` container. If your page has breadcrumbs or a back link it should be below these, but before the `<h1>`.
+Put the error summary at the top of the `main` container. If your page includes breadcrumbs or a back link, place it below these, but above the `<h1>`.
 
 {{ example({group: "components", item: "error-summary", example: "full-page-example", html: true, nunjucks: true, open: false, size: "s"}) }}
 


### PR DESCRIPTION
Add full page example to error summary component to help users understand where it should be positioned and what size column it should be in.

Relates to issues:
https://github.com/alphagov/govuk-design-system/issues/851
https://github.com/alphagov/govuk-design-system/issues/860

This example has placeholder content. @amyhupe can we talk about how we might include "component context" in the content pattern as it feels like we might need to do this more often.

For other observers, this is currently low priority. No need to look at it w/c 13/05/19.