### PR TITLE
Update "Updating your code" page

### DIFF
--- a/src/get-started/updating-your-code/index.md.njk
+++ b/src/get-started/updating-your-code/index.md.njk
@@ -794,7 +794,7 @@ GOV.UK Frontend uses ["Block, Element, Modifier" (BEM)](http://getbem.com/) and 
       <td class="govuk-table__cell ">Deprecated: inline-block is now the default for any components</td>
     </tr>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell ">@extend contain-floats</td>
+      <td class="govuk-table__cell ">@extend %contain-floats</td>
       <td class="govuk-table__cell ">@include govuk-clearfix</td>
     </tr>
   </tbody>

--- a/src/get-started/updating-your-code/index.md.njk
+++ b/src/get-started/updating-your-code/index.md.njk
@@ -811,12 +811,8 @@ GOV.UK Frontend uses ["Block, Element, Modifier" (BEM)](http://getbem.com/) and 
   </thead>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell ">@include ie-lte(8)</td>
-      <td class="govuk-table__cell ">@include govuk-ie-lte(8)</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell ">@include ie(6)</td>
-      <td class="govuk-table__cell ">@include govuk-ie(6)</td>
+      <td class="govuk-table__cell ">@include ie(8)</td>
+      <td class="govuk-table__cell ">@include govuk-if-ie8</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This PR updates the ["Updating from GOV.UK Elements and Frontend Toolkit" page](https://deploy-preview-883--govuk-design-system-preview.netlify.com/get-started/updating-your-code/) to:
- Update extend example in Shims section to reference a placeholder selector
- ~~Remove Internet Explorer section (as the mixins were removed in #631)~~ Update Internet Explorer section to expose current mixin (`govuk-if-ie8`)

Update: it seems like this is fixing #875