### PR TITLE
Fix help text for bodyEnd block

### DIFF
--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -244,7 +244,7 @@ To change the components that are included by default, set their equivalent bloc
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">bodyEnd</td>
       <td class="govuk-table__cell">
-        Add content just after just before the closing <code>&lt;/body&gt;</code> element
+        Add content just before the closing <code>&lt;/body&gt;</code> element
       </td>
     </tr>
 


### PR DESCRIPTION
The block is put just before the closing body tag:
https://github.com/alphagov/govuk-frontend/blob/b52474c4c1c98c9886b48caafa3746bf7782859d/package/template.njk#L58

Previous text was ambiguous.