### PR TITLE
Improve links to Slack channels

### DIFF
--- a/src/community/develop-a-component-or-pattern/index.md.njk
+++ b/src/community/develop-a-component-or-pattern/index.md.njk
@@ -32,7 +32,7 @@ If you’re happy to go ahead, the team will assign you to the issue as a contri
 
 While you’re working on your contribution, the Design System team will arrange a weekly catch up to find out how you’re getting on and if you need any help. 
 
-Find examples of the component or pattern already in use. The best way to do this is to ask the government design community. Use the [Design Slack channel](https://ukgovernmentdigital.slack.com/messages/C062GAGLW/) and the [digital service designers mailing list](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en-GB#!forum/digital-service-designers).
+Find examples of the component or pattern already in use. The best way to do this is to ask the government design community. Use the [#design channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=design) and the [digital service designers mailing list](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en-GB#!forum/digital-service-designers).
 
 Examples and research from government services are usually most relevant. But look at how other organisations solve the problem too.
 

--- a/src/community/develop-a-component-or-pattern/index.md.njk
+++ b/src/community/develop-a-component-or-pattern/index.md.njk
@@ -32,7 +32,7 @@ If you’re happy to go ahead, the team will assign you to the issue as a contri
 
 While you’re working on your contribution, the Design System team will arrange a weekly catch up to find out how you’re getting on and if you need any help. 
 
-Find examples of the component or pattern already in use. The best way to do this is to ask the government design community. Use the [#design channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=design) and the [digital service designers mailing list](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en-GB#!forum/digital-service-designers).
+Find examples of the component or pattern already in use. The best way to do this is to ask the government design community on the [digital service designers mailing list](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en-GB#!forum/digital-service-designers) or the [#design channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=design).
 
 Examples and research from government services are usually most relevant. But look at how other organisations solve the problem too.
 

--- a/src/get-in-touch.njk
+++ b/src/get-in-touch.njk
@@ -12,7 +12,7 @@ layout: layout-single-page.njk
 
      <h2 class="govuk-heading-l">Slack</h2>
 
-     <p class="govuk-body">Use <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system" data-hsupport="slack">#govuk-design-system</a>, on cross-government Slack (<a class="govuk-link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6" data-hsupport="slackapp">open in app</a>)</a></p>
+     <p class="govuk-body">Use the <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system" data-hsupport="slack">#govuk-design-system channel on cross-government Slack</a>.</p>
 
      <h2 class="govuk-heading-l">Email</h2>
 

--- a/src/index.njk
+++ b/src/index.njk
@@ -64,8 +64,9 @@ description: Design your service using GOV.UK styles, components and patterns
           </a>
         </li>
         <li>
-          <a href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system" class="govuk-link" data-hsupport="slack">
-            get in touch on Slack</a> (<a class="govuk-link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6" data-hsupport="slackapp">open in app</a>)
+          get in touch using the 
+          <a href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system" class="govuk-link" data-hsupport="slack">
+            #govuk-design-system channel on cross-government Slack</a>
         </li>
         </ul>
       </div>

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -1,5 +1,5 @@
 <div class="app-contact-panel">
   <h2 class="app-contact-panel__heading">Get in touch</h2>
   <p class="app-contact-panel__body">
-    If you’ve got a question, idea or suggestion share it in <a class="govuk-link app-contact-panel__link" href="https://ukgovernmentdigital.slack.com/messages/govuk-design-system" data-hsupport="slack">#govuk-design-system</a> on cross-government Slack (<a class="govuk-link app-contact-panel__link" href="slack://channel?team=T04V6EBTR&amp;id=C6DMEH5R6" data-hsupport="slackapp">open in app</a>) or email the Design System team on <a class="govuk-link app-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">govuk-design-system-support@digital.cabinet-office.gov.uk</a></p>
+    If you’ve got a question, idea or suggestion share it in the <a class="govuk-link app-contact-panel__link" href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system" data-hsupport="slack">#govuk-design-system channel on cross-government Slack</a> or email the Design System team on <a class="govuk-link app-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">govuk-design-system-support@digital.cabinet-office.gov.uk</a>.</p>
 </div>


### PR DESCRIPTION
Updates the existing Slack links to use Slack's 'deep link' redirect. These will try to open the channel in the user's Slack app if it's installed, whilst providing links to download the app and to open in browser to help users if it's not.

This allows us to remove the 'open in app' links which were flagged as part of a recent audit as it does not make sense out of context.

> “As I navigated out of context, I discovered a link which read to me as “Open in app.” It was not immediately clear to me while situated out of context which app the link related to as this was not obvious within the link text. Although I could establish the purpose of the link in context in a testing environment some users might not be aware of which app is intended to open. Including the app name within the link text will enable users to clearly understand what will occur if the link is selected. This was present using JAWS, NVDA, VoiceOver for iPhone and Mac”

It also makes the way we describe channels consistent, and adds a full stop to the end of the sentence in the get in touch panel, because grammar.

Fixes #895 
Fixes #898 