### PR TITLE
Update visually hidden text in check your answers

### DIFF
--- a/src/patterns/check-answers/default/index.njk
+++ b/src/patterns/check-answers/default/index.njk
@@ -73,7 +73,7 @@ layout: layout-example-full-page.njk
                 {
                   href: "#",
                   text: "Change",
-                  visuallyHiddenText: "contact information"
+                  visuallyHiddenText: "address"
                 }
               ]
             }


### PR DESCRIPTION
In #912 we updated a key from 'contact information' to 'address' but did not update the visually hidden text at the same time.