### PR TITLE
Prevent back to top arrow SVG from being focusable

### DIFF
--- a/views/partials/_back-to-top.njk
+++ b/views/partials/_back-to-top.njk
@@ -2,7 +2,10 @@
 To avoid a large focus area we use a wrapper element. #}
 <div class="app-back-to-top app-back-to-top--hidden" data-module="app-back-to-top">
   <a class="govuk-link govuk-link--no-visited-state" href="#top">
-    <svg class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+    {#- The SVG needs `focusable="false"` so that Internet Explorer does not
+       treat it as an interactive element - without this it will be 'focusable'
+       when using the keyboard to navigate. #}
+    <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
       <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
     </svg>Back to top
   </a>


### PR DESCRIPTION
This was flagged in a recent accessibility audit:

> An ‘svg’ image has been used to present the ‘back to top’ arrow which is currently receiving focus for keyboard only users in Internet Explorer. When selected this took the user to the top of the page. This is a known bug in Internet Explorer, and can be overcome using focusable="false" on the SVG.

I’ve also added `role=“presentation”` as the link includes the text ‘Back to top’ and the arrow is just an additional affordance. This is consistent with what we do with the crown in the header.

Closes #900 