### PR TITLE
Fix duplicate iframe titles

### DIFF
--- a/lib/metalsmith-title-checker.js
+++ b/lib/metalsmith-title-checker.js
@@ -5,23 +5,78 @@
  * @return {Function}
  */
 
+function groupFilesByTitle (filenames, files) {
+  const groupedFiles = {}
+
+  filenames
+    .forEach((filename, index) => {
+      const { title } = files[filename]
+      // If an title exists and is not the current index it means it is a duplicate.
+      if (!groupedFiles[title]) {
+        groupedFiles[title] = []
+      }
+      groupedFiles[title].push({
+        // Add the filename to the file object for convenience
+        '__filename': filename,
+        ...files[filename]
+      })
+    })
+
+  return groupedFiles
+}
+
+function getDuplicateTitles (groupedFiles) {
+  const duplicateGroupedTitles = {}
+
+  for (const title in groupedFiles) {
+    const group = groupedFiles[title]
+
+    const groupedWithoutExcludedFiles =
+    group
+      // Default examples always have a duplicated title,
+      // this is OK since the iframes are appended with 'example'.
+      .filter(file => !file['__filename'].includes('/default/'))
+      // Code examples always have a duplicated title,
+      // as it's only used for the code example not the iframe.
+      .filter(file => !file['__filename'].endsWith('code.njk'))
+
+    if (groupedWithoutExcludedFiles.length > 1) {
+      duplicateGroupedTitles[title] = groupedWithoutExcludedFiles
+    }
+  }
+
+  return duplicateGroupedTitles
+}
+
 module.exports = function titleChecker () {
   return (files, metalsmith, done) => {
-    const filesWithoutTitles =
+    const nunjucksFileNames =
       Object
         .keys(files)
         // Filter files that are Nunjucks, which have frontmatter.
         .filter(filename => filename.endsWith('.njk'))
-        // Filter out files that do not have titles.
-        .filter(filename => {
-          var data = files[filename]
-          return !data.title
-        })
+
+    const groupedFilesByTitle = groupFilesByTitle(nunjucksFileNames, files)
+    const filesWithDuplicateTitles = getDuplicateTitles(groupedFilesByTitle)
+
+    if (Object.keys(filesWithDuplicateTitles).length) {
+      let duplicateErrorMessage = ''
+      for (const title in filesWithDuplicateTitles) {
+        const group = filesWithDuplicateTitles[title]
+        duplicateErrorMessage += `The title "${title}" is duplicated ${group.length} times in the following file(s):\n`
+        duplicateErrorMessage += group.map(file => `- ${file['__filename']}`).join('\n')
+        duplicateErrorMessage += `\n\n`
+      }
+      throw Error(duplicateErrorMessage)
+    }
+
+    const filesWithoutTitles = nunjucksFileNames.filter(filename => !files[filename].title)
 
     if (filesWithoutTitles.length) {
       throw Error(
         `The following file(s) do not have titles:\n\n` +
-        filesWithoutTitles.map(file => `"${file}"`).join(',\n')
+        filesWithoutTitles.map(file => `- ${file}`).join('\n') +
+        '\n'
       )
     }
     done()

--- a/src/components/character-count/error/index.njk
+++ b/src/components/character-count/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Character count
+title: Error – Character count
 layout: layout-example.njk
 ---
 

--- a/src/components/character-count/label-page-heading/index.njk
+++ b/src/components/character-count/label-page-heading/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Character count
+title: Label page heading – Character count
 layout: layout-example.njk
 ---
  {% from "character-count/macro.njk" import govukCharacterCount %}

--- a/src/components/character-count/threshold/index.njk
+++ b/src/components/character-count/threshold/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Character count
+title: Threshold – Character count
 layout: layout-example.njk
 ---
 

--- a/src/components/character-count/word-count/index.njk
+++ b/src/components/character-count/word-count/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Character count
+title: Word count – Character count
 layout: layout-example.njk
 ---
 

--- a/src/components/error-summary/full-page-example/index.njk
+++ b/src/components/error-summary/full-page-example/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Linking from the error summary to an answer that uses multiple fields
+title: Full page example
 layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---
@@ -67,7 +67,7 @@ ignore_in_sitemap: true
           text: "Continue"
         }) }}
 
-      </form>  
+      </form>
     </div>
   </div>
 {% endblock %}

--- a/src/components/file-upload/error/index.njk
+++ b/src/components/file-upload/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: File upload
+title: Error – File upload
 layout: layout-example.njk
 ignore_in_sitemap: true
 ---

--- a/src/components/summary-list/without-actions/index.njk
+++ b/src/components/summary-list/without-actions/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Summary list
+title: Without actions – Summary list
 layout: layout-example.njk
 ---
 

--- a/src/components/summary-list/without-borders/index.njk
+++ b/src/components/summary-list/without-borders/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Summary list
+title: Without borders – Summary list
 layout: layout-example.njk
 ---
 

--- a/src/components/table/column-widths-custom-classes/index.njk
+++ b/src/components/table/column-widths-custom-classes/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Table
+title: Custom width using custom classes – Table
 layout: layout-example.njk
 stylesheets:
 - column-width-custom-classes.css

--- a/src/components/table/column-widths/index.njk
+++ b/src/components/table/column-widths/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Table
+title: Custom width using override classes – Table
 layout: layout-example.njk
 ---
 

--- a/src/get-started/labels-legends-headings/label-h1/index.njk
+++ b/src/get-started/labels-legends-headings/label-h1/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Labels, legends and headings
+title: Labels as page headings - Making labels and legends headings
 layout: layout-example.njk
 ignore_in_sitemap: true
 ---

--- a/src/get-started/labels-legends-headings/label-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/label-m-s/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Labels, legends and headings
+title: Styling labels - Making labels and legends headings
 layout: layout-example.njk
 ignore_in_sitemap: true
 ---

--- a/src/get-started/labels-legends-headings/legend-h1/index.njk
+++ b/src/get-started/labels-legends-headings/legend-h1/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Labels, legends and headings
+title: Legends as page headings - Making labels and legends headings
 layout: layout-example.njk
 ignore_in_sitemap: true
 ---

--- a/src/get-started/labels-legends-headings/legend-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/legend-m-s/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Labels, legends and headings
+title: Styling legends - Making labels and legends headings
 layout: layout-example.njk
 ignore_in_sitemap: true
 ---

--- a/src/patterns/dates/error/index.njk
+++ b/src/patterns/dates/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Date input with errors
+title: Dates with errors
 layout: layout-example.njk
 ignore_in_sitemap: true
 ---

--- a/src/patterns/problem-with-the-service-pages/link-to-another-service/index.njk
+++ b/src/patterns/problem-with-the-service-pages/link-to-another-service/index.njk
@@ -1,5 +1,5 @@
 ---
-title: A link to another service
+title: A link to another service – There is a problem with the service pages
 layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---

--- a/src/patterns/question-pages/date-of-birth/index.njk
+++ b/src/patterns/question-pages/date-of-birth/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Question pages
+title: Date of birth – Question pages
 layout: layout-example-full-page.njk
 ---
 

--- a/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
+++ b/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
@@ -1,5 +1,5 @@
 ---
-title: A link to another service
+title: A link to another service – Service unavailable pages
 layout: layout-example-full-page.njk
 ignore_in_sitemap: true
 ---

--- a/src/styles/layout/common-two-thirds-one-third/index.njk
+++ b/src/styles/layout/common-two-thirds-one-third/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Two-thirds / One-third – Layout
+title: Common two-thirds / One-third – Layout
 layout: layout-example.njk
 ignore_in_sitemap: true
 ---

--- a/src/styles/layout/common-two-thirds-two-thirds-one-third/index.njk
+++ b/src/styles/layout/common-two-thirds-two-thirds-one-third/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Two-thirds with two Rows – Layout
+title: Common two-thirds with two Rows – Layout
 layout: layout-example.njk
 ignore_in_sitemap: true
 ---

--- a/src/styles/layout/common-two-thirds/index.njk
+++ b/src/styles/layout/common-two-thirds/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Two-thirds – Layout
+title: Common two-thirds – Layout
 layout: layout-example.njk
 ignore_in_sitemap: true
 ---

--- a/src/styles/typography/captions-inside/index.njk
+++ b/src/styles/typography/captions-inside/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Headings with captions – Typography
+title: Headings with captions nested – Typography
 layout: layout-example.njk
 ignore_in_sitemap: true
 ---


### PR DESCRIPTION
By making sure our titles are unique we ensure the examples can be navigated to independently.

I've also added a check to the title checker that ensures duplicate titles fail our builds which should hopefully avoid this in the future.

Through doing this I've noticed our titles are really inconsistent in formatting, and in some cases are not very well done, this could make it harder to understand what an example is about.

I have made the minimum changes to ensure the titles are unique but I think we should raise another issue to review the titles from a style perspective and improve them, but I think how / if we do that is up to @amyhupe and @m-green...

Fixes #901