### PR TITLE
Make back to top link focusable

### DIFF
--- a/src/stylesheets/components/_back-to-top.scss
+++ b/src/stylesheets/components/_back-to-top.scss
@@ -15,7 +15,7 @@
 }
 
 @supports (position: sticky) {
-  .js-enabled .app-back-to-top--hidden {
-    display: none;
+  .js-enabled .app-back-to-top--hidden .app-back-to-top__link {
+    @include govuk-visually-hidden-focusable;
   }
 }

--- a/views/partials/_back-to-top.njk
+++ b/views/partials/_back-to-top.njk
@@ -1,7 +1,7 @@
 {# Safari on OSX with `position: -webkit-sticky` requires a block level element.
 To avoid a large focus area we use a wrapper element. #}
 <div class="app-back-to-top app-back-to-top--hidden" data-module="app-back-to-top">
-  <a class="govuk-link govuk-link--no-visited-state" href="#top">
+  <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
     {#- The SVG needs `focusable="false"` so that Internet Explorer does not
        treat it as an interactive element - without this it will be 'focusable'
        when using the keyboard to navigate. #}


### PR DESCRIPTION
Make sure you can tab to the back to top link even when it's invisible, this is consistent with how the skip link works.

Closes #899