### PR TITLE
Avoid unnecessary 301 redirects

### DIFF
--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -2,11 +2,11 @@
   <ul class="app-mobile-nav__list">
     {% for item in navigation %}
     <li>
-      <a class="govuk-link js-mobile-nav-subnav-toggler{% if path.startsWith(item.url) %} app-mobile-nav__subnav-toggler--active{% endif %}" href="/{{ item.url }}">{{ item.label }}</a>
+      <a class="govuk-link js-mobile-nav-subnav-toggler{% if path.startsWith(item.url) %} app-mobile-nav__subnav-toggler--active{% endif %}" href="/{{ item.url }}/">{{ item.label }}</a>
       {% if item.items %}
       <ul class="app-mobile-nav__subnav js-app-mobile-nav-subnav {% if path.startsWith(item.url) %}app-mobile-nav__subnav--active{% endif %}">
         <li{% if path == item.url %} class="current-page"{% endif %}>
-          <a class="govuk-link" href="/{{ item.url }}">{{ item.label }} overview</a>
+          <a class="govuk-link" href="/{{ item.url }}/">{{ item.label }} overview</a>
         </li>
 
         {% for theme, items in item.items | groupby("theme") %}
@@ -17,7 +17,7 @@
           <ul class="app-mobile-nav__theme-nav">
           {% for subitem in items %}
             <li{% if path == subitem.url %} class="current-page"{% endif %}>
-              <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
+              <a class="govuk-link" href="/{{ subitem.url }}/">{{ subitem.label }}</a>
             </li>
           {% endfor %}
           </ul>

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -2,7 +2,7 @@
   <ul class="app-navigation__list govuk-width-container">
     {% for item in navigation %}
     <li{% if path == item.url or item.url and path.startsWith(item.url) %} class="app-navigation--current-page"{% endif %}>
-      <a class="govuk-link" href="/{{ item.url }}" data-topnav="{{ item.label }}">{{ item.label }}</a>
+      <a class="govuk-link" href="/{{ item.url }}/" data-topnav="{{ item.label }}">{{ item.label }}</a>
     </li>
     {% endfor %}
   </ul>

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -9,7 +9,7 @@
           <ul class="app-subnav__section">
           {% for subitem in items %}
             <li class="app-subnav__section-item{% if subitem.url == path %} app-subnav__section-item--current{% endif %}">
-              <a class="app-subnav__link govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
+              <a class="app-subnav__link govuk-link" href="/{{ subitem.url }}/">{{ subitem.label }}</a>
               {% if (subitem.headings) and (subitem.url == path) %}
                 <ul class="app-subnav__section app-subnav__section--nested">
                   {% for link in subitem.headings %}


### PR DESCRIPTION
The links in the navigation currently omit the trailing slash. For example, the 'Components' link links to `/components`.

If you try to visit this URL you get a 301 to `/components/`.

By adding the trailing slashes to the links in the navigation, we save a round trip to the server to get the 301 response.

Fixes #816 