### PR TITLE
Fix broken link to organisation colours

### DIFF
--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -71,7 +71,7 @@ should use the `$govuk-error-colour` Sass variable rather than
 
 If you need to use tints of this palette, use either 25% or 50%.
 
-You can find departmental colours in the GOV.UK Frontend [_colours-organisations](https://github.com/alphagov/govuk-frontend/blob/master/src/settings/_colours-organisations.scss) file.
+You can find departmental colours in the GOV.UK Frontend [_colours-organisations](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/settings/_colours-organisations.scss) file.
 
 <table class="govuk-body app-colour-list" summary="Table of extended colours">
   <tbody>


### PR DESCRIPTION
This link was broken when we namespaced GOV.UK Frontend as part of the currently unreleased 3.0.

Fixes #934