### PR TITLE
Remove panel component guidance on contrast requirements

### DIFF
--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -25,8 +25,6 @@ Never use the panel component to highlight important information within body con
 
 ## How it works
 
-If you add extra content to the panel, to meet colour contrast ratio requirements use a font size of <code>govuk-body-l</code> for normal weight and <code>govuk-body</code> for bold.
-
 There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}


### PR DESCRIPTION
As the panel colour in frontend v3 has been updated,
it now meets contrast ratio requirements at any font size.