### PR TITLE
Add smoke tests for CloudFoundry deploys

### DIFF
--- a/bin/deploy-travis
+++ b/bin/deploy-travis
@@ -11,4 +11,4 @@ cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
 
 # Zero downtime push comes from "Blue/Green Deploy plugin" which is installed in before_deploy
 # step in Travis
-cf blue-green-deploy $APP_NAME -f manifest.yml
+cf blue-green-deploy $APP_NAME -f manifest.yml --smoke-test ./smoke-test

--- a/bin/smoke-test
+++ b/bin/smoke-test
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# The first and only argument passed to the smoke test script ($1) is the fully
+# qualified domain name of the newly pushed app
+app_fqdn="$1"
+
+echo "Running smoke tests against $app_fqdn"
+
+# Check that the /_status/ page exists and contains the string 'Tweet tweet'
+grep -q "Tweet tweet" <<< "$(curl -sL "https://$app_fqdn/__canary__/")"

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -157,6 +157,12 @@ http {
         deny all;
         return 404;
       }
+
+      # Allow smoke tests without authentication
+
+      location /__canary__/ {
+        auth_basic off;
+      }
     }
   }
 }

--- a/src/__canary__.html
+++ b/src/__canary__.html
@@ -1,0 +1,14 @@
+---
+layout: false
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="robots" content="noindex">
+    <title>200 OK</title>
+  </head>
+  <body>
+    Tweet tweet
+  </body>
+</html>


### PR DESCRIPTION
This creates a new HTML page which will be built and deployed to `/__canary__/index.html` containing nothing but the words ‘Tweet tweet’ (following [the pattern set by GOV.UK][1])

It adds a smoke-test script which verifies the existence and content of that file, returning an error exit code if is not present.

Finally, it tells the Blue/Green deploy script that we use to use that smoke test, which means if e.g. nginx fails to start the deploy will not continue, and the existing container and route will be maintained.

This should hopefully give us more confidence when rolling out changes to the CloudFoundry / nginx configuration.

[1]: https://www.gov.uk/__canary__