### PR TITLE
Update nginx buildpack to v1.0.14

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,7 +9,7 @@ applications:
   # by GitHub URL
   #
   # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
-  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.0.3
+  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.0.14
   # Run two instances to ensure availability
   #
   # https://docs.cloud.service.gov.uk/managing_apps.html#scaling


### PR DESCRIPTION
This effectively just updates nginx from v1.15.6 to v1.17.1.

Tested by manually pushing an app to the PaaS:

Existing app:

```
$ curl -sI https://govuk-design-system-origin.cloudapps.digital/ | grep Server
Server: nginx/1.15.6
```

App with this change:

```
$ curl -sI https://design-system-buildpack-14.cloudapps.digital/ | grep Server
Server: nginx/1.17.1
```