### PR TITLE
Replace straight quotes with curly ones

### DIFF
--- a/src/community/propose-a-component-or-pattern/index.md.njk
+++ b/src/community/propose-a-component-or-pattern/index.md.njk
@@ -16,9 +16,9 @@ Follow the 3 steps to propose a component or pattern for the Design System.
 
 Check if someone else has already suggested your idea or something similar on the [community backlog](/community/backlog). 
 
-If your idea is on the backlog and marked as 'proposed', follow the link and comment on the issue. Say you need the component or pattern and share any examples or evidence you have to support the proposal.
+If your idea is on the backlog and marked as ‘proposed’, follow the link and comment on the issue. Say you need the component or pattern and share any examples or evidence you have to support the proposal.
 
-If it’s marked 'to do' and you would like to work on it, read how to [develop a component or pattern](/community/develop-a-component-or-pattern).
+If it’s marked ‘to do’ and you would like to work on it, read how to [develop a component or pattern](/community/develop-a-component-or-pattern).
 
 ## 2. Raise an issue
 
@@ -36,7 +36,7 @@ At the meeting, the working group will review your proposal and decide if it is 
 
 After the meeting, the Design System team will let you know the decision and recommendations, if there are any.
 
-If the working group agrees your proposal is useful and unique, the Design System team will mark it as 'to do' on the [community backlog](/community/backlog). 
+If the working group agrees your proposal is useful and unique, the Design System team will mark it as ‘to do’ on the [community backlog](/community/backlog).
 
 At this point, you can either start to [develop the component or pattern](/community/develop-a-component-or-pattern) or leave it for someone else to work on.
 

--- a/src/components/accordion/index.md.njk
+++ b/src/components/accordion/index.md.njk
@@ -17,7 +17,7 @@ The accordion component lets users show and hide sections of related content on 
 
 ## When to use this component
 
-Only use an accordion if there's evidence it’s helpful for users to:
+Only use an accordion if there’s evidence it’s helpful for users to:
 
 - see an overview of multiple, related sections of content
 - show and hide those sections as needed
@@ -89,11 +89,11 @@ The plus and minus icon is on the right side of the component, which means users
 
 The hover colour is a light grey which some users might not see.
 
-The 'Open all' button reads out as 'Open all sections' for screen readers. This is potentially confusing for users as the visual content is different to what screen readers read out.
+The ‘Open all’ button reads out as ‘Open all sections’ for screen readers. This is potentially confusing for users as the visual content is different to what screen readers read out.
 
 ### Next steps
 Investigate the problem of some users not seeing the plus and minus icons on the right, for example people using screen magnifiers.
 
 The plus and minus icons used in this component are the most commonly used accordion controls in government services.
 
-However, more research is needed to find out how this compares to other approaches. For example [GOV.UK Step by step navigation](https://www.gov.uk/learn-to-drive-a-car) uses the words 'Show' and 'Hide' on the left side. [Check the MOT history of a vehicle](https://www.gov.uk/check-mot-history) uses up and down arrows instead of plus and minus icons.
+However, more research is needed to find out how this compares to other approaches. For example [GOV.UK Step by step navigation](https://www.gov.uk/learn-to-drive-a-car) uses the words ‘Show’ and ‘Hide’ on the left side. [Check the MOT history of a vehicle](https://www.gov.uk/check-mot-history) uses up and down arrows instead of plus and minus icons.

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -70,7 +70,7 @@ Warning buttons are designed to make users think carefully before they use them.
 
 Only use warning buttons for actions with serious destructive consequences that cannot be easily undone by a user. For example, permanently deleting an account.
 
-When letting users carry out an action like this, it's a good idea to include an additional step which asks them to confirm it.
+When letting users carry out an action like this, it’s a good idea to include an additional step which asks them to confirm it.
 
 In this instance, use another style of button for the initial call to action, and a warning button for the final confirmation.
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -36,7 +36,7 @@ Always position checkboxes to the left of their labels. This makes them easier t
 
 Unlike with radios, users can select multiple options from a list of checkboxes. Do not assume that users will know how many options they can select based on the visual difference between radios and checkboxes alone. 
 
-If needed, add a hint explaining this, for example, 'Select all that apply'.
+If needed, add a hint explaining this, for example, ‘Select all that apply’.
 
 Do not pre-select checkbox options as this makes it more likely that users will:
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -41,7 +41,7 @@ Never automatically tab users between the fields of the date input because this 
 
 ### Use the autocomplete attribute for a date of birth
 
-Use the `autocomplete` attribute on the date input component when you're asking for a date of birth. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.
+Use the `autocomplete` attribute on the date input component when you’re asking for a date of birth. This lets browsers autofill the information on a user’s behalf if they’ve entered it previously.
 
 To do this, set the `autocomplete` attribute on the 3 fields to `bday-day`, `bday-month` and `bday-year`. See how to do this in the HTML and Nunjucks tabs in the following example. 
 

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -43,7 +43,7 @@ For each error:
 - use a red border to visually connect the message and the question it belongs to
 - if the error relates to specific text fields within the question, give these a red border as well
 
-To help screen reader users, the error message component includes a hidden 'Error:' before the error message. These users will hear, for example, "Error: The date your passport was issued must be in the past".
+To help screen reader users, the error message component includes a hidden ‘Error:’ before the error message. These users will hear, for example, “Error: The date your passport was issued must be in the past”.
 
 If your error message is written in another language, you can change the prefix as needed, as shown in this example.
 

--- a/src/components/radios/hint/index.njk
+++ b/src/components/radios/hint/index.njk
@@ -17,7 +17,7 @@ ignore_in_sitemap: true
     }
   },
   hint: {
-    text: "You'll need an account to prove your identity and complete your Self Assessment."
+    text: "You’ll need an account to prove your identity and complete your Self Assessment."
   },
   items: [
     {
@@ -27,7 +27,7 @@ ignore_in_sitemap: true
         classes: "govuk-label--s"
       },
       hint: {
-        text: "You'll have a user ID if you've registered for Self Assessment or filed a tax return online before."
+        text: "You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before."
       }
     },
     {
@@ -37,7 +37,7 @@ ignore_in_sitemap: true
         classes: "govuk-label--s"
       },
       hint: {
-        text: "You'll have an account if you've already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
+        text: "You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
       }
     }
   ]

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -31,18 +31,18 @@ Always position radios to the left of their labels. This makes them easier to fi
 
 Unlike with checkboxes, users can only select one option from a list of radios. Do not assume that users will know how many options they can select based on the visual difference between radios and checkboxes alone.
 
-If needed, add a hint explaining this, for example, 'Select one option'.
+If needed, add a hint explaining this, for example, ‘Select one option’.
 
 Do not pre-select radio options as this makes it more likely that users will:
 
-- not realise they've missed a question
+- not realise they’ve missed a question
 - submit the wrong answer
 
-Users cannot go back to having no option selected once they have selected one, without refreshing their browser window. Therefore, you should include 'None of the above' or 'I do not know' if they are valid options.
+Users cannot go back to having no option selected once they have selected one, without refreshing their browser window. Therefore, you should include ‘None of the above’ or ‘I do not know’ if they are valid options.
 
 Order radio options alphabetically by default.
 
-In some cases, it can be helpful to order them from most-to-least common options. For example, you could order options for 'Where do you live?' based on population size.
+In some cases, it can be helpful to order them from most-to-least common options. For example, you could order options for ‘Where do you live?’ based on population size.
 
 However you should do this with extreme caution as it can reinforce bias in your service. If in doubt, order alphabetically.
 

--- a/src/components/text-input/error/index.njk
+++ b/src/components/text-input/error/index.njk
@@ -13,7 +13,7 @@ ignore_in_sitemap: true
   id: "event-name",
   name: "event-name",
   hint: {
-    text: "The name you'll use on promotional material."
+    text: "The name you’ll use on promotional material."
   },
   errorMessage: {
     text: "Enter an event name"

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -67,13 +67,13 @@ Use hint for help that’s relevant to the majority of users, like how their inf
 
 ### Use the autocomplete attribute
 
-Use the `autocomplete` attribute on text inputs to help users complete forms more quickly. This lets you specify an input's purpose so browsers can autofill the information on a user's behalf if they’ve entered it previously.
+Use the `autocomplete` attribute on text inputs to help users complete forms more quickly. This lets you specify an input’s purpose so browsers can autofill the information on a user’s behalf if they’ve entered it previously.
 
 For example, to enable autofill on a postcode field, set the `autocomplete` attribute to `postal-code`. See how to do this in the HTML and Nunjucks tabs in the following example.
 
 {{ example({group: "components", item: "text-input", example: "input-autocomplete-attribute", displayExample: false, html: true, nunjucks: true, open: true, size: "s"}) }}
 
-If you are working in production and there is a relevant [input purpose](https://www.w3.org/TR/WCAG21/#input-purposes), you'll need to use the `autocomplete` attribute to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
+If you are working in production and there is a relevant [input purpose](https://www.w3.org/TR/WCAG21/#input-purposes), you’ll need to use the `autocomplete` attribute to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
 
 You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
 

--- a/src/components/text-input/input-hint-text/index.njk
+++ b/src/components/text-input/input-hint-text/index.njk
@@ -11,7 +11,7 @@ ignore_in_sitemap: true
     text: "Event name"
   },
   hint: {
-    text: "The name you'll use on promotional material."
+    text: "The name you’ll use on promotional material."
   },
   id: "event-name",
   name: "event-name"

--- a/src/errors/404.njk
+++ b/src/errors/404.njk
@@ -10,7 +10,7 @@ ignore_in_sitemap: true
 
     <p class="govuk-body">If you typed the web address, check it is correct.</p>
     <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
-    <p class="govuk-body">If you're looking for the 'page not found' pattern see <a class="govuk-link" href="/patterns/page-not-found-pages/">page not found pages</a>.</p>
+    <p class="govuk-body">If you’re looking for the ‘page not found’ pattern see <a class="govuk-link" href="/patterns/page-not-found-pages/">page not found pages</a>.</p>
 
     <p class="govuk-body">
       <a class="govuk-link" href="/get-in-touch">Contact the Design System team</a> if you believe you are seeing this message in error.

--- a/src/get-started/extending-and-modifying-components/index.md.njk
+++ b/src/get-started/extending-and-modifying-components/index.md.njk
@@ -73,7 +73,7 @@ Styles, components and patterns in the GOV.UK Design System use the `govuk-` pre
 
 When writing code for your application, use a different prefix, like `app-`.
 
-If your department has its own design resources, they should use a new separate prefix. It's a good idea to use departmental initials, like `hmcts-` or `dvla-`.
+If your department has its own design resources, they should use a new separate prefix. It’s a good idea to use departmental initials, like `hmcts-` or `dvla-`.
 
 Apply this principle anywhere you name components, such as to:
 

--- a/src/get-started/updating-your-code/index.md.njk
+++ b/src/get-started/updating-your-code/index.md.njk
@@ -327,7 +327,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
 
 ## Class names
 
-GOV.UK Frontend uses ["Block, Element, Modifier" (BEM)](http://getbem.com/) and [Inverted Triangle CSS (ITCSS)](https://www.creativebloq.com/web-design/manage-large-scale-web-projects-new-css-architecture-itcss-41514731) to structure CSS and define class names. This means all of the existing class names have changed.
+GOV.UK Frontend uses [“Block, Element, Modifier” (BEM)](http://getbem.com/) and [Inverted Triangle CSS (ITCSS)](https://www.creativebloq.com/web-design/manage-large-scale-web-projects-new-css-architecture-itcss-41514731) to structure CSS and define class names. This means all of the existing class names have changed.
 
 ### Typography class names
 

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -42,7 +42,7 @@ When using an address lookup, you should:
 
 #### Allow different postcode formats
 
-It is easier for users if you accept and ignore unwanted characters. This is better than rejecting the input and telling a user they've not provided a valid postcode.
+It is easier for users if you accept and ignore unwanted characters. This is better than rejecting the input and telling a user they’ve not provided a valid postcode.
 
 You should allow postcodes that contain upper and lower case letters, no spaces, additional spaces at the beginning, middle or end and punctuation like hyphens, brackets, dashes and full stops.
 
@@ -116,7 +116,7 @@ Textareas let users enter an address in any format and make it easy to copy and 
 
 #### Use the autocomplete attribute on a textarea
 
-Use the `autocomplete` attribute on the textarea component when you're asking for an address. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.
+Use the `autocomplete` attribute on the textarea component when you’re asking for an address. This lets browsers autofill the information on a user’s behalf if they’ve entered it previously.
 
 To do this, set the `autocomplete` attribute to `street-address` as shown in the HTML and Nunjucks tabs in the textarea example above.
 

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -38,7 +38,7 @@ Ask for memorable dates, like dates of birth, using the [date input](../../compo
 
 #### Use the autocomplete attribute when asking for a date of birth
 
-Use the `autocomplete` attribute when you're asking for a date of birth. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.
+Use the `autocomplete` attribute when you’re asking for a date of birth. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.
 
 To do this, set the `autocomplete` attribute on the 3 fields to `bday-day`, `bday-month` and `bday-year`. See how to do this in the HTML and Nunjucks tabs in the memorable date example above.
 

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -51,7 +51,7 @@ Help your users to enter a valid email address by:
 - setting the `spellcheck` attribute to `false` so that browsers do not spellcheck the email address
 - confirming their address back to them so they can check and change it
 
-You should also set the `autocomplete` attribute to `email`. This lets browsers autofill the email address on a user's behalf if they’ve entered it previously.
+You should also set the `autocomplete` attribute to `email`. This lets browsers autofill the email address on a user’s behalf if they’ve entered it previously.
 
 If you are working in production you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html). You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
 

--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -51,26 +51,26 @@ If users are from outside the UK, use the labels:
 
 Make middle names optional.
 
-Make it clear whether you need someone’s common name, or their name as it's written on official documents such as a passport or driving licence.
+Make it clear whether you need someone’s common name, or their name as it’s written on official documents such as a passport or driving licence.
 
 ### Use the autocomplete attribute on name fields
 
-Use the `autocomplete` attribute on the text input component when you're asking for a user's name. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.
+Use the `autocomplete` attribute on the text input component when you’re asking for a user’s name. This lets browsers autofill the information on a user’s behalf if they’ve entered it previously.
 
-If you are asking for a user's full name in a single field, set the `autocomplete` attribute to `name`. 
+If you are asking for a user’s full name in a single field, set the `autocomplete` attribute to `name`. 
 
 If you are asking users to enter their name in multiple fields, set the `autocomplete` attribute on both fields using:
 
-- `given-name` for fields labelled 'First name' or 'Given name' 
-- `family-name` for fields labelled 'Last name' or 'Family name'
+- `given-name` for fields labelled “First name” or “Given name” 
+- `family-name` for fields labelled “Last name” or “Family name”
 
 If you are working in production you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
 
 You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
 
-### Do not spellcheck user's names
+### Do not spellcheck user’s names
 
-Sometimes, browsers will spellcheck the information a user enters into a text input. To make sure user's names will not be spellchecked, set the `spellcheck` attribute to `false` as shown in this example.
+Sometimes, browsers will spellcheck the information a user enters into a text input. To make sure user’s names will not be spellchecked, set the `spellcheck` attribute to `false` as shown in this example.
 
 {{ example({group: "patterns", item: "names", example: "default", html: true, nunjucks: true, open: true, displayExample: false}) }}
 

--- a/src/patterns/payment-card-details/index.md.njk
+++ b/src/patterns/payment-card-details/index.md.njk
@@ -42,7 +42,7 @@ When you validate the card number, the card security code information should upd
 
 Do not use CVV or other acronyms for the card security code.
 
-If you need to ask for a user's name elsewhere in your service, do not assume that the name on their card will be the same.
+If you need to ask for a user’s name elsewhere in your service, do not assume that the name on their card will be the same.
 
 ## Research on this pattern
 

--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -28,7 +28,7 @@ You should validate telephone numbers so you can let users know if they have ent
 
 ### Use the autocomplete attribute
 
-Use the `autocomplete` attribute on telephone number inputs. This lets browsers autofill the information on a user's behalf if they’ve entered it previously. 
+Use the `autocomplete` attribute on telephone number inputs. This lets browsers autofill the information on a user’s behalf if they’ve entered it previously.
 
 To do this, set the `autocomplete` attribute to `tel`, as shown in the HTML and Nunjucks tabs in the examples on this page. 
 

--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -23,7 +23,7 @@ than `{{ colours.applied['Brand colour'][0]['colour'] | trim }}`.
 This means that your service will always use the most recent colour palette
 whenever you update.
 
-Only use the variables in the context they're designed for. In all other cases,
+Only use the variables in the context they’re designed for. In all other cases,
 you should reference the [colour palette](#colour-palette) directly. For
 example, if you wanted to use red to represent some data in a graph you should
 use `govuk-colour("red")` rather than `$govuk-error-colour`.


### PR DESCRIPTION
This commit replaces several straight quotes with their curly
equivalents, to match the rest of the design system documentation.

Straight quotes have been retained when they have been in a technical
context, such as code comments or as string delimiters.

This follows the guidance set out by this 2015 blog post:
https://designnotes.blog.gov.uk/2015/09/16/tips-for-creating-good-typography/

For more information, see https://practicaltypography.com