### PR TITLE
Changed 'one' to 1 in copy under 'accordions, tabs and details'

### DIFF
--- a/src/components/accordion/index.md.njk
+++ b/src/components/accordion/index.md.njk
@@ -49,7 +49,7 @@ You should also take into account the number of sections of content – accordio
 
 Tabs may work better for users who need to switch quickly between 2 sections. Accordions push other sections down the page when they open, but tabs do not move which makes it easier to switch.
 
-Consider using an accordion instead of the [details](/components/details/) component if there are multiple related sections of content. The details component might be better if you only have one or 2 sections of content. The details component is less visually prominent than an accordion, so tends to work better for content which is not as important to users.
+Consider using an accordion instead of the [details](/components/details/) component if there are multiple related sections of content. The details component might be better if you only have 1 or 2 sections of content. The details component is less visually prominent than an accordion, so tends to work better for content which is not as important to users.
 
 ## How it works
 


### PR DESCRIPTION
To be consistent with GOV.UK style guide.