### PR TITLE
Replace straight quotes in curly quotes

### DIFF
--- a/src/components/radios/hint/index.njk
+++ b/src/components/radios/hint/index.njk
@@ -17,7 +17,7 @@ ignore_in_sitemap: true
     }
   },
   hint: {
-    text: "You'll need an account to prove your identity and complete your Self Assessment."
+    text: "You’ll need an account to prove your identity and complete your Self Assessment."
   },
   items: [
     {
@@ -27,7 +27,7 @@ ignore_in_sitemap: true
         classes: "govuk-label--s"
       },
       hint: {
-        text: "You'll have a user ID if you've registered for Self Assessment or filed a tax return online before."
+        text: "You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before."
       }
     },
     {
@@ -37,7 +37,7 @@ ignore_in_sitemap: true
         classes: "govuk-label--s"
       },
       hint: {
-        text: "You'll have an account if you've already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
+        text: "You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
       }
     }
   ]

--- a/src/components/text-input/error/index.njk
+++ b/src/components/text-input/error/index.njk
@@ -13,7 +13,7 @@ ignore_in_sitemap: true
   id: "event-name",
   name: "event-name",
   hint: {
-    text: "The name you'll use on promotional material."
+    text: "The name you’ll use on promotional material."
   },
   errorMessage: {
     text: "Enter an event name"

--- a/src/components/text-input/input-hint-text/index.njk
+++ b/src/components/text-input/input-hint-text/index.njk
@@ -11,7 +11,7 @@ ignore_in_sitemap: true
     text: "Event name"
   },
   hint: {
-    text: "The name you'll use on promotional material."
+    text: "The name you’ll use on promotional material."
   },
   id: "event-name",
   name: "event-name"

--- a/src/errors/404.njk
+++ b/src/errors/404.njk
@@ -10,7 +10,7 @@ ignore_in_sitemap: true
 
     <p class="govuk-body">If you typed the web address, check it is correct.</p>
     <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
-    <p class="govuk-body">If you're looking for the 'page not found' pattern see <a class="govuk-link" href="/patterns/page-not-found-pages/">page not found pages</a>.</p>
+    <p class="govuk-body">If you’re looking for the ‘page not found’ pattern see <a class="govuk-link" href="/patterns/page-not-found-pages/">page not found pages</a>.</p>
 
     <p class="govuk-body">
       <a class="govuk-link" href="/get-in-touch">Contact the Design System team</a> if you believe you are seeing this message in error.


### PR DESCRIPTION
This commit replaces several straight quotes with their curly
equivalents, to match the rest of the design system documentation.

Straight quotes have been retained when they have been in a technical
context, such as code comments or as string delimiters.

This follows the guidance set out by this 2015 blog post:
https://designnotes.blog.gov.uk/2015/09/16/tips-for-creating-good-typography/

For more information, see https://practicaltypography.com

This commit ignores that of Markdown for the reasons given at:
https://github.com/alphagov/govuk-design-system/pull/952#issuecomment-509230660

cf. #952 