### PR TITLE
Add explicit routes to the manifest file

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,9 @@
 ---
 applications:
 - name: govuk-design-system-origin
+  routes:
+    - route: govuk-design-system-origin.cloudapps.digital
+    - route: design-system.service.gov.uk
   # NGINX requires 20 MB of RAM to serve static assets. Reduce RAM allocation
   # from the default 1 GB allocated to containers by default to 64M.
   memory: 64M


### PR DESCRIPTION
When the blue green deploy plugin runs, it’s picking `design-system.service.gov.uk` as the first route and using that to generate the fully qualified domain name used for smoke tests.

This means that smoke tests are running against `govuk-design-system-origin-new.design-system.service.gov.uk` which is not valid.

Specifying the routes in the manifest (and, importantly, putting the `cloudapps.digital` domain first) should fix this.

This behaviour was not seen in testing as we were not testing against an instance with a cdn-route.