### PR TITLE
Revise guidance on creating pull requests

### DIFF
--- a/src/community/propose-a-content-change-using-github/index.md.njk
+++ b/src/community/propose-a-content-change-using-github/index.md.njk
@@ -68,17 +68,15 @@ If you are happy with your changes, select ‘Create pull request’. You'll hav
 
 ## 5. Create a pull request
 
-A pull request is a request to the GOV.UK Design System team to add ('pull') your changes into the project. The changes can then be published.
+A pull request is a request to the GOV.UK Design System team to add (‘pull’) your changes into the project and publish them in the Design System.
 
-At this point, you can write additional comments about the work you’ve done if you want to.
+Once you’ve created a pull request, your proposed change and any comments you’ve written will be publicly visible meaning that anyone can see them on GitHub.
 
-These comments will be shared with the GOV.UK Design System team when you submit the pull request. 
+You’ll see the description you entered in step 3 and can add some additional information if you want to.
 
-The comment field will be pre-filled with the information you entered when you proposed the file change in step 3. Changing the information here will not change the original description, but will send it in addition.
+Once you’re happy, select ‘create pull request’.
 
 ![Create pull request view in GitHub. It is pre-filled with the summary and the description from the previous propose change view. There is a button to create a pull request.](create-pull-request-view-github.png)
-
-Once you’re happy with your change, select ‘Create pull request’.
 
 ## 6. Wait for the team to review your pull request
 


### PR DESCRIPTION
Updated to:

- make it clearer that pull requests are publicly visible on GitHub, and so can be seen by other people
- remove 'changing the information here will not change the original description, but will send it in addition' as it's not clear to the user what the difference between those two things is; why they should care or what they should do about it.
- try and remove some overlap with step 6 (the Design System team being notified of the PR)