### PR TITLE
Update navigation focus styles

### DIFF
--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -18,7 +18,7 @@ MobileNav.prototype.bindUIEvents = function () {
   var $nav = this.$nav
   var $navToggler = this.$navToggler
 
-  $navToggler.addEventListener('click', function (e) {
+  $navToggler.addEventListener('click', function (event) {
     if ($nav.classList.contains(navActiveClass)) {
       $nav.classList.remove(navActiveClass)
       $nav.setAttribute('aria-hidden', 'true')
@@ -39,18 +39,21 @@ MobileNav.prototype.bindUIEvents = function () {
     if (!$toggler.classList.contains('js-mobile-nav-subnav-toggler')) {
       return
     }
-    var $nextSubNav = $toggler.parentNode.querySelector('.js-app-mobile-nav-subnav')
+    // The presentational touch area of the toggler is on it's parent.
+    var $togglerLinkArea = $toggler.parentNode
+
+    var $nextSubNav = $togglerLinkArea.parentNode.querySelector('.js-app-mobile-nav-subnav')
 
     if ($nextSubNav) {
       if ($nextSubNav.classList.contains(subNavActiveClass)) {
         $nextSubNav.classList.remove(subNavActiveClass)
-        $toggler.classList.remove(subNavTogglerActiveClass)
+        $togglerLinkArea.classList.remove(subNavTogglerActiveClass)
 
         $nextSubNav.setAttribute('aria-hidden', 'true')
         $toggler.setAttribute('aria-expanded', 'false')
       } else {
         $nextSubNav.classList.add(subNavActiveClass)
-        $toggler.classList.add(subNavTogglerActiveClass)
+        $togglerLinkArea.classList.add(subNavTogglerActiveClass)
 
         $nextSubNav.setAttribute('aria-hidden', 'false')
         $toggler.setAttribute('aria-expanded', 'true')

--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -1,12 +1,12 @@
 .app-mobile-nav {
   display: none;
+}
 
-  &--active {
-    display: block;
+.app-mobile-nav--active {
+  display: block;
 
-    @include govuk-media-query($from: tablet) {
-      display: none;
-    }
+  @include govuk-media-query($from: tablet) {
+    display: none;
   }
 }
 
@@ -20,64 +20,65 @@
   margin: 0;
   padding: 0;
   list-style: none;
+}
+
+.app-mobile-nav-subnav-toggler {
+  position: relative;
+  padding: 16px govuk-spacing(4) 17px govuk-spacing(4);
   background-color: $app-light-grey;
+}
 
+.app-mobile-nav-subnav-toggler__link {
+  @include govuk-typography-weight-bold; // Override .govuk-link weight
+  font-size: 19px; // We do not have a font mixin that produces 19px on mobile
+  font-size: govuk-px-to-rem(19px); // sass-lint:disable-line no-duplicate-properties
 
-  & > li {
-    @include govuk-typography-common;
-    @include govuk-typography-weight-bold;
-    font-size: 19px; // We do not have a font mixin that produces 19px on mobile
-    font-size: govuk-px-to-rem(19px); // sass-lint:disable-line no-duplicate-properties
+  &:not(:focus):hover {
+    color: $govuk-link-colour;
+  }
+}
 
-    & > a {
-      @include govuk-typography-weight-bold; // Override .govuk-link weight
-      display: block;
-      padding: 16px govuk-spacing(4) 17px govuk-spacing(4);
-      text-decoration: none;
+.app-mobile-nav-subnav-toggler__link,
+.app-mobile-nav__link {
+  text-decoration: none;
 
-      &:hover,
-      &:focus,
-      &:visited {
-        color: govuk-colour("blue");
-        background-color: inherit;
-      }
-    }
+  // Expand the touch area of the link to the full menu width
+  &:after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
   }
 }
 
 .app-mobile-nav__subnav {
   display: none;
-  margin: 0;
-  padding: govuk-spacing(2) 0 0 0;
-  list-style: none;
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
   border-top: 1px solid govuk-colour("light-grey");
   border-bottom: 1px solid govuk-colour("light-grey");
-  background-color: govuk-colour("white");
-
-  & > li {
-    & > a {
-      @include govuk-font(19);
-      display: block;
-      padding: govuk-spacing(2) govuk-spacing(4);
-
-      text-decoration: none;
-    }
-
-    &.current-page a {
-      border-left: 4px solid govuk-colour("blue");
-    }
-  }
 }
 
 .js-enabled .app-mobile-nav__subnav--active {
   display: block;
 }
 
-.app-mobile-nav__current-page {
-  border-left: 4px solid govuk-colour("blue");
+.app-mobile-nav__subnav-item {
+  display: block;
+  position: relative;
+  padding: (govuk-spacing(2) + 2px) govuk-spacing(4);
+}
+
+.app-mobile-nav__subnav-item--current {
+  $_current-indicator-width: 4px;
+  padding-left: govuk-spacing(4) - $_current-indicator-width;
+  border-left: $_current-indicator-width solid govuk-colour("blue");
 }
 
 .app-mobile-nav__theme {
+  @include govuk-typography-common;
   margin: 0;
   padding: govuk-spacing(4) govuk-spacing(4) govuk-spacing(1) govuk-spacing(4);
   color: govuk-colour("dark-grey");
@@ -85,36 +86,5 @@
   // it does not re-size on mobile viewport
   font-size: 19px;
   font-size: govuk-px-to-rem(19px); // sass-lint:disable-line no-duplicate-properties
-  font-weight: 400;
-}
-
-.app-mobile-nav__theme-nav {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  background-color: govuk-colour("white");
-
-  & > li {
-    @include govuk-font(19);
-
-    & > a {
-      display: block;
-      padding: govuk-spacing(3) govuk-spacing(4) govuk-spacing(2) govuk-spacing(4);
-
-      text-decoration: none;
-    }
-
-    &.current-page a {
-      padding-left: govuk-spacing(4) - 4px;
-      border-left: 4px solid govuk-colour("blue");
-    }
-
-    &:last-child a {
-      padding-bottom: govuk-spacing(5);
-    }
-  }
-}
-
-.js-enabled .app-mobile-nav__subnav-toggler--active {
-  border-top: 1px solid govuk-colour("white");
+  font-weight: normal;
 }

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -1,5 +1,6 @@
+$navigation-height: 53px;
+
 .app-navigation {
-  $navigation-height: 53px;
   box-sizing: border-box;
   @include govuk-font(19, $weight: bold);
   width: 100%;
@@ -11,48 +12,50 @@
   @include govuk-media-query($from: tablet) {
     margin-left: -(govuk-spacing(3));
   }
+}
 
-  &__list {
-    padding: 0;
-    list-style: none;
+.app-navigation__list {
+  padding: 0;
+  list-style: none;
+}
 
-    & > li {
-      box-sizing: border-box;
-      height: $navigation-height;
-      float: left;
-      line-height: $navigation-height;
-      -moz-box-sizing: border-box;
-      -webkit-box-sizing: border-box;
+.app-navigation__list-item {
+  box-sizing: border-box;
+  display: block;
+  position: relative;
+  height: $navigation-height;
+  padding: 0 govuk-spacing(3);
+  float: left;
+  line-height: $navigation-height;
+}
 
-      &:hover {
-        border-bottom: 4px solid govuk-colour("light-blue");
-      }
+.app-navigation__list-item--current {
+  box-shadow: inset 0 -4px 0 0 govuk-colour("blue");
+}
 
-      &.app-navigation--current-page {
-        border-bottom: 4px solid govuk-colour("blue") !important;
+.app-navigation__link {
+  @include govuk-typography-weight-bold;
+  text-decoration: none;
 
-        a:hover {
-          color: $govuk-link-colour;
-        }
-      }
-
-      a {
-        @include govuk-typography-weight-bold; // Override .govuk-link weight
-        display: block;
-        padding: 0 govuk-spacing(3);
-        color: $govuk-link-colour;
-        text-decoration: none;
-
-        &:visited {
-          color: $govuk-link-colour;
-        }
-
-        &:hover,
-        &:focus {
-          color: $govuk-link-hover-colour;
-          background-color: inherit;
-        }
-      }
-    }
+  &:not(:focus):visited {
+    color: $govuk-link-colour;
   }
+
+  &:not(:focus):hover {
+    text-decoration: underline;
+  }
+
+  // Extend the touch area of the link to the list
+  &:after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+}
+
+.app-navigation__list-item--current .app-navigation__link:hover {
+  text-decoration: none;
 }

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -3,10 +3,6 @@
   .app-subnav {
     padding: govuk-spacing(6) govuk-spacing(3) 0 0;
     @include govuk-font(16);
-
-    @include govuk-media-query($from: tablet) {
-      margin-left: -(govuk-spacing(3));
-    }
   }
 
   .app-subnav__section {
@@ -16,44 +12,53 @@
   }
 
   .app-subnav__link {
-    display: block;
-    padding: 8px govuk-spacing(6) 8px govuk-spacing(2);
-    border-left: 4px solid transparent;
+    padding: 2px 0;
     text-decoration: none;
 
-    &:focus {
-      background: inherit;
-    }
-
-    &:hover,
-    &:active,
-    &:visited {
+    &:not(:focus):hover {
       color: $govuk-link-colour;
-    }
-
-    &:hover {
-      border-left-color: $govuk-link-hover-colour;
+      text-decoration: underline;
     }
   }
 
+  .app-subnav__section-item {
+    margin-bottom: govuk-spacing(1);
+    padding-top: govuk-spacing(1);
+    padding-bottom: govuk-spacing(1);
+  }
+
+  .app-subnav__section-item--current {
+    $_current-indicator-width: 4px;
+    margin-left: -(govuk-spacing(2) + $_current-indicator-width);
+    padding-left: govuk-spacing(2);
+    border-left: $_current-indicator-width solid govuk-colour("blue");
+    background-color: govuk-colour("white");
+  }
+
   .app-subnav__section-item--current .app-subnav__link {
-    border-left-color: $govuk-link-colour;
-    background: $app-light-grey;
     font-weight: bold;
   }
 
   .app-subnav__section--nested {
+    margin-top: govuk-spacing(2);
     margin-bottom: 0;
+    padding-left: govuk-spacing(4);
+  }
+
+  .app-subnav__section--nested .app-subnav__section-item::before {
+    content: "—";
+    margin-left: -(govuk-spacing(4));
+    color: govuk-colour("dark-grey");
   }
 
   .app-subnav__section--nested .app-subnav__link {
-    padding-left: govuk-spacing(4);
-    font-weight: 400;
+    padding-left: 0;
+    font-weight: normal;
   }
 
   .app-subnav__theme {
     margin: 0;
-    padding: govuk-spacing(2) govuk-spacing(3);
+    padding: govuk-spacing(2) govuk-spacing(3) govuk-spacing(2) 0;
     color: govuk-colour("dark-grey");
     @include govuk-font(19);
   }

--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -1,32 +1,38 @@
 <nav id="app-mobile-nav" class="app-mobile-nav js-app-mobile-nav" role="navigation">
   <ul class="app-mobile-nav__list">
     {% for item in navigation %}
-    <li>
-      <a class="govuk-link js-mobile-nav-subnav-toggler{% if path.startsWith(item.url) %} app-mobile-nav__subnav-toggler--active{% endif %}" href="/{{ item.url }}">{{ item.label }}</a>
-      {% if item.items %}
-      <ul class="app-mobile-nav__subnav js-app-mobile-nav-subnav {% if path.startsWith(item.url) %}app-mobile-nav__subnav--active{% endif %}">
-        <li{% if path == item.url %} class="current-page"{% endif %}>
-          <a class="govuk-link" href="/{{ item.url }}">{{ item.label }} overview</a>
-        </li>
-
-        {% for theme, items in item.items | groupby("theme") %}
-        <li>
-          {% if theme != 'undefined' %}
-          <h4 class="app-mobile-nav__theme">{{ theme }}</h4>
-          {% endif %}
-          <ul class="app-mobile-nav__theme-nav">
-          {% for subitem in items %}
-            <li{% if path == subitem.url %} class="current-page"{% endif %}>
-              <a class="govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
+      <li>
+        <div class="app-mobile-nav-subnav-toggler{% if path.startsWith(item.url) %} app-mobile-nav__subnav-toggler--active{% endif %}">
+          <a class="govuk-link govuk-link--no-visited-state app-mobile-nav-subnav-toggler__link js-mobile-nav-subnav-toggler" href="/{{ item.url }}">
+            {{ item.label }}
+          </a>
+        </div>
+        {% if item.items %}
+          <ul class="app-mobile-nav__list app-mobile-nav__subnav js-app-mobile-nav-subnav {% if path.startsWith(item.url) %}app-mobile-nav__subnav--active{% endif %}">
+            <li class="app-mobile-nav__subnav-item{% if path == item.url %} app-mobile-nav__subnav-item--current{% endif %}">
+              <a class="govuk-link govuk-link--no-visited-state app-mobile-nav__link" href="/{{ item.url }}">
+                {{ item.label }} overview
+              </a>
             </li>
-          {% endfor %}
+            {% for theme, items in item.items | groupby("theme") %}
+              <li>
+                {% if theme != 'undefined' %}
+                  <h4 class="app-mobile-nav__theme">{{ theme }}</h4>
+                {% endif %}
+                <ul class="app-mobile-nav__list">
+                  {% for subitem in items %}
+                    <li class="app-mobile-nav__subnav-item{% if path == subitem.url %} app-mobile-nav__subnav-item--current{% endif %}">
+                      <a class="govuk-link govuk-link--no-visited-state app-mobile-nav__link" href="/{{ subitem.url }}">
+                        {{ subitem.label }}
+                      </a>
+                    </li>
+                  {% endfor %}
+                </ul>
+              </li>
+            {% endfor %}
           </ul>
-        </li>
-        {% endfor %}
-
-      </ul>
-      {% endif %}
-    </li>
+        {% endif %}
+      </li>
     {% endfor %}
   </ul>
 </nav>

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -1,8 +1,8 @@
 <nav class="app-navigation govuk-clearfix">
   <ul class="app-navigation__list govuk-width-container">
     {% for item in navigation %}
-    <li{% if path == item.url or item.url and path.startsWith(item.url) %} class="app-navigation--current-page"{% endif %}>
-      <a class="govuk-link" href="/{{ item.url }}" data-topnav="{{ item.label }}">{{ item.label }}</a>
+    <li class="app-navigation__list-item{% if path == item.url or item.url and path.startsWith(item.url) %} app-navigation__list-item--current{% endif %}">
+      <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/{{ item.url }}" data-topnav="{{ item.label }}">{{ item.label }}</a>
     </li>
     {% endfor %}
   </ul>

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -9,13 +9,13 @@
           <ul class="app-subnav__section">
           {% for subitem in items %}
             <li class="app-subnav__section-item{% if subitem.url == path %} app-subnav__section-item--current{% endif %}">
-              <a class="app-subnav__link govuk-link" href="/{{ subitem.url }}">{{ subitem.label }}</a>
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/{{ subitem.url }}">{{ subitem.label }}</a>
               {% if (subitem.headings) and (subitem.url == path) %}
                 <ul class="app-subnav__section app-subnav__section--nested">
                   {% for link in subitem.headings %}
                     {% if link.depth == 2 %}
                       <li class="app-subnav__section-item">
-                        <a class="app-subnav__link govuk-link" href="/{{ subitem.url }}/#{{ link.url }}" >
+                        <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/{{ subitem.url }}/#{{ link.url }}" >
                           {{ link.text }}
                         </a>
                       </li>


### PR DESCRIPTION
Update navigation focus styles to be inline with GOV.UK Frontend 3.0.0

This work also includes some refactoring to use BEM, which was necessary for the mobile navigation but a nice to have everywhere else.

Closes #958