### PR TITLE
Update the header

### DIFF
--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -108,31 +108,26 @@
     min-height: 40px; // match the height of the search box
     margin-top: govuk-spacing(2);
     margin-bottom: govuk-spacing(2);
-    padding-right: 0;
-    padding-left: 0;
-    border: 1px solid transparent;
-    background-color: govuk-colour("black");
-    box-shadow: 0 0 0 govuk-colour("black");
+    padding-right: govuk-spacing(1);
+    padding-left: govuk-spacing(1);
+    border: 1px solid transparent; // Override the button default border, keep this around for when users change their colours
+    box-shadow: none; // Override the button default box shadow
 
-    &:active,
-    &:focus,
+    &,
     &:hover {
-      background-color: govuk-colour("black"); // Override the button default green
-      box-shadow: 0 0 0 govuk-colour("black"); // Override the button default green
+      background-color: transparent; // Override the button default green
     }
 
     &::after {
       @include govuk-shape-arrow($direction: down, $base: 10px, $display: inline-block);
       content: "";
       margin-left: govuk-spacing(1);
-      border-color: govuk-colour("white");
+      border-top-color: currentColor;
     }
 
-    &--active.app-header-mobile-nav-toggler {
-      &::after {
-        @include govuk-shape-arrow($direction: up, $base: 10px, $display: inline-block);
-        border-color: govuk-colour("white");
-      }
+    &--active::after {
+      @include govuk-shape-arrow($direction: up, $base: 10px, $display: inline-block);
+      border-bottom-color: currentColor;
     }
 
     .js-enabled & {

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -1,101 +1,21 @@
-// Known issues:
-//
-// When the GOV.UK logotype is focussed in Firefox, the outline is drawn based
-// on a different box to the background, which leads to 'gaps' on the top and
-// bottom between the outline and the background.
-//
-// This seems to only happen when the link is displayed 'inline-block', but
-// removing this affects the positioning of the underline and causes other
-// issues with the display of the focus style in IE8-11.
-
 @include govuk-exports("app-header") {
 
+  // Move the blue border from the container to the header so that it spans
+  // the full width of the page
   .app-header {
-    box-sizing: border-box;
-    width: 100%;
-    border-bottom: 10px solid govuk-colour("blue");
-    color: govuk-colour("white");
-    background: govuk-colour("black");
-    @include govuk-clearfix;
-
-    @include govuk-media-query($from: desktop) {
-      padding: govuk-spacing(2) 0;
-    }
+    border-bottom: 10px solid $govuk-brand-colour;
   }
 
-  .app-header__logotype {
-    margin-right: govuk-spacing(1);
+  .app-header__container {
+    margin-bottom: 0;
+    border-bottom: 0;
   }
 
-  .app-header__logotype-crown {
-    margin-right: 1px;
-    fill: currentColor;
-    vertical-align: middle;
-  }
-
-  .app-header__logotype-crown-fallback-image {
-    width: 36px;
-    height: 32px;
-    border: 0;
-    vertical-align: middle;
-  }
-
-  .app-header__title {
-    @include govuk-font(24);
-  }
-
-  .app-header__link {
-    // Font size needs to be set on the link so that the box sizing is correct
-    // in Firefox
-    @include govuk-typography-common;
-    @include govuk-typography-weight-bold;
-    display: inline-block;
-
-    font-size: 30px; // We do not have a mixin that produces 30px font size\
-    line-height: 30px;
-    @include govuk-clearfix;
-
-    &:link,
-    &:visited {
-      margin-bottom: -1px; // Negate transparent bottom border
-      border-bottom: 1px solid transparent;
-      color: govuk-colour("white");
-      text-decoration: none;
-    }
-
-    &:hover,
-    &:active {
-      border-bottom-color: currentColor;
-    }
-
-    &:focus {
-      color: $govuk-focus-text-colour;
-    }
-  }
-
-  @include govuk-media-query($media-type: print) {
-    .app-header {
-      border-bottom-width: 0;
-      color: govuk-colour("black");
-      background: transparent;
-    }
-
-    // Hide the inverted crown when printing in browsers that do not support SVG.
-    .app-header__logotype-crown-fallback-image {
-      display: none;
-    }
-
-    .app-header__link {
-      &:link,
-      &:visited {
-        color: govuk-colour("black");
-      }
-
-      // Do not append link href to GOV.UK link when printing (e.g. '(/)')
-      &:after {
-        display: none;
-      }
-    }
+  // Override the default 33% width on the logo in GOV.UK Frontend (prevents
+  // unnecessary wrapping of "GOV.UK Design System" on smaller tablet / desktop
+  // viewports)
+  .app-header__logo {
+    width: auto;
   }
 
   .app-header-mobile-nav-toggler-wrapper {
@@ -136,19 +56,4 @@
       }
     }
   }
-
-  // Begin adjustments for font baseline offset
-  // These should be removed when the font is updated with the correct baseline
-  .app-header__logotype-crown,
-  .app-header__logotype-crown-fallback-image {
-    position: relative;
-    top: -4px;
-  }
-
-  .app-header {
-    $offset: 3px;
-    padding-top: govuk-spacing(2) + $offset;
-    padding-bottom: govuk-spacing(2) - $offset;
-  }
-  // End adjustments
 }

--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -9,18 +9,6 @@
     }
   }
 
-  .app-pane__header {
-    @include govuk-media-query($from: tablet) {
-      display: flex;
-      flex-direction: column;
-      flex: 1 0 auto;
-
-      > * {
-        flex: 1 0 auto;
-      }
-    }
-  }
-
   .app-pane__nav {
     @include govuk-media-query($from: tablet) {
       display: flex;

--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -20,8 +20,7 @@ $icon-size: 40px;
 
     @include govuk-media-query($from: desktop) {
       margin: 0;
-      margin-top: -6px; //negative margin to vertically align search in header
-      margin-bottom: -1px;
+      margin-top: -5px; //negative margin to vertically align search in header
       float: right;
     }
 
@@ -71,14 +70,14 @@ $icon-size: 40px;
   }
 
   .app-site-search__input--default {
-    padding: 9px govuk-spacing(2) govuk-spacing(1);
+    padding: govuk-spacing(1);
   }
 
   .app-site-search__input--focused {
     width: 100%;
     margin-left: 0;
     outline: 3px solid $govuk-focus-colour;
-    outline-offset: 0;
+    outline-offset: -2px;
   }
 
   .app-site-search__input--show-all-values {

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -30,10 +30,8 @@
 {% block main %}
 <div class="app-pane {% block appPaneClasses %}{% endblock %}" id="top">
   {% include "_cookie-banner.njk" %}
-  <div class="app-pane__header">
-    {% include "_header.njk" %}
-    {% include "_banner.njk" %}
-  </div>
+  {% include "_header.njk" %}
+  {% include "_banner.njk" %}
   <div class="app-pane__nav">
     {% include "_navigation.njk" %}
     {% include "_mobile-navigation.njk" %}

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -1,51 +1,62 @@
-<header class="app-header" role="banner">
-  <div class="govuk-width-container">
-      <a href="/" class="govuk-link app-header__link">
-      <span class="app-header__logotype">
-  {#
-        We use an inline SVG for the crown so that we can cascade the
-        currentColor into the crown whilst continuing to support older browsers
-        which do not support external SVGs without a Javascript polyfill. This
-        adds approximately 1kb to every page load.
+<header class="govuk-header app-header" role="banner" data-module="govuk-header">
+  <div class="govuk-header__container govuk-width-container app-header__container">
+    <div class="govuk-header__logo app-header__logo">
+      <a href="/" class="govuk-header__link govuk-header__link--homepage">
+        <span class="govuk-header__logotype">
+          {#- We use an inline SVG for the crown so that we can cascade the
+          currentColor into the crown whilst continuing to support older browsers
+          which do not support external SVGs without a Javascript polyfill. This
+          adds approximately 1kb to every page load.
 
-        We use currentColour so that we can easily invert it when printing and
-        when the focus state is applied. This also benefits users who override
-        colours in their browser as they will still see the crown.
+          We use currentColour so that we can easily invert it when printing and
+          when the focus state is applied. This also benefits users who override
+          colours in their browser as they will still see the crown.
 
-        The SVG needs `focusable="false"` so that Internet Explorer does not treat
-        it as an interactive element - without this it will be 'focusable' when
-        using the keyboard to navigate. #}
-        <svg role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" class="app-header__logotype-crown" width="36" height="32" viewBox="0 0 132 97">
-          <path d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z" fill="currentColor" fill-rule="evenodd"></path>
-  {#
-          Fallback PNG image for older browsers.
+          The SVG needs `focusable="false"` so that Internet Explorer does not
+          treat it as an interactive element - without this it will be
+          'focusable' when using the keyboard to navigate. #}
+          <svg
+            role="presentation"
+            focusable="false"
+            class="govuk-header__logotype-crown"
+            xmlns="http://www.w3.org/2000/svg"
+            viewbox="0 0 132 97"
+            height="30"
+            width="36"
+          >
+            <path
+              fill="currentColor" fill-rule="evenodd"
+              d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+            ></path>
+            {#- Fallback PNG image for older browsers.
 
-          The <image> element is a valid SVG element. In SVG, you would specify
-          the URL of the image file with the xlink:href – as we don't reference an
-          image it has no effect. It's important to include the empty xlink:href
-          attribute as this prevents versions of IE which support SVG from
-          downloading the fallback image when they don't need to.
+            The <image> element is a valid SVG element. In SVG, you would specify
+            the URL of the image file with the xlink:href – as we don't reference an
+            image it has no effect. It's important to include the empty xlink:href
+            attribute as this prevents versions of IE which support SVG from
+            downloading the fallback image when they don't need to.
 
-          In other browsers <image> is synonymous for the <img> tag and will be
-          interpreted as such, displaying the fallback image. #}
-          <image src="/assets/images/govuk-logotype-crown.png" xlink:href="" class="app-header__logotype-crown-fallback-image"></image>
-        </svg>
-        <span class="app-header__logotype-text">
-          GOV.UK
+            In other browsers <image> is synonymous for the <img> tag and will be
+            interpreted as such, displaying the fallback image. #}
+            <image src="/assets/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+          </svg>
+          <span class="govuk-header__logotype-text">
+            GOV.UK
+          </span>
         </span>
-      </span>
-    </span>
-    <span class="app-header__title">
-      Design System
-    </span>
-  </a>
-  <div class="app-site-search" data-module="app-search" data-search-index="/{{ fingerprint['search-index.json'] }}">
-    <label class="govuk-visually-hidden" for="app-site-search__input">Search Design system</label>
-    <a class="app-site-search__link govuk-link" href="/sitemap">Sitemap</a>
-  </div>
-  <div class="app-header-mobile-nav-toggler-wrapper">
-    <button id="app-mobile-nav-toggler" class="govuk-button app-header-mobile-nav-toggler js-app-mobile-nav-toggler">
-      Menu
-    </button>
+        <span class="govuk-header__product-name">
+          Design System
+        </span>
+      </a>
+    </div>
+    <div class="app-site-search" data-module="app-search" data-search-index="/{{ fingerprint['search-index.json'] }}">
+      <label class="govuk-visually-hidden" for="app-site-search__input">Search Design system</label>
+      <a class="app-site-search__link govuk-link" href="/sitemap">Sitemap</a>
+    </div>
+    <div class="app-header-mobile-nav-toggler-wrapper">
+      <button id="app-mobile-nav-toggler" class="govuk-button app-header-mobile-nav-toggler js-app-mobile-nav-toggler">
+        Menu
+      </button>
+    </div>
   </div>
 </header>


### PR DESCRIPTION
Updates the header to:

- use the new focus style for the menu button
- use most of the header markup and CSS from GOV.UK Frontend, with some targeted overrides where required
- align the search within the header, align the text within the search input correctly, and update its focus state

<details>
<summary>Screenshots</summary>
<img width="1392" alt="Screen Shot 2019-07-18 at 12 13 06" src="https://user-images.githubusercontent.com/121939/61453371-d4433780-a955-11e9-8484-dfc8c4a802a2.png">
<img width="1392" alt="Screen Shot 2019-07-18 at 12 13 09" src="https://user-images.githubusercontent.com/121939/61453373-d4433780-a955-11e9-91c7-b6e476c40115.png">
<img width="1392" alt="Screen Shot 2019-07-18 at 12 13 15" src="https://user-images.githubusercontent.com/121939/61453374-d4dbce00-a955-11e9-8546-e7d9ca196c79.png">

![localhost_3000_components_back-link_](https://user-images.githubusercontent.com/121939/61453408-e7ee9e00-a955-11e9-9e78-1a3e022aa593.png)
![localhost_3000_components_(iPhone X)](https://user-images.githubusercontent.com/121939/61453400-e1602680-a955-11e9-8542-40a6a7eddf34.png)
![localhost_3000_components_(iPhone X) (1)](https://user-images.githubusercontent.com/121939/61453402-e329ea00-a955-11e9-98e6-7af5daa5c83e.png)
</details>

This covers #961 and part of the work to remove baseline adjustments from the Design System (#957)