### PR TITLE
Update template page Nunjucks config

### DIFF
--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -46,8 +46,7 @@ as available views:
 
 ```
 nunjucks.configure([
-  "node_modules/govuk-frontend/",
-  "node_modules/govuk-frontend/govuk/components/"
+  "node_modules/govuk-frontend/"
 ], {
   autoescape: true
 })


### PR DESCRIPTION
Following what we'll advise users to do in https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md#if-youre-using-nunjucks they shouldn't need to load the `/components` directory as this would hide the path in their files. Instead, they would do the following:
```
{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
```