### PR TITLE
Initialise Javascript of v3 GOV.UK Frontend components

### DIFF
--- a/src/javascripts/govuk-frontend.js
+++ b/src/javascripts/govuk-frontend.js
@@ -8,14 +8,17 @@ import Radios from 'govuk-frontend/govuk/components/radios/radios'
 import Header from 'govuk-frontend/govuk/components/header/header'
 import Tabs from 'govuk-frontend/govuk/components/tabs/tabs'
 
-new Button(document).init()
+var $button = document.querySelector('[data-module="govuk-button"]')
+if ($button) {
+  new Button($button).init()
+}
 
 var $accordion = document.querySelector('[data-module="accordion"]')
 if ($accordion) {
   new Accordion($accordion).init()
 }
 
-var $details = document.querySelector('details')
+var $details = document.querySelector('[data-module="govuk-details"]')
 if ($details) {
   new Details($details).init()
 }

--- a/src/javascripts/govuk-frontend.js
+++ b/src/javascripts/govuk-frontend.js
@@ -1,3 +1,4 @@
+import common from 'govuk-frontend/govuk/common'
 import Accordion from 'govuk-frontend/govuk/components/accordion/accordion'
 import Button from 'govuk-frontend/govuk/components/button/button'
 import Details from 'govuk-frontend/govuk/components/details/details'
@@ -8,23 +9,25 @@ import Radios from 'govuk-frontend/govuk/components/radios/radios'
 import Header from 'govuk-frontend/govuk/components/header/header'
 import Tabs from 'govuk-frontend/govuk/components/tabs/tabs'
 
-var $button = document.querySelector('[data-module="govuk-button"]')
-if ($button) {
+var nodeListForEach = common.nodeListForEach
+
+var $buttons = document.querySelectorAll('[data-module="govuk-button"]')
+nodeListForEach($buttons, function ($button) {
   new Button($button).init()
-}
+})
 
-var $accordion = document.querySelector('[data-module="govuk-accordion"]')
-if ($accordion) {
+var $accordions = document.querySelectorAll('[data-module="govuk-accordion"]')
+nodeListForEach($accordions, function ($accordion) {
   new Accordion($accordion).init()
-}
+})
 
-var $details = document.querySelector('[data-module="govuk-details"]')
-if ($details) {
-  new Details($details).init()
-}
+var $details = document.querySelectorAll('[data-module="govuk-details"]')
+nodeListForEach($details, function ($detail) {
+  new Details($detail).init()
+})
 
-var $errorSummary = document.querySelector('[data-module="govuk-error-summary"]')
-if ($errorSummary) {
+var $errorSummaries = document.querySelectorAll('[data-module="govuk-error-summary"]')
+nodeListForEach($errorSummaries, function ($errorSummary) {
   var errorSummary = new ErrorSummary($errorSummary)
   // Override the `init` method since it automatically focuses the ErrorSummary.
   // This is not ideal when showing examples for this component
@@ -33,29 +36,29 @@ if ($errorSummary) {
     this.$module.addEventListener('click', ErrorSummary.prototype.handleClick.bind(this))
   }
   errorSummary.init()
-}
+})
 
-var $characterCount = document.querySelector('[data-module="govuk-character-count"]')
-if ($characterCount) {
+var $characterCounts = document.querySelectorAll('[data-module="govuk-character-count"]')
+nodeListForEach($characterCounts, function ($characterCount) {
   new CharacterCount($characterCount).init()
-}
+})
 
-var $checkbox = document.querySelector('[data-module="govuk-checkboxes"]')
-if ($checkbox) {
+var $checkboxes = document.querySelectorAll('[data-module="govuk-checkboxes"]')
+nodeListForEach($checkboxes, function ($checkbox) {
   new Checkboxes($checkbox).init()
-}
+})
 
-var $radio = document.querySelector('[data-module="govuk-radios"]')
-if ($radio) {
+var $radios = document.querySelectorAll('[data-module="govuk-radios"]')
+nodeListForEach($radios, function ($radio) {
   new Radios($radio).init()
-}
+})
 
-var $header = document.querySelector('[data-module="govuk-header"]')
-if ($header) {
+var $headers = document.querySelectorAll('[data-module="govuk-header"]')
+nodeListForEach($headers, function ($header) {
   new Header($header).init()
-}
+})
 
-var $tabs = document.querySelector('[data-module="govuk-tabs"]')
-if ($tabs) {
-  new Tabs($tabs).init()
-}
+var $tabs = document.querySelectorAll('[data-module="govuk-tabs"]')
+nodeListForEach($tabs, function ($tab) {
+  new Tabs($tab).init()
+})

--- a/src/javascripts/govuk-frontend.js
+++ b/src/javascripts/govuk-frontend.js
@@ -13,7 +13,7 @@ if ($button) {
   new Button($button).init()
 }
 
-var $accordion = document.querySelector('[data-module="accordion"]')
+var $accordion = document.querySelector('[data-module="govuk-accordion"]')
 if ($accordion) {
   new Accordion($accordion).init()
 }
@@ -23,7 +23,7 @@ if ($details) {
   new Details($details).init()
 }
 
-var $errorSummary = document.querySelector('[data-module="error-summary"]')
+var $errorSummary = document.querySelector('[data-module="govuk-error-summary"]')
 if ($errorSummary) {
   var errorSummary = new ErrorSummary($errorSummary)
   // Override the `init` method since it automatically focuses the ErrorSummary.
@@ -35,27 +35,27 @@ if ($errorSummary) {
   errorSummary.init()
 }
 
-var $characterCount = document.querySelector('[data-module="character-count"]')
+var $characterCount = document.querySelector('[data-module="govuk-character-count"]')
 if ($characterCount) {
   new CharacterCount($characterCount).init()
 }
 
-var $checkbox = document.querySelector('[data-module="checkboxes"]')
+var $checkbox = document.querySelector('[data-module="govuk-checkboxes"]')
 if ($checkbox) {
   new Checkboxes($checkbox).init()
 }
 
-var $radio = document.querySelector('[data-module="radios"]')
+var $radio = document.querySelector('[data-module="govuk-radios"]')
 if ($radio) {
   new Radios($radio).init()
 }
 
-var $header = document.querySelector('[data-module="header"]')
+var $header = document.querySelector('[data-module="govuk-header"]')
 if ($header) {
   new Header($header).init()
 }
 
-var $tabs = document.querySelector('[data-module="tabs"]')
+var $tabs = document.querySelector('[data-module="govuk-tabs"]')
 if ($tabs) {
   new Tabs($tabs).init()
 }


### PR DESCRIPTION
Implement the changes to how JS is initialised in v3 components:
- Initialise GOV.UK Frontend button and details components using `data-module`
  - Initialise all instances of button since the Design System contains a page with two buttons
- Namespace `data-module` value of other GOV.UK Frontend components which use Javascript


