### PR TITLE
Update examples to use new design and focus states

### DIFF
--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -27,10 +27,13 @@
   padding: 5px govuk-spacing(2);
   @include govuk-font(14);
   background: govuk-colour("light-grey");
+  text-decoration: none;
 
-  a {
-    color: $govuk-link-colour;
-    text-decoration: none;
+  // Override the focus state to remove the top 'yellow' shadow to avoid
+  // spilling out from the parent container. The yellow part of the focused link
+  // is already bigger than usual because of its padding.
+  .app-prose-scope &:focus {
+    box-shadow: 0 4px 0 0 $govuk-focus-text-colour;
   }
 }
 

--- a/src/stylesheets/components/_options.scss
+++ b/src/stylesheets/components/_options.scss
@@ -1,11 +1,9 @@
 .app-options {
-  margin-bottom: govuk-spacing(1);
-  padding: govuk-spacing(2) govuk-spacing(2) 0 govuk-spacing(2);
-  background-color: govuk-colour("white");
+  margin-bottom: govuk-spacing(2);
+  padding: 0;
 
   @include govuk-media-query($from: tablet) {
-    margin-bottom: govuk-spacing(4);
-    padding: govuk-spacing(5) govuk-spacing(5) 0 govuk-spacing(5);
+    margin-bottom: govuk-spacing(3);
   }
 }
 

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -59,8 +59,19 @@
   border-left: 1px solid $govuk-border-colour;
   background: govuk-colour("white");
 
+  // Offset the added borders
+  .app-prose-scope & {
+    margin: 0 -1px;
+  }
+
+  // No left hand border is required for the first tab, as it would just double
+  // up the border of its parent
   &:first-child {
     border-left: 0;
+
+    .app-prose-scope & {
+      margin-left: 0;
+    }
   }
 
   a {

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -13,33 +13,35 @@
   .app-prose-scope & { // A specific selector to reset .app-prose-scope ul
     margin-bottom: 0;
     padding: 0;
+    font-size: 0; // Prevent white space taking up space between tabs
   }
 }
 
 .app-tabs__item {
+  @include govuk-font(19);
   display: inline-block;
   position: relative;
-  z-index: 2;
-  margin: 0;
+  padding: govuk-spacing(4);
 
   a {
     display: block;
-    margin-top: -1px;
-    padding: govuk-spacing(3);
-    border-top: 2px solid transparent;
-    border-bottom: 2px solid transparent;
-    color: $govuk-link-colour;
-    background: inherit;
-    font-weight: bold;
-    text-decoration: none;
-
-    .app-prose-scope &:focus { // A specific selector to reset .app-prose-scope a:focus
-      color: $govuk-link-colour;
-      background: inherit;
-    }
 
     .app-prose-scope &:visited {
       color: $govuk-link-colour;
+    }
+
+    .app-prose-scope &:focus {
+      color: $govuk-focus-text-colour;
+    }
+
+    // Extend the touch area of the <a> to fill the entire tab
+    &::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
     }
   }
 
@@ -49,10 +51,19 @@
 }
 
 .app-tabs__item--current {
+  border-right: 1px solid $govuk-border-colour;
+  border-left: 1px solid $govuk-border-colour;
+  background: govuk-colour("white");
+
+  &:first-child {
+    border-left: 0;
+  }
+
   a {
-    border-top-color: govuk-colour("blue");
-    border-bottom-color: govuk-colour("blue");
-    background-color: darken(govuk-colour("light-grey"), 3%);
+    .app-prose-scope & {
+      color: $govuk-text-colour;
+      text-decoration: none;
+    }
   }
 }
 

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -136,20 +136,3 @@
   padding-right: 0;
   padding-bottom: 0;
 }
-
-
-.app-tabs__container--with-close-button pre {
-  padding-bottom: govuk-spacing(6);
-}
-
-.app-tabs__text {
-  padding: govuk-spacing(4) govuk-spacing(4) govuk-spacing(4) govuk-spacing(4);
-
-  // magical number 1080px below as the content is inside a narrow panel
-  // and cannot rely on predefined media queries
-  // govuk-media-query converts pixels to ems
-
-  @include govuk-media-query($from: 1080px) {
-    padding-bottom: 0;
-  }
-}

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -1,4 +1,8 @@
-// Tabs styles
+
+// =========================================================
+// Tabs (desktop)
+// =========================================================
+
 .app-tabs {
   margin: -1px auto;
   padding: 0;
@@ -67,48 +71,63 @@
   }
 }
 
-// Tab drawer heading for accordion look on mobile
-.app-tabs__heading {
-  a {
-    display: none;
-    position: relative;
-    z-index: 2;
-    padding: govuk-spacing(3);
-    border: 1px solid $govuk-border-colour;
-    border-top: 0;
-    color: $govuk-link-colour;
-    background: inherit;
-    font-weight: bold;
-    text-decoration: none;
+// =========================================================
+// 'Accordion' (mobile and tablet)
+// =========================================================
 
-    &:visited {
+.app-tabs__heading {
+  display: none;
+  position: relative;
+  padding: govuk-spacing(3);
+  border: 1px solid $govuk-border-colour;
+  border-top: 0;
+
+  @include govuk-media-query($until: desktop) {
+    display: block;
+  }
+
+  a {
+    // Extend the touch area of the <a> to fill the entire heading
+    &:after {
+      content: "";
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+    }
+
+    .app-prose-scope &:visited {
       color: $govuk-link-colour;
     }
 
-    &:focus {
-      color: govuk-colour("black");
+    .app-prose-scope &:focus {
+      color: $govuk-focus-text-colour;
     }
-
-    @include govuk-media-query($until: desktop) {
-      display: block;
-    }
-  }
-}
-
-@include govuk-media-query($until: desktop) {
-  .app-tabs__heading:nth-of-type(1) {
-    border-top: 1px solid $govuk-border-colour;
   }
 }
 
 .app-tabs__heading--current {
-  background-color: darken(govuk-colour("light-grey"), 3%);
+  border-bottom: 0;
+
+  a {
+    text-decoration: none;
+  }
 }
 
-// Tab containers
+// =========================================================
+// Code blocks
+// =========================================================
+
 .app-tabs__container {
-  margin-top: -2px;
+  padding: 20px;
   border: 1px solid $govuk-border-colour;
+  background-color: govuk-colour("white");
+
+  // When used for tabs, position to underlap tabs
+  @include govuk-media-query($from: desktop) {
+    margin-top: -2px;
+  }
 }
 
 .app-tabs__container--hidden {
@@ -119,16 +138,17 @@
   position: relative;
   max-width: inherit;
   margin-bottom: 0;
+  padding: 0;
   border: 0;
+  outline: 1px solid transparent;
+  background-color: govuk-colour("light-grey");
   font-size: inherit;
 }
 
 .app-tabs__container pre code {
   display: block;
-  // Extra 3px to compensate for border and box shadow of button
-  padding-top: govuk-spacing(7) + 3px;
-  padding-right: govuk-spacing(4);
-  padding-bottom: govuk-spacing(4);
+  padding: govuk-spacing(4);
+  padding-top: 45px; // Allow extra space for the copy code button
   overflow-x: auto;
 }
 

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -148,8 +148,11 @@
 .app-tabs__container pre code {
   display: block;
   padding: govuk-spacing(4);
-  padding-top: 45px; // Allow extra space for the copy code button
   overflow-x: auto;
+
+  .js-enabled & {
+    padding-top: 45px; // Allow extra space for the copy code button
+  }
 }
 
 .app-tabs__container pre {

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -176,8 +176,8 @@ body {
   // @include govuk-focusable;
   position: absolute;
   z-index: 1;
-  top: govuk-spacing(4);
-  right: govuk-spacing(4);
+  top: govuk-spacing(2);
+  right: govuk-spacing(2);
   min-width: 110px;
   padding: 4px 10px 2px 10px;
   border: 1px solid $copy-button-colour;

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -192,6 +192,18 @@ body {
     margin-top: 2px;
     box-shadow: none;
   }
+
+  &:focus:not(:hover) {
+    color: $govuk-focus-text-colour;
+    background-color: $govuk-focus-colour;
+  }
+
+  &:active,
+  &:focus {
+    border-color: $govuk-focus-colour;
+    outline: 2px solid transparent;
+    box-shadow: 0 0 0 2px $govuk-focus-colour;
+  }
 }
 
 $colour-list-breakpoint: 980px;

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -30,13 +30,11 @@
 <div class="app-example-wrapper" id="{{ exampleId }}" data-module="app-tabs">
   {% if display %}
   <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
-    <span class="app-example__new-window">
-      <a href="{{ exampleURL }}" target="_blank">
-        Open this
-        <span class="govuk-visually-hidden"> "{{ exampleTitle }}" </span>
-        example in a new window
-      </a>
-    </span>
+    <a href="{{ exampleURL }}" class="app-example__new-window" target="_blank">
+      Open this
+      <span class="govuk-visually-hidden"> "{{ exampleTitle }}" </span>
+      example in a new window
+    </a>
     <iframe title="{{ exampleTitle }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0"></iframe>
   </div>
   {% endif %}


### PR DESCRIPTION
This includes:
- the focus state of the 'open in new link' window
- the tabs interface used on desktop breakpoints
- the accordion interface used on mobile and tablet breakpoints

Closes #960 

<details>
<summary>Screenshots - Desktop</summary>

![Default](https://user-images.githubusercontent.com/121939/61540168-05df0000-aa35-11e9-9253-68899c11fb76.png)
![Open](https://user-images.githubusercontent.com/121939/61540167-05df0000-aa35-11e9-941d-292a6b18a631.png)
![Open in new window focused](https://user-images.githubusercontent.com/121939/61540165-05466980-aa35-11e9-8c1a-82bbbb0eb36d.png)
![Tab focused](https://user-images.githubusercontent.com/121939/61540164-05466980-aa35-11e9-804b-d067cd9003cd.png)

</details>

<details>
<summary>Screenshots - Desktop (custom colours)</summary>

![Custom colours](https://user-images.githubusercontent.com/121939/61540220-227b3800-aa35-11e9-8b15-8afa30ddb447.png)
![Custom colours open](https://user-images.githubusercontent.com/121939/61540221-227b3800-aa35-11e9-940e-43708c603bf2.png)
![Custom colours open in new window focused](https://user-images.githubusercontent.com/121939/61540222-227b3800-aa35-11e9-8785-9785b6e84500.png)
![Custom colours tab focused](https://user-images.githubusercontent.com/121939/61540223-227b3800-aa35-11e9-8dc5-8d2687594449.png)

</details>

<details>
<summary>Screenshots - Mobile</summary>

![Mobile](https://user-images.githubusercontent.com/121939/61540249-2eff9080-aa35-11e9-8f17-8dfa2c8c4197.png)
![Mobile open](https://user-images.githubusercontent.com/121939/61540246-2eff9080-aa35-11e9-8e6c-e2ab0d9b4d98.png)
![Mobile heading focused](https://user-images.githubusercontent.com/121939/61540244-2eff9080-aa35-11e9-9442-089e8af891ae.png)

</details>