### PR TITLE
Update GOV.UK Frontend 3.0.0 pre-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6023,8 +6023,8 @@
       }
     },
     "govuk-frontend": {
-      "version": "github:alphagov/govuk-frontend#f8599ba86e4c8fc60f6c41ccacfef0def59575ac",
-      "from": "github:alphagov/govuk-frontend#f8599ba8"
+      "version": "github:alphagov/govuk-frontend#407b17876b25d3283bafa8ee3226e437a27830aa",
+      "from": "github:alphagov/govuk-frontend#407b1787"
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "autoprefixer": "^9.5.1",
     "clipboard": "^2.0.4",
     "connect": "^3.6.6",
-    "govuk-frontend": "github:alphagov/govuk-frontend#f8599ba8",
+    "govuk-frontend": "github:alphagov/govuk-frontend#407b1787",
     "gray-matter": "^4.0.2",
     "highlight.js": "^9.15.6",
     "html5shiv": "^3.7.3",


### PR DESCRIPTION
This updates the release to as close to what we will ship to users.