### PR TITLE
Remove contrast ratio note from confirmation pages

### DIFF
--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -31,8 +31,6 @@ Your confirmation page must include:
 - a link to your feedback page
 - a way for users to save a record of the transaction, for example, as a PDF
 
-If you add extra content to the panel, to meet colour contrast ratio requirements use a font size of <code>govuk-body-l</code> for normal weight and <code>govuk-body</code> for bold.
-
 {{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second", size: "xl"}) }}
 
 ### Help users who bookmark the page


### PR DESCRIPTION
As the panel colour in GOV.UK Frontend v3.0 has been updated, it now meets contrast ratio requirements at any font size.

We removed the guidance from the panel component in 22bad33, but didn’t notice it was in here as well.