### PR TITLE
Remove 'Ethnicity' from the backlog

### DIFF
--- a/src/community/backlog/index.md.njk
+++ b/src/community/backlog/index.md.njk
@@ -270,15 +270,6 @@ Here is a list of the components, patterns and updates currently on the Design S
         To do
       </td>
     </tr>
-
-    <tr>
-      <td class="govuk-table__cell">
-        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/83">Ethnicity</a>
-      </td>
-      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
-        To do
-      </td>
-    </tr>
     <tr>
       <td class="govuk-table__cell">
         <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/117">Feedback link</a>


### PR DESCRIPTION
This has now been released as the [Ethnic groups pattern](https://design-system.service.gov.uk/patterns/ethnic-group/).