### PR TITLE
Update for v3 release

### DIFF
--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -12,7 +12,7 @@ The Design System and GOV.UK Frontend were last tested for accessibility in May 
 
 You can see the [issues DAC raised and what the team has fixed](https://github.com/issues?q=is%3Aissue+archived%3Afalse+org%3Aalphagov+label%3A%22audit%3A+may-2019%22+).
 
-There are a small number of [accessibility issues that still need to be fixed](https://github.com/issues?q=is%3Aissue+archived%3Afalse+org%3Aalphagov+label%3A%22audit%3A+may-2019%22+is%3Aopen).
+There are a small number of [accessibility issues that the team still needs to fix](https://github.com/issues?q=is%3Aissue+archived%3Afalse+org%3Aalphagov+label%3A%22audit%3A+may-2019%22+is%3Aopen).
 
 Where possible, the team aims to research components and patterns with a representative range of users, including those with disabilities. 
 
@@ -22,7 +22,7 @@ It also tests components to ensure they work with a broad range of [browsers, de
 
 While the GOV.UK Design System team takes steps to ensure the Design System is as accessible as possible by default, this does not remove the need for contextual research. 
 
-Using GOV.UK Frontend does not mean your service automatically meets level AA of WCAG 2.1. You will still need to make sure your service as a whole meets accessibility requirements.
+Using GOV.UK Frontend does not mean your service automatically meets level AA of WCAG 2.1. You'll still need to make sure your service as a whole meets accessibility requirements.
 
 You must research styles, components and patterns as part of your service to ensure that they are accessible in context.  
 
@@ -38,9 +38,9 @@ The Design System and Frontend were introduced in June 2018 to replace the follo
 
 The GOV.UK Design System team no longer supports these products and will not be making updates to help them meet level AA of WCAG 2.1. 
 
-If you are using these products, you should start [updating your service to use the Design System and Frontend](https://design-system.service.gov.uk/get-started/updating-your-code/). Read guidance on [how to get started](https://design-system.service.gov.uk/get-started/).
+If you're using these products, you should start [updating your service to use the Design System and Frontend](https://design-system.service.gov.uk/get-started/updating-your-code/). Read guidance on [how to get started](https://design-system.service.gov.uk/get-started/).
 
 If you have any questions or need help, you can contact the GOV.UK Design System team:
 
-- on [#govuk-design-system channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)
+- using the [#govuk-design-system channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)
 - by email at govuk-design-system-support@digital.cabinet-office.gov.uk

--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -38,7 +38,7 @@ The Design System and Frontend were introduced in June 2018 to replace the follo
 
 The GOV.UK Design System team no longer supports these products and will not be making updates to help them meet level AA of WCAG 2.1. 
 
-If you're using these products, you should start [updating your service to use the Design System and Frontend](https://design-system.service.gov.uk/get-started/updating-your-code/). Read guidance on [how to get started](https://design-system.service.gov.uk/get-started/).
+If you're using these products, you should start [updating your service to use the Design System and Frontend](https://design-system.service.gov.uk/get-started/updating-your-code/).
 
 If you have any questions or need help, you can contact the GOV.UK Design System team:
 

--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -8,11 +8,11 @@ layout: layout-single-page-prose.njk
 
 The GOV.UK Design System team works hard to ensure that this Design System and GOV.UK Frontend, the codebase it uses, are accessible.
 
-This Design System and GOV.UK Frontend were last tested for accessibility in May 2019. The test was carried out by accessibility specialists [DAC (Digital Accessibility Centre)](https://digitalaccessibilitycentre.org/) against level AA of the Web Content Accessibility Guidelines (WCAG) 2.1.
+The Design System and GOV.UK Frontend were last tested for accessibility in May 2019. The test was carried out by accessibility specialists [DAC (Digital Accessibility Centre)](https://digitalaccessibilitycentre.org/) against level AA of the Web Content Accessibility Guidelines (WCAG) 2.1.
 
-You can see the [issues DAC raised and what we fixed](https://github.com/issues?q=is%3Aissue+archived%3Afalse+org%3Aalphagov+label%3A%22audit%3A+may-2019%22+).
+You can see the [issues DAC raised and what the team has fixed](https://github.com/issues?q=is%3Aissue+archived%3Afalse+org%3Aalphagov+label%3A%22audit%3A+may-2019%22+).
 
-There are a small number of [accessibility issues that we still need to fix](https://github.com/issues?q=is%3Aissue+archived%3Afalse+org%3Aalphagov+label%3A%22audit%3A+may-2019%22+is%3Aopen).
+There are a small number of [accessibility issues that still need to be fixed](https://github.com/issues?q=is%3Aissue+archived%3Afalse+org%3Aalphagov+label%3A%22audit%3A+may-2019%22+is%3Aopen).
 
 Where possible, the team aims to research components and patterns with a representative range of users, including those with disabilities. 
 
@@ -22,7 +22,7 @@ It also tests components to ensure they work with a broad range of [browsers, de
 
 While the GOV.UK Design System team takes steps to ensure the Design System is as accessible as possible by default, this does not remove the need for contextual research. 
 
-Using GOV.UK Frontend does not mean you automatically meet level AA of WCAG 2.1. You will still need to make sure your service as a whole meets accessibility requirements.
+Using GOV.UK Frontend does not mean your service automatically meets level AA of WCAG 2.1. You will still need to make sure your service as a whole meets accessibility requirements.
 
 You must research styles, components and patterns as part of your service to ensure that they are accessible in context.  
 
@@ -38,12 +38,9 @@ The Design System and Frontend were introduced in June 2018 to replace the follo
 
 The GOV.UK Design System team no longer supports these products and will not be making updates to help them meet level AA of WCAG 2.1. 
 
-If you are using these products, it’s recommended that you begin [updating your service now to use the Design System and Frontend](https://design-system.service.gov.uk/get-started/updating-your-code/).
+If you are using these products, you should start [updating your service to use the Design System and Frontend](https://design-system.service.gov.uk/get-started/updating-your-code/). Read guidance on [how to get started](https://design-system.service.gov.uk/get-started/).
 
-Doing this will allow you to update your service in a much more manageable way, than waiting to update straight to Frontend v.3.0.0.
+If you have any questions or need help, you can contact the GOV.UK Design System team:
 
-If you would like to start using the Design System and Frontend, read guidance on [how to get started](https://design-system.service.gov.uk/get-started/).
-
-The GOV.UK Design System team will keep this page up to date with updates and when the new version of Frontend is available.
-
-If you have any questions in the meantime, [get in touch](https://design-system.service.gov.uk/get-in-touch/).
+- on [#govuk-design-system channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)
+- by email at govuk-design-system-support@digital.cabinet-office.gov.uk


### PR DESCRIPTION
This PR:

- removes future-tense references to v3 release, which has now been done
- adds information on how to get in touch with the team for help
- removes instances of "we" in line with the [Design System team style guide](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)