### PR TITLE
Move beta banner below mobile navigation

### DIFF
--- a/src/stylesheets/components/_contact-panel.scss
+++ b/src/stylesheets/components/_contact-panel.scss
@@ -4,7 +4,6 @@
   @include govuk-responsive-margin(6, "bottom");
   padding-top: govuk-spacing(3);
   border-top: 2px solid govuk-colour("blue");
-  
 
   .app-contact-panel__heading,
   .app-contact-panel__body,

--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -1,5 +1,6 @@
 .app-mobile-nav {
   display: none;
+  border-bottom: 1px solid $govuk-border-colour;
 }
 
 .app-mobile-nav--active {

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -1,20 +1,19 @@
 $navigation-height: 50px;
 
 .app-navigation {
-  box-sizing: border-box;
   @include govuk-font(19, $weight: bold);
+  box-sizing: border-box;
   width: 100%;
+  background-color: $app-light-grey;
 
   @include govuk-media-query($until: tablet) {
     display: none;
   }
-
-  @include govuk-media-query($from: tablet) {
-    margin-left: -(govuk-spacing(3));
-  }
 }
 
 .app-navigation__list {
+  position: relative;
+  left: -(govuk-spacing(3));
   padding: 0;
   list-style: none;
 }

--- a/src/stylesheets/components/_pane.scss
+++ b/src/stylesheets/components/_pane.scss
@@ -9,15 +9,6 @@
     }
   }
 
-  .app-pane__nav {
-    @include govuk-media-query($from: tablet) {
-      display: flex;
-      background-color: $app-light-grey;
-      flex-direction: column;
-      flex: 1 0 auto;
-    }
-  }
-
   .app-pane__body {
     @include govuk-media-query($from: tablet) {
       display: flex;

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -31,10 +31,10 @@
 <div class="app-pane {% block appPaneClasses %}{% endblock %}" id="top">
   {% include "_cookie-banner.njk" %}
   {% include "_header.njk" %}
+  {% include "_mobile-navigation.njk" %}
   {% include "_banner.njk" %}
   <div class="app-pane__nav">
     {% include "_navigation.njk" %}
-    {% include "_mobile-navigation.njk" %}
   </div>
   {% block body %}
     {{ contents | safe }}

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -33,9 +33,7 @@
   {% include "_header.njk" %}
   {% include "_mobile-navigation.njk" %}
   {% include "_banner.njk" %}
-  <div class="app-pane__nav">
-    {% include "_navigation.njk" %}
-  </div>
+  {% include "_navigation.njk" %}
   {% block body %}
     {{ contents | safe }}
   {% endblock %}


### PR DESCRIPTION
This makes it easier to access the navigation for users that use screen readers as the menu button is closer to the menu itself.

Many users of screen readers also use high magnification which brings up the mobile style layout.

I've also refactored some unneeded wrapper code.

## Screenshots

### Before
<img width="376" alt="" src="https://user-images.githubusercontent.com/2445413/62127730-af8e7e80-b2ca-11e9-858d-0c9c1ca42036.png">

### After
<img width="380" alt="" src="https://user-images.githubusercontent.com/2445413/62127729-af8e7e80-b2ca-11e9-81b1-bbca30e80022.png">

Fixes https://github.com/alphagov/govuk-design-system/issues/939