### PR TITLE
Set cookie banner background to white

### DIFF
--- a/src/stylesheets/components/_cookie-banner.scss
+++ b/src/stylesheets/components/_cookie-banner.scss
@@ -7,7 +7,7 @@
 
   padding-top: govuk-spacing(3);
   padding-bottom: govuk-spacing(3);
-  background-color: lighten(desaturate(govuk-colour("light-blue"), 8.46), 42.55);
+  background-color: govuk-colour("white");
 }
 
 .app-cookie-banner {


### PR DESCRIPTION
Since the colours changed the colour function transforms no longer result in the correct colour.

Instead of bringing back the colour by adjusting the transforms we've decided to go with white which is consistent with GOV.UK Publishing's cookie banner.

## Screenshots

### Before
<img width="395" alt="" src="https://user-images.githubusercontent.com/2445413/62128395-3c860780-b2cc-11e9-97fc-5e2bfae6fa0c.png">

### After
<img width="396" alt="" src="https://user-images.githubusercontent.com/2445413/62128396-3d1e9e00-b2cc-11e9-99f9-8cd1293974ca.png">

Closes https://github.com/alphagov/govuk-design-system/issues/995