### PR TITLE
Improve current nav when changed colours

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -30,7 +30,7 @@ $navigation-height: 50px;
 }
 
 .app-navigation__list-item--current {
-  box-shadow: inset 0 -4px 0 0 govuk-colour("blue");
+  border-bottom: 4px solid govuk-colour("blue");
 }
 
 .app-navigation__link {


### PR DESCRIPTION
Box shadow disappears when changing colours in your browser, for example Firefox

## Screenshot

### Before
<img width="349" alt="" src="https://user-images.githubusercontent.com/2445413/62129214-16616700-b2ce-11e9-9c9d-61aa1886a2ec.png">

### After
<img width="387" alt="" src="https://user-images.githubusercontent.com/2445413/62129216-16616700-b2ce-11e9-8247-da23d4f000d7.png">
