### PR TITLE
Adjust site search so that icon is always visible

### DIFF
--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -1,6 +1,15 @@
 // Site search using Accessible autocomplete
 // below styles are based on the default accessible autocomplete stylesheet
 
+@function encode-hex($hex) {
+  // Turn colour into a string
+  $output: inspect($hex);
+  // Slice the '#' from the start of the string so we can add it back on encoded.
+  $output: str-slice($output, 2);
+  // Add the '#' back on the start, but as an encoded character for embedding.
+  @return "%23" + $output;
+}
+
 $icon-size: 40px;
 
 @include govuk-not-ie8 {
@@ -41,7 +50,7 @@ $icon-size: 40px;
     display: block;
     position: relative;
     height: $icon-size;
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='white'%3E%3C/path%3E%3C/svg%3E") govuk-colour("blue") no-repeat top left;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='#{encode-hex(govuk-colour("dark-grey"))}'%3E%3C/path%3E%3C/svg%3E") govuk-colour("white") no-repeat top left;
     background-size: $icon-size $icon-size;
   }
 
@@ -49,10 +58,13 @@ $icon-size: 40px;
   .app-site-search__input {
     box-sizing: border-box;
     width: 100%;
-    min-height: $icon-size;
+    height: $icon-size;
     margin-bottom: 0; // BUG: Safari 10 on macOS seems to add an implicit margin.
+    padding: govuk-spacing(1);
+    padding-left: $icon-size - govuk-spacing(1);
     border: 2px solid govuk-colour("white");
     border-radius: 0; // Safari 10 on iOS adds implicit border rounding.
+    background: transparent;
     -webkit-appearance: none;
   }
 
@@ -63,19 +75,9 @@ $icon-size: 40px;
 
   .app-site-search__input {
     position: relative;
-    width: calc(100% - #{$icon-size});
-    height: $icon-size;
-    margin-left: $icon-size;
-    background-color: govuk-colour("white");
-  }
-
-  .app-site-search__input--default {
-    padding: govuk-spacing(1);
   }
 
   .app-site-search__input--focused {
-    width: 100%;
-    margin-left: 0;
     outline: 3px solid $govuk-focus-colour;
     outline-offset: -2px;
   }
@@ -129,6 +131,7 @@ $icon-size: 40px;
   .app-site-search__option {
     display: block;
     position: relative;
+    padding: govuk-spacing(2);
     border-bottom: solid govuk-colour("mid-grey");
     border-width: 1px 0;
     cursor: pointer;
@@ -167,11 +170,6 @@ $icon-size: 40px;
     color: govuk-colour("dark-grey");
     background-color: govuk-colour("white");
     cursor: not-allowed;
-  }
-
-  .app-site-search__hint,
-  .app-site-search__option {
-    padding: govuk-spacing(2);
   }
 
   .app-site-search__hint,


### PR DESCRIPTION
We've had reports that the button style can be confusing when it disappears.

To try and make this interaction simpler we keep the icon at all times but allow it to be pressed to focus the input.

By doing this I re-introduced the hint text appearing, which I'm not sure if was intentionally hidden before. This seems to make changed colours interaction more confusing, so not sure if we should hide this or not.

This mirrors a similar style on GOV.UK Publishing.

## Screenshots

### Before
![](https://user-images.githubusercontent.com/2445413/62132058-3eec5f80-b2d4-11e9-9e08-90a342a857e0.png)

### After
![](https://user-images.githubusercontent.com/2445413/62132076-43187d00-b2d4-11e9-8f5c-e89cefe6b1ca.png)

### Interaction

| Before | After |
| ------ | ------ |
| ![](https://user-images.githubusercontent.com/2445413/62132164-72c78500-b2d4-11e9-9fba-d14750a324eb.gif) | ![](https://user-images.githubusercontent.com/2445413/62132159-722eee80-b2d4-11e9-81a1-57bc46ed9b69.gif) |

### Interaction mobile

| Before | After |
| ------ | ------ |
| ![](https://user-images.githubusercontent.com/2445413/62132162-722eee80-b2d4-11e9-986e-d615cd654dc4.gif) | ![](https://user-images.githubusercontent.com/2445413/62132158-722eee80-b2d4-11e9-960c-95b5f766d3bf.gif) |

### Interaction changed colours

| Before | After |
| ------ | ------ |
| ![](https://user-images.githubusercontent.com/2445413/62132157-722eee80-b2d4-11e9-8f33-f42bfa2e31c6.gif) | ![](https://user-images.githubusercontent.com/2445413/62132160-722eee80-b2d4-11e9-9e87-b4c4a27c939e.gif) |

Closes https://github.com/alphagov/govuk-design-system/issues/937