### PR TITLE
Update WCAG link for contrast

### DIFF
--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -12,7 +12,7 @@ Always use the GOV.UK colour palette.
 ## Colour contrast
 You must make sure that the contrast ratio of text and interactive elements in
 your service meets [level AA of the Web Content Accessibility Guidelines
-(WCAG 2.0)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html).
+(WCAG 2.1)](https://www.w3.org/TR/WCAG21/#contrast-minimum).
 
 ## Main colours
 
@@ -35,7 +35,7 @@ use `govuk-colour("red")` rather than `$govuk-error-colour`.
     <tr>
       <td colspan="3">
         <h3 class="govuk-heading-m {% if not loop.first %}govuk-!-padding-top-6{% endif %}">
-        {{groupName}} 
+        {{groupName}}
         </h3>
       </td>
     </tr>


### PR DESCRIPTION
Update WCAG link for contrast from WCAG 2.0 to WCAG 2.1

My linter also seem to have removed a space on save, can put it back if it was intended.