### PR TITLE
Ensure open in new window link is not too verbose

### DIFF
--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -11,12 +11,11 @@
 {% if params.titleSuffix %}
   {% set exampleTitle = exampleTitle + " " + params.titleSuffix %}
 {% endif %}
-{% set exampleTitle = exampleTitle + " example" %}
 
 {% if params.id %}
   {% set exampleId = params.id %}
 {% else %}
-  {% set exampleId = exampleTitle | slugger %}
+  {% set exampleId = (exampleTitle + " example") | slugger %}
 {% endif %}
 
 {% if params.open %}
@@ -32,10 +31,11 @@
   <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
     <a href="{{ exampleURL }}" class="app-example__new-window" target="_blank">
       Open this
-      <span class="govuk-visually-hidden"> "{{ exampleTitle }}" </span>
+      {# Don't use full title visually as the context is shown based on location of this link #}
+      <span class="govuk-visually-hidden">{{ exampleTitle | lower }}</span>
       example in a new window
     </a>
-    <iframe title="{{ exampleTitle }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0"></iframe>
+    <iframe title="{{ exampleTitle + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0"></iframe>
   </div>
   {% endif %}
 


### PR DESCRIPTION
For users using assistive technologies, the link has more detail, for
other users we simplify it to just 'example' relying on the visual
location of the link giving the context without the additional detail.

Fixes https://github.com/alphagov/govuk-design-system/issues/959