### PR TITLE
Add margin and padding as aliases of spacing

### DIFF
--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -2,7 +2,7 @@
 title: Spacing
 description: The Design System uses a responsive spacing scale which adapts based on screen size
 section: Styles
-aliases:
+aliases: margin, padding
 backlog_issue_id:
 layout: layout-pane.njk
 show_page_nav: true


### PR DESCRIPTION
Based on feedback from a user on Slack:

> "Is it easy to add search terms to the design system search? I can never find the margin and padding override classes - but have learnt that ‘width’ gets me to the page I want"