### PR TITLE
Add lazy loading for examples

### DIFF
--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -35,7 +35,7 @@
       <span class="govuk-visually-hidden">{{ exampleTitle | lower }}</span>
       example in a new window
     </a>
-    <iframe title="{{ exampleTitle + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0"></iframe>
+    <iframe title="{{ exampleTitle + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0" loading="lazy"></iframe>
   </div>
   {% endif %}
 


### PR DESCRIPTION
For longer pages this prevents all examples being loaded even if they're not in view.

I have tried loading the [layout page with lazy loading](https://deploy-preview-1012--govuk-design-system-preview.netlify.com/styles/layout/) and the [layout page without lazy loading](https://govuk-design-system-preview.netlify.com/styles/layout/) and recorded the results under simulated slow 3G.

| Metric | Current | With lazy loading |
| ----- | ------- | ------------ |
| HTTP Requests | 130 | 37 |
| Data Transferred | 1.3 MB | 502 KB |
| Resources used | 5.1 MB | 1.6 MB |
| Time to DOMContentLoaded | 5.58s | 5.60s |
| Time to finish | 37.22s |  17.65s |
| Time to fully load | 34.80s | 17.65s |

This is only available in Chromium browsers so far such as Chrome 76 stable, see https://caniuse.com/#feat=loading-lazy-attr for more information.

https://web.dev/native-lazy-loading