### PR TITLE
Add link to text input width guidance

### DIFF
--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -127,4 +127,6 @@ If you need to constrain the width of an element independently of the [grid syst
 
 As with the spacing override classes the width override classes start with `govuk-!-`. The second part of the class name signifies the width on larger screen sizes. For example, `govuk-!-width-one-half`  will apply a width of 50% and `govuk-!-width-two-thirds`will apply a width of 66.66%.
 
+These examples are for the generic width override classes - read specific [guidance on setting text input width](/components/text-input/#use-appropriately-sized-text-inputs).
+
 {{ example({group: "styles", item: "spacing", example: "input-width", html: true, open: true, size: "xl"}) }}


### PR DESCRIPTION
If you search for 'width' you find the guidance in Styles. This shows the generic width override classes, but we have specific guidance on that (that uses character width, not % width), so this PR adds a link. The words might not be right :)