### PR TITLE
Remove "form group" search alias from fieldset

### DIFF
--- a/src/components/fieldset/index.md.njk
+++ b/src/components/fieldset/index.md.njk
@@ -2,7 +2,7 @@
 title: Fieldset
 description: Use the fieldset component to group related form inputs
 section: Components
-aliases: form group
+aliases: 
 backlog_issue_id: 48
 layout: layout-pane.njk
 ---


### PR DESCRIPTION
This issue https://github.com/alphagov/govuk-design-system/issues/1022 highlights a confusion between "form group" being an alias of `<fieldset>` and the class `govuk-form-group` which wraps all form components.

I suggest we remove the alias from the search to avoid this.