### PR TITLE
Replace 'less' with 'fewer' for countable nouns

### DIFF
--- a/src/components/character-count/error/index.njk
+++ b/src/components/character-count/error/index.njk
@@ -14,6 +14,6 @@ layout: layout-example.njk
     text: "Enter a job description"
   },
   errorMessage: {
-    text: "Job description must be 350 characters or less"
+    text: "Job description must be 350 characters or fewer"
   }
 }) }}

--- a/src/components/character-count/index.md.njk
+++ b/src/components/character-count/index.md.njk
@@ -89,8 +89,8 @@ For example, ‘Enter a summary’.
 
 #### If the input is too long
 
-Say ‘[whatever it is] must be [number] characters or less’.<br>
-For example, ‘Summary must be 400 characters or less’.
+Say ‘[whatever it is] must be [number] characters or fewer’.<br>
+For example, ‘Summary must be 400 characters or fewer’.
 
 ## Research on this component
 

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -116,10 +116,10 @@ An error for a specific situation is more helpful. It will tell someone what has
 Some errors work better as instructions and some work better as descriptions. For example:
 
 - ‘Enter your first name’ is clearer, more direct and natural than ‘First name must have an entry’
-- ‘Enter a first name that is 35 characters or less’ is wordier, less direct and natural than ‘First name must be 35 characters or less’
+- ‘Enter a first name that is 35 characters or fewer’ is wordier, less direct and natural than ‘First name must be 35 characters or fewer’
 - ‘Enter a date after 31 August 2017 for when you started the course’ is wordier, less direct and natural than ‘Date you started the course must be after 31 August 2017’
 
-Use both instructions and descriptions, but use them consistently. For example, use an instruction for empty fields like ‘Enter your name’, but a description like ‘Name must be 35 characters or less’ for entries that are too long.
+Use both instructions and descriptions, but use them consistently. For example, use an instruction for empty fields like ‘Enter your name’, but a description like ‘Name must be 35 characters or fewer’ for entries that are too long.
 
 
 ### Use error message templates

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -108,8 +108,8 @@ For example, ‘Enter your first name’.
 
 #### If the input is too long
 
-Say ‘[whatever it is] must be [number] characters or less’.<br>
-For example, ‘Address line 1 must be 35 characters or less’.
+Say ‘[whatever it is] must be [number] characters or fewer’.<br>
+For example, ‘Address line 1 must be 35 characters or fewer’.
 
 #### If the input is too short
 
@@ -148,8 +148,8 @@ For example, ‘Hours worked a week must be 16 or more’.
 
 #### If the number is too high
 
-Say ‘[whatever it is] must be [highest] or less’.<br>
-For example, ‘Hours worked a week must be 99 or less’.
+Say ‘[whatever it is] must be [highest] or fewer’.<br>
+For example, ‘Hours worked a week must be 99 or fewer’.
 
 #### If the input must be between 2 numbers
 

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -65,8 +65,8 @@ For example, ‘Enter summary’.
 
 #### If the input is too long
 
-Say ‘[whatever it is] must be [number] characters or less’.<br>
-For example, ‘Summary must be 400 characters or less’.
+Say ‘[whatever it is] must be [number] characters or fewer’.<br>
+For example, ‘Summary must be 400 characters or fewer’.
 
 #### If the input is too short
 


### PR DESCRIPTION
Sorry in advance: this must have been discussed before.

It is inaccurate to say "less" of a number of discrete items. [Plain Words](https://en.wikipedia.org/wiki/The_Complete_Plain_Words):

> _Less_ appertains to degree, quantity or extent; _fewer_ to number. Thus, _less_ outlay, _fewer_ expenses, _less_ help, _fewer_ helpers; _less_ milk, _fewer_ eggs.

This PR changes "less" to "fewer" in that context.

EDIT: correct spelling of “innacurate”