### PR TITLE
Serve CSS with explicit UTF8 charset

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -26,6 +26,7 @@ http {
 
   default_type application/octet-stream;
   include nginx/mime.types;
+  charset_types text/html text/xml text/plain application/javascript application/rss+xml text/css;
 
   # Enabling sendfile eliminates copying file data into buffer and sends it
   # directly


### PR DESCRIPTION
Override charset_types to include text/css.

The default value for charset_types is:

```nginx
charset_types text/html text/xml text/plain text/vnd.wap.wml application/javascript application/rss+xml;
```

We don’t serve any text/vnd.wap.wml (!) so we can omit that, and we can add text/css.

This change means that CSS files are served with `charset=utf8` as part of the Content-Type header:

```
Content-Type: text/css; charset=utf-8
```

I am hoping this will fix encoding issues like those seen in #1023.

## Before
```bash
➜ curl -I https://govuk-design-system-origin.cloudapps.digital/stylesheets/main-43960fd538bd98817b7759e86cdfde51.css
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: max-age=315360000
Content-Length: 124472
Content-Type: text/css
Date: Tue, 27 Aug 2019 12:09:15 GMT
Etag: "5d64fa3a-1e638"
Expires: Thu, 31 Dec 2037 23:55:55 GMT
Last-Modified: Tue, 27 Aug 2019 09:39:06 GMT
Server: nginx/1.17.1
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
Vary: Accept-Encoding
X-Vcap-Request-Id: 73a994f8-b7f3-493c-70ef-9ab00aae2095
```


## After
```bash
➜ curl -I https://govuk-design-system-css-utf8.cloudapps.digital/stylesheets/main-e73e0f7b537165bbde61ecc748bff54a.css
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: max-age=315360000
Content-Length: 124685
Content-Type: text/css; charset=utf-8
Date: Tue, 27 Aug 2019 12:09:22 GMT
Etag: "5d396e54-1e70d"
Expires: Thu, 31 Dec 2037 23:55:55 GMT
Last-Modified: Thu, 25 Jul 2019 08:54:44 GMT
Server: nginx/1.17.1
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
Vary: Accept-Encoding
X-Vcap-Request-Id: 46bc42d7-b582-4a0b-4674-4c166f9e3519
```