### PR TITLE
Accessibility improvements for the mobile navigation

### DIFF
--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -88,7 +88,6 @@ MobileNav.prototype.includeAria = function () {
 
       $nextSubNav.setAttribute('id', nextSubNavId)
       $nextSubNav.setAttribute('aria-hidden', navIsOpen ? 'false' : 'true')
-      $nextSubNav.setAttribute('aria-labelledby', subNavTogglerId)
 
       $toggler.setAttribute('id', subNavTogglerId)
       $toggler.setAttribute('aria-label', (navIsOpen ? 'Hide' : 'Show') + ' pages within ' + $toggler.innerText.trim())

--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -77,7 +77,7 @@ MobileNav.prototype.includeAria = function () {
   var $subNavTogglers = this.$module.querySelectorAll('.js-mobile-nav-subnav-toggler')
 
   nodeListForEach($subNavTogglers, function ($toggler, index) {
-    var $nextSubNav = $toggler.parentNode.querySelector('.js-app-mobile-nav-subnav')
+    var $nextSubNav = $toggler.parentNode.parentNode.querySelector('.js-app-mobile-nav-subnav')
 
     if ($nextSubNav) {
       var navIsOpen = $nextSubNav.classList.contains(subNavActiveClass)

--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -65,7 +65,7 @@ MobileNav.prototype.bindUIEvents = function () {
 
 MobileNav.prototype.includeAria = function () {
   this.$nav.setAttribute('aria-hidden', 'true')
-  this.$nav.setAttribute('aria-labelledby', 'app-header-mobile-nav-toggler')
+  this.$nav.setAttribute('aria-label', 'Top-level')
 
   var $navToggler = this.$navToggler
   $navToggler.setAttribute('aria-label', 'Toggle mobile menu')

--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -53,12 +53,14 @@ MobileNav.prototype.bindUIEvents = function () {
 
         $nextSubNav.setAttribute('aria-hidden', 'true')
         $toggler.setAttribute('aria-expanded', 'false')
+        $toggler.setAttribute('aria-label', 'Show pages within ' + $toggler.innerText.trim())
       } else {
         $nextSubNav.classList.add(subNavActiveClass)
         $togglerLinkArea.classList.add(subNavTogglerActiveClass)
 
         $nextSubNav.setAttribute('aria-hidden', 'false')
         $toggler.setAttribute('aria-expanded', 'true')
+        $toggler.setAttribute('aria-label', 'Hide pages within ' + $toggler.innerText.trim())
       }
       event.preventDefault()
     }
@@ -89,7 +91,7 @@ MobileNav.prototype.includeAria = function () {
       $nextSubNav.setAttribute('aria-labelledby', subNavTogglerId)
 
       $toggler.setAttribute('id', subNavTogglerId)
-      $toggler.setAttribute('aria-label', 'Toggle subnavigation for ' + $toggler.innerText)
+      $toggler.setAttribute('aria-label', (navIsOpen ? 'Hide' : 'Show') + ' pages within ' + $toggler.innerText.trim())
       $toggler.setAttribute('aria-expanded', navIsOpen ? 'true' : 'false')
       $toggler.setAttribute('aria-controls', nextSubNavId)
     }

--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -25,11 +25,13 @@ MobileNav.prototype.bindUIEvents = function () {
 
       $navToggler.classList.remove(navTogglerActiveClass)
       $navToggler.setAttribute('aria-expanded', 'false')
+      $navToggler.setAttribute('aria-label', 'Show top-level navigation')
     } else {
       $nav.classList.add(navActiveClass)
       $nav.setAttribute('aria-hidden', 'false')
 
       $navToggler.setAttribute('aria-expanded', 'true')
+      $navToggler.setAttribute('aria-label', 'Hide top-level navigation')
       $navToggler.classList.add(navTogglerActiveClass)
     }
   })
@@ -68,7 +70,7 @@ MobileNav.prototype.includeAria = function () {
   this.$nav.setAttribute('aria-label', 'Top-level')
 
   var $navToggler = this.$navToggler
-  $navToggler.setAttribute('aria-label', 'Toggle mobile menu')
+  $navToggler.setAttribute('aria-label', 'Show top-level navigation')
   $navToggler.setAttribute('aria-expanded', 'false')
   $navToggler.setAttribute('aria-controls', 'app-mobile-nav')
 

--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -8,7 +8,7 @@
           </a>
         </div>
         {% if item.items %}
-          <ul class="app-mobile-nav__list app-mobile-nav__subnav js-app-mobile-nav-subnav {% if path.startsWith(item.url) %}app-mobile-nav__subnav--active{% endif %}">
+          <ul class="app-mobile-nav__list app-mobile-nav__subnav js-app-mobile-nav-subnav {% if path.startsWith(item.url) %}app-mobile-nav__subnav--active{% endif %}" aria-label="{{ item.label }}">
             <li class="app-mobile-nav__subnav-item{% if path == item.url %} app-mobile-nav__subnav-item--current{% endif %}">
               <a class="govuk-link govuk-link--no-visited-state app-mobile-nav__link" href="/{{ item.url }}/">
                 {{ item.label }} overview


### PR DESCRIPTION
This fixes #1033, but also a few other issues I noticed once I started digging into the code. A lot of the ARIA attributes were not being applied because of a change that was made when the focus styles were changed.

I suggest reviewing each commit individually.

There might be a simpler approach we could take with some of this stuff - we could also leave the labels as 'Toggle X'. I might be trying to be too clever updating them based on the expanded/collapsed state. I'm not actually even sure whether all of the aria-labels are required. I think the label on the menu button is useful, but I was half-tempted to remove the aria-labels from the sub-navigation and from the section. 

Thoguhts?