### PR TITLE
Update colours in code blocks to improve contrast

### DIFF
--- a/src/stylesheets/components/_highlight.scss
+++ b/src/stylesheets/components/_highlight.scss
@@ -3,7 +3,7 @@
 
 .hljs-comment,
 .hljs-quote {
-  color: #999998;
+  color: #0b0c0c;
   font-style: italic;
 }
 
@@ -19,12 +19,12 @@
 .hljs-variable,
 .hljs-template-variable,
 .hljs-tag .hljs-attr {
-  color: #007f80;
+  color: #00703c;
 }
 
 .hljs-string,
 .hljs-doctag {
-  color: #dd1144;
+  color: #d13118;
 }
 
 .hljs-title,
@@ -47,7 +47,7 @@
 .hljs-tag,
 .hljs-name,
 .hljs-attribute {
-  color: #000080;
+  color: #003078;
   font-weight: normal;
 }
 

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -4,7 +4,7 @@ $govuk-page-width: 1100px !default;
 
 // App-specific variables
 $app-light-grey: #f8f8f8;
-$app-code-color: #c62950;
+$app-code-color: #d13118;
 
 // App-specific components
 @import "components/back-to-top";


### PR DESCRIPTION
This pull request replaces colours in the Design System code blocks, in order to meet constrast (4.5) against the background ```#f3f2f1```.

The updated colours are``` #dd1144```, ```#007f80```, ```#99998``` and ```#000080```,
they have been replaced with ```#d13118``` (4.51), ```#00703c```(5.5), ```#0b0c0c```(17.5)  and ```#003078```(11.09) respectively. These changes also update inline code snippets.

This solution creates the least amount of visual difference, whilst using most of the colours from the GOV.UK colour palette. 

### Old 
![Screen Shot 2019-09-11 at 16 36 08](https://user-images.githubusercontent.com/7225720/64711922-4d708e00-d4b2-11e9-9244-f91e128ee9dd.png)

### New
![Screen Shot 2019-09-11 at 16 35 38](https://user-images.githubusercontent.com/7225720/64711923-4d708e00-d4b2-11e9-91d6-b20f67a1eb4a.png)



Fixes #1032