### PR TITLE
Document `govuk-grid-column-three-quarters`

### DIFF
--- a/src/styles/layout/combinations/index.njk
+++ b/src/styles/layout/combinations/index.njk
@@ -41,16 +41,19 @@ stylesheets:
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-quarter">
-    <p>govuk-grid-column-one-quarter</p>
+  <div class="govuk-grid-column-three-quarters">
+    <p>govuk-grid-column-three-quarters</p>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <p>govuk-grid-column-one-quarter</p>
-  </div>
+  </div>  
+</div>
+
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-one-quarter">
     <p>govuk-grid-column-one-quarter</p>
   </div>
-  <div class="govuk-grid-column-one-quarter">
-    <p>govuk-grid-column-one-quarter</p>
+  <div class="govuk-grid-column-three-quarters">
+    <p>govuk-grid-column-three-quarters</p>
   </div>
 </div>

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -99,6 +99,10 @@ The available widths are:
 
 {{ example({group: "styles", item: "layout", example: "one-quarter", html: true, open: true, size: "s"}) }}
 
+### Three-quarters
+
+{{ example({group: "styles", item: "layout", example: "three-quarters", html: true, open: true, size: "s"}) }}
+
 ### Example combinations
 
 {{ example({group: "styles", item: "layout", example: "combinations", html: true, open: true, size: "xl"}) }}

--- a/src/styles/layout/three-quarters/index.njk
+++ b/src/styles/layout/three-quarters/index.njk
@@ -1,0 +1,13 @@
+---
+title: Three-quarters – Layout
+layout: layout-example.njk
+ignore_in_sitemap: true
+stylesheets:
+- ../grid-annotate.css
+---
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <p>govuk-grid-column-three-quarters</p>
+  </div>
+</div>


### PR DESCRIPTION
This PR adds an example of the **3/4** column and adds a **1/4** / **3/4** and **3/4** / **1/4** examples to the combinations section.

This PR fixes https://github.com/alphagov/govuk-design-system/issues/1047