### PR TITLE
Fix options table links

### DIFF
--- a/__tests__/component-options.test.js
+++ b/__tests__/component-options.test.js
@@ -7,11 +7,11 @@ const PORT = configPaths.testPort
 let page
 let baseUrl = 'http://localhost:' + PORT
 
-beforeAll(async () => {
+beforeEach(async () => {
   page = await setupPage()
 })
 
-afterAll(async () => {
+afterEach(async () => {
   await page.close()
 })
 
@@ -60,5 +60,27 @@ describe('Component page', () => {
       .map(element => element.textContent.trim()), id)
 
     expect(nunjucksTableHeadings.sort()).toEqual(['Name', 'Type', 'Description'].sort())
+  })
+
+  it('macro options should be opened and in view when linked to', async () => {
+    await page.goto(baseUrl + '/components/back-link/#options-back-link-example', { waitUntil: 'load' })
+
+    // Check if example's macro options details element is open
+    await page.waitForSelector('#options-back-link-example-details[open=open]')
+
+    // Check if the example has been scrolled into the viewport
+    const $example = await page.$('#options-back-link-example')
+    expect(await $example.isIntersectingViewport()).toBe(true)
+  })
+
+  it('macro options subtable should be opened and in view when linked to', async () => {
+    await page.goto(baseUrl + '/components/text-input/#options-text-input-example--label', { waitUntil: 'load' })
+
+    // Check if example's macro options details element is open
+    await page.waitForSelector('#options-text-input-example-details[open=open]')
+
+    // Check if the example has been scrolled into the viewport
+    const $example = await page.$('#options-text-input-example--label')
+    expect(await $example.isIntersectingViewport()).toBe(true)
   })
 })

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -218,7 +218,10 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
       },
       filters: {
         highlight: highlighter,
-        slugger
+        slugger,
+        kebabCase: (string) => {
+          return string.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase()
+        }
       },
 
       // Markdown engine options

--- a/src/javascripts/components/options-table.js
+++ b/src/javascripts/components/options-table.js
@@ -11,7 +11,7 @@ var OptionsTable = {
     if (hash.match('^#options-')) {
       var exampleName = hash.split('#options-')[1]
 
-      // Is hash for a specific options table? eg. #options-example-default--hint
+      // Is hash for a specific options table? eg. #options-checkboxes-example--hint
       var isLinkToTable = hash.indexOf('--') > -1
       if (isLinkToTable) {
         exampleName = exampleName.split('--')[0]

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -116,7 +116,7 @@
                       {% if (option.name === "hint" or option.name === "label") %}
                         See <a href="#options-{{ exampleId }}--{{ option.name }}">{{ option.name }}</a>.
                       {% else %}
-                        See <a href="/components/{{ option.slug }}/#options-example-default">{{ option.name }}</a>.
+                        See <a href="/components/{{ option.slug }}/#options-{{ option.name | kebabCase }}-example">{{ option.name }}</a>.
                       {% endif %}
                     {% endif %}
                     {% if (option.params) %}


### PR DESCRIPTION
We fixed issues with ID's not being unique which changed how the first example's ID is generated.

Now it contains the component name instead of a generic 'default' id.

This means when linking between components the macro options behaviour is currently broken.

You can see this by going to the textarea component macro options and press 'errorMessage', it will load the page but not show the macro options for the Error Message component.

Fixes https://github.com/alphagov/govuk-design-system/issues/1008

I'll need to update all the component READMEs in GOV.UK Frontend also.

