### PR TITLE
Change the recommended number of max failed login attempts before locking the user out

### DIFF
--- a/src/patterns/passwords/index.md.njk
+++ b/src/patterns/passwords/index.md.njk
@@ -57,7 +57,7 @@ If a user enters their account details incorrectly, do not reveal whether they g
 
 Revealing the source of the error can help fraudsters break into people’s accounts.
 
-Give users at least 10 attempts to enter their password correctly before you lock their account or do any further security checks.
+Give users between 5 and 10 attempts to enter their password correctly before you lock their account or do any further security checks.
 
 ### Hide passwords by default
 


### PR DESCRIPTION
Change based on NCSC guidance:
"If using account lockout, we recommend you allow between 5 and 10 login attempts before the account is frozen" (https://www.ncsc.gov.uk/collection/passwords/updating-your-approach)