### PR TITLE
Adding a user journey to the feedback page guide

### DIFF
--- a/src/patterns/confirmation-pages/index.md.njk
+++ b/src/patterns/confirmation-pages/index.md.njk
@@ -10,7 +10,9 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-Let users know they’ve completed a transaction.
+Use this pattern to let users know they’ve completed a transaction. 
+
+Include a link to the [GOV.UK feedback page](https://www.gov.uk/service-manual/service-assessments/get-feedback-page) to allow users to tell you what they think of your transaction.
 
 {{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
@@ -28,7 +30,7 @@ Your confirmation page must include:
 - details of what happens next and when
 - contact details for the service
 - links to information or services that users are likely to need next
-- a link to your feedback page
+- a link to your [feedback page](https://www.gov.uk/service-manual/service-assessments/get-feedback-page) 
 - a way for users to save a record of the transaction, for example, as a PDF
 
 {{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second", size: "xl"}) }}


### PR DESCRIPTION
Searches for "GDS done page" take users to this page rather than the relevant page in the Service Manual.

DIT had this problem today and couldn't find the right information.

I've also proposed that the Service Manual page is updated to include the still-used term "done page".