### PR TITLE
Back to top link improvements

### DIFF
--- a/src/javascripts/application.js
+++ b/src/javascripts/application.js
@@ -43,5 +43,4 @@ new Search($searchContainer).init()
 
 // Initialise back to top
 var $backToTop = document.querySelector('[data-module="app-back-to-top"]')
-var $observedElement = document.querySelector('.app-subnav')
-new BackToTop($backToTop, { $observedElement: $observedElement }).init()
+new BackToTop($backToTop).init()

--- a/src/stylesheets/components/_back-to-top.scss
+++ b/src/stylesheets/components/_back-to-top.scss
@@ -1,8 +1,27 @@
 .app-back-to-top {
-  position: -webkit-sticky; // Needed for Safari on OSX
-  position: sticky; // sass-lint:disable-line no-duplicate-properties
-  top: govuk-spacing(6);
+  margin-top: govuk-spacing(4);
   margin-bottom: govuk-spacing(6);
+}
+
+@include govuk-media-query($from: tablet) {
+  .app-back-to-top {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    margin-top: auto;
+    margin-bottom: govuk-spacing(8);
+  }
+
+  .js-enabled .app-back-to-top--fixed {
+    position: fixed;
+    top: calc(100% - #{govuk-spacing(8)});
+    bottom: auto;
+    left: auto;
+  }
+
+  .js-enabled .app-back-to-top--hidden .app-back-to-top__link {
+    @include govuk-visually-hidden-focusable;
+  }
 }
 
 .app-back-to-top__icon {
@@ -12,10 +31,4 @@
   margin-top: -(govuk-spacing(1));
   margin-right: govuk-spacing(2);
   vertical-align: middle;
-}
-
-@supports (position: sticky) {
-  .js-enabled .app-back-to-top--hidden .app-back-to-top__link {
-    @include govuk-visually-hidden-focusable;
-  }
 }

--- a/src/stylesheets/components/_contact-panel.scss
+++ b/src/stylesheets/components/_contact-panel.scss
@@ -1,7 +1,6 @@
 
 .app-contact-panel {
   @include govuk-responsive-margin(9, "top");
-  @include govuk-responsive-margin(6, "bottom");
   padding-top: govuk-spacing(3);
   border-top: 2px solid govuk-colour("blue");
 

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -1,6 +1,9 @@
 @include govuk-exports("app-subnav") {
 
   .app-subnav {
+    // Since the back to top link is outside the flow of the document we need to create a space for it.
+    // This number is magic and was determined by manually judging the visual spacing.
+    margin-bottom: 100px;
     padding: govuk-spacing(6) govuk-spacing(3) 0 0;
     @include govuk-font(16);
   }

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -68,11 +68,12 @@ body {
 
 .app-content {
 
-  padding: govuk-spacing(3) govuk-spacing(0);
+  padding: govuk-spacing(3) govuk-spacing(0) govuk-spacing(4);
 
   @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(6);
     padding-right: 0;
+    padding-bottom: govuk-spacing(8);
   }
 
   h1 {
@@ -375,5 +376,11 @@ p code {
   pre + h3,
   pre + h4 {
     padding-top: govuk-spacing(2);
+  }
+
+  // Ensure that content at the bottom of the page does not have margins
+  // so that they line up with the back to top link.
+  > :last-child {
+    margin-bottom: 0;
   }
 }

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -10,7 +10,6 @@
 <div class="app-pane__body govuk-width-container">
   <div class="app-pane__subnav app-hide-mobile">
     {% include "_subnav.njk" %}
-    {% include "_back-to-top.njk" %}
   </div>
   <div class="app-pane__content">
     <main id="main-content" class="app-content" role="main">
@@ -66,6 +65,7 @@
       {% endif %}
     </main>
   </div>
+  {% include "_back-to-top.njk" %}
 </div>
 {% include "_footer.njk" %}
 {% endblock %}

--- a/views/partials/_back-to-top.njk
+++ b/views/partials/_back-to-top.njk
@@ -1,5 +1,3 @@
-{# Safari on OSX with `position: -webkit-sticky` requires a block level element.
-To avoid a large focus area we use a wrapper element. #}
 <div class="app-back-to-top app-back-to-top--hidden" data-module="app-back-to-top">
   <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
     {#- The SVG needs `focusable="false"` so that Internet Explorer does not

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -50,14 +50,14 @@
   <p class="govuk-body app-contact-panel__body">
     If you’ve got a question about the GOV.UK Design System you can contact the team:
   </p>
-  <ul class="govuk-list govuk-list--bullet">
+  <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
     <li>
       on
       <a class="govuk-link app-contact-panel__link" href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system" data-hsupport="slack">
         #govuk-design-system channel on cross-government Slack
       </a>
     </li>
-    <li>
+    <li class="govuk-!-margin-bottom-0">
       by email at
       <a class="govuk-link app-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">
         govuk-design-system-support@digital.cabinet-office.gov.uk

--- a/views/partials/_in-page-subnav.njk
+++ b/views/partials/_in-page-subnav.njk
@@ -1,4 +1,4 @@
-<div class="app-pane__subnav-mobile-overview app-hide-desktop app-hide-tablet govuk-!-padding-top-2">
+<div class="app-pane__subnav-mobile-overview app-hide-desktop app-hide-tablet govuk-!-padding-top-4">
   <nav>
     {% for item in navigation %}
       {% if path.startsWith(item.url) %}


### PR DESCRIPTION
This resolves the majority of issues raised by the recent accessibility audit relating to the back to top link, with only an investigation into NVDA's anchor link remaining.

Fixes https://github.com/alphagov/govuk-design-system/issues/899

## Move the back to top link after the main content

This means that anyone using a keyboard can access the back to top link
if they're navigating to the bottom, whereas perviously the link was
just after the navigation.

Moving this forces us to have to change our approach having the back to top link follow the user.
We cannot use `position: sticky`, so have to make more use of
intersection observers and implement the desired behaviour ourself.

## Move the link to the bottom of the page visually

- mirrors the source order better
- users with motor impairments this may be easier to access as it's
closer to the bottom of the page.
- fallback for older browsers and JavaScript being disabled is the link at the bottom of the page.

## Mobile
On smaller screens or mobile, the back to top link is at the bottom of the page and does not move.

![](https://user-images.githubusercontent.com/2445413/66922854-c7e77d00-f01f-11e9-8752-09b516729e50.png)

## Desktop

### Longer navigation that content
For navigations that are longer than the main content the back to top link sits at the bottom of the page and does not move

![](https://user-images.githubusercontent.com/2445413/66922944-ea799600-f01f-11e9-961a-99485d9537ba.png)

### Small navigation with long content scrolling
With a smaller navigation and long content, scrolling will make the back to top link follow the user at the bottom of the page
![](https://user-images.githubusercontent.com/2445413/66923143-30365e80-f020-11e9-9a68-e086a57fce32.gif)

### Small navigation with long content tabbing with keyboard
With a smaller navigation and long content tabbing will allow the user to go through the main content before arriving at the back to top link at the end
![](https://user-images.githubusercontent.com/2445413/66923203-47754c00-f020-11e9-9b7a-28d44de0b5c5.gif)

### Small navigation with short content tabbing with keyboard
Smaller navigations with short content we hide the back to top link by default and allow it to be tabbed to.

![](https://user-images.githubusercontent.com/2445413/66923241-5a881c00-f020-11e9-8b73-07415751c95e.gif)




## Todo

- [x] Test in NVDA