### PR TITLE
Add guidance about different heading size usage

### DIFF
--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -21,11 +21,11 @@ If you’re not sure whether you should be using GDS Transport, read the Service
 
 Use headings consistently to create a clear hierarchy throughout your service.
 
-Markup headings semantically using the appropriate <h#> level HTML element and use a heading class to apply the GOV.UK styling.
+Mark up headings semantically using the appropriate <h#> level HTML element and use a heading class to apply the GOV.UK styling.
 
-For long form content you should use the corresponding size class. For example an `<h1>` should use `govuk-heading-xl`, an `<h2>` should use `govuk-heading-l`.
+For long form content use the corresponding size class. For example an `<h1>` should use `govuk-heading-xl`, an `<h2>` should use `govuk-heading-l`.
 
-For [question pages](../../patterns/question-pages), primarily when [making labels and legends headings](../../get-started/labels-legends-headings/) you should use a smaller legend or label  class with an `<h1>` if the question is particularly long or causing the page to feel imbalanced.
+For [question pages](../../patterns/question-pages) and other short form content, try using the corresponding size class first. But change it if it makes the page feel unbalanced. For example, if you’re using an especially long question as your `<h1>`, try using `govuk-heading-l` for the `<h1>`, `govuk-heading-l` for the `<h2>` and so on.
 
 Write all headings in sentence case.
 

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -21,7 +21,11 @@ If you’re not sure whether you should be using GDS Transport, read the Service
 
 Use headings consistently to create a clear hierarchy throughout your service.
 
-Markup headings semantically using the appropriate <h#> level HTML element and use the corresponding heading class to apply the GOV.UK styling.
+Markup headings semantically using the appropriate <h#> level HTML element and use a heading class to apply the GOV.UK styling.
+
+For long form content you should use the corresponding size class. For example an `<h1>` should use `govuk-heading-xl`, an `<h2>` should use `govuk-heading-l`.
+
+For [question pages](../../patterns/question-pages), primarily when [making labels and legends headings](../../get-started/labels-legends-headings/) you should use a smaller legend or label  class with an `<h1>` if the question is particularly long or causing the page to feel imbalanced.
 
 Write all headings in sentence case.
 


### PR DESCRIPTION
This has come up a number of times since the design system was launched, it would be good to clarify that using a different size heading class is ok and is down to the designer.

This is very much a draft and isn't nesassarily the solution, just wanted to get it in before I remove my GitHub credentials and do one more PR :)