### PR TITLE
Improve video alternative text

### DIFF
--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -18,12 +18,14 @@ Help users provide an address using one of the following:
 
 ## Address lookup
 
-<video class="govuk-!-margin-bottom-2" role="region" aria-labelledby="passports-address-lookup-description" controls muted>
-  <source src="passports-address-lookup.mp4" type="video/mp4">
-</video>
-<span id="passports-address-lookup-description">
-  This video shows the address lookup in practice. It doesn't have any audio.
-</span>
+<div class="app-video">
+  <video class="app-video__player" role="region" aria-labelledby="passports-address-lookup-video-description" controls muted>
+    <source src="passports-address-lookup.mp4" type="video/mp4">
+  </video>
+  <p class="app-video__description" id="passports-address-lookup-video-description">
+    This video shows the address lookup in practice. It doesn't have any audio.
+  </p>
+</div>
 
 ### When to use an address lookup
 

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -18,9 +18,12 @@ Help users provide an address using one of the following:
 
 ## Address lookup
 
-<video role="region" aria-label="Visual demonstration of the address lookup user interaction described. This video has no audio." controls muted>
+<video class="govuk-!-margin-bottom-2" role="region" aria-labelledby="passports-address-lookup-description" controls muted>
   <source src="passports-address-lookup.mp4" type="video/mp4">
 </video>
+<span id="passports-address-lookup-description">
+  This video shows the card number validation in practice. It doesn't have any audio.
+</span>
 
 ### When to use an address lookup
 

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -22,7 +22,7 @@ Help users provide an address using one of the following:
   <source src="passports-address-lookup.mp4" type="video/mp4">
 </video>
 <span id="passports-address-lookup-description">
-  This video shows the card number validation in practice. It doesn't have any audio.
+  This video shows the address lookup in practice. It doesn't have any audio.
 </span>
 
 ### When to use an address lookup

--- a/src/patterns/payment-card-details/index.md.njk
+++ b/src/patterns/payment-card-details/index.md.njk
@@ -30,9 +30,14 @@ Show logos for the cards you accept as icons so users can see whether their card
 
 Use Issuer Identification Number (IIN) lookups to validate the card number as the user enters it. Once you’ve been able to identify the user’s card type, leave only the relevant logo highlighted and grey out the others.
 
-<video role="region" aria-label="Visual demonstration of the card number validation user interaction described. This video has no audio." controls>
-  <source src="card-number.mp4" type="video/mp4">
-</video>
+<div class="app-video">
+  <video class="app-video__player" role="region" aria-labelledby="card-number-video-description" controls muted>
+    <source src="card-number.mp4" type="video/mp4">
+  </video>
+  <p class="app-video__description" id="card-number-video-description">
+    This video shows the card number validation in practice. It doesn't have any audio.
+  </p>
+</div>
 
 If JavaScript is not available, display all of the logos anyway, as they still help users to understand which card types you support.
 

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -174,8 +174,6 @@ body {
   $copy-button-colour: #00823b;
 
   @include govuk-font(16);
-  // TODO: Need to make copy button focusable/hoverable but we need some design decision to be made
-  // @include govuk-focusable;
   position: absolute;
   z-index: 1;
   top: govuk-spacing(2);

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -114,10 +114,11 @@ body {
     padding: govuk-spacing(2);
   }
 
-  // TODO: Need to make Video focusable but we need some design decision to be made
-  // video {
-  //   @include govuk-focusable;
-  // }
+  video:focus {
+    border-color: $govuk-focus-text-colour;
+    outline: $govuk-focus-width solid $govuk-focus-text-colour;
+    box-shadow: 0 0 0 ($govuk-focus-width * 2) $govuk-focus-colour;
+  }
 
 
   // IE8 does not support the video element, so we hide the element entirely.

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -99,31 +99,39 @@ body {
     max-width: 38em;
   }
 
-  video,
+  .app-video__player,
   img {
     box-sizing: border-box;
     width: 100%;
     max-width: 722px;
     height: auto;
     @include govuk-responsive-margin(2, "top");
-    @include govuk-responsive-margin(6, "bottom");
     border: 1px solid $govuk-border-colour;
   }
 
   img {
     padding: govuk-spacing(2);
+    @include govuk-responsive-margin(6, "bottom");
   }
 
-  video:focus {
+  .app-video__player {
+    @include govuk-responsive-margin(2, "bottom");
+  }
+
+  .app-video__player:focus {
     border-color: $govuk-focus-text-colour;
     outline: $govuk-focus-width solid $govuk-focus-text-colour;
     box-shadow: 0 0 0 ($govuk-focus-width * 2) $govuk-focus-colour;
   }
 
+  .app-video__description {
+    @include govuk-responsive-margin(6, "bottom");
+  }
+
 
   // IE8 does not support the video element, so we hide the element entirely.
   @if $govuk-is-ie8 == true {
-    video {
+    .app-video {
       display: none;
     }
   }


### PR DESCRIPTION
## Show label for video to everyone.

We used to have an invisible label for users of assistive technologies that explained the video was complementary and did not have any audio.

We've moved this onto the page for everyone to see based on @selfthinker 's recommendations since this will make it useful for people that are using other assistive technologies such as magnification tools.

I have used `aria-labelledby` to associate this label with the video to keep the existing behaviour.

Thanks to @amyhupe  for improving the content for the label.

![](https://user-images.githubusercontent.com/2445413/67101301-47f51a80-f1b9-11e9-9c61-5453bfde5e55.png)

## Add a consistent focus style for the video
I think this was one of the only thing we've forgot to add a focus style to that follows the new guidelines.

![](https://user-images.githubusercontent.com/2445413/67101435-85f23e80-f1b9-11e9-900f-8854fa223e9a.png)

Fixes https://github.com/alphagov/govuk-design-system/issues/904