### PR TITLE
Ensure all wrapper forms submit via POST

### DIFF
--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -19,7 +19,7 @@
   <body class="app-example-page">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
     <!-- Disable browser validation for any examples that include form elements -->
-    <form novalidate>
+    <form action="/form-handler" method="post" novalidate>
       {% block body %}
         {{ contents | safe }}
       {% endblock %}


### PR DESCRIPTION
This makes sure that any accidental personally identifiable information
is not stored in logs as using the GET method means that these are put
into the URL.

This approach is consistent with how the other examples are setup.

Fixes https://github.com/alphagov/govuk-design-system/issues/1066