### PR TITLE
Exclude the canary from the sitemap 🐤🚫

### DIFF
--- a/src/__canary__.html
+++ b/src/__canary__.html
@@ -1,5 +1,6 @@
 ---
 layout: false
+ignore_in_sitemap: true
 ---
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
We use the `/__canary__` route to check instance health when deploying before we make the new site live, but we don’t want it to be indexed and it definitely doesn’t need to be included in the sitemap (which it currently is).