### PR TITLE
Exclude all examples from sitemap

### DIFF
--- a/lib/generate-sitemap.js
+++ b/lib/generate-sitemap.js
@@ -58,6 +58,12 @@ const plugin = (opts) => {
       if (!match(file, pattern)[0]) {
         return false
       }
+
+      // Exclude examples from the sitemap
+      if (frontmatter.layout && frontmatter.layout.startsWith('layout-example')) {
+        return false
+      }
+
       // Ignore files if set to true
       if (frontmatter.ignore_in_sitemap) {
         return false

--- a/src/components/button/disabled/index.njk
+++ b/src/components/button/disabled/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Disabled button
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/components/button/prevent-double-click/index.njk
+++ b/src/components/button/prevent-double-click/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Button with prevent double click
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/components/button/start/index.njk
+++ b/src/components/button/start/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Start now button
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Checkboxes with conditionally revealing content
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/src/components/date-input/error/index.njk
+++ b/src/components/date-input/error/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Date input with errors
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/components/error-message/label/index.njk
+++ b/src/components/error-message/label/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Error message with Label
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/error-message/legend/index.njk
+++ b/src/components/error-message/legend/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Error message with Legend
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/src/components/error-summary/full-page-example/index.njk
+++ b/src/components/error-summary/full-page-example/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Full page example
 layout: layout-example-full-page.njk
-ignore_in_sitemap: true
 ---
 
 {% extends "example-wrappers/full-page.njk" %}

--- a/src/components/error-summary/linking-checkboxes-radios/index.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Linking from the error summary to checkboxes
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}

--- a/src/components/error-summary/linking-multiple-fields/index.njk
+++ b/src/components/error-summary/linking-multiple-fields/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Linking from the error summary to an answer that uses multiple fields
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/components/error-summary/linking/index.njk
+++ b/src/components/error-summary/linking/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Linking from the error summary to an answer that uses a single field
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}

--- a/src/components/fieldset/address-group/index.njk
+++ b/src/components/fieldset/address-group/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Fieldset address group
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - address-wrapper.css
 ---

--- a/src/components/file-upload/error/index.njk
+++ b/src/components/file-upload/error/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Error – File upload
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}

--- a/src/components/footer/full/index.njk
+++ b/src/components/footer/full/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Footer with secondary navigation and links to meta information
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/footer/macro.njk" import govukFooter %}

--- a/src/components/footer/with-meta/index.njk
+++ b/src/components/footer/with-meta/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Footer with links to meta information
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/footer/macro.njk" import govukFooter %}

--- a/src/components/footer/with-navigation/index.njk
+++ b/src/components/footer/with-navigation/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Footer with secondary navigation
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/footer/macro.njk" import govukFooter %}

--- a/src/components/header/with-service-name-and-navigation/index.njk
+++ b/src/components/header/with-service-name-and-navigation/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Header with service name and navigation
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 

--- a/src/components/header/with-service-name/index.njk
+++ b/src/components/header/with-service-name/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Header with service name
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 

--- a/src/components/phase-banner/beta/index.njk
+++ b/src/components/phase-banner/beta/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Phase banner with beta text
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Radios with conditionally revealing content
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/radios/divider/index.njk
+++ b/src/components/radios/divider/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Radios with a text divider
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/radios/error/index.njk
+++ b/src/components/radios/error/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Inline radios with error
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/radios/hint/index.njk
+++ b/src/components/radios/hint/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Radio items with hint
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/radios/stacked/index.njk
+++ b/src/components/radios/stacked/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Stacked radios
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/table/numbers/index.njk
+++ b/src/components/table/numbers/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Numbers in a table
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/table/macro.njk" import govukTable %}

--- a/src/components/text-input/error/index.njk
+++ b/src/components/text-input/error/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Text input with errors
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-autocomplete-attribute/index.njk
+++ b/src/components/text-input/input-autocomplete-attribute/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Text input with autocomplete attribute
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-fixed-width/index.njk
+++ b/src/components/text-input/input-fixed-width/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Fixed width inputs
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-fluid-width/index.njk
+++ b/src/components/text-input/input-fluid-width/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Fluid width inputs
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-hint-text/index.njk
+++ b/src/components/text-input/input-hint-text/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Hint text
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/textarea/specifying-rows/index.njk
+++ b/src/components/textarea/specifying-rows/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Textarea appropriately-sized with rows
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 

--- a/src/get-started/labels-legends-headings/label-h1/index.njk
+++ b/src/get-started/labels-legends-headings/label-h1/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Labels as page headings - Making labels and legends headings
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/get-started/labels-legends-headings/label-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/label-m-s/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Styling labels - Making labels and legends headings
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 

--- a/src/get-started/labels-legends-headings/legend-h1/index.njk
+++ b/src/get-started/labels-legends-headings/legend-h1/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Legends as page headings - Making labels and legends headings
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/get-started/labels-legends-headings/legend-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/legend-m-s/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Styling legends - Making labels and legends headings
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 

--- a/src/patterns/addresses/error/index.njk
+++ b/src/patterns/addresses/error/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Postcode error
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Multiple text inputs Addresses
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - address-wrapper.css
 ---

--- a/src/patterns/addresses/textarea/index.njk
+++ b/src/patterns/addresses/textarea/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Textarea addresses
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 

--- a/src/patterns/dates/error/index.njk
+++ b/src/patterns/dates/error/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Dates with errors
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/patterns/email-addresses/error/index.njk
+++ b/src/patterns/email-addresses/error/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Email input with errors
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/names/error/index.njk
+++ b/src/patterns/names/error/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Name input with errors
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/national-insurance-numbers/error/index.njk
+++ b/src/patterns/national-insurance-numbers/error/index.njk
@@ -1,7 +1,6 @@
 ---
 title: National insurance number input with errors
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/problem-with-the-service-pages/link-to-another-service/index.njk
+++ b/src/patterns/problem-with-the-service-pages/link-to-another-service/index.njk
@@ -1,7 +1,6 @@
 ---
 title: A link to another service – There is a problem with the service pages
 layout: layout-example-full-page.njk
-ignore_in_sitemap: true
 ---
 
 {% extends "example-wrappers/full-page.njk" %}

--- a/src/patterns/problem-with-the-service-pages/offline-support/index.njk
+++ b/src/patterns/problem-with-the-service-pages/offline-support/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Service has offline support but no specific page that includes numbers and opening times
 layout: layout-example-full-page.njk
-ignore_in_sitemap: true
 ---
 
 {% extends "example-wrappers/full-page.njk" %}

--- a/src/patterns/question-pages/passport/index.njk
+++ b/src/patterns/question-pages/passport/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Passport – Question pages
 layout: layout-example-full-page.njk
-ignore_in_sitemap: true
 ---
 
 {% extends "example-wrappers/full-page.njk" %}

--- a/src/patterns/question-pages/postcode/index.njk
+++ b/src/patterns/question-pages/postcode/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Postcode – Question pages
 layout: layout-example-full-page.njk
-ignore_in_sitemap: true
 ---
 
 {% extends "example-wrappers/full-page.njk" %}

--- a/src/patterns/question-pages/progress/index.njk
+++ b/src/patterns/question-pages/progress/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Progress indicator – Question pages
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <span class="govuk-caption-xl">Question 3 of 9</span>

--- a/src/patterns/question-pages/section-headings/index.njk
+++ b/src/patterns/question-pages/section-headings/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Section headings – Question pages
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <span class="govuk-caption-xl">About you</span>

--- a/src/patterns/service-unavailable-pages/after-service-closes/index.njk
+++ b/src/patterns/service-unavailable-pages/after-service-closes/index.njk
@@ -1,7 +1,6 @@
 ---
 title: After a service closes
 layout: layout-example-full-page.njk
-ignore_in_sitemap: true
 ---
 
 {% extends "example-wrappers/full-page.njk" %}

--- a/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
+++ b/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
@@ -1,7 +1,6 @@
 ---
 title: When you know when a service will be available
 layout: layout-example-full-page.njk
-ignore_in_sitemap: true
 ---
 
 {% extends "example-wrappers/full-page.njk" %}

--- a/src/patterns/service-unavailable-pages/before-service-opens/index.njk
+++ b/src/patterns/service-unavailable-pages/before-service-opens/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Before a service opens
 layout: layout-example-full-page.njk
-ignore_in_sitemap: true
 ---
 
 {% extends "example-wrappers/full-page.njk" %}

--- a/src/patterns/service-unavailable-pages/default/index.njk
+++ b/src/patterns/service-unavailable-pages/default/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Service unavailable
 layout: layout-example-full-page.njk
-ignore_in_sitemap: true
 ---
 
 {% extends "example-wrappers/full-page.njk" %}

--- a/src/patterns/service-unavailable-pages/general/index.njk
+++ b/src/patterns/service-unavailable-pages/general/index.njk
@@ -1,7 +1,6 @@
 ---
 title: General page
 layout: layout-example-full-page.njk
-ignore_in_sitemap: true
 ---
 
 {% extends "example-wrappers/full-page.njk" %}

--- a/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
+++ b/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
@@ -1,7 +1,6 @@
 ---
 title: A link to another service – Service unavailable pages
 layout: layout-example-full-page.njk
-ignore_in_sitemap: true
 ---
 
 {% extends "example-wrappers/full-page.njk" %}

--- a/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
+++ b/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Nothing has replaced the service
 layout: layout-example-full-page.njk
-ignore_in_sitemap: true
 ---
 
 {% extends "example-wrappers/full-page.njk" %}

--- a/src/patterns/service-unavailable-pages/service-replaced/index.njk
+++ b/src/patterns/service-unavailable-pages/service-replaced/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Something has replaced the service
 layout: layout-example-full-page.njk
-ignore_in_sitemap: true
 ---
 
 {% extends "example-wrappers/full-page.njk" %}

--- a/src/patterns/telephone-numbers/error-empty-field/index.njk
+++ b/src/patterns/telephone-numbers/error-empty-field/index.njk
@@ -1,7 +1,6 @@
 ---
 layout: layout-example.njk
 title: Error, empty field – Telephone numbers
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/telephone-numbers/international/index.njk
+++ b/src/patterns/telephone-numbers/international/index.njk
@@ -1,7 +1,6 @@
 ---
 layout: layout-example.njk
 title: International – Telephone numbers
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/styles/images/alt-text/index.njk
+++ b/src/styles/images/alt-text/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Alt text – Images
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../images.css
 ---

--- a/src/styles/images/representative/index.njk
+++ b/src/styles/images/representative/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Illustrations or representative – Images
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../images.css
 ---

--- a/src/styles/layout/combinations/index.njk
+++ b/src/styles/layout/combinations/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Combinations – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../grid-annotate.css
 - ../grid-combinations-annotate.css

--- a/src/styles/layout/common-two-thirds-one-third/index.njk
+++ b/src/styles/layout/common-two-thirds-one-third/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Common two-thirds / One-third – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}

--- a/src/styles/layout/common-two-thirds-two-thirds-one-third/index.njk
+++ b/src/styles/layout/common-two-thirds-two-thirds-one-third/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Common two-thirds with two Rows – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}

--- a/src/styles/layout/common-two-thirds/index.njk
+++ b/src/styles/layout/common-two-thirds/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Common two-thirds – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}

--- a/src/styles/layout/desktop/index.njk
+++ b/src/styles/layout/desktop/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Desktop grid classes – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../grid-annotate.css
 - ../grid-combinations-annotate.css

--- a/src/styles/layout/full-width/index.njk
+++ b/src/styles/layout/full-width/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Full width – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../grid-annotate.css
 ---

--- a/src/styles/layout/layout-wrappers-l/index.njk
+++ b/src/styles/layout/layout-wrappers-l/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Page wrapper without content after the header – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../layout-wrappers-annotate.css
 ---

--- a/src/styles/layout/layout-wrappers/index.njk
+++ b/src/styles/layout/layout-wrappers/index.njk
@@ -2,7 +2,6 @@
 title: Page wrapper – Layout
 
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../layout-wrappers-annotate.css
 ---

--- a/src/styles/layout/nested/index.njk
+++ b/src/styles/layout/nested/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Nested – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../grid-annotate.css
 - ../grid-nested-annotate.css

--- a/src/styles/layout/one-half/index.njk
+++ b/src/styles/layout/one-half/index.njk
@@ -1,7 +1,6 @@
 ---
 title: One-half – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../grid-annotate.css
 ---

--- a/src/styles/layout/one-quarter/index.njk
+++ b/src/styles/layout/one-quarter/index.njk
@@ -1,7 +1,6 @@
 ---
 title: One-quarter – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../grid-annotate.css
 ---

--- a/src/styles/layout/one-third/index.njk
+++ b/src/styles/layout/one-third/index.njk
@@ -1,7 +1,6 @@
 ---
 title: One-third – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../grid-annotate.css
 ---

--- a/src/styles/layout/tablet-desktop/index.njk
+++ b/src/styles/layout/tablet-desktop/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Desktop and tablet grid classes – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../grid-annotate.css
 ---

--- a/src/styles/layout/three-quarters/index.njk
+++ b/src/styles/layout/three-quarters/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Three-quarters – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../grid-annotate.css
 ---

--- a/src/styles/layout/two-thirds/index.njk
+++ b/src/styles/layout/two-thirds/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Two-thirds – Layout
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - ../grid-annotate.css
 ---

--- a/src/styles/spacing/input-width/index.njk
+++ b/src/styles/spacing/input-width/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Overriding input width – Spacing
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/styles/spacing/spacing-scale-margin/index.njk
+++ b/src/styles/spacing/spacing-scale-margin/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Margin scale – Spacing
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <p class="govuk-body govuk-!-margin-bottom-9">A paragraph with a margin-bottom override (spacing unit 9).</p>

--- a/src/styles/spacing/spacing-scale-padding/index.njk
+++ b/src/styles/spacing/spacing-scale-padding/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Padding scale – Spacing
 layout: layout-example.njk
-ignore_in_sitemap: true
 stylesheets:
 - spacing-scale.css
 ---

--- a/src/styles/typography/body/index.njk
+++ b/src/styles/typography/body/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Body – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <p class="govuk-body">govuk-body</p>

--- a/src/styles/typography/captions-inside/index.njk
+++ b/src/styles/typography/captions-inside/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Headings with captions nested – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <h1 class="govuk-heading-xl">

--- a/src/styles/typography/captions/index.njk
+++ b/src/styles/typography/captions/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Headings with captions – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <span class="govuk-caption-xl">govuk-caption-xl</span>

--- a/src/styles/typography/font-size/index.njk
+++ b/src/styles/typography/font-size/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Font size – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <p class="govuk-body govuk-!-font-size-80">govuk-!-font-size-80</p>

--- a/src/styles/typography/font-weight/index.njk
+++ b/src/styles/typography/font-weight/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Font weight – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <p class="govuk-body govuk-!-font-weight-regular">govuk-!-font-weight-regular</p>

--- a/src/styles/typography/headings/index.njk
+++ b/src/styles/typography/headings/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Headings – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <h1 class="govuk-heading-xl">govuk-heading-xl</h1>

--- a/src/styles/typography/lead/index.njk
+++ b/src/styles/typography/lead/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Lead – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <p class="govuk-body-l">govuk-body-l</p>

--- a/src/styles/typography/link-no-visited-state/index.njk
+++ b/src/styles/typography/link-no-visited-state/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Links with no visited state – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <a href="#" class="govuk-link govuk-link--no-visited-state">govuk-link govuk-link--no-visited-state</a>

--- a/src/styles/typography/link/index.njk
+++ b/src/styles/typography/link/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Links – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <a href="#" class="govuk-link">govuk-link</a>

--- a/src/styles/typography/list-bullet/index.njk
+++ b/src/styles/typography/list-bullet/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Bulleted lists – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <p class="govuk-body">You can buy:</p>

--- a/src/styles/typography/list-number/index.njk
+++ b/src/styles/typography/list-number/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Numbered lists – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <ol class="govuk-list govuk-list--number">

--- a/src/styles/typography/list/index.njk
+++ b/src/styles/typography/list/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Lists – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <ul class="govuk-list">

--- a/src/styles/typography/section-break/index.njk
+++ b/src/styles/typography/section-break/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Section break – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/src/styles/typography/small/index.njk
+++ b/src/styles/typography/small/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Body small – Typography
 layout: layout-example.njk
-ignore_in_sitemap: true
 ---
 
 <p class="govuk-body-s">govuk-body-s</p>


### PR DESCRIPTION
Rather than relying on authors remembering to add `ignore_in_sitemap: true` to the frontmatter of every example, automatically exclude any pages that use a layout starting with `layout-example` – covering both `layout-example.njk` and `layout-example-full-page.njk`.

We can then remove `ignore_in_sitemap: true` from the frontmatter of the examples, as it is redundant.

Fixes #1074 