### PR TITLE
Update nginx buildpack to v1.1.1

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -12,7 +12,7 @@ applications:
   # by GitHub URL
   #
   # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
-  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.0.14
+  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.1
   # Run two instances to ensure availability
   #
   # https://docs.cloud.service.gov.uk/managing_apps.html#scaling


### PR DESCRIPTION
This effectively just updates nginx from v1.17.1 to v1.17.5.

Tested by manually pushing an app to the PaaS:

Existing app:

$ curl -Is https://design-system.service.gov.uk | grep server
server: nginx/1.17.1

App with this change:

$ curl -Is https://design-system-nginx-1-1-1.cloudapps.digital/ | grep server
server: nginx/1.17.5