### PR TITLE
Remove reference to 'GOV.UK page'

### DIFF
--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -1,6 +1,6 @@
 ---
 title: Button
-description: Use the button component to help users carry out an action on a GOV.UK page
+description: Use the button component to help users carry out an action
 section: Components
 aliases:
 backlog_issue_id: 34
@@ -13,7 +13,7 @@ layout: layout-pane.njk
 
 ## When to use this component
 
-Use the button component to help users carry out an action on a GOV.UK page like starting an application or saving their information.
+Use the button component to help users carry out an action like starting an application or saving their information.
 
 ## How it works
 


### PR DESCRIPTION
Mentioning 'on a GOV.UK page' here:

> Use the button component to help users carry out an action on a GOV.UK page like starting an application or saving their information.

...seems confusing to me. It’s not clear whether that includes services using a `*.service.gov.uk` domain or not. End-users might perceive everything to be "GOV.UK" but within government it seems common to refer to GOV.UK as being the content platform only, not the services.

I think it might be clearer to drop this reference, which would also be more consistent with other component descriptions.