### PR TITLE
Fix sticky navigation logic erroring on some pages

### DIFF
--- a/src/javascripts/components/back-to-top.js
+++ b/src/javascripts/components/back-to-top.js
@@ -22,6 +22,7 @@ BackToTop.prototype.init = function () {
 
   var footerIsIntersecting = false
   var subNavIsIntersecting = false
+  var subNavIntersectionRatio = 0
 
   var observer = new window.IntersectionObserver(function (entries) {
     // Find the elements we care about from the entries
@@ -38,6 +39,7 @@ BackToTop.prototype.init = function () {
     }
     if (subNavEntry) {
       subNavIsIntersecting = subNavEntry.isIntersecting
+      subNavIntersectionRatio = subNavEntry.intersectionRatio
     }
 
     // If the subnav or the footer not visible then fix the back to top link to follow the user
@@ -49,7 +51,7 @@ BackToTop.prototype.init = function () {
 
     // If the subnav is visible but you can see it all at once, then a back to top link is likely not as useful.
     // We hide the link but make it focusable for screen readers users who might still find it useful.
-    if (subNavIsIntersecting && subNavEntry.intersectionRatio === 1) {
+    if (subNavIsIntersecting && subNavIntersectionRatio === 1) {
       this.$module.classList.add('app-back-to-top--hidden')
     } else {
       this.$module.classList.remove('app-back-to-top--hidden')


### PR DESCRIPTION
Entries only appear when an element that is being observed enters or leaves the viewport.

This means that we cannot rely on the subNav entry being avaliable to check it's intersectionRatio.

This change to the logic caches the ratio outside of the observer so it's always up-to-date with the last time an entry for the subNav is avaliable.

This has no impact on users that I can tell fortunately.

Fixes https://github.com/alphagov/govuk-design-system/issues/1088