### PR TITLE
Fix search on updated colours

### DIFF
--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -76,6 +76,10 @@ $icon-size: 40px;
     background-repeat: no-repeat;
     background-position: center left -2px;
     background-size: $icon-size $icon-size;
+
+    &::placeholder {
+      color: govuk-colour("dark-grey");
+    }
   }
 
   .app-site-search__input--focused {

--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -158,7 +158,9 @@ $icon-size: 40px;
   .app-site-search__option--focused,
   .app-site-search__option:hover {
     border-color: govuk-colour("blue");
-    outline: none;
+    // Add a transparent outline for when users change their colours.
+    outline: 3px solid transparent;
+    outline-offset: -3px;
     color: govuk-colour("white");
     background-color: govuk-colour("blue");
 

--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -50,8 +50,6 @@ $icon-size: 40px;
     display: block;
     position: relative;
     height: $icon-size;
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='#{encode-hex(govuk-colour("dark-grey"))}'%3E%3C/path%3E%3C/svg%3E") govuk-colour("white") no-repeat top left;
-    background-size: $icon-size $icon-size;
   }
 
   .app-site-search__hint,
@@ -64,7 +62,6 @@ $icon-size: 40px;
     padding-left: $icon-size - govuk-spacing(1);
     border: 2px solid govuk-colour("white");
     border-radius: 0; // Safari 10 on iOS adds implicit border rounding.
-    background: transparent;
     -webkit-appearance: none;
   }
 
@@ -75,6 +72,10 @@ $icon-size: 40px;
 
   .app-site-search__input {
     position: relative;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='#{encode-hex(govuk-colour("dark-grey"))}'%3E%3C/path%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: center left -2px;
+    background-size: $icon-size $icon-size;
   }
 
   .app-site-search__input--focused {


### PR DESCRIPTION
I was helping Amy get some screenshots of the website with colours changed and noticed some issues with the search that can be improved.

- remove background on inputs so in Firefox the input renders correctly, move the icon image to the input itself
- update the placeholder text to the same colour as the icon (should we consider doing this in GOV.UK Frontend?)
- add a transparent outline for selected items

| Before input | After input |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/69645547-3fb4b880-105e-11ea-853f-75019c6f6136.png) | ![](https://user-images.githubusercontent.com/2445413/69645569-45120300-105e-11ea-8716-4095f0a6e0da.png) |

| Before highlights | After highlights |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/69645458-1c8a0900-105e-11ea-84c7-e800a6a14279.png) | ![](https://user-images.githubusercontent.com/2445413/69645474-23188080-105e-11ea-904b-ccef376081ee.png) |


