### PR TITLE
Add about page for the team

### DIFF
--- a/src/about.md.njk
+++ b/src/about.md.njk
@@ -1,0 +1,28 @@
+---
+title: About
+description: about the GOV.UK Design System team
+layout: layout-single-page-prose.njk
+---
+
+# About
+
+The GOV.UK Design System is built by the GOV.UK Design System team at the
+[Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service) in London.
+
+The team helps teams across the UK Government build well designed,
+efficiently built services that provide a consistent user experience.
+
+If you want to contact the team you can
+[get in touch via email or Slack](https://design-system.service.gov.uk/get-in-touch/).
+
+## Team members
+
+- Amy Hupe – Senior Content Designer
+- Hanna Laakso – Frontend Developer
+- Kelly Lee – Delivery Manager
+- Mark Green – Technical Writer
+- Nick Colley – Senior Frontend Developer
+- Oliver Byford – Senior Developer (Tech Lead)
+- Rosie Clayton – User Researcher
+- Roxanne Asadi – Senior Product Manager
+- Tim Paul – Product Manager

--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -1,21 +1,18 @@
 ---
-title: About
-description: about the GOV.UK Design System team
+title: GOV.UK Design System team
+description: about the GOV.UK Design System team and who works on it
 layout: layout-single-page-prose.njk
 ---
 
-# About
+# GOV.UK Design System team
 
-The GOV.UK Design System is built by the GOV.UK Design System team at the
-[Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service) in London.
-
-The team helps teams across the UK Government build well designed,
-efficiently built services that provide a consistent user experience.
+The GOV.UK Design System team at the
+[Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service) maintains this design system.
 
 If you want to contact the team you can
 [get in touch via email or Slack](https://design-system.service.gov.uk/get-in-touch/).
 
-## Team members
+## Members
 
 - Amy Hupe – Senior Content Designer
 - Hanna Laakso – Frontend Developer
@@ -25,4 +22,4 @@ If you want to contact the team you can
 - Oliver Byford – Senior Developer (Tech Lead)
 - Rosie Clayton – User Researcher
 - Roxanne Asadi – Senior Product Manager
-- Tim Paul – Product Manager
+- Tim Paul – Product Manager (Head of Interaction Design at GDS)

--- a/src/index.njk
+++ b/src/index.njk
@@ -33,12 +33,12 @@ description: Design your service using GOV.UK styles, components and patterns
           The GOV.UK Design System is for everyone, with a strong community sitting behind it. It brings together the latest research, design and development from across government to make sure it’s representative and relevant for its users.</p>
 
         <p class="govuk-body">
-          You can contribute to the Design System by: 
+          You can contribute to the Design System by:
         </p>
         <ul class="govuk-list govuk-list--bullet">
           <li><a href="/community/propose-a-component-or-pattern" class="govuk-link" data-hcontribute="guidelinegh">proposing a new component or pattern</a></li>
           <li><a href="/community/develop-a-component-or-pattern" class="govuk-link" data-hcontribute="guidelinegh">developing a component or pattern</a></li>
-        </ul> 
+        </ul>
 
         <p class="govuk-body">
           You can also see what people are currently working on in the <a href="/community/backlog" class="govuk-link" data-hcontribute="guidelinegh">community backlog</a>.
@@ -53,18 +53,18 @@ description: Design your service using GOV.UK styles, components and patterns
       <div class="govuk-grid-column-two-thirds">
         <h2 id="support" class="govuk-heading-l">Support</h2>
         <p class="govuk-body">
-          The GOV.UK Design System is maintained by the Government Digital Service.
+          The GOV.UK Design System is <a class="govuk-link" href="/design-system-team">maintained by a team the Government Digital Service</a>.
           If you’ve got a question, idea or suggestion you can:
         </p>
         <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
         <li>
-          email 
+          email
           <a href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" class="govuk-link" data-hsupport="email">
             govuk-design-system-support@digital.cabinet-office.gov.uk
           </a>
         </li>
         <li>
-          get in touch using the 
+          get in touch using the
           <a href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system" class="govuk-link" data-hsupport="slack">
             #govuk-design-system channel on cross-government Slack</a>
         </li>

--- a/views/partials/_footer.njk
+++ b/views/partials/_footer.njk
@@ -37,6 +37,7 @@
         "href": "/privacy-policy",
         "text": "Privacy policy"
       }
-    ]
+    ],
+    "html": 'Built by the <a href="/design-system-team" class="govuk-footer__link">GOV.UK Design System team</a>'
   }
 }) }}


### PR DESCRIPTION
Add an about page with who we are, and link to it from the footer.

We want to have an official list we can point to for who is on the team.

I considered including our GitHub handles but as long as we have our real names on GitHub you can still cross reference this list.

I've added our job title roles to mirror what we do in internal weeknotes, this is to help people understand what we do on the team.

I've also added a summary of who we are, where we're based, what we're trying to do (based on our mission statement) and how to contact us.

For now I've put this page at `/about` with a title of `about` but we might want to change this.

## Screenshots

### Footer
<img width="408" alt="Screen Shot 2019-12-09 at 16 56 17" src="https://user-images.githubusercontent.com/2445413/70455826-db094d00-1aa4-11ea-8703-c14ba847958f.png">
