### PR TITLE
Fix examples width being too wide

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -4,7 +4,7 @@ description: Design your service using GOV.UK styles, components and patterns
 ---
 
 {% include "_masthead.njk" %}
-<div class="govuk-width-container app-site-width-container">
+<div class="app-width-container">
   <div class="govuk-main-wrapper govuk-main-wrapper--l">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third govuk-!-margin-bottom-8">

--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -62,7 +62,7 @@ ignore_in_sitemap: true
 {% block header %}
   {{ govukHeader({
     homepageUrl: "#",
-    containerClasses: "govuk-width-container",
+    containerClasses: "app-width-container",
     serviceName: "Service name",
     serviceUrl: "#",
     navigation: [

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -57,7 +57,7 @@ ignore_in_sitemap: true
 {% block header %}
   {{ govukHeader({
     homepageUrl: "#",
-    containerClasses: "govuk-width-container",
+    containerClasses: "app-width-container",
     serviceName: "Service name",
     serviceUrl: "#",
     navigation: [

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -1,5 +1,3 @@
-$govuk-page-width: 1100px !default;
-
 @import "govuk-frontend/govuk/all";
 
 // App-specific variables
@@ -30,6 +28,11 @@ $app-code-color: #d13118;
 
 body {
   margin: 0;
+}
+
+// We don't change the global width container width so that examples are the current width.
+.app-width-container {
+  @include govuk-width-container(1100px);
 }
 
 .app-hide-mobile {

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -7,7 +7,7 @@
 {% block appPaneClasses %}app-pane--enabled{% endblock %}
 
 {% block body %}
-<div class="app-pane__body govuk-width-container">
+<div class="app-pane__body app-width-container">
   <div class="app-pane__subnav app-hide-mobile">
     {% include "_subnav.njk" %}
   </div>

--- a/views/layouts/layout-single-page.njk
+++ b/views/layouts/layout-single-page.njk
@@ -3,7 +3,7 @@
 {% block body %}
 <div class="app-pane__content">
   <main id="main-content" class="govuk-main-wrapper govuk-main-wrapper--l" role="main">
-    <div class="govuk-width-container app-site-width-container">
+    <div class="app-width-container">
       {{ contents | safe }}
     </div>
   </main>

--- a/views/partials/_banner.njk
+++ b/views/partials/_banner.njk
@@ -16,7 +16,7 @@
       "text": "preview",
       "classes": "app-tag--review"
     },
-    "classes": "app-phase-banner govuk-width-container",
+    "classes": "app-phase-banner app-width-container",
     "html": phaseBannerText
   }) }}
 {% else %}
@@ -24,7 +24,7 @@
       "tag": {
         "text": "beta"
       },
-      "classes": "app-phase-banner govuk-width-container",
+      "classes": "app-phase-banner app-width-container",
       "html": "This is a new service – your <a class=\"govuk-link\" href=\"/get-in-touch\">feedback</a> will help us to improve it."
     }) }}
   {% endif %}

--- a/views/partials/_cookie-banner.njk
+++ b/views/partials/_cookie-banner.njk
@@ -1,4 +1,4 @@
 
 <div class="app-cookie-banner js-cookie-banner">
-  <p class="govuk-width-container">GOV.UK uses cookies to make the site simpler. <a href="/cookies" class="govuk-link">Find out more about cookies</a></p>
+  <p class="app-width-container">GOV.UK uses cookies to make the site simpler. <a href="/cookies" class="govuk-link">Find out more about cookies</a></p>
 </div>

--- a/views/partials/_footer.njk
+++ b/views/partials/_footer.njk
@@ -2,7 +2,7 @@
 
 {{ govukFooter({
   "classes": "app-footer app-footer--full",
-  "containerClasses" : "app-site-width-container",
+  "containerClasses" : "app-width-container",
   "navigation": [
     {
       "title": "Related resources",

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -1,5 +1,5 @@
 <header class="govuk-header app-header" role="banner" data-module="govuk-header">
-  <div class="govuk-header__container govuk-width-container app-header__container">
+  <div class="govuk-header__container app-width-container app-header__container">
     <div class="govuk-header__logo app-header__logo">
       <a href="/" class="govuk-header__link govuk-header__link--homepage">
         <span class="govuk-header__logotype">

--- a/views/partials/_masthead.njk
+++ b/views/partials/_masthead.njk
@@ -1,5 +1,5 @@
 <div class="app-masthead">
-  <div class="govuk-width-container app-site-width-container">
+  <div class="app-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-xl app-masthead__title">Design your service using GOV.UK styles, components and&nbsp;patterns</h1>

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -1,5 +1,5 @@
 <nav class="app-navigation govuk-clearfix">
-  <ul class="app-navigation__list govuk-width-container">
+  <ul class="app-navigation__list app-width-container">
     {% for item in navigation %}
     <li class="app-navigation__list-item{% if path == item.url or item.url and path.startsWith(item.url) %} app-navigation__list-item--current{% endif %}">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/{{ item.url }}/" data-topnav="{{ item.label }}">{{ item.label }}</a>


### PR DESCRIPTION
By introducing an application specific width container we make sure the examples within the Design System are the default width.

This commit also tidies up some unused class names.

Fixes https://github.com/alphagov/govuk-design-system/issues/798