### PR TITLE
Add autocomplete values for address fields

### DIFF
--- a/src/patterns/addresses/error/index.njk
+++ b/src/patterns/addresses/error/index.njk
@@ -15,5 +15,6 @@ layout: layout-example.njk
   value: "Not a postcode",
   errorMessage: {
     text: "Enter a real postcode"
-  }
+  },
+  autocomplete: "postal-code"
 }) }}

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -21,7 +21,8 @@ stylesheets:
       html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
     },
     id: "address-line-1",
-    name: "address-line-1"
+    name: "address-line-1",
+    autocomplete: "address-line1"
   }) }}
 
   {{ govukInput({
@@ -29,7 +30,8 @@ stylesheets:
       html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
     },
     id: "address-line-2",
-    name: "address-line-2"
+    name: "address-line-2",
+    autocomplete: "address-line2"
   }) }}
 
   {{ govukInput({
@@ -38,7 +40,8 @@ stylesheets:
     },
     classes: "govuk-!-width-two-thirds",
     id: "address-town",
-    name: "address-town"
+    name: "address-town",
+    autocomplete: "address-level2"
   }) }}
 
   {{ govukInput({
@@ -56,7 +59,8 @@ stylesheets:
     },
     classes: "govuk-input--width-10",
     id: "address-postcode",
-    name: "address-postcode"
+    name: "address-postcode",
+    autocomplete: "postal-code"
   }) }}
 
 {% endcall %}


### PR DESCRIPTION
I have avoided adding an autocomplete for county as the specification talks about 'post towns', and county is an optional field.

> The broadest administrative level in the address, i.e. the province within which the locality is found; for example, in the US, this would be the state; in Switzerland it would be the canton; in the UK, the post town.

https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-address-level1

This is based on research done by the community:

https://github.com/alphagov/govuk-design-system/issues/1090#issuecomment-557045858

I'm not sure if there's any content changes to support this, for example we talk about these values here and there might be some tweaks needed: 

https://design-system.service.gov.uk/patterns/addresses/#use-the-autocomplete-attribute-on-multiple-address-fields

Closes https://github.com/alphagov/govuk-design-system/issues/1090
