### PR TITLE
Add logit-ssl-drain service to PaaS manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,10 @@
 ---
 applications:
 - name: govuk-design-system-origin
+  # Send application logs to logit
+  # https://docs.cloud.service.gov.uk/monitoring_apps.html#configure-app
+  services:
+    - logit-ssl-drain
   routes:
     - route: govuk-design-system-origin.cloudapps.digital
     - route: design-system.service.gov.uk


### PR DESCRIPTION
Since we create new applications when we deploy using blue/green deployment, we need to specifiy the service that sends logs so it's applied on deployment.