### PR TITLE
Remove Amy

### DIFF
--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -14,7 +14,6 @@ If you want to contact the team you can
 
 ## Members
 
-- Amy Hupe – Senior Content Designer
 - Hanna Laakso – Frontend Developer
 - Kelly Lee – Delivery Manager
 - Mark Green – Technical Writer


### PR DESCRIPTION
Amy left GDS on 19 December so removing her from the team page.