### PR TITLE
Amend assetURL description with 2i fix

### DIFF
--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -148,7 +148,7 @@ Variables can be set with:
 
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">assetUrl</td>
-      <td class="govuk-table__cell">Set the domain for the Open Graph meta tag image asset. If you need to use both your own domain and your own image path and filename, add <code>&lt;meta property="og:image" content="YOUR-ABSOLUTE-URL"&gt;</code> inside the <code>head</code> <a href="#blocks">block</a> instead.</td>
+      <td class="govuk-table__cell">Set the domain for the Open Graph meta tag image asset. If you need to use both your own domain and your own image path and filename, add <code>&lt;meta property="og:image" content="YOUR-ABSOLUTE-URL"&gt;</code> inside the <code>head</code> <a href="#blocks">block</a> instead of using `assetUrl`.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This adds a minor bit of clarification to the description of the `assetUrl` variable in Page template, as suggested by a 2ier.