### PR TITLE
Discard unused partial

### DIFF
--- a/views/partials/_toc-styles.njk
+++ b/views/partials/_toc-styles.njk
@@ -1,7 +1,0 @@
-<nav class="app-toc">
-  <ul class="app-toc__section">
-    <li class="app-toc__section-item{% if path == 'styles/typography' %} app-toc__section-item--current{% endif %}">
-      <a class="govuk-link" href="/styles/typography/">Typography</a>
-    </li>
-  </ul>
-</nav>


### PR DESCRIPTION
This file was introduced in 88269ad but has not been used since 402c5c4. When _toc-components.njk and _toc-patterns.njk were removed, this should have been removed as well.