### PR TITLE
Update borders to match current start page design

### DIFF
--- a/src/patterns/start-pages/default/related-items.scss
+++ b/src/patterns/start-pages/default/related-items.scss
@@ -5,7 +5,7 @@
 
 .app-related-items {
   padding-top: govuk-spacing(2);
-  border-top: 10px solid govuk-colour("blue");
+  border-top: 2px solid govuk-colour("blue");
 }
 
 .app-related-items li {


### PR DESCRIPTION
## Before

<img width="1392" alt="Screenshot 2020-01-03 at 17 33 27GMT" src="https://user-images.githubusercontent.com/121939/71738690-4b5e8080-2e4f-11ea-9de3-5f4ffc47f237.png">


## After

<img width="1392" alt="Screenshot 2020-01-03 at 17 33 55GMT" src="https://user-images.githubusercontent.com/121939/71738697-4f8a9e00-2e4f-11ea-9df6-2b2b0fe93ad4.png">


## Current Start Page

<img width="1392" alt="Screenshot 2020-01-03 at 17 34 03GMT" src="https://user-images.githubusercontent.com/121939/71738701-531e2500-2e4f-11ea-962a-fa5aec4f4b11.png">
