### PR TITLE
Update 'Open in new window' design

### DIFF
--- a/src/styles/page-template/block-areas/index.njk
+++ b/src/styles/page-template/block-areas/index.njk
@@ -8,8 +8,6 @@ stylesheets:
 
 {% extends "govuk/template.njk" %}
 
-{% set bodyClasses = "app-example-page" %}
-
 {% block head -%}
   {# Since we’re not extending the Design System layout we need to add this manually #}
   <meta name="robots" content="noindex, nofollow">

--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -22,12 +22,11 @@
 .app-example__toolbar {
   padding: 10px;
   border-bottom: 1px solid $govuk-border-colour;
-  background: $app-light-grey;
+  background: $govuk-body-background-colour;
 }
 
 .app-example__new-window {
   @include govuk-font(14);
-  text-decoration: none;
 }
 
 .app-example__frame {

--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -2,13 +2,13 @@
 .app-example-wrapper {
   @include govuk-responsive-margin(6, "top");
   @include govuk-responsive-margin(6, "bottom");
-  @include govuk-font(19);
 }
 
 .app-example {
   position: relative;
   border: 1px solid $govuk-border-colour;
-  background: govuk-colour("light-grey");
+  // Add a 'checkerboard' background
+  background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQoU2P88ePHfwY0wMHBwYguxjgUFKI7GsTH5m4M3w1ChQAZTSeO0/AZpgAAAABJRU5ErkJggg==") repeat;
 }
 
 .app-example--tabs {
@@ -19,22 +19,15 @@
   }
 }
 
-.app-example__new-window {
-  position: absolute;
-  z-index: 1;
-  top: 0;
-  left: 0;
-  padding: 5px govuk-spacing(2);
-  @include govuk-font(14);
-  background: govuk-colour("light-grey");
-  text-decoration: none;
+.app-example__toolbar {
+  padding: 10px;
+  border-bottom: 1px solid $govuk-border-colour;
+  background: $app-light-grey;
+}
 
-  // Override the focus state to remove the top 'yellow' shadow to avoid
-  // spilling out from the parent container. The yellow part of the focused link
-  // is already bigger than usual because of its padding.
-  .app-prose-scope &:focus {
-    box-shadow: 0 4px 0 0 $govuk-focus-text-colour;
-  }
+.app-example__new-window {
+  @include govuk-font(14);
+  text-decoration: none;
 }
 
 .app-example__frame {
@@ -76,4 +69,8 @@
   @include govuk-media-query($from: desktop) {
     resize: both;
   }
+}
+
+.app-example__code {
+  @include govuk-font($size: 19);
 }

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -173,7 +173,7 @@ body {
 }
 
 .app-example-page {
-  padding: govuk-spacing(6) * 2 govuk-spacing(6) govuk-spacing(6);
+  padding: govuk-spacing(6);
 }
 
 .app-example-page--full-page {

--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -1,5 +1,4 @@
 {% extends "govuk/template.njk" %}
-{% set bodyClasses = 'app-example-page' %}
 {% block pageTitle %}{{ title }} – Example – GOV.UK Design System{% endblock %}
 {% block head %}
   <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -29,12 +29,14 @@
 <div class="app-example-wrapper" id="{{ exampleId }}" data-module="app-tabs">
   {% if display %}
   <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
-    <a href="{{ exampleURL }}" class="app-example__new-window" target="_blank">
-      Open this
-      {# Don't use full title visually as the context is shown based on location of this link #}
-      <span class="govuk-visually-hidden">{{ exampleTitle | lower }}</span>
-      example in a new window
-    </a>
+    <div class="app-example__toolbar">
+      <a href="{{ exampleURL }}" class="app-example__new-window" target="_blank">
+        Open this
+        {# Don't use full title visually as the context is shown based on location of this link #}
+        <span class="govuk-visually-hidden">{{ exampleTitle | lower }}</span>
+        example in a new window
+      </a>
+    </div>
     <iframe title="{{ exampleTitle + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0" loading="lazy"></iframe>
   </div>
   {% endif %}
@@ -62,9 +64,11 @@
   <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
   {% endif %}
   <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-html" role="tabpanel">
-    <pre data-module="app-copy"><code class="hljs html">
-      {{- getHTMLCode(examplePath) | highlight('html') | safe -}}
-    </code></pre>
+    <div class="app-example__code">
+      <pre data-module="app-copy"><code class="hljs html">
+        {{- getHTMLCode(examplePath) | highlight('html') | safe -}}
+      </code></pre>
+    </div>
   </div>
   {% endif %}
 
@@ -142,9 +146,11 @@
         }
       })}}
     {% endif %}
-    <pre data-module="app-copy"><code class="hljs js">
-      {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
-    </code></pre>
+    <div class="app-example__code">
+      <pre data-module="app-copy"><code class="hljs js">
+        {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
+      </code></pre>
+    </div>
   </div>
   {% endif %}
 </div>


### PR DESCRIPTION
Update the 'Open in new window' link so that it sits within its own 'toolbar', rather than overlapping the example.

## Before

<img width="1392" alt="Screenshot 2020-01-06 at 10 39 51" src="https://user-images.githubusercontent.com/121939/71814196-9ce75500-3073-11ea-8d6c-6635228b8b2d.png">

## After
<img width="1392" alt="Screenshot 2020-01-06 at 10 39 50" src="https://user-images.githubusercontent.com/121939/71814197-9ce75500-3073-11ea-9127-336326b09a38.png">


This allows us to remove the padding from full-page examples without the open in new window link overlapping the header, and simplifies things like the focus state.

## Before

<img width="1392" alt="Screenshot 2020-01-06 at 10 39 42" src="https://user-images.githubusercontent.com/121939/71814163-85a86780-3073-11ea-9e97-45633f4325f6.png">

## After
<img width="1392" alt="Screenshot 2020-01-06 at 10 39 35" src="https://user-images.githubusercontent.com/121939/71814165-85a86780-3073-11ea-901a-43a7dcf4ad3b.png">

It also updates the 'canvas' behind the example (seen only when resizing the example) to a 'checkerboard' design.

## Before

<img width="1392" alt="Screenshot 2020-01-06 at 10 47 47" src="https://user-images.githubusercontent.com/121939/71814235-ab357100-3073-11ea-8d61-71d64b0e368b.png">

## After

<img width="1392" alt="Screenshot 2020-01-06 at 10 47 49" src="https://user-images.githubusercontent.com/121939/71814237-ab357100-3073-11ea-9835-a4e38ecae7bb.png">
