### PR TITLE
Fix example form submission prevention

### DIFF
--- a/src/javascripts/example.js
+++ b/src/javascripts/example.js
@@ -21,5 +21,4 @@ ExamplePage.prototype.preventFormSubmission = function ($form) {
   })
 }
 
-var $examplePageContainer = document.querySelector('.app-example-page')
-new ExamplePage($examplePageContainer).init()
+new ExamplePage(document).init()


### PR DESCRIPTION
I'm unclear how this wasn't picked up by CI in #1116 but we removed the `app-example-page` class from full page examples, which this Javascript relies on to prevent form submissions within examples.

As this is only included in full page examples, we can just initialise on the whole document.