### PR TITLE
Don't unneccesarily self-close tags

### DIFF
--- a/src/__canary__.html
+++ b/src/__canary__.html
@@ -5,7 +5,7 @@ ignore_in_sitemap: true
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <meta name="robots" content="noindex">
     <title>200 OK</title>
   </head>

--- a/src/patterns/step-by-step-navigation/index.md.njk
+++ b/src/patterns/step-by-step-navigation/index.md.njk
@@ -145,17 +145,17 @@ It’s not currently possible to include step by step navigation on confirmation
 
 This pattern is commonly used across GOV.UK. You can see examples of it being used in the following services.
 
-**Driver and Vehicle Standards Agency**<br/>
+**Driver and Vehicle Standards Agency**<br>
 Learn to drive a car
 
-**Department for Work and Pensions**<br/>
-Employ someone<br/>
+**Department for Work and Pensions**<br>
+Employ someone<br>
 What to do when someone dies
 
-**UK Visas and Immigration**<br/>
+**UK Visas and Immigration**<br>
 Visit the UK on a Standard Visitor visa
 
-**Department for Transport**<br/>
+**Department for Transport**<br>
 Get a Blue Badge
 
 See a full list of [live services using step by step navigation](https://live-stuff.herokuapp.com/step-by-steps).

--- a/src/styles/page-template/block-areas/index.njk
+++ b/src/styles/page-template/block-areas/index.njk
@@ -13,15 +13,15 @@ stylesheets:
   <meta name="robots" content="noindex, nofollow">
 
   <!--[if !IE 8]><!-->
-    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all">
   <!--<![endif]-->
   <!--[if lt IE 9]>
-    <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all">
     <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
   <script src="/javascripts/vendor/modernizr.js"></script>
   {% for stylesheet in stylesheets %}
-    <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all">
   {%- endfor %}
 {%- endblock %}
 

--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -34,13 +34,13 @@ ignore_in_sitemap: true
 
 {% block head %}
   <!--[if !IE 8]><!-->
-    <link href="/govuk-frontend/all.css" rel="stylesheet" />
+    <link href="/govuk-frontend/all.css" rel="stylesheet">
   <!--<![endif]-->
 
   {# For Internet Explorer 8, you need to compile specific stylesheet #}
   {# see https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/supporting-internet-explorer-8.md #}
   <!--[if IE 8]>
-    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet" />
+    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
   <![endif]-->
 
   {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -35,10 +35,10 @@ ignore_in_sitemap: true
 {% block head %}
   <meta name="robots" content="noindex, nofollow">
   <!--[if !IE 8]><!-->
-    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all">
   <!--<![endif]-->
   <!--[if lt IE 9]>
-    <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all">
     <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
   <script src="/javascripts/vendor/modernizr.js"></script>

--- a/src/styles/page-template/default/code.njk
+++ b/src/styles/page-template/default/code.njk
@@ -7,13 +7,13 @@ ignore_in_sitemap: true
 
 {% block head %}
   <!--[if !IE 8]><!-->
-    <link href="/govuk-frontend/govuk/all.css" rel="stylesheet" />
+    <link href="/govuk-frontend/govuk/all.css" rel="stylesheet">
   <!--<![endif]-->
 
   {# For Internet Explorer 8, you need to compile specific stylesheet #}
   {# see https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/supporting-internet-explorer-8.md #}
   <!--[if IE 8]>
-    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet" />
+    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
   <![endif]-->
 
   {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}

--- a/src/styles/page-template/default/index.njk
+++ b/src/styles/page-template/default/index.njk
@@ -7,10 +7,10 @@ layout: false
 {% block head %}
   <meta name="robots" content="noindex, nofollow">
   <!--[if !IE 8]><!-->
-    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all">
   <!--<![endif]-->
   <!--[if lt IE 9]>
-    <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all">
     <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
   <script src="/javascripts/vendor/modernizr.js"></script>


### PR DESCRIPTION
We're currently inconsistent as to whether we self-close void elements or not.

The self-closing / has no effect on the start tags of void elements in HTML5.[1]

For this reason, we should standardise on omitting them.

[1]: https://html.spec.whatwg.org/dev/syntax.html#start-tags