### PR TITLE
Add pages to redirect users from removed pages

### DIFF
--- a/src/community/how-you-can-contribute.md.njk
+++ b/src/community/how-you-can-contribute.md.njk
@@ -1,0 +1,6 @@
+---
+title: How you can contribute
+destination: /community/
+layout: layout-redirect.njk
+ignore_in_sitemap: true
+---

--- a/src/cookies.md.njk
+++ b/src/cookies.md.njk
@@ -1,0 +1,6 @@
+---
+title: Cookies
+destination: /privacy-policy/
+layout: layout-redirect.njk
+ignore_in_sitemap: true
+---

--- a/views/layouts/layout-redirect.njk
+++ b/views/layouts/layout-redirect.njk
@@ -1,0 +1,15 @@
+{% extends "layout-single-page.njk" %}
+
+{% set contents %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">This page has been archived</h1>
+    <p class="govuk-body">
+        You can view the up to date information about
+        <a class="govuk-link" href="{{ destination }}">{{ title }}</a>.
+    </p>
+  </div>
+</div>
+{% endset %}
+
+{% set title = title + ' page has been archived' %}

--- a/views/layouts/layout-redirect.njk
+++ b/views/layouts/layout-redirect.njk
@@ -1,5 +1,11 @@
 {% extends "layout-single-page.njk" %}
 
+{% block head %}
+  {{ super() }}
+  {# Make sure redirect pages are not indexed by search engines #}
+  <meta name="robots" content="noindex">
+{% endblock %}
+
 {% set contents %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
Simpler approach to solve: https://github.com/alphagov/govuk-design-system/pull/1135

We decided against:

- updating the nginx configuration as we're worried it could break the live site and don't have a staging environment
- using meta refresh or JavaScript to automatically redirect the page as we're not sure the impact it could have on people using assistive technologies.

Content tries to mirror the [Page not found pattern](https://design-system.service.gov.uk/patterns/page-not-found-pages/)

Closes https://github.com/alphagov/govuk-design-system/pull/1135

Closes https://github.com/alphagov/govuk-design-system/issues/536