### PR TITLE
Fix navigation top and bottom margins

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -14,6 +14,7 @@ $navigation-height: 50px;
 .app-navigation__list {
   position: relative;
   left: -(govuk-spacing(3));
+  margin: 0;
   padding: 0;
   list-style: none;
 }


### PR DESCRIPTION
We're using app-width-container on a `<ul>` here, which isn't something we generally expect people to do.

We were relying on the top and bottom margins being reset by app-width-container - since v3.5.0 this doesn't happen so the space above the navigation is now bigger.

Adding an explicit top and bottom margin to the app-navigation__list class fixes this.