### PR TITLE
Add guidance on how to ask users for numbers

### DIFF
--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -59,6 +59,18 @@ Fluid width inputs will resize with the viewport.
 
 {{ example({group: "components", item: "text-input", example: "input-fluid-width", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
+### Numbers
+
+If it’s likely that the user will need to enter a number and you want to bring up the numeric keypad on a mobile device, set the `inputmode` attribute to `numeric` and the `pattern` attribute to `[0-9]*`. See how to do this in the HTML and Nunjucks tabs in the following example.
+
+
+Do not use `<input type=”number”>` unless your user research shows that there’s a need for it. With `<input type=”number”>` there’s a risk of users accidentally incrementing a number when they’re trying to do something else - for example, scroll up or down the page. And if the user tries to enter something that’s not a number, there’s no explicit feedback about what they’re doing wrong.
+
+There are specific patterns for:
+
+- [dates](/patterns/dates/)
+- [telephone numbers](/patterns/telephone-numbers/)
+
 ### Hint text
 
 Use hint for help that’s relevant to the majority of users, like how their information will be used, or where to find it.

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -63,6 +63,7 @@ Fluid width inputs will resize with the viewport.
 
 If it’s likely that the user will need to enter a number and you want to bring up the numeric keypad on a mobile device, set the `inputmode` attribute to `numeric` and the `pattern` attribute to `[0-9]*`. See how to do this in the HTML and Nunjucks tabs in the following example.
 
+{{ example({group: "components", item: "text-input", example: "number-input", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 Do not use `<input type=”number”>` unless your user research shows that there’s a need for it. With `<input type=”number”>` there’s a risk of users accidentally incrementing a number when they’re trying to do something else - for example, scroll up or down the page. And if the user tries to enter something that’s not a number, there’s no explicit feedback about what they’re doing wrong.
 

--- a/src/components/text-input/number-input/index.njk
+++ b/src/components/text-input/number-input/index.njk
@@ -1,0 +1,23 @@
+---
+title: Number input
+layout: layout-example.njk
+---
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "Account number"
+  },
+  classes: "govuk-input--width-10",
+  hint: {
+    text: "Must be between 6 and 8 digits long"
+  },
+  id: "account-number",
+  name: "account-number",
+  inputmode: "numeric",
+  pattern: "[0-9]*",
+  attributes: {
+    spellcheck: "false"
+  }
+}) }}

--- a/src/patterns/bank-details/default/index.njk
+++ b/src/patterns/bank-details/default/index.njk
@@ -29,10 +29,10 @@ layout: layout-example.njk
   },
   id: "sort-code",
   name: "sort-code",
+  inputmode: "numeric",
+  pattern: "[0-9]*",
   attributes: {
-    spellcheck: "false",
-    inputmode: "numeric",
-    pattern: "[0-9]*"
+    spellcheck: "false"
   }
 }) }}
 
@@ -46,10 +46,10 @@ layout: layout-example.njk
   },
   id: "account-number",
   name: "account-number",
+  inputmode: "numeric",
+  pattern: "[0-9]*",
   attributes: {
-    spellcheck: "false",
-    inputmode: "numeric",
-    pattern: "[0-9]*"
+    spellcheck: "false"
   }
 }) }}
 

--- a/src/patterns/bank-details/error/index.njk
+++ b/src/patterns/bank-details/error/index.njk
@@ -16,10 +16,10 @@ layout: layout-example.njk
   value: "12",
   id: "sort-code",
   name: "sort-code",
+  inputmode: "numeric",
+  pattern: "[0-9]*",
   attributes: {
-    spellcheck: "false",
-    inputmode: "numeric",
-    pattern: "[0-9]*"
+    spellcheck: "false"
   },
   errorMessage: {
     text: "Enter a valid sort code like 309430"


### PR DESCRIPTION
This PR:
- Adds guidance on asking users for numbers
- Adds a code example
- Updates the bank details pattern to use the [new number input API](https://github.com/alphagov/govuk-frontend/pull/1527)

Fixes https://github.com/alphagov/govuk-design-system/issues/1128