### PR TITLE
Add information on using the design system

### DIFF
--- a/src/get-started/index.md.njk
+++ b/src/get-started/index.md.njk
@@ -7,10 +7,19 @@ show_subnav: true
 
 The examples in the GOV.UK Design System come with code to make it easy for you to use them in your project. 
 
-Get started:
-
+There are guides to getting started:
 
 - [prototyping](prototyping)
 - [in production](production)
 
-If you’ve used GOV.UK Elements, GOV.UK Template or the GOV.UK Frontend Toolkit before, you might also find it useful to read the guide on [updating your code](updating-your-code).
+If you’re currently working with one of our legacy products - GOV.UK Elements, GOV.UK Template or the GOV.UK Frontend Toolkit - you might find the guide on [updating your code](updating-your-code) useful.
+
+## Using styles, components and patterns
+
+When something is published in the design system as a [style](/styles/), [component](/components/) or [pattern](/patterns/) we include details of how and when it’s been tested in user research. This should help you decide whether it’s something you can re-use or adapt for your service.
+
+You can ask questions or share your views on how to use a style, component or pattern by joining the discussion on GitHub. There are links at the end of each style, component and pattern page - under the ‘Help improve this page’ heading.
+
+Bear in mind that ideas discussed on GitHub may not have been tested. You can use them as a starting point, but it’s important to carry out user research to check that they work for your service. Then when you’ve carried out your user research, add your findings to the relevant discussion.
+
+GitHub discussions are open to everyone, including members of the public. The views expressed there are the views of individuals and not the views of the [GOV.UK Design System team](/design-system-team/).

--- a/src/get-started/index.md.njk
+++ b/src/get-started/index.md.njk
@@ -12,13 +12,15 @@ There are guides to getting started:
 - [prototyping](prototyping)
 - [in production](production)
 
-If you’re currently working with one of our legacy products - GOV.UK Elements, GOV.UK Template or the GOV.UK Frontend Toolkit - you might find the guide on [updating your code](updating-your-code) useful.
+You may find the [guide on updating your code](updating-your-code) useful if you’re currently working with one of our legacy products - GOV.UK Elements, GOV.UK Template or the GOV.UK Frontend Toolkit.
 
 ## Using styles, components and patterns
 
 When something is published in the design system as a [style](/styles/), [component](/components/) or [pattern](/patterns/) we include details of how and when it’s been tested in user research. This should help you decide whether it’s something you can re-use or adapt for your service.
 
 You can ask questions or share your views on how to use a style, component or pattern by joining the discussion on GitHub. There are links at the end of each style, component and pattern page - under the ‘Help improve this page’ heading.
+
+## GitHub discussions about styles, components and patterns
 
 Bear in mind that ideas discussed on GitHub may not have been tested. You can use them as a starting point, but it’s important to carry out user research to check that they work for your service. Then when you’ve carried out your user research, add your findings to the relevant discussion.
 

--- a/src/get-started/index.md.njk
+++ b/src/get-started/index.md.njk
@@ -12,13 +12,13 @@ There are guides to getting started:
 - [prototyping](prototyping)
 - [in production](production)
 
-You may find the [guide on updating your code](updating-your-code) useful if you’re currently working with one of our legacy products - GOV.UK Elements, GOV.UK Template or the GOV.UK Frontend Toolkit.
+You may find the [guide on updating your code](updating-your-code) useful if you’re working with one of our legacy products - GOV.UK Elements, GOV.UK Template or the GOV.UK Frontend Toolkit.
 
 ## Using styles, components and patterns
 
-When something is published in the design system as a [style](/styles/), [component](/components/) or [pattern](/patterns/) we include details of how and when it’s been tested in user research. This should help you decide whether it’s something you can re-use or adapt for your service.
+When something is published in the GOV.UK design system as a [style](/styles/), [component](/components/) or [pattern](/patterns/) we include details of how and when it’s been tested in user research. This should help you decide whether it’s something you can use or adapt for your service.
 
-You can ask questions or share your views on how to use a style, component or pattern by joining the discussion on GitHub. There are links at the end of each style, component and pattern page - under the ‘Help improve this page’ heading.
+You can ask questions or share your research by joining the discussion on GitHub. There are links at the end of each style, component and pattern page - under the ‘Help improve this page’ heading.
 
 ## GitHub discussions about styles, components and patterns
 


### PR DESCRIPTION
Adds information the help users understand:

- the difference between published styles, components and patterns vs ideas in GitHub discussions
- that GitHub discussions are open - so the views expressed aren't "official" in any sense

Closes https://github.com/alphagov/design-system-team-internal/issues/211