### PR TITLE
Remove full stop on email line of contact panel

### DIFF
--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -61,7 +61,7 @@
       by email at
       <a class="govuk-link app-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">
         govuk-design-system-support@digital.cabinet-office.gov.uk
-      </a>.
+      </a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/37163/75754406-9ba97000-5d24-11ea-94e2-d5fee63aa409.png)

After:

![image](https://user-images.githubusercontent.com/37163/75754424-a2d07e00-5d24-11ea-9ea2-04f66f1ed41e.png)
