### PR TITLE
Update deployment docs

### DIFF
--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -29,7 +29,7 @@ Travis is deployed using [deploy-travis](bin/deploy-travis).
 
 We log into CloudFoundry using the configured environment variables. We then run a smoke test to make sure that the app built correctly.
 
-## Hosting on Platform as a Service
+## Hosting on GOV.UK Platform as a Service (PaaS)
 
 We deploy to the `govuk-design-system-origin` app using the
 [blue-green-deploy][bgd] plugin.
@@ -40,6 +40,8 @@ credentials for which can be found in our credential store.
 
 We use an [application manifest](../../manifest.yml) to configure the app name
 and the type of buildpack that we want to use.
+
+See [PaaS documentation](https://docs.cloud.service.gov.uk/) for how to sign in and deploy apps.
 
 ### nginx
 


### PR DESCRIPTION
We don't want to replicate PaaS's documentation on signing in and deploying apps so would expect team members to consult PaaS docs to do those things. Useful to have a link to it here. 

Also made the naming a bit clearer since "Platform as a Service" is a computing concept by itself so wanted to clarify that we're talking about the GOV.UK service.