### PR TITLE
Remove IP addresses in logs from data collected

### DIFF
--- a/src/privacy-policy.md.njk
+++ b/src/privacy-policy.md.njk
@@ -13,7 +13,6 @@ We collect:
 
 - questions, queries or feedback you leave
 - your email address, if you contact us
-- your Internet Protocol (IP) address, which is anonymised before it's stored in our server logs
 
 This data can be viewed by authorised people in the [Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service) (GDS) and our suppliers, to:
 


### PR DESCRIPTION
We have [dropped IP addresses from our logs entirely](https://github.com/alphagov/govuk-design-system/pull/1158) so we can update the privacy policy to reflect this

Closes https://github.com/alphagov/design-system-team-internal/issues/269