### PR TITLE
Change default heading size and update guidance

### DIFF
--- a/src/components/character-count/label-page-heading/index.njk
+++ b/src/components/character-count/label-page-heading/index.njk
@@ -9,7 +9,7 @@ layout: layout-example.njk
   maxlength: 200,
   label: {
     text: "Describe the nature of your event",
-    classes: "govuk-label--xl",
+    classes: "govuk-label--l",
     isPageHeading: true
   }
 }) }}

--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -52,7 +52,7 @@ layout: layout-example.njk
     legend: {
       text: "How would you like to be contacted?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/checkboxes/default/index.njk
+++ b/src/components/checkboxes/default/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "Which types of waste do you transport?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/checkboxes/error/index.njk
+++ b/src/components/checkboxes/error/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "What is your nationality?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/checkboxes/hint/index.njk
+++ b/src/components/checkboxes/hint/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "What is your nationality?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/date-input/date-of-birth/index.njk
+++ b/src/components/date-input/date-of-birth/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "What is your date of birth?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/date-input/default/index.njk
+++ b/src/components/date-input/default/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "When was your passport issued?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/date-input/error/index.njk
+++ b/src/components/date-input/error/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "When was your passport issued?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/error-message/default/index.njk
+++ b/src/components/error-message/default/index.njk
@@ -10,7 +10,7 @@ layout: layout-example.njk
     legend: {
       text: "When was your passport issued?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/error-message/legend/index.njk
+++ b/src/components/error-message/legend/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "What is your nationality?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/error-summary/full-page-example/index.njk
+++ b/src/components/error-summary/full-page-example/index.njk
@@ -35,7 +35,7 @@ layout: layout-example-full-page.njk
             legend: {
               isPageHeading: true,
               text: 'When was your passport issued?',
-              classes: 'govuk-fieldset__legend--xl'
+              classes: 'govuk-fieldset__legend--l'
             }
           },
           id: 'passport-issued',

--- a/src/components/error-summary/linking-checkboxes-radios/index.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/index.njk
@@ -23,7 +23,7 @@ layout: layout-example.njk
     legend: {
       text: "What is your nationality?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/error-summary/linking-multiple-fields/index.njk
+++ b/src/components/error-summary/linking-multiple-fields/index.njk
@@ -21,7 +21,7 @@ layout: layout-example.njk
     legend: {
       isPageHeading: true,
       text: 'When was your passport issued?',
-      classes: 'govuk-fieldset__legend--xl'
+      classes: 'govuk-fieldset__legend--l'
     }
   },
   id: 'passport-issued',

--- a/src/components/error-summary/linking/index.njk
+++ b/src/components/error-summary/linking/index.njk
@@ -16,7 +16,7 @@ layout: layout-example.njk
   ]
 }) }}
 
-<h1 class="govuk-heading-xl">Your details</h1>
+<h1 class="govuk-heading-l">Your details</h1>
 
 {{ govukInput({
   label: {

--- a/src/components/fieldset/address-group/index.njk
+++ b/src/components/fieldset/address-group/index.njk
@@ -11,7 +11,7 @@ stylesheets:
 {% call govukFieldset({
   legend: {
     text: "What is your address?",
-    classes: "govuk-fieldset__legend--xl",
+    classes: "govuk-fieldset__legend--l",
     isPageHeading: true
   }
 }) %}

--- a/src/components/fieldset/default/index.njk
+++ b/src/components/fieldset/default/index.njk
@@ -8,7 +8,7 @@ layout: layout-example.njk
 {{ govukFieldset({
   legend: {
     text: "Legend as page heading",
-    classes: "govuk-fieldset__legend--xl",
+    classes: "govuk-fieldset__legend--l",
     isPageHeading: true
   }
 }) }}

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -52,7 +52,7 @@ layout: layout-example.njk
     legend: {
       text: "How would you prefer to be contacted?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/radios/default/index.njk
+++ b/src/components/radios/default/index.njk
@@ -13,7 +13,7 @@ layout: layout-example.njk
     legend: {
       text: "Have you changed your name?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/radios/divider/index.njk
+++ b/src/components/radios/divider/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "Where do you live?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   items: [

--- a/src/components/radios/error/index.njk
+++ b/src/components/radios/error/index.njk
@@ -13,7 +13,7 @@ layout: layout-example.njk
     legend: {
       text: "Have you changed your name?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/radios/hint/index.njk
+++ b/src/components/radios/hint/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "How do you want to sign in?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/components/radios/stacked/index.njk
+++ b/src/components/radios/stacked/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "Where do you live?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   items: [

--- a/src/errors/404.njk
+++ b/src/errors/404.njk
@@ -6,7 +6,7 @@ ignore_in_sitemap: true
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Page not found</h1>
+    <h1 class="govuk-heading-l">Page not found</h1>
 
     <p class="govuk-body">If you typed the web address, check it is correct.</p>
     <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>

--- a/src/errors/generic.njk
+++ b/src/errors/generic.njk
@@ -6,7 +6,7 @@ ignore_in_sitemap: true
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
     <p class="govuk-body-l">Try again later.</p>
 
     <p class="govuk-body">

--- a/src/get-started/labels-legends-headings/label-h1/index.njk
+++ b/src/get-started/labels-legends-headings/label-h1/index.njk
@@ -7,12 +7,12 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    text: "govuk-label--xl",
-    classes: "govuk-label--xl",
+    text: "govuk-label--l",
+    classes: "govuk-label--l",
     isPageHeading: true
   },
   hint: {
-    text: "This example shows an <h1> around a <label> with the class of govuk-label--xl"
+    text: "This example shows an <h1> around a <label> with the class of govuk-label--l"
   },
   id: "example",
   name: "example"

--- a/src/get-started/labels-legends-headings/legend-h1/index.njk
+++ b/src/get-started/labels-legends-headings/legend-h1/index.njk
@@ -12,13 +12,13 @@ layout: layout-example.njk
   name: "checkbox",
   fieldset: {
     legend: {
-      text: "govuk-fieldset__legend--xl",
+      text: "govuk-fieldset__legend--l",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {
-    text: "This example shows an <h1> inside a <legend> with the class of govuk-fieldset__legend--xl."
+    text: "This example shows an <h1> inside a <legend> with the class of govuk-fieldset__legend--l."
   },
   items: [
     {

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -11,7 +11,7 @@ stylesheets:
 {% call govukFieldset({
   legend: {
     text: "What is your address?",
-    classes: "govuk-fieldset__legend--xl",
+    classes: "govuk-fieldset__legend--l",
     isPageHeading: true
   }
 }) %}

--- a/src/patterns/bank-details/branch/index.njk
+++ b/src/patterns/bank-details/branch/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
   fieldset: {
     legend: {
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl",
+      classes: "govuk-fieldset__legend--l",
       text: "How do you want to be paid?"
     }
   },

--- a/src/patterns/bank-details/default/index.njk
+++ b/src/patterns/bank-details/default/index.njk
@@ -6,7 +6,7 @@ layout: layout-example.njk
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-<h1 class="govuk-heading-xl">Bank or building society account details</h1>
+<h1 class="govuk-heading-l">Bank or building society account details</h1>
 
 {{ govukInput({
   label: {

--- a/src/patterns/check-answers/default/index.njk
+++ b/src/patterns/check-answers/default/index.njk
@@ -20,7 +20,7 @@ layout: layout-example-full-page.njk
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
 
-      <h1 class="govuk-heading-xl">Check your answers before sending your application</h1>
+      <h1 class="govuk-heading-l">Check your answers before sending your application</h1>
 
       <h2 class="govuk-heading-m">Personal details</h2>
 

--- a/src/patterns/dates/default/index.njk
+++ b/src/patterns/dates/default/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "When was your passport issued?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/patterns/dates/error/index.njk
+++ b/src/patterns/dates/error/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "When was your passport issued?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/patterns/dates/memorable-date/index.njk
+++ b/src/patterns/dates/memorable-date/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "What is your date of birth?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {

--- a/src/patterns/ethnic-group/default/index.njk
+++ b/src/patterns/ethnic-group/default/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "What is your ethnic group?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   items: [

--- a/src/patterns/ethnic-group/error/index.njk
+++ b/src/patterns/ethnic-group/error/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "What is your ethnic group?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   errorMessage: {

--- a/src/patterns/page-not-found-pages/default/index.njk
+++ b/src/patterns/page-not-found-pages/default/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">Page not found</h1>
+        <h1 class="govuk-heading-l">Page not found</h1>
         <p class="govuk-body">
           If you typed the web address, check it is correct.
         </p>

--- a/src/patterns/problem-with-the-service-pages/default/index.njk
+++ b/src/patterns/problem-with-the-service-pages/default/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+      <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
       <p class="govuk-body">Try again later.</p>
       <p class="govuk-body">We saved your answers. They will be available for 30 days.</p>
       <p class="govuk-body">

--- a/src/patterns/problem-with-the-service-pages/link-to-another-service/index.njk
+++ b/src/patterns/problem-with-the-service-pages/link-to-another-service/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+      <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
       <p class="govuk-body">Try again later.</p>
       <p class="govuk-body">
         You can <a class="govuk-link" href="#">change other VAT details</a>.

--- a/src/patterns/problem-with-the-service-pages/offline-support/index.njk
+++ b/src/patterns/problem-with-the-service-pages/offline-support/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+      <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
       <p class="govuk-body">Try again later.</p>
       <p class="govuk-body">
         We have not saved your answers. When the service is available, you will have to start again.

--- a/src/patterns/question-pages/date-of-birth/index.njk
+++ b/src/patterns/question-pages/date-of-birth/index.njk
@@ -26,7 +26,7 @@ layout: layout-example-full-page.njk
             legend: {
               text: "What is your date of birth?",
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           hint: {

--- a/src/patterns/question-pages/default/index.njk
+++ b/src/patterns/question-pages/default/index.njk
@@ -27,7 +27,7 @@ layout: layout-example-full-page.njk
             legend: {
               text: "Where do you live?",
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           items: [

--- a/src/patterns/question-pages/passport/index.njk
+++ b/src/patterns/question-pages/passport/index.njk
@@ -19,7 +19,7 @@ layout: layout-example-full-page.njk
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Passport details</h1>
+      <h1 class="govuk-heading-l">Passport details</h1>
 
       <form action="/form-handler" method="post" novalidate>
 

--- a/src/patterns/question-pages/postcode/index.njk
+++ b/src/patterns/question-pages/postcode/index.njk
@@ -23,7 +23,7 @@ layout: layout-example-full-page.njk
         label: {
           text: "What is your home postcode?",
           isPageHeading: true,
-          classes: "govuk-label--xl"
+          classes: "govuk-label--l"
         },
         classes: "govuk-input--width-10",
         id: "postcode",

--- a/src/patterns/question-pages/progress/index.njk
+++ b/src/patterns/question-pages/progress/index.njk
@@ -3,7 +3,7 @@ title: Progress indicator – Question pages
 layout: layout-example.njk
 ---
 
-<span class="govuk-caption-xl">Question 3 of 9</span>
-<h1 class="govuk-heading-xl">
+<span class="govuk-caption-l">Question 3 of 9</span>
+<h1 class="govuk-heading-l">
  Your details
 </h1>

--- a/src/patterns/question-pages/section-headings/index.njk
+++ b/src/patterns/question-pages/section-headings/index.njk
@@ -3,7 +3,7 @@ title: Section headings – Question pages
 layout: layout-example.njk
 ---
 
-<span class="govuk-caption-xl">About you</span>
-<h1 class="govuk-heading-xl">
+<span class="govuk-caption-l">About you</span>
+<h1 class="govuk-heading-l">
   What is your home address?
 </h1>

--- a/src/patterns/service-unavailable-pages/after-service-closes/index.njk
+++ b/src/patterns/service-unavailable-pages/after-service-closes/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+    <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
     <p class="govuk-body">
       You cannot use the online service to renew your tax credits.
     </p>

--- a/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
+++ b/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+    <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
     <p class="govuk-body">
       You will be able to use the service on Monday 19&nbsp;November&nbsp;2018.
     </p>

--- a/src/patterns/service-unavailable-pages/before-service-opens/index.njk
+++ b/src/patterns/service-unavailable-pages/before-service-opens/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+    <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
     <p class="govuk-body">
       You will be able to renew your tax credits from Tuesday 24&nbsp;April&nbsp;2018.
     </p>

--- a/src/patterns/service-unavailable-pages/default/index.njk
+++ b/src/patterns/service-unavailable-pages/default/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+      <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
       <p class="govuk-body">
         You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.
       </p>

--- a/src/patterns/service-unavailable-pages/general/index.njk
+++ b/src/patterns/service-unavailable-pages/general/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+      <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
       <p class="govuk-body">
         You will be able to use the service later.
       </p>

--- a/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
+++ b/src/patterns/service-unavailable-pages/link-to-another-service/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+    <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
     <p class="govuk-body">
       You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.
     </p>

--- a/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
+++ b/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+    <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
     <p class="govuk-body">
       The submit an employment intermediary report service has closed.
     </p>

--- a/src/patterns/service-unavailable-pages/service-replaced/index.njk
+++ b/src/patterns/service-unavailable-pages/service-replaced/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+    <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
     <p class="govuk-body">Universal Credit has replaced tax credits.</p>
     <p class="govuk-body"><a class="govuk-link" href="#">
       Contact the Tax Credits Helpline</a> if you need to speak to someone about your tax credits.

--- a/src/patterns/start-pages/default/index.njk
+++ b/src/patterns/start-pages/default/index.njk
@@ -31,7 +31,7 @@ stylesheets:
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Service name goes here</h1>
+      <h1 class="govuk-heading-l">Service name goes here</h1>
 
       <p class="govuk-body">Use this service to:</p>
 

--- a/src/styles/images/representative/index.njk
+++ b/src/styles/images/representative/index.njk
@@ -7,7 +7,7 @@ stylesheets:
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Do you have a V11 reminder letter printed in your name?</h1>
+    <h1 class="govuk-heading-l">Do you have a V11 reminder letter printed in your name?</h1>
     <img src="v11.gif" alt="">
   </div>
 </div>

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -19,13 +19,11 @@ If you’re not sure whether you should be using GDS Transport, read the Service
 
 ## Headings
 
-Use headings consistently to create a clear hierarchy throughout your service.
+Mark up headings semantically using the appropriate <h#> level HTML element and use a heading class to apply the GOV.UK styling. 
 
-Mark up headings semantically using the appropriate <h#> level HTML element and use a heading class to apply the GOV.UK styling.
+The styling should reflect the hierarchy of the page. If your `h1` is styled as `govuk-heading-l`, your `h2`s should be styled as `govuk-heading-m` and so on.
 
-For long form content use the corresponding size class. For example an `<h1>` should use `govuk-heading-xl`, an `<h2>` should use `govuk-heading-l`.
-
-For [question pages](../../patterns/question-pages) and other short form content, try using the corresponding size class first. But change it if it makes the page feel unbalanced. For example, if you’re using an especially long question as your `<h1>`, try using `govuk-heading-l` for the `<h1>`, `govuk-heading-l` for the `<h2>` and so on.
+You should style headings consistently throughout your service. Use `govuk-heading-l` for your `h1`s by default. Use `govuk-heading-xl` for your `h1`s when your service has lots of longer pages with multiple levels of headings.
 
 Write all headings in sentence case.
 

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -19,11 +19,11 @@ If you’re not sure whether you should be using GDS Transport, read the Service
 
 ## Headings
 
-Mark up headings semantically using the appropriate <h#> level HTML element and use a heading class to apply the GOV.UK styling. 
+Mark up headings semantically using the appropriate <h#> level HTML element and use a heading class to apply the GOV.UK styling. Style headings consistently to create a clear visual hierarchy throughout your service.
 
-The styling should reflect the hierarchy of the page. If your `h1` is styled as `govuk-heading-l`, your `h2`s should be styled as `govuk-heading-m` and so on.
+If your service has lots of long form content, use the corresponding size class. For example an `<h1>` should use `govuk-heading-xl`, an `<h2>` should use `govuk-heading-l` and so on. 
 
-You should style headings consistently throughout your service. Use `govuk-heading-l` for your `h1`s by default. Use `govuk-heading-xl` for your `h1`s when your service has lots of longer pages with multiple levels of headings.
+If your service has lots of [question pages](../../patterns/question-pages), short form content or pages with long headings, start with `govuk-heading-l` for an `<h1>`. But change it if your pages feel unbalanced – semantic and visual hierarchy do not always need to be the same.
 
 Write all headings in sentence case.
 


### PR DESCRIPTION
Made some changes to: 
- change the default heading size on examples from `govuk-heading-xl` to `govuk-heading-l`
- adjust the guidance on headings to reflect this change

Closes [698](https://github.com/alphagov/govuk-design-system/issues/698)