### PR TITLE
Fix footer width on custom page example

### DIFF
--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -103,6 +103,7 @@ ignore_in_sitemap: true
 
 {% block footer %}
   {{ govukFooter({
+    containerClasses: "app-width-container",
     meta: {
       items: [
         {


### PR DESCRIPTION
The footer is missing the app-width-container container class which means the footer is using a different width to the rest of the page.

Add the missing container class, which means it now displays correctly.

## Before

<img width="1392" alt="Screenshot 2020-03-23 at 09 45 24" src="https://user-images.githubusercontent.com/121939/77303566-1560c800-6ceb-11ea-8e30-7926b58365b8.png">

## After

<img width="1392" alt="Screenshot 2020-03-23 at 09 45 33" src="https://user-images.githubusercontent.com/121939/77303582-198ce580-6ceb-11ea-8019-b450e3f14b92.png">
