### PR TITLE
Update 'updating from old frameworks' guidance to work with new migration guide

### DIFF
--- a/src/get-started/updating-your-code/index.md.njk
+++ b/src/get-started/updating-your-code/index.md.njk
@@ -7,7 +7,7 @@ order: 3
 description: Updating variables, functions and mixins when you migrate to GOV.UK Frontend
 ---
 
-This is part of [migrating from our old frameworks to GOV.UK Frontend](xxx).
+This is part of [migrating from our old frameworks to GOV.UK Frontend](https://frontend.design-system.service.gov.uk/migrating-from-legacy-products/).
 
 The tables below show the old and new names for components, classes and mixins, to help you find what you need.
 

--- a/src/get-started/updating-your-code/index.md.njk
+++ b/src/get-started/updating-your-code/index.md.njk
@@ -1,6 +1,6 @@
 ---
 layout: layout-pane.njk
-title: Replace our old variables, functions and mixins
+title: Replace variables, functions and mixins from our old frameworks
 section: Get started
 theme: How to guides
 order: 3

--- a/src/get-started/updating-your-code/index.md.njk
+++ b/src/get-started/updating-your-code/index.md.njk
@@ -1,23 +1,15 @@
 ---
 layout: layout-pane.njk
-title: Updating from GOV.UK Elements and Frontend Toolkit
+title: Replace our old variables, functions and mixins
 section: Get started
 theme: How to guides
 order: 3
-description: Updating your code to work with the GOV.UK Design System
+description: Updating variables, functions and mixins when you migrate to GOV.UK Frontend
 ---
 
-[GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) is the frontend codebase that replaces GOV.UK Elements, Frontend&nbsp;Toolkit and parts of GOV.UK Template.
+This is part of [migrating from our old frameworks to GOV.UK Frontend](xxx).
 
 The tables below show the old and new names for components, classes and mixins, to help you find what you need.
-
-## Page template
-
-Previously, to keep your pages consistent with the rest of GOV.UK you would have needed to use [GOV.UK Template](http://alphagov.github.io/govuk_template/).
-
-This has been brought into GOV.UK Frontend. You can consume it using Nunjucks or HTML.
-
-If you are not using Nunjucks you can [get the page template HTML](../../styles/page-template/#default).
 
 ### Nunjucks
 


### PR DESCRIPTION
When we publish the migration guidance, this PS updates the 'Updating from GOV.UK Elements and Frontend Toolkit' page to:

- change the title to better reflect the content, and so it doesn't 'compete' with the main migration guidance
- add a link to the main migration guidance
- remove anything that's better covered in the main migration guide

Do not merge until:

- [ ] we've published the migration guidance
- [x] we've added the missing link from this page to the migration guidance
