### PR TITLE
Update example error text for invalid dates

### DIFF
--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -79,7 +79,10 @@ For example, ‘Enter your date of birth and include a day, month and year’.
 #### If the date entered is not a real one
 
 Say ‘Enter a real [whatever it is]’.<br>
-For example, ‘Enter a real date of birth’.
+For example, ‘Enter a real date of birth’.<br>
+or for other types of date<br>
+Say ‘[whatever it is] must be a real date’<br>
+For example, ‘The date your contract started must be a real date’
 
 #### If the date is in the future when it needs to be in the past
 


### PR DESCRIPTION
Hope this works for everyone: Using Date of birth as the *only* example for `Enter a real date of birth` works fine for that but not for other types of date e.g. `Enter a real date you got the property` or even adjusted for grammar `Enter a real date for when you got the property` (note I had to add `for when` in) whereas `[whatever it is] must be a real date` works like `The date you got the property must be a real date`