### PR TITLE
Route to get in touch page, add notice for public

### DIFF
--- a/src/get-in-touch.njk
+++ b/src/get-in-touch.njk
@@ -10,6 +10,21 @@ layout: layout-single-page.njk
 
      <p class="govuk-body-l">If you’ve got a question, idea or suggestion get in touch with the Design System team.</p>
 
+      {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+      {% set callout %}
+        The GOV.UK Design System team provide support to people who work in the government.<br>
+        <br>
+        We cannot give general advice to the public. We do not have access to information about you held by government departments.<br>
+        <br>
+        For other enquiries, use <a class="govuk-link" href="https://www.gov.uk/contact">the contact form on GOV.UK</a>.
+      {% endset %}
+
+      {{ govukWarningText({
+        html: callout,
+        iconFallbackText: "Warning"
+      }) }}
+
      <h2 class="govuk-heading-l">Slack</h2>
 
      <p class="govuk-body">Use the <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system" data-hsupport="slack">#govuk-design-system channel on cross-government Slack</a>.</p>

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -48,20 +48,6 @@
   <h2 class="app-contact-panel__heading">Need help?</h2>
 
   <p class="govuk-body app-contact-panel__body">
-    If you’ve got a question about the GOV.UK Design System you can contact the team:
+    If you’ve got a question about the GOV.UK Design System, <a class="govuk-link" href="/get-in-touch/">contact the team</a>.
   </p>
-  <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
-    <li>
-      on
-      <a class="govuk-link app-contact-panel__link" href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system" data-hsupport="slack">
-        #govuk-design-system channel on cross-government Slack
-      </a>
-    </li>
-    <li class="govuk-!-margin-bottom-0">
-      by email at
-      <a class="govuk-link app-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">
-        govuk-design-system-support@digital.cabinet-office.gov.uk
-      </a>
-    </li>
-  </ul>
 </div>


### PR DESCRIPTION
We're seeing an increased number of members of the public use the Design System support email address for enquiries about other government services like universal credit.

We think that this is because they are searching for e.g. 'government email address' or 'government phone number' and finding our patterns relating to asking for email addresses or asking for phone numbers.

Remove the email address from the bottom of every page, instead routing users to the existing 'get in touch' page.

Add warning text to the 'get in touch' page that explains the purpose of the support email address, and direct users to the GOV.UK contact form for other enquiries.

This is based on wording used by Notify, who have implemented something similar. (https://www.notifications.service.gov.uk/support/public)