### PR TITLE
Update references to global banner colour

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -30,7 +30,7 @@ description: Design your service using GOV.UK styles, components and patterns
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 id="telling-users-how-coronavirus-affects-your-service" class="govuk-heading-l">Telling users how coronavirus affects your&nbsp;service</h2>
         <p class="govuk-body">
-          Do not use a red emergency banner or black and lime global message banner to tell people about problems with a GOV.UK service, including problems related to coronavirus.
+          Do not use a red emergency banner or black global message banner to tell people about problems with a GOV.UK service, including problems related to coronavirus.
           <a class="govuk-link" href="/patterns/understand-the-impact-of-an-emergency/">Help users understand the impact of an emergency on your service</a>.
         </p>
       </div>

--- a/src/patterns/understand-the-impact-of-an-emergency/index.md.njk
+++ b/src/patterns/understand-the-impact-of-an-emergency/index.md.njk
@@ -8,7 +8,7 @@ backlog_issue_id: 212
 layout: layout-pane.njk
 ---
 
-Do not use a red emergency banner or black and lime global message banner to tell people about problems with a GOV.UK service, including problems related to coronavirus.
+Do not use a red emergency banner or black global message banner to tell people about problems with a GOV.UK service, including problems related to coronavirus.
 
 These banner designs are only used for specific messages published through the central GOV.UK publishing platform, with the agreement of Cabinet Office.
 


### PR DESCRIPTION
The accent colour of the GOV.UK global coronavirus banner has changed (and may change again). This PR updates the GOV.UK Design System to reflect that.