### PR TITLE
non-money decimal examples

### DIFF
--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -171,13 +171,13 @@ For example, ‘Hours worked a week must be between 16 and 99’.
 
 #### If the input is not an amount of money and the field allows decimals
 
-Say ‘[whatever it is] must be an amount of money [optional example that includes decimals and non-decimals]’.<br>
-For example, ‘How much you earn an hour must be an amount of money, like 7.50 or 8’.
+Say ‘[whatever it is] must be a number [optional example that includes decimals and non-decimals]’.<br>
+For example, ‘How high you are must be a number in metres, like 1.50 or 2’.
 
 #### If the input is not an amount of money and the field needs decimals
 
-Say ‘[whatever it is] must be an amount of money [optional example that includes decimals]’.<br>
-For example, ‘How much you earn an hour must be an amount of money, like 7.50 or 8.00’.
+Say ‘[whatever it is] must be a number with decimal places [optional example that includes decimals]’.<br>
+For example, ‘How high you are must be a number with decimal places in metres, like 1.50 or 2.00’.
 
 #### If the input is an amount of money that needs decimals
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -171,8 +171,8 @@ For example, ‘Hours worked a week must be between 16 and 99’.
 
 #### If the input is not an amount of money and the field allows decimals
 
-Say ‘[whatever it is] must be a number [optional example that includes decimals and non-decimals]’.<br>
-For example, ‘How high you are must be a number in metres, like 1.50 or 2’.
+Say ‘[whatever it is] must be a number (with or without decimal places) [optional example that includes decimals and non-decimals]’.<br>
+For example, ‘How high you are must be a number (with or without decimal places) in metres, like 1.50 or 2’.
 
 #### If the input is not an amount of money and the field needs decimals
 


### PR DESCRIPTION
This is a confusing example, as it says a decimal that is not money, then uses money as the example

Have adjusted to make it a more comprehensible one.