### PR TITLE
Change Frontend docs links to TDT

### DIFF
--- a/src/get-started/production/index.md.njk
+++ b/src/get-started/production/index.md.njk
@@ -26,7 +26,7 @@ There are 2 ways to include GOV.UK Frontend in your project. You can either inst
 
 ### Option 1: install using npm
 
-We recommend [installing GOV.UK Frontend using npm](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md).
+We recommend [installing GOV.UK Frontend using npm](https://frontend.design-system.service.gov.uk/installing_with_npm/#install-with-node-js-package-manager-npm).
 
 Using this option, you will be able to:
 
@@ -37,7 +37,7 @@ Using this option, you will be able to:
 
 ### Option 2: include compiled files
 
-If your project does not use npm, or if you want to try out GOV.UK Frontend in your project without installing it through npm, you can [download and include compiled stylesheets, JavaScript and the asset files](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-from-dist.md).
+If your project does not use npm, or if you want to try out GOV.UK Frontend in your project without installing it through npm, you can [download and include compiled stylesheets, JavaScript and the asset files](https://frontend.design-system.service.gov.uk/installing_from_dist/#install-from-dist).
 
 Using this option, you will be able to include all the CSS and JavaScript of GOV.UK Frontend in your project.
 

--- a/src/get-started/production/index.md.njk
+++ b/src/get-started/production/index.md.njk
@@ -26,7 +26,7 @@ There are 2 ways to include GOV.UK Frontend in your project. You can either inst
 
 ### Option 1: install using npm
 
-We recommend [installing GOV.UK Frontend using npm](https://frontend.design-system.service.gov.uk/installing_with_npm/#install-with-node-js-package-manager-npm).
+We recommend [installing GOV.UK Frontend using npm](https://frontend.design-system.service.gov.uk/installing-with-npm/#install-with-node-js-package-manager-npm).
 
 Using this option, you will be able to:
 
@@ -37,7 +37,7 @@ Using this option, you will be able to:
 
 ### Option 2: include compiled files
 
-If your project does not use npm, or if you want to try out GOV.UK Frontend in your project without installing it through npm, you can [download and include compiled stylesheets, JavaScript and the asset files](https://frontend.design-system.service.gov.uk/installing_from_dist/#install-from-dist).
+If your project does not use npm, or if you want to try out GOV.UK Frontend in your project without installing it through npm, you can [download and include compiled stylesheets, JavaScript and the asset files](https://frontend.design-system.service.gov.uk/installing-from-dist/#install-from-dist).
 
 Using this option, you will be able to include all the CSS and JavaScript of GOV.UK Frontend in your project.
 

--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -38,7 +38,7 @@ ignore_in_sitemap: true
   <!--<![endif]-->
 
   {# For Internet Explorer 8, you need to compile specific stylesheet #}
-  {# see https://frontend.design-system.service.gov.uk/supporting_ie8/#support-internet-explorer-8 #}
+  {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
   <!--[if IE 8]>
     <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
   <![endif]-->

--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -38,7 +38,7 @@ ignore_in_sitemap: true
   <!--<![endif]-->
 
   {# For Internet Explorer 8, you need to compile specific stylesheet #}
-  {# see https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/supporting-internet-explorer-8.md #}
+  {# see https://frontend.design-system.service.gov.uk/supporting_ie8/#support-internet-explorer-8 #}
   <!--[if IE 8]>
     <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
   <![endif]-->

--- a/src/styles/page-template/default/code.njk
+++ b/src/styles/page-template/default/code.njk
@@ -11,7 +11,7 @@ ignore_in_sitemap: true
   <!--<![endif]-->
 
   {# For Internet Explorer 8, you need to compile specific stylesheet #}
-  {# see https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/supporting-internet-explorer-8.md #}
+  {# see https://frontend.design-system.service.gov.uk/supporting_ie8/#support-internet-explorer-8 #}
   <!--[if IE 8]>
     <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
   <![endif]-->

--- a/src/styles/page-template/default/code.njk
+++ b/src/styles/page-template/default/code.njk
@@ -11,7 +11,7 @@ ignore_in_sitemap: true
   <!--<![endif]-->
 
   {# For Internet Explorer 8, you need to compile specific stylesheet #}
-  {# see https://frontend.design-system.service.gov.uk/supporting_ie8/#support-internet-explorer-8 #}
+  {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
   <!--[if IE 8]>
     <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
   <![endif]-->

--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -142,7 +142,7 @@ Variables can be set with:
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">assetPath</td>
       <td class="govuk-table__cell">
-        Specify a path to the <a href="https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md#importing-assets">GOV.UK Frontend assets</a> (icons, images, font files).
+        Specify a path to the <a href="https://frontend.design-system.service.gov.uk/installing_with_npm/#install-with-node-js-package-manager-npm">GOV.UK Frontend assets</a> (icons, images, font files).
       </td>
     </tr>
 

--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -142,7 +142,7 @@ Variables can be set with:
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">assetPath</td>
       <td class="govuk-table__cell">
-        Specify a path to the <a href="https://frontend.design-system.service.gov.uk/installing_with_npm/#install-with-node-js-package-manager-npm">GOV.UK Frontend assets</a> (icons, images, font files).
+        Specify a path to the <a href="https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#font-and-image-assets">GOV.UK Frontend assets</a> (icons, images, font files).
       </td>
     </tr>
 


### PR DESCRIPTION
This updates relevant links in the Design System so that they point to the Tech Docs Template domain rather than the Frontend docs repo.