### PR TITLE
Reduce size of heading in example

### DIFF
--- a/src/components/date-input/error-single/index.njk
+++ b/src/components/date-input/error-single/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     legend: {
       text: "When was your passport issued?",
       isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
+      classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {


### PR DESCRIPTION
To be consistent with the new default heading size