### PR TITLE
Clarify radio error message examples

### DIFF
--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -98,26 +98,25 @@ In services like these, the risk that they will not be noticed is lower because 
 
 ### Error messages
 
+Display an error message if none of the radios are selected.
+
 Error messages should be styled like this:
 
 {{ example({group: "components", item: "radios", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
-#### If nothing is selected and the options are ‘yes’ and ‘no’
+#### If it’s a ‘yes’ or ‘no’ question
 
-Say ‘Select yes if [whatever it is is true]’.<br>
-For example, ‘Select yes if Sarah normally lives with you’.
+Say ‘Select yes if [whatever it is is true]’. For example, ‘Select yes if Sarah normally lives with you’.
 
-#### If nothing is selected and the question has options in it
+#### If there are two options which aren’t ‘yes’ and ‘no’
 
-Say ‘Select if [whatever it is]’.<br>
-For example, ‘Select if you are employed or self-employed’.
+Say ‘Select if [whatever it is]’. For example, ‘Select if you are employed or self-employed’.
 
-#### If nothing is selected and the question does not have options in it
+#### If there are more than two options
 
-Say ‘Select [whatever it is]’.<br>
-For example, ‘Select the day of the week you pay your rent’.
+Say ‘Select [whatever it is]’. For example, ‘Select the day of the week you pay your rent’.
 
 ## Research on this component
 


### PR DESCRIPTION
This PR clarifies some of the error messages on the radio button component page.

Should probably be reviewed by @christopherthomasdesign 