### PR TITLE
Use active voice for guidance on grouping controls

### DIFF
--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -26,7 +26,7 @@ Do not use the checkboxes component if users can only choose one option from a s
 
 ## How it works
 
-Checkboxes are grouped together in a `<fieldset>` with a `<legend>` that describes them, as shown in the examples on this page. This is usually a question, like ‘How would you like to be contacted?’.
+Group checkboxes together in a `<fieldset>` with a `<legend>` that describes them, as shown in the examples on this page. This is usually a question, like ‘How would you like to be contacted?’.
 
 If you are asking just [one question per page](../../patterns/question-pages/#start-by-asking-one-question-per-page) as recommended, you can set the contents of the `<legend>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -21,7 +21,7 @@ Do not use the radios component if users might need to select more than one opti
 
 ## How it works
 
-Radios are grouped together in a `<fieldset>` with a `<legend>` that describes them, as shown in the examples on this page. This is usually a question, like ‘Where do you live?’.
+Group radios together in a `<fieldset>` with a `<legend>` that describes them, as shown in the examples on this page. This is usually a question, like ‘Where do you live?’.
 
 If you are asking just [one question per page](../../patterns/question-pages/#start-by-asking-one-question-per-page) as recommended, you can set the contents of the `<legend>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
 


### PR DESCRIPTION
This is consistent with the active voice used in the following sentences, and makes it explicitly instructional rather than making it sound like this is automatic behaviour that checkboxes and radios provide.