### PR TITLE
Update 'not a real date' example

### DIFF
--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -89,7 +89,7 @@ For example, ‘13’ in the month field can’t be correct.<br>
 
 Highlight the day, month or year field with the incorrect information. Or highlight the date as a whole if there’s incorrect information in more than one field, or it's not clear which field is incorrect.<br>
 
-Say ‘Enter a real [whatever it is]’. For example, ‘Enter a real date of birth’.
+Say ‘[Whatever it is] must be a real date’. For example, ‘Date of birth must be a real date’.
 
 #### If the date is in the future when it needs to be in the past
 


### PR DESCRIPTION
This updates the example under 'If the date entered can’t be correct' in [Date input](https://design-system.service.gov.uk/components/date-input/), so that it works in a wider range of contexts, and better matches other examples on the page. 