### PR TITLE
Use 'For example:' not 'For example -'

### DIFF
--- a/src/patterns/understand-the-impact-of-an-emergency/index.md.njk
+++ b/src/patterns/understand-the-impact-of-an-emergency/index.md.njk
@@ -18,7 +18,7 @@ If your service is getting more demand than usual, check that you’ve set up [T
 
 ## How it works
 
-Keep messages short. For example -
+Keep messages short. For example: 
 
 > “There may be a delay in processing your application because of the coronavirus outbreak. If you need help urgently, [add call to action].”
 


### PR DESCRIPTION
This change is being made based on feedback from the working group, and is consistent with how we use 'For example' elsewhere in the Design System.

Closes #1242 