### PR TITLE
Make table examples consistent

### DIFF
--- a/src/components/table/column-widths-custom-classes/index.njk
+++ b/src/components/table/column-widths-custom-classes/index.njk
@@ -33,7 +33,7 @@ stylesheets:
         text: "£109.80 per week"
       },
       {
-        text: "59.10 per week"
+        text: "£59.10 per week"
       }
     ],
     [

--- a/src/components/table/column-widths/index.njk
+++ b/src/components/table/column-widths/index.njk
@@ -31,7 +31,7 @@ layout: layout-example.njk
         text: "£109.80 per week"
       },
       {
-        text: "59.10 per week"
+        text: "£59.10 per week"
       }
     ],
     [


### PR DESCRIPTION
Spotted that two of the examples had missing pound signs, I added them in.