### PR TITLE
Remove current page from breadcrumbs

### DIFF
--- a/src/components/breadcrumbs/default/index.njk
+++ b/src/components/breadcrumbs/default/index.njk
@@ -15,7 +15,8 @@ layout: layout-example.njk
       href: "#"
     },
     {
-      text: "Travel abroad"
+      text: "Travel abroad",
+      href: "#"
     }
   ]
 }) }}

--- a/src/components/breadcrumbs/index.md.njk
+++ b/src/components/breadcrumbs/index.md.njk
@@ -25,7 +25,7 @@ If you’re using other navigational elements on the page, such as a sidebar, co
 
 ## How it works
 
-The breadcrumbs component should start with the highest level page in your service and end with the parent section of the current page.
+The breadcrumb should start with your 'home' page and end with the parent section of the current page.
 
 There are 2 ways to use the breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 

--- a/src/components/breadcrumbs/index.md.njk
+++ b/src/components/breadcrumbs/index.md.njk
@@ -25,7 +25,7 @@ If you’re using other navigational elements on the page, such as a sidebar, co
 
 ## How it works
 
-The breadcrumbs component should include the user’s current page, which should be visually different from the other links in the breadcrumb.
+The breadcrumbs component should start with the highest level page in your service and end with the parent section of the current page.
 
 There are 2 ways to use the breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 


### PR DESCRIPTION
Remove guidance about adding the current page title (and update examples), to be consistent with how breadcrumbs work on GOV.UK pages.

Fixes #1228