### PR TITLE
Avoid exclusionary language in Passwords pattern

### DIFF
--- a/src/patterns/passwords/index.md.njk
+++ b/src/patterns/passwords/index.md.njk
@@ -37,7 +37,7 @@ Make sure you:
 - set a minimum length of at least 8 characters
 - do not set a maximum length
 - explain the constraints to users
-- use a blacklist of commonly used passwords
+- do not allow commonly used passwords
 
 ### Do not make users keep changing their passwords
 


### PR DESCRIPTION
> It's fairly common to say whitelisting and blacklisting to describe desirable and undesirable things in cyber security. For instance, when talking about which applications you will allow or deny on your corporate network; or deciding which bad passwords you want your users not to be able to use.
> 
> However, there's an issue with the terminology. It only makes sense if you equate white with 'good, permitted, safe' and black with 'bad, dangerous, forbidden'. There are some obvious problems with this.
>
> – https://www.ncsc.gov.uk/blog-post/terminology-its-not-black-and-white

Closes #736