### PR TITLE
Simplify 'Help improve this page' section

### DIFF
--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -13,9 +13,8 @@
         </a>
       </li>
       <li>
-        <a class="govuk-link app-contact-panel__link" href="{{ fileEditURL }}">
-          propose a change
-        </a> – read more about
+        <a class="govuk-link app-contact-panel__link" href="{{ fileEditURL }}">propose a change</a>
+         – read more about
         <a class="govuk-link app-contact-panel__link" href="/community/propose-a-content-change-using-github/">
           how to propose changes in GitHub
         </a>
@@ -24,15 +23,11 @@
   {% else %}
       <p class="govuk-body">
         If you spot a problem with this guidance you can
-        <a class="govuk-link app-contact-panel__link" href="{{ fileEditURL }}">
-          propose a change
-        </a>.
+        <a class="govuk-link app-contact-panel__link" href="{{ fileEditURL }}">propose a change</a>.
       </p>
       <p class="govuk-body">
         If you're not sure how to do this, read guidance on
-        <a class="govuk-link app-contact-panel__link" href="/community/propose-a-content-change-using-github/">
-          how to propose changes in GitHub
-        </a>.
+        <a class="govuk-link app-contact-panel__link" href="/community/propose-a-content-change-using-github/">how to propose changes in GitHub</a>.
       </p>
   {% endif %}
 {% endif %}

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -4,24 +4,17 @@
 
   {% if backlog_issue_id %}
     <p class="govuk-body">
-    To help make sure the {{ title }} page is useful, relevant and up to date, you can:
+    To help make sure that this page is useful, relevant and up to date, you can:
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
         <a class="govuk-link app-contact-panel__link" href="https://github.com/alphagov/govuk-design-system-backlog/issues/{{ backlog_issue_id }}">
-          share research or feedback about
-          {% if section === 'Components' or section === 'Patterns' %}
-            the
-          {% endif %}
-          {{ title }}
-          {% if section === 'Components' %} component{% endif %}
-          {% if section === 'Patterns' %} pattern{% endif %}
-          on GitHub
+          share your research or feedback on GitHub
         </a>
       </li>
       <li>
         <a class="govuk-link app-contact-panel__link" href="{{ fileEditURL }}">
-          propose a change to this page
+          propose a change
         </a> – read more about
         <a class="govuk-link app-contact-panel__link" href="/community/propose-a-content-change-using-github/">
           how to propose changes in GitHub
@@ -30,7 +23,7 @@
     </ul>
   {% else %}
       <p class="govuk-body">
-        If you spot a problem with the {{ title }} guidance you can
+        If you spot a problem with this guidance you can
         <a class="govuk-link app-contact-panel__link" href="{{ fileEditURL }}">
           propose a change
         </a>.


### PR DESCRIPTION
We try to interpolate the current page title within the 'Help improve this page' section to make it clear what we're asking for, but it doesn't always work – especially with patterns:

> To help make sure the There is a problem with the service pages page is useful, relevant and up to date, you can:
>
> - share research or feedback about the There is a problem with the service pages pattern on GitHub
> - propose a change to this page – read more about how to propose changes in GitHub

Simplify it to be more generic – where there is a linked backlog it will now say:

> To help make sure that this page is useful, relevant and up to date, you can:
>
> - share your research or feedback on GitHub
> - propose a change – read more about how to propose changes in GitHub

Where there is no associated backlog item, it'll say:

> If you spot a problem with this guidance you can propose a change.
>
> If you're not sure how to do this, read guidance on how to propose changes in GitHub.

This also removes an extra space from some of the links in this panel.

Closes #1243 