### PR TITLE
Add links to importing docs

### DIFF
--- a/src/get-started/production/index.md.njk
+++ b/src/get-started/production/index.md.njk
@@ -30,7 +30,7 @@ We recommend [installing GOV.UK Frontend using npm](https://frontend.design-syst
 
 Using this option, you will be able to:
 
-- selectively include the CSS or JavaScript for individual components
+- selectively [include the CSS or JavaScript](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/) for individual components
 - build your own styles or components based on the palette or typography and spacing mixins
 - customise the build (for example, overriding colours or enabling global styles)
 - use the component Nunjucks templates
@@ -44,7 +44,7 @@ Using this option, you will be able to include all the CSS and JavaScript of GOV
 You will not be able to:
 
 
-- selectively include the CSS or JavaScript for individual components
+- selectively [include the CSS or JavaScript](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/) for individual components
 - build your own styles or components based on the palette or typography and spacing mixins
 - customise the build, for example, overriding colours or enabling global styles
 - use the component Nunjucks templates


### PR DESCRIPTION
This adds link from the [Get started > Production](https://design-system.service.gov.uk/get-started/production/#option-1-install-using-npm) page to the importing docs in Frontend, as we've had feedback that users on this page could not find how to selectively include CSS and JavaScript for individual components.