### PR TITLE
Update header to use latest markup

### DIFF
--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -16,7 +16,7 @@
           treat it as an interactive element - without this it will be
           'focusable' when using the keyboard to navigate. #}
           <svg
-            role="presentation"
+            aria-hidden="true"
             focusable="false"
             class="govuk-header__logotype-crown"
             xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
The markup for the header was changed in https://github.com/alphagov/govuk-frontend/pull/1724:

> role="none"/"presentational" does not do enough to hide the child fallback image used in older browsers.
>
> We have found that Chrome's new "Get image descriptions from Google" feature will notice this fallback image.
>
> This means when screenreaders such as NVDA visit the logo, it'll announce "Unlabelled graphic, To get missing image descriptions, open the context menu." for this fallback image.
>
> By using aria-hidden="true" we can ensure that the SVG and it's children are all hidden from the accessibility tree, which I have confirmed in NVDA + Chrome.

This change went out as part of GOV.UK Frontend v3.6.0. It was missed when updating the Design System to use v3.6.0 in #1187 (it's a non-breaking change, as the existing markup works fine – this is just an improvement)

Thanks to @selfthinker for flagging this.