### PR TITLE
Fix duplicated examples on label and legend headings page

### DIFF
--- a/src/get-started/labels-legends-headings/label-h1/index.njk
+++ b/src/get-started/labels-legends-headings/label-h1/index.njk
@@ -17,16 +17,3 @@ layout: layout-example.njk
   id: "example",
   name: "example"
 }) }}
-
-{{ govukInput({
-  label: {
-    text: "govuk-label--l",
-    classes: "govuk-label--l",
-    isPageHeading: true
-  },
-  hint: {
-    text: "This example shows an <h1> around a <label> with the class of govuk-label--l"
-  },
-  id: "example-2",
-  name: "example-2"
-}) }}

--- a/src/get-started/labels-legends-headings/legend-h1/index.njk
+++ b/src/get-started/labels-legends-headings/legend-h1/index.njk
@@ -36,31 +36,3 @@ layout: layout-example.njk
   ]
 }) }}
 
-{{ govukCheckboxes({
-  idPrefix: "checkbox-2",
-  name: "checkbox-2",
-  fieldset: {
-    legend: {
-      text: "govuk-fieldset__legend--l",
-      isPageHeading: true,
-      classes: "govuk-fieldset__legend--l"
-    }
-  },
-  hint: {
-    text: "This example shows an <h1> inside a <legend> with the class of govuk-fieldset__legend--l."
-  },
-  items: [
-    {
-      value: "checkbox",
-      text: "Checkbox 1"
-    },
-    {
-      value: "checkbox",
-      text: "Checkbox 2"
-    },
-    {
-      value: "checkbox",
-      text: "Checkbox 3"
-    }
-  ]
-}) }}


### PR DESCRIPTION
This is to fix an error made in #1201 

The [Making labels and legends headings](https://design-system.service.gov.uk/get-started/labels-legends-headings/) page is currently showing duplicated examples:
<img width="838" alt="Screenshot 2020-05-20 at 16 49 15" src="https://user-images.githubusercontent.com/19834460/82469047-6ad30e80-9abb-11ea-9d8c-376ce0fe76e5.png">

I've removed the second example in each:
<img width="833" alt="Screenshot 2020-05-20 at 16 49 32" src="https://user-images.githubusercontent.com/19834460/82469070-76263a00-9abb-11ea-81b3-9f36c11ff58a.png">

Before #1201, the examples included both a `l` and `xl` size. However, I think since we're changing our default heading size to `l` now, I think showing the `xl` example here again could be confusing and inconsistent with our other guidance. Happy to add back in if others feel strongly about keeping it though.