### PR TITLE
Update nginx buildpack to v1.1.9

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -16,7 +16,7 @@ applications:
   # by GitHub URL
   #
   # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
-  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.3
+  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.9
   # Run two instances to ensure availability
   #
   # https://docs.cloud.service.gov.uk/managing_apps.html#scaling

--- a/manifest.yml
+++ b/manifest.yml
@@ -16,7 +16,8 @@ applications:
   # by GitHub URL
   #
   # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
-  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.9
+  buildpacks:
+    - https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.9
   # Run two instances to ensure availability
   #
   # https://docs.cloud.service.gov.uk/managing_apps.html#scaling


### PR DESCRIPTION
This effectively just updates nginx from v1.17.7 to v1.17.10.

Tested by manually pushing an app to the PaaS.