### PR TITLE
Add input prefix and suffix

### DIFF
--- a/src/components/text-input/decimal-input/index.njk
+++ b/src/components/text-input/decimal-input/index.njk
@@ -7,13 +7,13 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    text: "Cost per item, in pounds"
+    text: "Weight, in kilograms"
   },
-  classes: "govuk-input--width-10",
-  hint: {
-    text: "For example, 23.99"
+  classes: "govuk-input--width-5",
+  id: "weight",
+  name: "weight",
+  suffix: {
+    text: "kg"
   },
-  id: "cost",
-  name: "cost",
   spellcheck: false
 }) }}

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -98,11 +98,11 @@ Use prefixes and suffixes to help users enter things like currencies and measure
 
 {{ example({group: "components", item: "text-input", example: "input-prefix-suffix", html: true, nunjucks: true, closed: true, size: "s"}) }}
 
-Prefixes and suffixes are useful when you use symbols and abbreviations that are commonly known and understood. Symbols and abbreviations should be explained in the label or hint. For example, put “Cost, in pounds” in the label, and use the “£” symbol in the text input prefix.
+Prefixes and suffixes are useful when there's a commonly understood symbol or abbreviation for the type of information you're asking for. Do not rely on prefixes or suffixes alone, because people who use a screen reader won't see them.
 
-Prefixes and suffixes are visual aids and are not available to assistive technologies.
+If you need a specific type of information, say so in the input label or hint text as well. For example, put "Cost, in pounds" in the input label and use the "£" symbol in the prefix.
 
-Some users may not notice or understand the prefix or suffix, and may add their own into the input as part of their entry. Allow for this in your validation and do not show an error.
+Some users may miss the fact that the input already has a suffix or prefix, and enter a prefix or suffix into the input. Allow for this in your validation and do not show an error.
 
 #### Text inputs with a prefix
 
@@ -146,7 +146,7 @@ Error messages should be styled like this:
 
 {{ example({group: "components", item: "text-input", example: "error", html: true, nunjucks: true, closed: true, size: "s"}) }}
 
-#### Prefixes and suffixes
+#### If the input has a prefix or a suffix
 
 {{ example({group: "components", item: "text-input", example: "input-prefix-suffix-error", html: true, nunjucks: true, closed: true, size: "s"}) }}
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -92,6 +92,24 @@ Use hint for help that’s relevant to the majority of users, like how their inf
 
 {{ example({group: "components", item: "text-input", example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s"}) }}
 
+### Prefixes and suffixes
+
+Use prefixes and suffixes to help users enter things like currencies and measurements.
+
+{{ example({group: "components", item: "text-input", example: "input-prefix-suffix", html: true, nunjucks: true, closed: true, size: "s"}) }}
+
+Prefixes and suffixes are visual aids and are not available to assistive technologies. Instead, word the label to provide the necessary context.
+
+Some users may not notice or understand the prefix or suffix, and may add their own into the input as part of their entry. Allow for this in your validation and do not throw an error.
+
+#### Text inputs with a prefix
+
+{{ example({group: "components", item: "text-input", example: "input-prefix", html: true, nunjucks: true, closed: true, size: "s"}) }}
+
+#### Text inputs with a suffix
+
+{{ example({group: "components", item: "text-input", example: "input-suffix", html: true, nunjucks: true, closed: true, size: "s"}) }}
+
 ### Use the autocomplete attribute
 
 Use the `autocomplete` attribute on text inputs to help users complete forms more quickly. This lets you specify an input's purpose so browsers can autofill the information on a user's behalf if they’ve entered it previously.

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -98,9 +98,11 @@ Use prefixes and suffixes to help users enter things like currencies and measure
 
 {{ example({group: "components", item: "text-input", example: "input-prefix-suffix", html: true, nunjucks: true, closed: true, size: "s"}) }}
 
-Prefixes and suffixes are visual aids and are not available to assistive technologies. Instead, word the label to provide the necessary context.
+Prefixes and suffixes are useful when you use symbols and abbreviations that are commonly known and understood. Symbols and abbreviations should be explained in the label or hint. For example, put “Cost, in pounds” in the label, and use the “£” symbol in the text input prefix.
 
-Some users may not notice or understand the prefix or suffix, and may add their own into the input as part of their entry. Allow for this in your validation and do not throw an error.
+Prefixes and suffixes are visual aids and are not available to assistive technologies.
+
+Some users may not notice or understand the prefix or suffix, and may add their own into the input as part of their entry. Allow for this in your validation and do not show an error.
 
 #### Text inputs with a prefix
 
@@ -143,6 +145,10 @@ Browsers do not consistently spellcheck user’s input by default. If you are as
 Error messages should be styled like this:
 
 {{ example({group: "components", item: "text-input", example: "error", html: true, nunjucks: true, closed: true, size: "s"}) }}
+
+#### Prefixes and suffixes
+
+{{ example({group: "components", item: "text-input", example: "input-prefix-suffix-error", html: true, nunjucks: true, closed: true, size: "s"}) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -59,6 +59,12 @@ Fluid width inputs will resize with the viewport.
 
 {{ example({group: "components", item: "text-input", example: "input-fluid-width", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
+### Hint text
+
+Use hint for help that’s relevant to the majority of users, like how their information will be used, or where to find it.
+
+{{ example({group: "components", item: "text-input", example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s"}) }}
+
 ### Numbers
 
 #### Asking for whole numbers
@@ -85,12 +91,6 @@ Do not set the `inputmode` attribute to `decimal` as it causes some devices to b
 #### Avoid using inputs with a type of number
 
 Do not use `<input type="number">` unless your user research shows that there’s a need for it. With `<input type="number">` there’s a risk of users accidentally incrementing a number when they’re trying to do something else - for example, scroll up or down the page. And if the user tries to enter something that’s not a number, there’s no explicit feedback about what they’re doing wrong.
-
-### Hint text
-
-Use hint for help that’s relevant to the majority of users, like how their information will be used, or where to find it.
-
-{{ example({group: "components", item: "text-input", example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ### Prefixes and suffixes
 

--- a/src/components/text-input/input-prefix-suffix-error/index.njk
+++ b/src/components/text-input/input-prefix-suffix-error/index.njk
@@ -9,7 +9,9 @@ layout: layout-example.njk
   id: "cost-per-item-error",
   name: "cost-per-item-error",
   label: {
-    text: "Cost per item, in pounds"
+    text: "What is the cost per item, in pounds?",
+    classes: "govuk-label--l",
+    isPageHeading: true
   },
   prefix: {
     text: "£"

--- a/src/components/text-input/input-prefix-suffix-error/index.njk
+++ b/src/components/text-input/input-prefix-suffix-error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Input prefix and suffix with error
+title: Text input with prefix and suffix with error
 layout: layout-example.njk
 ---
 
@@ -20,10 +20,6 @@ layout: layout-example.njk
   errorMessage: {
     text: "Enter a cost per item, in pounds"
   },
-  classes: "govuk-input--width-10",
-  inputmode: "numeric",
-  pattern: "[0-9]*",
-  attributes: {
-    spellcheck: "false"
-  }
+  classes: "govuk-input--width-5",
+  spellcheck: false
 }) }}

--- a/src/components/text-input/input-prefix-suffix-error/index.njk
+++ b/src/components/text-input/input-prefix-suffix-error/index.njk
@@ -1,0 +1,29 @@
+---
+title: Input prefix and suffix with error
+layout: layout-example.njk
+---
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  id: "cost-per-item-error",
+  name: "cost-per-item-error",
+  label: {
+    text: "Cost per item, in pounds"
+  },
+  prefix: {
+    text: "£"
+  },
+  suffix: {
+    text: "per item"
+  },
+  errorMessage: {
+    text: "Enter a cost per item, in pounds"
+  },
+  classes: "govuk-input--width-10",
+  inputmode: "numeric",
+  pattern: "[0-9]*",
+  attributes: {
+    spellcheck: "false"
+  }
+}) }}

--- a/src/components/text-input/input-prefix-suffix/index.njk
+++ b/src/components/text-input/input-prefix-suffix/index.njk
@@ -1,0 +1,26 @@
+---
+title: Input prefix and suffix
+layout: layout-example.njk
+---
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  id: "cost-per-item",
+  name: "cost-per-item",
+  label: {
+    text: "Cost per item, in pounds"
+  },
+  prefix: {
+    text: "£"
+  },
+  suffix: {
+    text: "per item"
+  },
+  classes: "govuk-input--width-10",
+  inputmode: "numeric",
+  pattern: "[0-9]*",
+  attributes: {
+    spellcheck: "false"
+  }
+}) }}

--- a/src/components/text-input/input-prefix-suffix/index.njk
+++ b/src/components/text-input/input-prefix-suffix/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Input prefix and suffix
+title: Text input with prefix and suffix
 layout: layout-example.njk
 ---
 
@@ -17,10 +17,6 @@ layout: layout-example.njk
   suffix: {
     text: "per item"
   },
-  classes: "govuk-input--width-10",
-  inputmode: "numeric",
-  pattern: "[0-9]*",
-  attributes: {
-    spellcheck: "false"
-  }
+  classes: "govuk-input--width-5",
+  spellcheck: false
 }) }}

--- a/src/components/text-input/input-prefix-suffix/index.njk
+++ b/src/components/text-input/input-prefix-suffix/index.njk
@@ -9,7 +9,9 @@ layout: layout-example.njk
   id: "cost-per-item",
   name: "cost-per-item",
   label: {
-    text: "Cost per item, in pounds"
+    text: "What is the cost per item, in pounds?",
+    classes: "govuk-label--l",
+    isPageHeading: true
   },
   prefix: {
     text: "£"

--- a/src/components/text-input/input-prefix/index.njk
+++ b/src/components/text-input/input-prefix/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Input prefix
+title: Text input with prefix
 layout: layout-example.njk
 ---
 
@@ -14,10 +14,6 @@ layout: layout-example.njk
   prefix: {
     text: "£"
   },
-  classes: "govuk-input--width-10",
-  inputmode: "numeric",
-  pattern: "[0-9]*",
-  attributes: {
-    spellcheck: "false"
-  }
+  classes: "govuk-input--width-5",
+  spellcheck: false
 }) }}

--- a/src/components/text-input/input-prefix/index.njk
+++ b/src/components/text-input/input-prefix/index.njk
@@ -9,7 +9,9 @@ layout: layout-example.njk
   id: "cost",
   name: "cost",
   label: {
-    text: "Cost, in pounds"
+    text: "What is the cost in pounds?",
+    classes: "govuk-label--l",
+    isPageHeading: true
   },
   prefix: {
     text: "£"

--- a/src/components/text-input/input-prefix/index.njk
+++ b/src/components/text-input/input-prefix/index.njk
@@ -1,0 +1,23 @@
+---
+title: Input prefix
+layout: layout-example.njk
+---
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  id: "cost",
+  name: "cost",
+  label: {
+    text: "Cost, in pounds"
+  },
+  prefix: {
+    text: "£"
+  },
+  classes: "govuk-input--width-10",
+  inputmode: "numeric",
+  pattern: "[0-9]*",
+  attributes: {
+    spellcheck: "false"
+  }
+}) }}

--- a/src/components/text-input/input-suffix/index.njk
+++ b/src/components/text-input/input-suffix/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Input suffix
+title: Text input with suffix
 layout: layout-example.njk
 ---
 
@@ -14,10 +14,6 @@ layout: layout-example.njk
   suffix: {
     text: "kg"
   },
-  classes: "govuk-input--width-10",
-  inputmode: "numeric",
-  pattern: "[0-9]*",
-  attributes: {
-    spellcheck: "false"
-  }
+  classes: "govuk-input--width-5",
+  spellcheck: false
 }) }}

--- a/src/components/text-input/input-suffix/index.njk
+++ b/src/components/text-input/input-suffix/index.njk
@@ -1,0 +1,23 @@
+---
+title: Input suffix
+layout: layout-example.njk
+---
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  id: "weight",
+  name: "weight",
+  label: {
+    text: "Weight, in kilograms"
+  },
+  suffix: {
+    text: "kg"
+  },
+  classes: "govuk-input--width-10",
+  inputmode: "numeric",
+  pattern: "[0-9]*",
+  attributes: {
+    spellcheck: "false"
+  }
+}) }}

--- a/src/components/text-input/input-suffix/index.njk
+++ b/src/components/text-input/input-suffix/index.njk
@@ -9,7 +9,9 @@ layout: layout-example.njk
   id: "weight",
   name: "weight",
   label: {
-    text: "Weight, in kilograms"
+    text: "What is the weight in kilograms?",
+    classes: "govuk-label--l",
+    isPageHeading: true
   },
   suffix: {
     text: "kg"


### PR DESCRIPTION
## What

Adds prefix and suffix elements to the input component.

## Why

A number of local and departmental design systems ([GOV.UK Publishing Components](https://components.publishing.service.gov.uk/component-guide/input/with_prefix_and_suffix), [HMRC](https://design.tax.service.gov.uk/hmrc-design-patterns/currency-input/), [MOJ](https://moj-design-system.herokuapp.com/components/currency-input) and [ONS](https://ons-design-system.netlify.app/patterns/numeric-values/)) are using prefixes and suffixes to indicate currencies and measurements.

## Examples

### Prefix

#### HTML

```html
<div class="govuk-form-group">
  <label class="govuk-label" for="cost">
    Cost, in pounds
  </label>
  <div class="govuk-input__wrapper">
    <span class="govuk-input__prefix" aria-hidden="true">£</span>
    <input class="govuk-input govuk-input--width-10" id="cost" name="cost" type="text" pattern="[0-9]*" inputmode="numeric" spellcheck="false">
  </div>
</div>
```

#### Macro

```
{% from "input/macro.njk" import govukInput %}

{{ govukInput({
  id: "cost",
  name: "cost",
  label: {
    text: "Cost, in pounds"
  },
  prefix: {
    text: "£"
  },
  classes: "govuk-input--width-10",
  inputmode: "numeric",
  pattern: "[0-9]*",
  attributes: {
    spellcheck: "false"
  }
}) }}
```
<img width="275" alt="Screenshot 2020-05-29 at 14 31 55" src="https://user-images.githubusercontent.com/23444/83265293-30ebc180-a1b9-11ea-8af8-86ee3fc8fd6d.png">

### Suffix

#### HTML

```html
<div class="govuk-form-group">
  <label class="govuk-label" for="weight">
    Weight, in kilograms
  </label>
  <div class="govuk-input__wrapper">
    <input class="govuk-input govuk-input--width-10" id="weight" name="weight" type="text" pattern="[0-9]*" inputmode="numeric" spellcheck="false">
    <span class="govuk-input__suffix" aria-hidden="true">kg</span>
  </div>
</div>
```

#### Macro

```
{% from "input/macro.njk" import govukInput %}

{{ govukInput({
  id: "weight",
  name: "weight",
  label: {
    text: "Weight, in kilograms"
  },
  suffix: {
    text: "kg"
  },
  classes: "govuk-input--width-10",
  inputmode: "numeric",
  pattern: "[0-9]*",
  attributes: {
    spellcheck: "false"
  }
}) }}
```
<img width="275" alt="Screenshot 2020-05-29 at 14 32 51" src="https://user-images.githubusercontent.com/23444/83265361-4f51bd00-a1b9-11ea-95ad-b0bf368c2984.png">

Fixes https://github.com/alphagov/govuk-design-system/issues/1331

