### PR TITLE
Revert "Use 'buildpacks' instead of deprecated 'buildpack'"

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -16,8 +16,7 @@ applications:
   # by GitHub URL
   #
   # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
-  buildpacks:
-    - https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.9
+  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.9
   # Run two instances to ensure availability
   #
   # https://docs.cloud.service.gov.uk/managing_apps.html#scaling


### PR DESCRIPTION
The build is currently failing with:

> Could not push new version - Error reading manifest file:
> The following manifest fields cannot be used with legacy push: buildpacks

This reverts commit a7b6920f1d4dba2560d856d61eb6f4c57785cca7.