### PR TITLE
Make hover states clearer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2525,7 +2525,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
@@ -2551,7 +2551,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
@@ -6226,7 +6226,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -6241,9 +6241,8 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.7.0.tgz",
-      "integrity": "sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg=="
+      "version": "github:alphagov/govuk-frontend#3dc65f7e675b40a0fe9725e1618aa3b08cec8f9f",
+      "from": "github:alphagov/govuk-frontend#3dc65f7e"
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -13343,7 +13342,7 @@
     },
     "shelljs": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
       "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6241,8 +6241,8 @@
       }
     },
     "govuk-frontend": {
-      "version": "github:alphagov/govuk-frontend#3dc65f7e675b40a0fe9725e1618aa3b08cec8f9f",
-      "from": "github:alphagov/govuk-frontend#3dc65f7e"
+      "version": "github:alphagov/govuk-frontend#6f6ebbc49390e841151a0220569d7f3846eb43a8",
+      "from": "github:alphagov/govuk-frontend#6f6ebbc4"
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clipboard": "^2.0.4",
     "connect": "^3.6.6",
     "eslint": "^5.16.0",
-    "govuk-frontend": "github:alphagov/govuk-frontend#3dc65f7e",
+    "govuk-frontend": "github:alphagov/govuk-frontend#6f6ebbc4",
     "gray-matter": "^4.0.2",
     "highlight.js": "^9.15.6",
     "html5shiv": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clipboard": "^2.0.4",
     "connect": "^3.6.6",
     "eslint": "^5.16.0",
-    "govuk-frontend": "^3.7.0",
+    "govuk-frontend": "github:alphagov/govuk-frontend#3dc65f7e",
     "gray-matter": "^4.0.2",
     "highlight.js": "^9.15.6",
     "html5shiv": "^3.7.3",

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -43,7 +43,6 @@ $navigation-height: 50px;
 
   &:not(:focus):hover {
     color: $govuk-link-colour;
-    text-decoration: underline;
   }
 
   // Extend the touch area of the link to the list
@@ -59,4 +58,5 @@ $navigation-height: 50px;
 
 .app-navigation__list-item--current .app-navigation__link:hover {
   text-decoration: none;
+  box-shadow: none;
 }

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -57,6 +57,6 @@ $navigation-height: 50px;
 }
 
 .app-navigation__list-item--current .app-navigation__link:hover {
-  text-decoration: none;
   box-shadow: none;
+  text-decoration: none;
 }

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -19,7 +19,7 @@
     text-decoration: none;
 
     &:not(:focus):hover {
-      box-shadow: 0 -2px transparent, 0 2px #1d70b8;
+      box-shadow: 0 -2px transparent, 0 2px $govuk-link-colour;
     }
   }
 

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -19,7 +19,7 @@
     text-decoration: none;
 
     &:not(:focus):hover {
-      color: $govuk-link-colour;
+      box-shadow: 0 -2px transparent, 0 2px #1d70b8;
     }
   }
 

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -20,7 +20,6 @@
 
     &:not(:focus):hover {
       color: $govuk-link-colour;
-      text-decoration: underline;
     }
   }
 


### PR DESCRIPTION
New hover states for text links, to address [#1417](https://github.com/alphagov/govuk-frontend/issues/1417).

The proposed hover state uses a thicker underline rather than a subtle change of colour or adding/removing the existing underline. Explanation of the rationale can be found at [my comment on the issue](https://github.com/alphagov/govuk-frontend/issues/1417#issuecomment-590970918).