### PR TITLE
Move date pattern example further down the page

### DIFF
--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -12,8 +12,6 @@ layout: layout-pane.njk
 
 Help users enter or select a date.
 
-{{ example({group: "patterns", item: "dates", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
-
 ## When to use this pattern
 
 Follow this pattern whenever you need users to provide or select a date as part of your&nbsp;service.
@@ -33,6 +31,8 @@ In some cases you might need users to pick a date from a given selection.
 ### Asking for memorable dates
 
 Ask for memorable dates, like dates of birth, using the [date input](../../components/date-input) component.
+
+{{ example({group: "patterns", item: "dates", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ### Asking for dates from documents and cards
 


### PR DESCRIPTION
There is more than one way to ask for a date, and that using a date input is only one of the possible approaches, so position the date input example closer to the use case to make this clearer.

This also helps to differentiate the 'asking for dates' pattern from the date input component.