### PR TITLE
Remove link to 'dates' error messages

### DIFF
--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -122,7 +122,6 @@ Use template messages for common errors on:
 - [character count](/components/character-count/#error-messages)
 - [checkboxes](/components/checkboxes/#error-messages)
 - [date input](/components/date-input/#error-messages)
-- [dates](/patterns/dates/#error-messages)
 - [ethnic group](/patterns/ethnic-group/#error-messages)
 - [email address](/patterns/email-addresses/#error-messages)
 - [file upload](/components/file-upload/#error-messages)


### PR DESCRIPTION
Remove a broken link to error messages in the 'asking for dates' pattern – the guidance on error messages in this pattern was removed in 651ac78 as it duplicated the guidance in the date input component.