### PR TITLE
Default to labels or legends as headings in component examples

### DIFF
--- a/src/components/text-input/default/index.njk
+++ b/src/components/text-input/default/index.njk
@@ -7,7 +7,9 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    text: "Event name"
+    text: "Event name",
+    classes: "govuk-label--l",
+    isPageHeading: true
   },
   id: "event-name",
   name: "event-name"

--- a/src/components/text-input/default/index.njk
+++ b/src/components/text-input/default/index.njk
@@ -7,7 +7,7 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    text: "Event name",
+    text: "What is the name of the event?",
     classes: "govuk-label--l",
     isPageHeading: true
   },

--- a/src/components/text-input/error/index.njk
+++ b/src/components/text-input/error/index.njk
@@ -7,7 +7,9 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    text: "Event name"
+    text: "Event name",
+    classes: "govuk-label--l",
+    isPageHeading: true
   },
   id: "event-name",
   name: "event-name",

--- a/src/components/text-input/error/index.njk
+++ b/src/components/text-input/error/index.njk
@@ -7,7 +7,7 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    text: "Event name",
+    text: "What is the name of the event?",
     classes: "govuk-label--l",
     isPageHeading: true
   },

--- a/src/components/text-input/input-hint-text/index.njk
+++ b/src/components/text-input/input-hint-text/index.njk
@@ -7,7 +7,9 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    text: "Event name"
+    text: "Event name",
+    classes: "govuk-label--l",
+    isPageHeading: true
   },
   hint: {
     text: "The name you’ll use on promotional material."

--- a/src/components/text-input/input-hint-text/index.njk
+++ b/src/components/text-input/input-hint-text/index.njk
@@ -7,7 +7,7 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    text: "Event name",
+    text: "What is the name of the event?",
     classes: "govuk-label--l",
     isPageHeading: true
   },

--- a/src/components/text-input/number-input/index.njk
+++ b/src/components/text-input/number-input/index.njk
@@ -7,7 +7,9 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    text: "Account number"
+    text: "Account number",
+    classes: "govuk-label--l",
+    isPageHeading: true
   },
   classes: "govuk-input--width-10",
   hint: {

--- a/src/components/text-input/number-input/index.njk
+++ b/src/components/text-input/number-input/index.njk
@@ -7,7 +7,7 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    text: "Account number",
+    text: "What is your account number?",
     classes: "govuk-label--l",
     isPageHeading: true
   },

--- a/src/components/textarea/default/index.njk
+++ b/src/components/textarea/default/index.njk
@@ -8,7 +8,9 @@ layout: layout-example.njk
   name: "more-detail",
   id: "more-detail",
   label: {
-    text: "Can you provide more detail?"
+    text: "Can you provide more detail?",
+    classes: "govuk-label--l",
+    isPageHeading: true
   },
   hint: {
     text: "Do not include personal or financial information, like your National Insurance number or credit card details."

--- a/src/components/textarea/error/index.njk
+++ b/src/components/textarea/error/index.njk
@@ -8,7 +8,9 @@ layout: layout-example.njk
   name: "more-detail",
   id: "more-detail",
   label: {
-    text: "Can you provide more detail?"
+    text: "Can you provide more detail?",
+    classes: "govuk-label--l",
+    isPageHeading: true
   },
   hint: {
     text: "Do not include personal or financial information, like your National Insurance number or credit card details."

--- a/src/components/textarea/specifying-rows/index.njk
+++ b/src/components/textarea/specifying-rows/index.njk
@@ -9,7 +9,9 @@ layout: layout-example.njk
   id: "more-detail",
   rows: "8",
   label: {
-    text: "Can you provide more detail?"
+    text: "Can you provide more detail?",
+    classes: "govuk-label--l",
+    isPageHeading: true
   },
   hint: {
     text: "Do not include personal or financial information, like your National Insurance number or credit card details."


### PR DESCRIPTION
Default to labels/legends as headings in component examples. As a principle, we should make examples follow our 'one thing per page' guidance unless there's good reason not to. This PR should close #1021 and relates to https://github.com/alphagov/govuk-design-system/issues/1222

This covers just text input and textarea as far as I'm aware:

<img width="834" alt="Screenshot 2020-06-03 at 14 41 47" src="https://user-images.githubusercontent.com/19834460/83644951-c87e5500-a5a9-11ea-9cd6-c12e528d9579.png">

<img width="834" alt="Screenshot 2020-06-03 at 14 41 38" src="https://user-images.githubusercontent.com/19834460/83644964-cc11dc00-a5a9-11ea-8daf-ece3507ebde0.png">

Still have a couple of questions at this point:

1. Do we need to update any of the guidance on these page? In particular the lines `If you’re asking just one question per page as recommended, you can set the contents of the <label> as the page heading.` which feels a bit off if the component is set to that as standard. Might just be a subtle change of wording needed.

2. Am I right about it just being these two components? What about file upload?

3. Should some of our patterns follow this convention too? For example, [asking for email addresses](https://design-system.service.gov.uk/patterns/email-addresses/) which has only one field but a non-heading label

