### PR TITLE
Add guidance on asking for numbers with decimals

### DIFF
--- a/src/components/text-input/decimal-input/index.njk
+++ b/src/components/text-input/decimal-input/index.njk
@@ -15,7 +15,6 @@ layout: layout-example.njk
   },
   id: "cost",
   name: "cost",
-  inputmode: "decimal",
   attributes: {
     spellcheck: "false"
   }

--- a/src/components/text-input/decimal-input/index.njk
+++ b/src/components/text-input/decimal-input/index.njk
@@ -1,0 +1,22 @@
+---
+title: Example of an input asking for numbers with decimal places
+layout: layout-example.njk
+---
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "Cost per item, in pounds"
+  },
+  classes: "govuk-input--width-10",
+  hint: {
+    text: "For example, 23.99"
+  },
+  id: "cost",
+  name: "cost",
+  inputmode: "decimal",
+  attributes: {
+    spellcheck: "false"
+  }
+}) }}

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -61,16 +61,26 @@ Fluid width inputs will resize with the viewport.
 
 ### Numbers
 
+#### Asking for whole numbers
+
 If you're asking the user to enter a whole number and you want to bring up the numeric keypad on a mobile device, set the `inputmode` attribute to `numeric` and the `pattern` attribute to `[0-9]*`. See how to do this in the HTML and Nunjucks tabs in the following example.
 
 {{ example({group: "components", item: "text-input", example: "number-input", html: true, nunjucks: true, open: false, size: "m"}) }}
-
-Do not use `<input type=”number”>` unless your user research shows that there’s a need for it. With `<input type=”number”>` there’s a risk of users accidentally incrementing a number when they’re trying to do something else - for example, scroll up or down the page. And if the user tries to enter something that’s not a number, there’s no explicit feedback about what they’re doing wrong.
 
 There are specific patterns for:
 
 - [dates](/patterns/dates/)
 - [telephone numbers](/patterns/telephone-numbers/)
+
+#### Asking for numbers with decimal places
+
+If you're asking the user to enter a number that might include a decimal place and you want to bring up the numeric keypad on a mobile device, set the `inputmode` attribute to `decimal`. See how to do this in the HTML and Nunjucks tabs in the following example.
+
+{{ example({group: "components", item: "text-input", example: "decimal-input", html: true, nunjucks: true, open: false, size: "m"}) }}
+
+#### Avoid using inputs with a type of number
+
+Do not use `<input type=”number”>` unless your user research shows that there’s a need for it. With `<input type=”number”>` there’s a risk of users accidentally incrementing a number when they’re trying to do something else - for example, scroll up or down the page. And if the user tries to enter something that’s not a number, there’s no explicit feedback about what they’re doing wrong.
 
 ### Hint text
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -61,7 +61,7 @@ Fluid width inputs will resize with the viewport.
 
 ### Numbers
 
-If it’s likely that the user will need to enter a number and you want to bring up the numeric keypad on a mobile device, set the `inputmode` attribute to `numeric` and the `pattern` attribute to `[0-9]*`. See how to do this in the HTML and Nunjucks tabs in the following example.
+If you're asking the user to enter a whole number and you want to bring up the numeric keypad on a mobile device, set the `inputmode` attribute to `numeric` and the `pattern` attribute to `[0-9]*`. See how to do this in the HTML and Nunjucks tabs in the following example.
 
 {{ example({group: "components", item: "text-input", example: "number-input", html: true, nunjucks: true, open: false, size: "m"}) }}
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -76,7 +76,7 @@ There are specific patterns for:
 
 If you're asking the user to enter a number that might include a decimal place, use `input type="text"` without `inputmode` or `pattern` attributes.
 
-Unfortunately, setting `inputmode` to `decimal` causes some devices to bring up a keypad without a period key, preventing users from entering a decimal point.
+Do not set the `inputmode` attribute to `decimal` as it causes some devices to bring up a keypad without a period key, preventing users from entering a decimal point.
 
 {{ example({group: "components", item: "text-input", example: "decimal-input", html: true, nunjucks: true, open: false, size: "m"}) }}
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -74,7 +74,9 @@ There are specific patterns for:
 
 #### Asking for numbers with decimal places
 
-If you're asking the user to enter a number that might include a decimal place and you want to bring up the numeric keypad on a mobile device, set the `inputmode` attribute to `decimal`. See how to do this in the HTML and Nunjucks tabs in the following example.
+If you're asking the user to enter a number that might include a decimal place, use `input type="text"` without `inputmode` or `pattern` attributes.
+
+Unfortunately, setting `inputmode` to `decimal` causes some devices to bring up a keypad without a period key, preventing users from entering a decimal point.
 
 {{ example({group: "components", item: "text-input", example: "decimal-input", html: true, nunjucks: true, open: false, size: "m"}) }}
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -72,11 +72,11 @@ There are specific patterns for:
 - [dates](/patterns/dates/)
 - [telephone numbers](/patterns/telephone-numbers/)
 
-#### Asking for numbers with decimal places
+#### Asking for decimal numbers
 
-If you're asking the user to enter a number that might include a decimal place, use `input type="text"` without `inputmode` or `pattern` attributes.
+If you're asking the user to enter a number that might include decimal places, use `input type="text"` without `inputmode` or `pattern` attributes.
 
-Do not set the `inputmode` attribute to `decimal` as it causes some devices to bring up a keypad without a period key, preventing users from entering a decimal point.
+Do not set the `inputmode` attribute to `decimal` as it causes some devices to bring up a keypad without a key for the decimal separator.
 
 {{ example({group: "components", item: "text-input", example: "decimal-input", html: true, nunjucks: true, open: false, size: "m"}) }}
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -82,7 +82,7 @@ Do not set the `inputmode` attribute to `decimal` as it causes some devices to b
 
 #### Avoid using inputs with a type of number
 
-Do not use `<input type=”number”>` unless your user research shows that there’s a need for it. With `<input type=”number”>` there’s a risk of users accidentally incrementing a number when they’re trying to do something else - for example, scroll up or down the page. And if the user tries to enter something that’s not a number, there’s no explicit feedback about what they’re doing wrong.
+Do not use `<input type="number">` unless your user research shows that there’s a need for it. With `<input type="number">` there’s a risk of users accidentally incrementing a number when they’re trying to do something else - for example, scroll up or down the page. And if the user tries to enter something that’s not a number, there’s no explicit feedback about what they’re doing wrong.
 
 ### Hint text
 


### PR DESCRIPTION
When asking for numbers with decimal places, it's important to use `inputtype="decimal"` as `inputtype="number"` may trigger a keyboard that does not include a period key.

The `pattern` attribute is not required for numbers with decimals – it's used to trigger the numeric keypad on iOS < 12.2, but as far as we can tell there's no equivalent to trigger the keyboard for decimal numbers. On these devices it'll fall back to displaying the full alphanumeric keypad.

Closes #1212 