### PR TITLE
Remove bold labels on radio examples with hint text

### DIFF
--- a/src/components/radios/hint/index.njk
+++ b/src/components/radios/hint/index.njk
@@ -22,9 +22,6 @@ layout: layout-example.njk
     {
       value: "government-gateway",
       text: "Sign in with Government Gateway",
-      label: {
-        classes: "govuk-label--s"
-      },
       hint: {
         text: "You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before."
       }
@@ -32,9 +29,6 @@ layout: layout-example.njk
     {
       value: "govuk-verify",
       text: "Sign in with GOV.UK Verify",
-      label: {
-        classes: "govuk-label--s"
-      },
       hint: {
         text: "You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
       }

--- a/src/patterns/ethnic-group/default/index.njk
+++ b/src/patterns/ethnic-group/default/index.njk
@@ -19,9 +19,6 @@ layout: layout-example.njk
     {
       value: "asian-or-asian-british",
       text: "Asian or Asian British",
-      label: {
-        classes: 'govuk-label--s'
-      },
       hint: {
         text: 'Includes any Asian background, for example, Bangladeshi, Chinese, Indian, Pakistani'
       }
@@ -29,9 +26,6 @@ layout: layout-example.njk
     {
       value: "black-african-black-british-or-caribbean",
       text: "Black, African, Black British or Caribbean",
-      label: {
-        classes: 'govuk-label--s'
-      },
       hint: {
         text: 'Includes any Black background'
       }
@@ -39,9 +33,6 @@ layout: layout-example.njk
      {
       value: "mixed-or-multiple-ethnic-groups",
       text: "Mixed or multiple ethnic groups",
-      label: {
-        classes: 'govuk-label--s'
-      },
       hint: {
         text: 'Includes any Mixed background'
       }
@@ -49,9 +40,6 @@ layout: layout-example.njk
     {
       value: "white",
       text: "White",
-      label: {
-        classes: 'govuk-label--s'
-      },
       hint: {
         text: 'Includes any White background'
       }
@@ -59,9 +47,6 @@ layout: layout-example.njk
     {
       value: "another-ethnic-group",
       text: "Another ethnic group",
-      label: {
-        classes: 'govuk-label--s'
-      },
       hint: {
         text: 'Includes any other ethnic group, for example, Arab'
       }

--- a/src/patterns/ethnic-group/error/index.njk
+++ b/src/patterns/ethnic-group/error/index.njk
@@ -22,9 +22,6 @@ layout: layout-example.njk
     {
       value: "asian-or-asian-british",
       text: "Asian or Asian British",
-      label: {
-        classes: 'govuk-label--s'
-      },
       hint: {
         text: 'Includes any Asian background, for example, Bangladeshi, Chinese, Indian, Pakistani'
       }
@@ -32,9 +29,6 @@ layout: layout-example.njk
     {
       value: "black-african-black-british-or-caribbean",
       text: "Black, African, Black British or Caribbean",
-      label: {
-        classes: 'govuk-label--s'
-      },
       hint: {
         text: 'Includes any Black background'
       }
@@ -42,9 +36,6 @@ layout: layout-example.njk
      {
       value: "mixed-or-multiple-ethnic-groups",
       text: "Mixed or multiple ethnic groups",
-      label: {
-        classes: 'govuk-label--s'
-      },
       hint: {
         text: 'Includes any Mixed background'
       }
@@ -52,9 +43,6 @@ layout: layout-example.njk
     {
       value: "white",
       text: "White",
-      label: {
-        classes: 'govuk-label--s'
-      },
       hint: {
         text: 'Includes any White background'
       }
@@ -62,9 +50,6 @@ layout: layout-example.njk
     {
       value: "another-ethnic-group",
       text: "Another ethnic group",
-      label: {
-        classes: 'govuk-label--s'
-      },
       hint: {
         text: 'Includes any other ethnic group, for example, Arab'
       }


### PR DESCRIPTION
Removing the `govuk-label--s` class on labels on radios with hint text, to make them consistent with how we use hint text elsewhere. For example:

<img width="823" alt="Screenshot 2020-06-09 at 11 15 27" src="https://user-images.githubusercontent.com/19834460/84135967-8be7a900-aa42-11ea-8ab5-f6f83852acd1.png">


Closes #1150, relates to https://github.com/alphagov/govuk-design-system/issues/1222