### PR TITLE
Clarify guidance on asking multiple questions on a page

### DIFF
--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -41,7 +41,7 @@ Question pages must include a:
 
 If research shows it’s helpful for users, you can also include a [progress indicator](#using-progress-indicators).
 
-### Back link
+## Back link
 
 Some users do not trust browser back buttons when they’re entering data. 
 
@@ -51,48 +51,9 @@ However, do not break the browser back button. Make sure it takes users to the p
 
 An exception to this is when the user has performed an action they should only do once, like make a payment or complete an application. The browser back button should still work, but show the user a sensible message rather than let them perform the action again.
 
-### Page headings
+## Page headings
 
-Page headings can be questions or statements. If you're [asking one question per page](#start-by-asking-one-question-per-page), use a question. If you're asking [multiple questions on a page](#asking-multiple-questions-on-a-page), use a statement.
-
-### Continue button
-
-Make sure your ‘Continue’ button is:
-
-- labelled ‘Continue’, not ‘Next’
-- aligned to the left so users do not miss it
-
-### Using progress indicators
-
-Start by testing your form without a progress indicator to see if it’s simple enough that users do not need one.
-
-Try improving the order, type or number of questions before adding a progress indicator. If people still have difficulty, try adding a simple step or question indicator like this one.
-
-{{ example({group: "patterns", item: "question-pages", example: "progress", html: true, nunjucks: true, open: false}) }}
-
-Only include the total number of questions if you can do so reliably. As the user moves through the form, make sure the indicator updates to tell them which question they are on and the total number remaining.
-
-Do not use progress indicators that do all of the following:
-
-- show all questions at once
-- allow navigation to previous questions
-- show the current question
-
-An example of this looks like:
-
-![Screenshot of a progress indicator that shows five questions.](progress_indicators_horizontal.png)
-
-These can be problematic because they:
-
-- are often not noticed
-- take up lots of space
-- do not scale well on small screens
-- can distract and confuse some users
-- make it hard to write good labels for the steps
-- make it hard to handle conditional sections
-
-A number of GOV.UK services have removed this style of progress indicator without any negative effects.
-Read a blog post about [how the Carer’s Allowance team removed a 12-step progress indicator](https://designnotes.blog.gov.uk/2014/07/07/do-less-problems-as-shared-spaces/) with no effect on completion rates or times.
+Page headings can be questions or statements.
 
 ### Start by asking one question per page
 
@@ -134,4 +95,41 @@ You can style each `<label>` or `<legend>` to make the questions easier to scan.
 
 {{ example({group: "patterns", item: "question-pages", example: "passport", html: true, nunjucks: true, open: false}) }}
 
+## Continue button
 
+Make sure your ‘Continue’ button is:
+
+- labelled ‘Continue’, not ‘Next’
+- aligned to the left so users do not miss it
+
+## Using progress indicators
+
+Start by testing your form without a progress indicator to see if it’s simple enough that users do not need one.
+
+Try improving the order, type or number of questions before adding a progress indicator. If people still have difficulty, try adding a simple step or question indicator like this one.
+
+{{ example({group: "patterns", item: "question-pages", example: "progress", html: true, nunjucks: true, open: false}) }}
+
+Only include the total number of questions if you can do so reliably. As the user moves through the form, make sure the indicator updates to tell them which question they are on and the total number remaining.
+
+Do not use progress indicators that do all of the following:
+
+- show all questions at once
+- allow navigation to previous questions
+- show the current question
+
+An example of this looks like:
+
+![Screenshot of a progress indicator that shows five questions.](progress_indicators_horizontal.png)
+
+These can be problematic because they:
+
+- are often not noticed
+- take up lots of space
+- do not scale well on small screens
+- can distract and confuse some users
+- make it hard to write good labels for the steps
+- make it hard to handle conditional sections
+
+A number of GOV.UK services have removed this style of progress indicator without any negative effects.
+Read a blog post about [how the Carer’s Allowance team removed a 12-step progress indicator](https://designnotes.blog.gov.uk/2014/07/07/do-less-problems-as-shared-spaces/) with no effect on completion rates or times.

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -18,6 +18,19 @@ This pattern explains when to use question pages and what elements they need to 
 
 Follow this pattern whenever you need to ask users questions within your service.
 
+You should make sure you know why you’re asking every question and only ask users for information you really need.
+
+To help you work out what to ask, you can carry out a [question protocol](https://www.uxmatters.com/mt/archives/2010/06/the-question-protocol-how-to-make-sure-every-form-field-is-necessary.php).
+
+If you ask for optional information, mark the labels of optional fields with ‘(optional)’. Never mark mandatory fields with asterisks.
+
+On every question page you should:
+
+- make sure it’s clear to users why you’re asking each question
+- allow users to answer ‘I do not know’ or ‘I’m not sure’ if they are valid responses
+
+Read more about [designing good questions](https://www.gov.uk/service-manual/design/designing-good-questions) in the GOV.UK Service Manual.
+
 ## How it works
 
 Question pages must include a:
@@ -40,31 +53,7 @@ An exception to this is when the user has performed an action they should only d
 
 ### Page headings
 
-Page headings can be statements or questions.
-
-If you are only asking for one piece of information per page, you can set the contents of the `<label>` or `<legend>` as the page heading.
-
-This is good practice as it means that users of screen readers will only hear the contents once.
-
-Read more about why and [how to set legends and labels as page headings](../../get-started/labels-legends-headings/) or see examples below.
-
-#### Legend as page heading
-
-{{ example({group: "patterns", item: "question-pages", example: "date-of-birth", html: true, nunjucks: true, open: false}) }}
-
-#### Label as a page heading
-
-{{ example({group: "patterns", item: "question-pages", example: "postcode", html: true, nunjucks: true, open: false}) }}
-
-Do not use the same page heading across multiple pages.
-
-The page heading should relate specifically to the information being asked for on the current page, not any higher-level section the page is part of.
-
-If you need to show the high-level section, you can use the `govuk-caption` style.
-
-For example, ‘About you’
-
-{{ example({group: "patterns", item: "question-pages", example: "section-headings", html: true, open: true, hideTab:true}) }}
+Page headings can be questions or statements. If you're [asking one question per page](#start-by-asking-one-question-per-page), use a question. If you're asking [multiple questions on a page](#asking-multiple-questions-on-a-page), use a statement.
 
 ### Continue button
 
@@ -111,7 +100,25 @@ Asking just one question per question page helps users understand what you’re 
 
 To help you follow this approach, you can set the contents of a `<legend>` or `<label>` for a page’s input as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
 
-Read more about [why and how to set labels and legends as headings](../../get-started/labels-legends-headings).
+Read more about why and [how to set labels and legends as headings](../../get-started/labels-legends-headings) or see examples below.
+
+#### Legend as page heading
+
+{{ example({group: "patterns", item: "question-pages", example: "date-of-birth", html: true, nunjucks: true, open: false}) }}
+
+#### Label as a page heading
+
+{{ example({group: "patterns", item: "question-pages", example: "postcode", html: true, nunjucks: true, open: false}) }}
+
+Do not use the same page heading across multiple pages.
+
+The page heading should relate specifically to the information being asked for on the current page, not any higher-level section the page is part of.
+
+If you need to show the high-level section, you can use the `govuk-caption` style.
+
+For example, ‘About you’
+
+{{ example({group: "patterns", item: "question-pages", example: "section-headings", html: true, open: true, hideTab:true}) }}
 
 You can also learn more about how starting with [one thing per page](https://www.gov.uk/service-manual/design/form-structure#start-with-one-thing-per-page) helps users in the GOV.UK Service Manual.
 
@@ -127,17 +134,4 @@ You can style each `<label>` or `<legend>` to make the questions easier to scan.
 
 {{ example({group: "patterns", item: "question-pages", example: "passport", html: true, nunjucks: true, open: false}) }}
 
-### Asking users questions
 
-You should make sure you know why you’re asking every question and only ask users for information you really need.
-
-To help you work out what to ask, you can carry out a [question protocol](https://www.uxmatters.com/mt/archives/2010/06/the-question-protocol-how-to-make-sure-every-form-field-is-necessary.php).
-
-If you ask for optional information, mark the labels of optional fields with ‘(optional)’. Never mark mandatory fields with asterisks.
-
-On every question page you should:
-
-- make sure it’s clear to users why you’re asking each question
-- allow users to answer ‘I do not know’ or ‘I’m not sure’ if they are valid responses
-
-Read more about [designing good questions](https://www.gov.uk/service-manual/design/designing-good-questions) in the GOV.UK Service Manual.

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -41,7 +41,7 @@ Question pages must include a:
 
 If research shows it’s helpful for users, you can also include a [progress indicator](#using-progress-indicators).
 
-## Back link
+### Back link
 
 Some users do not trust browser back buttons when they’re entering data. 
 
@@ -51,11 +51,11 @@ However, do not break the browser back button. Make sure it takes users to the p
 
 An exception to this is when the user has performed an action they should only do once, like make a payment or complete an application. The browser back button should still work, but show the user a sensible message rather than let them perform the action again.
 
-## Page headings
+### Page headings
 
 Page headings can be questions or statements.
 
-### Start by asking one question per page
+#### Start by asking one question per page
 
 Asking just one question per question page helps users understand what you’re asking them to do, and focus on the specific question and its answer.
 
@@ -63,11 +63,11 @@ To help you follow this approach, you can set the contents of a `<legend>` or `<
 
 Read more about why and [how to set labels and legends as headings](../../get-started/labels-legends-headings) or see examples below.
 
-#### Legend as page heading
+A question page with a legend as the page heading:
 
 {{ example({group: "patterns", item: "question-pages", example: "date-of-birth", html: true, nunjucks: true, open: false}) }}
 
-#### Label as a page heading
+A question page with a label as the page heading:
 
 {{ example({group: "patterns", item: "question-pages", example: "postcode", html: true, nunjucks: true, open: false}) }}
 
@@ -83,7 +83,7 @@ For example, ‘About you’
 
 You can also learn more about how starting with [one thing per page](https://www.gov.uk/service-manual/design/form-structure#start-with-one-thing-per-page) helps users in the GOV.UK Service Manual.
 
-### Asking multiple questions on a page
+#### Asking multiple questions on a page
 
 Sometimes it makes sense to group a number of related questions on the same page.
 
@@ -95,14 +95,14 @@ You can style each `<label>` or `<legend>` to make the questions easier to scan.
 
 {{ example({group: "patterns", item: "question-pages", example: "passport", html: true, nunjucks: true, open: false}) }}
 
-## Continue button
+### Continue button
 
 Make sure your ‘Continue’ button is:
 
 - labelled ‘Continue’, not ‘Next’
 - aligned to the left so users do not miss it
 
-## Using progress indicators
+### Using progress indicators
 
 Start by testing your form without a progress indicator to see if it’s simple enough that users do not need one.
 
@@ -131,5 +131,4 @@ These can be problematic because they:
 - make it hard to write good labels for the steps
 - make it hard to handle conditional sections
 
-A number of GOV.UK services have removed this style of progress indicator without any negative effects.
-Read a blog post about [how the Carer’s Allowance team removed a 12-step progress indicator](https://designnotes.blog.gov.uk/2014/07/07/do-less-problems-as-shared-spaces/) with no effect on completion rates or times.
+A number of GOV.UK services have removed this style of progress indicator without any negative effects. Read a blog post about [how the Carer’s Allowance team removed a 12-step progress indicator](https://designnotes.blog.gov.uk/2014/07/07/do-less-problems-as-shared-spaces/) with no effect on completion rates or times.

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -42,15 +42,11 @@ An exception to this is when the user has performed an action they should only d
 
 Page headings can be statements or questions.
 
-If you need to ask for multiple related things on a page, use a statement as the heading.
-
-{{ example({group: "patterns", item: "question-pages", example: "passport", html: true, nunjucks: true, open: false}) }}
-
 If you are only asking for one piece of information per page, you can set the contents of the `<label>` or `<legend>` as the page heading.
 
 This is good practice as it means that users of screen readers will only hear the contents once.
 
-Read more about why and [how to set legends and labels as page headings](https://design-system.service.gov.uk/get-started/labels-legends-headings/) or see examples below.
+Read more about why and [how to set legends and labels as page headings](../../get-started/labels-legends-headings/) or see examples below.
 
 #### Legend as page heading
 
@@ -118,6 +114,18 @@ To help you follow this approach, you can set the contents of a `<legend>` or `<
 Read more about [why and how to set labels and legends as headings](../../get-started/labels-legends-headings).
 
 You can also learn more about how starting with [one thing per page](https://www.gov.uk/service-manual/design/form-structure#start-with-one-thing-per-page) helps users in the GOV.UK Service Manual.
+
+### Asking multiple questions on a page
+
+Sometimes it makes sense to group a number of related questions on the same page.
+
+User research will tell you when you can group pages together. For example, if you’re designing an internal service for government users who need to repeat and switch between tasks quickly.
+
+If you need to ask for multiple related things on a page, use a statement as the heading.
+
+You can style each `<label>` or `<legend>` to make the questions easier to scan. Read more about why and [how to style labels and legends](../../get-started/labels-legends-headings/#styling-options-for-labels-and-legends).
+
+{{ example({group: "patterns", item: "question-pages", example: "passport", html: true, nunjucks: true, open: false}) }}
 
 ### Asking users questions
 


### PR DESCRIPTION
Some small updates to the question pages pattern. Related to https://github.com/alphagov/govuk-design-system/issues/1222.

What's changed:
- moved the multiple questions example further down the page so that the default is clearly 'one thing per page'
- added guidance on when to group multiple questions on a page, and how to style labels and legends to make the page easier to scan

Questions worth considering:
- what about using headings rather than labels to group related fields? e.g. having a `h2` saying 'contact details' with a text input for email and phone number below
- not directly related to this work but the 'Asking users questions' section at the bottom of this page feels quite high level and possibly too foundational to be at the bottom of the page like it is?
