### PR TITLE
Add guidance for turning off HTML5 validation for number inputs

### DIFF
--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -67,7 +67,9 @@ If you're asking the user to enter a whole number and you want to bring up the n
 
 {{ example({group: "components", item: "text-input", example: "number-input", html: true, nunjucks: true, open: false, size: "m"}) }}
 
-There are specific patterns for:
+You should also [turn off HTML5 validation](/patterns/validation/#turn-off-html5-validation) to prevent browsers from validating the `pattern` attribute.
+
+There is specific guidance on how to ask for:
 
 - [dates](/patterns/dates/)
 - [telephone numbers](/patterns/telephone-numbers/)

--- a/src/patterns/bank-details/index.md.njk
+++ b/src/patterns/bank-details/index.md.njk
@@ -54,6 +54,10 @@ Let users choose to get paid by an alternative method.
 
 Adapt this question depending on what payment options your users need and what your service can support.
 
+### Turn off HTML5 validation
+
+You should [turn off HTML5 validation](/patterns/validation/#turn-off-html5-validation) to prevent browsers from validating the `pattern` attribute used by the bank details pattern.
+
 {{ example({group: "patterns", item: "bank-details", example: "branch", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 ### International bank account details


### PR DESCRIPTION
We include the `pattern` attribute on the [text input component for numbers](https://design-system.service.gov.uk/components/text-input/#numbers). This PR is a very rough attempt at drafting some guidance to explain that this requires [turning off HTML5 validation](https://design-system.service.gov.uk/patterns/validation/#turn-off-html5-validation).

We already expect teams to turn off HTML5 validation for [visual and accessibility reasons](https://design-system.service.gov.uk/patterns/validation/#turn-off-html5-validation). The guidance in this PR acts as an additional signpost from the text input for numbers component and the bank details pattern.

#### Further detail
We have an [open issue](https://github.com/alphagov/govuk-frontend/issues/1701) for removing the `pattern` attribute from the number input once traffic from iOS < 12.2+ drops off, which means that the guidance added in this PR can also be removed in the future.

(Also, wouldn't it be good if the Design System examples were more flexible and could incorporate multiple code snippets, in this case a number input component and a form tag, removing the need to explain code in the text content.) 

Fixes https://github.com/alphagov/govuk-design-system/issues/1191