### PR TITLE
Reword Ruby resources section and fix govuk-frontend-rails project URL

### DIFF
--- a/src/community/resources/index.md.njk
+++ b/src/community/resources/index.md.njk
@@ -67,13 +67,13 @@ A Gulp task to convert GOV.UK Frontend Nunjucks macros to Jinja2
 [Govdown](https://github.com/ukgovdatascience/govdown)⁠ - 
 A GOV.UK Design System theme for R Markdown
 
-### Ruby
+### Ruby on Rails
 
-[GOV.UK Frontend Rails](https://github.com/mec/govuk-frontend-rails)⁠ - 
-A Rails starter app using GOV.UK Frontend
+[GOV.UK Frontend Rails](https://github.com/dxw/dxw_govuk_frontend_rails)⁠ - 
+A Ruby Gem that adds the GOV.UK Frontend to Rails apps
 
 [GOV.UK Rails Boilerplate](https://github.com/DFE-Digital/govuk-rails-boilerplate)⁠ - 
-A Rails starter app using GOV.UK Frontend
+A complete Rails starter app using GOV.UK Frontend
 
 [GOV.UK Design System Formbuilder](https://github.com/DFE-Digital/govuk_design_system_formbuilder) - 
 A Rails form builder using GOV.UK Frontend


### PR DESCRIPTION
Following on from the conversation in alphagov/govuk-design-system#1293 this PR contains some tweaks to the Ruby section of the Community Resources page, namely:

* update the URL for `govuk-frontend-rails` so it points at the newer, maintained project. Also make its description more accurate
* add the word 'complete' to the DfE Boilerplate project description to indicate that it contains an _entire_ template app and not a generator/engine etc
* rename the section from 'Ruby' to 'Ruby on Rails' as all the linked projects are Rails-specific