### PR TITLE
Update guidance on error styling and messages

### DIFF
--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -53,11 +53,11 @@ You will not normally need to use the `autocomplete` attribute in prototypes, as
 
 ### Error messages
 
-Error messages should be styled like this if you’re highlighting the date as a whole:
+If you’re highlighting the whole date, style all the fields like this:
 
 {{ example({group: "components", item: "date-input", example: "error", html: true, nunjucks: true, open: false, size: "m"}) }}
 
-Or like this is you’re highlighting just one of the day, month or year:
+If you’re highlighting just one field - either the day, month or year - only style the field that has an error. The error message must say which field has an error, like this:
 
 {{ example({group: "components", item: "date-input", example: "error-single", html: true, nunjucks: true, open: false, size: "m"}) }}
 

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -35,7 +35,7 @@ For each error:
 
 - put the message in red after the question text and hint text
 - use a red border to visually connect the message and the question it belongs to
-- if the error relates to specific text fields within the question, give these a red border as well
+- if the error relates to a specific field within the question, give it a red border and refer to that field in the error message - for example: "you must enter a year"
 
 To help screen reader users, the error message component includes a hidden 'Error:' before the error message. These users will hear, for example, "Error: The date your passport was issued must be in the past".
 


### PR DESCRIPTION
### What

This PR will make a couple of changes to guidance on:
- date inputs
- error messages

### Why 

In [issue 1820 in Frontend](https://github.com/alphagov/govuk-frontend/issues/1820) we're proposing changing the border width on inputs with errors to 2px. This is to resolve the problem of fields with errors not having enough contrast with their focused states (both being 4px wide and without enough colour contrast between them).

This will mean that inputs with errors will be less visually prominent than before. This could cause problems with grouped inputs, such as for dates. This guidance tries to make it clear that in these cases, the error message MUST directly reference the field it's referring to.