### PR TITLE
Update documentation on using spellcheck attribute

### DIFF
--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -11,12 +11,10 @@ layout: layout-example.njk
   id: "contact-by-email",
   name: "contact-by-email",
   type: "email",
+  spellcheck: false,
   classes: "govuk-!-width-one-third",
   label: {
     text: "Email address"
-  },
-  attributes: {
-    spellcheck: "false"
   }
 }) }}
 {% endset -%}

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -11,12 +11,10 @@ layout: layout-example.njk
   id: "contact-by-email",
   name: "contact-by-email",
   type: "email",
+  spellcheck: false,
   classes: "govuk-!-width-one-third",
   label: {
     text: "Email address"
-  },
-  attributes: {
-    spellcheck: "false"
   }
 }) }}
 {% endset -%}

--- a/src/components/text-input/decimal-input/index.njk
+++ b/src/components/text-input/decimal-input/index.njk
@@ -15,7 +15,5 @@ layout: layout-example.njk
   },
   id: "cost",
   name: "cost",
-  attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}

--- a/src/components/text-input/input-spellcheck-disabled/index.njk
+++ b/src/components/text-input/input-spellcheck-disabled/index.njk
@@ -11,7 +11,5 @@ layout: layout-example.njk
   },
   id: "name",
   name: "name",
-  attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}

--- a/src/components/text-input/number-input/index.njk
+++ b/src/components/text-input/number-input/index.njk
@@ -19,7 +19,5 @@ layout: layout-example.njk
   name: "account-number",
   inputmode: "numeric",
   pattern: "[0-9]*",
-  attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}

--- a/src/patterns/bank-details/default/index.njk
+++ b/src/patterns/bank-details/default/index.njk
@@ -14,9 +14,7 @@ layout: layout-example.njk
   },
   id: "name-on-the-account",
   name: "name-on-the-account",
-  attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}
 
 {{ govukInput({
@@ -31,9 +29,7 @@ layout: layout-example.njk
   name: "sort-code",
   inputmode: "numeric",
   pattern: "[0-9]*",
-  attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}
 
 {{ govukInput({
@@ -48,9 +44,7 @@ layout: layout-example.njk
   name: "account-number",
   inputmode: "numeric",
   pattern: "[0-9]*",
-  attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}
 
 {{ govukInput({
@@ -63,9 +57,7 @@ layout: layout-example.njk
   },
   id: "roll-number",
   name: "roll-number",
-  attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}
 
 {{ govukButton({

--- a/src/patterns/bank-details/error/index.njk
+++ b/src/patterns/bank-details/error/index.njk
@@ -18,9 +18,7 @@ layout: layout-example.njk
   name: "sort-code",
   inputmode: "numeric",
   pattern: "[0-9]*",
-  attributes: {
-    spellcheck: "false"
-  },
+  spellcheck: false,
   errorMessage: {
     text: "Enter a valid sort code like 309430"
   }

--- a/src/patterns/bank-details/international/index.njk
+++ b/src/patterns/bank-details/international/index.njk
@@ -16,9 +16,7 @@ layout: layout-example.njk
   },
   id: "bic-code",
   name: "bic-code",
-  attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}
 
 {{ govukInput({
@@ -30,7 +28,5 @@ layout: layout-example.njk
   },
   id: "iban",
   name: "iban",
-  attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}

--- a/src/patterns/email-addresses/default/index.njk
+++ b/src/patterns/email-addresses/default/index.njk
@@ -16,7 +16,5 @@ layout: layout-example.njk
   name: "email",
   type: "email",
   autocomplete: "email",
-  attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}

--- a/src/patterns/email-addresses/error/index.njk
+++ b/src/patterns/email-addresses/error/index.njk
@@ -20,7 +20,5 @@ layout: layout-example.njk
   errorMessage: {
     text: "Enter an email address in the correct format, like name@example.com"
   },
-  attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}

--- a/src/patterns/names/default/index.njk
+++ b/src/patterns/names/default/index.njk
@@ -12,7 +12,5 @@ layout: layout-example.njk
   id: "full-name",
   name: "full-name",
   autocomplete: "name",
-  attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}

--- a/src/patterns/names/error/index.njk
+++ b/src/patterns/names/error/index.njk
@@ -15,7 +15,5 @@ layout: layout-example.njk
   errorMessage: {
     text: "Enter your full name"
   },
-   attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}

--- a/src/patterns/national-insurance-numbers/default/index.njk
+++ b/src/patterns/national-insurance-numbers/default/index.njk
@@ -15,7 +15,5 @@ layout: layout-example.njk
   classes: "govuk-input--width-10",
   id: "national-insurance-number",
   name: "national-insurance-number",
-  attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}

--- a/src/patterns/national-insurance-numbers/error/index.njk
+++ b/src/patterns/national-insurance-numbers/error/index.njk
@@ -19,7 +19,5 @@ layout: layout-example.njk
   errorMessage: {
     text: "Enter a National Insurance number in the correct format"
   },
-   attributes: {
-    spellcheck: "false"
-  }
+  spellcheck: false
 }) }}


### PR DESCRIPTION
Depends on: https://github.com/alphagov/govuk-design-system/issues/1309
Relates to: https://github.com/alphagov/govuk-frontend/issues/1832

## What
Update any documentation around enabling/disabling spellcheck for input and textarea components in the design system to use the new spellcheck attribute

## Why
The spellcheck attribute was added for the input and textarea components in this PR: https://github.com/alphagov/govuk-frontend/pull/1859 . We should replace the old way of doing things with the new way, so that we're consistent.