### PR TITLE
Add coronavirus aliases

### DIFF
--- a/src/patterns/understand-the-impact-of-an-emergency/index.md.njk
+++ b/src/patterns/understand-the-impact-of-an-emergency/index.md.njk
@@ -3,7 +3,7 @@ title: Understand the impact of an emergency on your service
 description: 
 section: Patterns
 theme: Help users to…
-aliases: 
+aliases: coronavirus, covid
 backlog_issue_id: 212
 layout: layout-pane.njk
 ---


### PR DESCRIPTION
Suggestion from Mark, before we remove the coronavirus section from the home page