### PR TITLE
Remove section about coronavirus

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -28,18 +28,6 @@ description: Design your service using GOV.UK styles, components and patterns
       </div>
 
       <div class="govuk-grid-column-two-thirds-from-desktop">
-        <h2 id="telling-users-how-coronavirus-affects-your-service" class="govuk-heading-l">Telling users how coronavirus affects your&nbsp;service</h2>
-        <p class="govuk-body">
-          Do not use a red emergency banner or black global message banner to tell people about problems with a GOV.UK service, including problems related to coronavirus.
-          <a class="govuk-link" href="/patterns/understand-the-impact-of-an-emergency/">Help users understand the impact of an emergency on your service</a>.
-        </p>
-      </div>
-
-      <div class="govuk-grid-column-full">
-        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
-      </div>
-
-      <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 id="community" class="govuk-heading-l">Community</h2>
         <p class="govuk-body">
           The GOV.UK Design System is for everyone, with a strong community sitting behind it. It brings together the latest research, design and development from across government to make sure it’s representative and relevant for its users.</p>


### PR DESCRIPTION
Following chat with Mark (we're adding aliases to the relevant pattern, so people who search will still find it)