### PR TITLE
Update Nunjucks guidance and link to new docs

### DIFF
--- a/src/get-started/production/index.md.njk
+++ b/src/get-started/production/index.md.njk
@@ -33,7 +33,7 @@ Using this option, you will be able to:
 - selectively [include the CSS or JavaScript](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/) for individual components
 - build your own styles or components based on the palette or typography and spacing mixins
 - customise the build (for example, overriding colours or enabling global styles)
-- use the component Nunjucks templates
+- use the [Nunjucks template and macros](https://frontend.design-system.service.gov.uk/use-nunjucks/) if your environment supports them
 
 ### Option 2: include compiled files
 
@@ -64,31 +64,13 @@ Explore the [Styles](../../styles/) section of the Design System to see what cla
 
 ## Using components
 
-The components in the Design System are designed to be accessible and responsive - there are 2 ways to implement them in your application.
+The components in the Design System are designed to be accessible and responsive.
 
-You can either use HTML or - if you’re using Nunjucks with node.js and you installed GOV.UK Frontend using npm - you can use a Nunjucks Macro.
+You can use them in your live application as either:
+
+- HTML
+- [Nunjucks macros](https://frontend.design-system.service.gov.uk/use-nunjucks/) - if you installed GOV.UK Frontend using npm and your application uses Node.js
 
 You can get the code from the HTML or Nunjucks tabs below any examples:
 
 {{ example({group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false}) }}
-
-### Using Nunjucks macros
-
-A Nunjucks macro is a simple template that generates more complex HTML.
-
-Nunjucks macros save you time by managing repetitive or error-prone tasks, like linking form labels to their controls.
-
-Nunjucks macros also make it easier to keep your application up to date. You can run a command to update component code instead of having to manually update your HTML.
-
-To use Nunjucks macros in your application, you’ll need to setup Nunjucks views to point to the location of GOV.UK Frontend components, which is `node_modules/govuk-frontend/govuk/components/`.
-
-To include a specific component macro in your page template, you need to import the macro.
-
-For example, to use the breadcrumb macro, use the import statement `{% raw %}{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}{% endraw %}`.
-
-{{ govukInsetText({
-  classes: "app-table--constrained",
-  html: "If you’re using Nunjucks macros in production be aware that using  <code>html</code> arguments, or ones ending with <code>Html</code> can be a <a href='https://en.wikipedia.org/wiki/Cross-site_scripting'>security risk</a>."
-}) }}
-
-There are various way to mitigate against that. One example is described in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).

--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -16,11 +16,11 @@ This page template combines the boilerplate markup and [components](../../compon
 - the [skip link](../../components/skip-link), [header](../../components/header) and [footer](../../components/footer) components
 - the favicon, and other related theme icons
 
-In the examples provided, we show both HTML and Nunjucks.
+In the examples provided, we show both HTML and [Nunjucks](https://frontend.design-system.service.gov.uk/use-nunjucks/).
 
 You can use the HTML examples if you are not able to use Nunjucks. If you use HTML you’ll need to update it manually when new versions are released.
 
-If you are using Nunjucks you can get this page template by installing GOV.UK Frontend.
+If you're using Nunjucks you can get this page template by installing GOV.UK Frontend.
 You’ll get updates to the page template when we update GOV.UK Frontend.
 
 
@@ -36,111 +36,60 @@ You can customise the page template, for example, by adding a service name and n
 
 {{ example({group: "styles", item: "page-template", example: "custom", customCode: true, html: true, nunjucks: true, open: false, size: "xl" }) }}
 
-## Nunjucks
+## Changing template content
 
+If you’re using Nunjucks, you can change the template’s content using options.
 
-### Configuring Nunjucks
+How you set an option depends on whether it's a 'variable' option or a 'block' option.
 
-When using Nunjucks you’ll need to add `node_modules/govuk-frontend/`
-as available views:
+To set a 'variable' option, use `set` to pass in a single value or string. For example, to add a class to the `<body>` element using the `bodyClasses` option:
 
-```js
-nunjucks.configure([
-  "node_modules/govuk-frontend/"
-], {
-  autoescape: true
-})
-```
-
-See the [Nunjucks getting started guide](https://mozilla.github.io/nunjucks/getting-started.html) for more information.
-
-Once you have configured Nunjucks, you can now extend `template.njk` in your view:
-
-```
+```javascript
 {% raw %}
-{% extends "govuk/template.njk" %}
+{% set bodyClasses = "EXAMPLE-CLASS" %}
 {% endraw %}
 ```
 
-### Changing template content
+To set a 'block' option, use `block` to pass in a multiline value or HTML markup. For example, to add a block of HTML before the closing </body> element in the page template using the `bodyEnd` option:
 
-The Nunjucks template allows 2 ways to change the content: [variables](https://mozilla.github.io/nunjucks/templating.html#set) or [blocks](https://mozilla.github.io/nunjucks/templating.html#block).
-
-The main difference between a variable and a block is that blocks can contain markup.
-
-#### Variables
-
-Variables can be set with:
-
-```js
+```javascript
 {% raw %}
-{% set variableName = "value" %}
+{% block bodyEnd %}
+  <div>
+     <p>Example text</p>
+  </div>
+{% endblock %}
 {% endraw %}
 ```
+
+To change the components that are included in the page template by default, set their equivalent blocks. For example:
+
+```javascript
+{% raw %}
+{% block header %}
+  {{ govukHeader ({
+    homepageUrl: "/custom-url"
+  }) }}
+{% endblock %}
+{% endraw %}
+```
+
+### Options
 
 <table class="govuk-table app-table--constrained">
-  <caption class="govuk-table__caption govuk-visually-hidden">Variables that can be used with Template</caption>
+  <caption class="govuk-table__caption govuk-visually-hidden">Options that you can use with the page template</caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col">Variable name</th>
+      <th class="govuk-table__header" scope="col">Option name</th>
+      <th class="govuk-table__header" scope="col">Option type</th>
       <th class="govuk-table__header" scope="col">Description</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
 
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell">htmlLang</td>
-      <td class="govuk-table__cell">Set the language of the whole document. If your <code>&lt;title&gt;</code> and <code>&lt;main&gt;</code> element are in a different language to the rest of the page, use <code>htmlLang</code> to set the language of the rest of the page.</td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">htmlClasses</td>
-      <td class="govuk-table__cell">Add a class to the <code>&lt;html&gt;</code> element.</td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">pageTitleLang</td>
-      <td class="govuk-table__cell">
-        Set the language of the <code>&lt;title&gt;</code> element if it's different to <code>htmlLang</code>.
-      </td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">themeColor</td>
-      <td class="govuk-table__cell">
-        Set the <a href="https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android">toolbar colour on some devices</a>
-      </td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">bodyClasses</td>
-      <td class="govuk-table__cell">Add a class to the <code>&lt;body&gt;</code> element.</td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">bodyAttributes</td>
-      <td class="govuk-table__cell">Add attributes to the <code>&lt;body&gt;</code> element. Add each attribute and its value in the <code>bodyAttributes</code> object.</td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">containerClasses</td>
-      <td class="govuk-table__cell">Add a class to the container. This is useful if you want to make the page wrapper a fixed width.</td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">mainClasses</td>
-      <td class="govuk-table__cell">Add a class to the <code>&lt;main&gt;</code> element. </td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">mainLang</td>
-      <td class="govuk-table__cell">
-        Set the language of the <code>&lt;main&gt;</code> element if it's different to <code>htmlLang</code>.
-      </td>
-    </tr>
-
-    <tr class="govuk-table__row">
       <td class="govuk-table__cell">assetPath</td>
+      <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">
         Specify a path to the <a href="https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#font-and-image-assets">GOV.UK Frontend assets</a> (icons, images, font files).
       </td>
@@ -148,100 +97,13 @@ Variables can be set with:
 
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">assetUrl</td>
+      <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">Set the domain for the Open Graph meta tag image asset. If you need to use both your own domain and your own image path and filename, add <code>&lt;meta property="og:image" content="YOUR-ABSOLUTE-URL"&gt;</code> inside the <code>head</code> <a href="#blocks">block</a> instead of using `assetUrl`.</td>
-    </tr>
-  </tbody>
-</table>
-
-#### Blocks
-
-Blocks can be set with:
-
-```js
-{% raw %}
-{% block blockName %}
-  HTML Here
-{% endblock %}
-{% endraw %}
-```
-
-To change the components that are included by default, set their equivalent blocks, for example:
-
-```js
-{% raw %}
-{% block header %}
-  {{ header({
-    homepageUrl: "/custom-url"
-  }) }}
-{% endblock %}
-{% endraw %}
-```
-
-<table class="govuk-table app-table--constrained">
-  <caption class="govuk-table__caption govuk-visually-hidden">Blocks that can be used with Template</caption>
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col">Block name</th>
-      <th class="govuk-table__header" scope="col">Description</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">pageTitle</td>
-      <td class="govuk-table__cell">
-        Override the default page title (<code>&lt;title&gt;</code> element).
-      </td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">headIcons</td>
-      <td class="govuk-table__cell">
-        Override the default icons used for GOV.UK branded pages.
-        <br>
-        For example: <code>&lt;link rel="shortcut icon" href="favicon.ico" type="image/x-icon" /&gt;</code>
-      </td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">head</td>
-      <td class="govuk-table__cell">
-        Add additional items inside the <code>&lt;head&gt;</code> element.
-        <br>
-        For example: <code>&lt;meta name="description" content="My page description"&gt;</code>
-      </td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">bodyStart</td>
-      <td class="govuk-table__cell">
-        Add content after the opening <code>&lt;body&gt;</code> element
-      </td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">skipLink</td>
-      <td class="govuk-table__cell">
-        Override the default <a class="govuk-link" href="../../components/skip-link/">skip link</a> component.
-      </td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">header</td>
-      <td class="govuk-table__cell">
-        Override the default <a class="govuk-link" href="../../components/header/">header</a> component.
-      </td>
-    </tr>
-
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">main</td>
-      <td class="govuk-table__cell">
-        Override the main section of the page, which by default wraps the <code>&lt;main&gt;</code> element, <code>beforeContent</code> block and <code>content</code> block.
-      </td>
     </tr>
 
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">beforeContent</td>
+      <td class="govuk-table__cell">Block</td>
       <td class="govuk-table__cell">
         Add content that needs to appear outside <code>&lt;main&gt;</code> element.
         <br>
@@ -251,7 +113,43 @@ To change the components that are included by default, set their equivalent bloc
     </tr>
 
     <tr class="govuk-table__row">
+      <td class="govuk-table__cell">bodyAttributes</td>
+      <td class="govuk-table__cell">Variable</td>      
+      <td class="govuk-table__cell">Add attributes to the <code>&lt;body&gt;</code> element. Add each attribute and its value in the <code>bodyAttributes</code> object.</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">bodyClasses</td>
+      <td class="govuk-table__cell">Variable</td>
+      <td class="govuk-table__cell">Add a class to the <code>&lt;body&gt;</code> element.</td>
+    </tr>
+
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">bodyEnd</td>
+      <td class="govuk-table__cell">Block</td>
+      <td class="govuk-table__cell">
+        Add content just before the closing <code>&lt;/body&gt;</code> element.
+      </td>
+    </tr>
+    
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">bodyStart</td>
+      <td class="govuk-table__cell">Block</td>
+      <td class="govuk-table__cell">
+        Add content after the opening <code>&lt;body&gt;</code> element.
+      </td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">containerClasses</td>
+      <td class="govuk-table__cell">Variable</td>
+      <td class="govuk-table__cell">Add a class to the container. This is useful if you want to make the page wrapper a fixed width.</td>
+    </tr>
+
+    <tr class="govuk-table__row">
       <td class="govuk-table__cell">content</td>
+      <td class="govuk-table__cell">Block</td>
       <td class="govuk-table__cell">
         Add content that needs to appear centered in the <code>&lt;main&gt;</code> element.
       </td>
@@ -259,15 +157,103 @@ To change the components that are included by default, set their equivalent bloc
 
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">footer</td>
+      <td class="govuk-table__cell">Block</td>
       <td class="govuk-table__cell">
         Override the default <a class="govuk-link" href="../../components/footer/">footer</a> component.
       </td>
     </tr>
 
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell">bodyEnd</td>
+      <td class="govuk-table__cell">head</td>
+      <td class="govuk-table__cell">Block</td>
       <td class="govuk-table__cell">
-        Add content just before the closing <code>&lt;/body&gt;</code> element
+        Add additional items inside the <code>&lt;head&gt;</code> element.
+        <br>
+        For example: <code>&lt;meta name="description" content="My page description"&gt;</code>
+      </td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">header</td>
+      <td class="govuk-table__cell">Block</td>
+      <td class="govuk-table__cell">
+        Override the default <a class="govuk-link" href="../../components/header/">header</a> component.
+      </td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">headIcons</td>
+      <td class="govuk-table__cell">Block</td>
+      <td class="govuk-table__cell">
+        Override the default icons used for GOV.UK branded pages.
+        <br>
+        For example: <code>&lt;link rel="shortcut icon" href="favicon.ico" type="image/x-icon" /&gt;</code>
+      </td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">htmlClasses</td>
+      <td class="govuk-table__cell">Variable</td>
+      <td class="govuk-table__cell">Add a class to the <code>&lt;html&gt;</code> element.</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">htmlLang</td>
+      <td class="govuk-table__cell">Variable</td>
+      <td class="govuk-table__cell">Set the language of the whole document. If your <code>&lt;title&gt;</code> and <code>&lt;main&gt;</code> element are in a different language to the rest of the page, use <code>htmlLang</code> to set the language of the rest of the page.</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">main</td>
+      <td class="govuk-table__cell">Block</td>
+      <td class="govuk-table__cell">
+        Override the main section of the page, which by default wraps the <code>&lt;main&gt;</code> element, <code>beforeContent</code> block and <code>content</code> block.
+      </td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">mainClasses</td>
+      <td class="govuk-table__cell">Variable</td>
+      <td class="govuk-table__cell">Add a class to the <code>&lt;main&gt;</code> element. </td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">mainLang</td>
+      <td class="govuk-table__cell">Variable</td>
+      <td class="govuk-table__cell">
+        Set the language of the <code>&lt;main&gt;</code> element if it's different to <code>htmlLang</code>.
+      </td>
+    </tr>
+    
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">pageTitle</td>
+      <td class="govuk-table__cell">Block</td>
+      <td class="govuk-table__cell">
+        Override the default page title (<code>&lt;title&gt;</code> element).
+      </td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">pageTitleLang</td>
+      <td class="govuk-table__cell">Variable</td>
+      <td class="govuk-table__cell">
+        Set the language of the <code>&lt;title&gt;</code> element if it's different to <code>htmlLang</code>.
+      </td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">skipLink</td>
+      <td class="govuk-table__cell">Block</td>
+      <td class="govuk-table__cell">
+        Override the default <a class="govuk-link" href="../../components/skip-link/">skip link</a> component.
+      </td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">themeColor</td>
+      <td class="govuk-table__cell">Variable</td>
+      <td class="govuk-table__cell">
+        Set the <a href="https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android">toolbar colour on some devices</a>.
       </td>
     </tr>
 


### PR DESCRIPTION
As part of [Improving guidance for using Nunjucks docs](https://github.com/alphagov/govuk-design-system/issues/1281), this improves the Nunjucks guidance in the Design System to: 

- remove the Nunjucks guidance from [Get Started > Production](https://design-system.service.gov.uk/get-started/production/) and link to the [new improved Frontend docs on Nunjucks](https://github.com/alphagov/govuk-frontend-docs/pull/67)
- link to the same new docs from [page template](https://design-system.service.gov.uk/styles/page-template/)
- improve the page template-specific Nunjucks guidance so we talk about `set` and `block` as alternate ways of passing in the same options rather than 2 different types of option
- combined the 'variable' and 'block' tables, and put the combined table in alphabetical order so it's easier to use 

Thanks to @hannalaakso for her help pairing to create this new documentation.