### PR TITLE
Do not autolink email address in emails pattern

### DIFF
--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -77,7 +77,7 @@ Make sure errors follow the guidance in [error message](/components/error-messag
 
 #### If the email address is not in the correct format and there is no example
 
-Say ‘Enter an email address in the correct format, like name@example.com’.
+Say ‘Enter an email address in the correct format, like name<i></i>@example.com’.
 
 #### If the email address is not in the correct format and there is an example
 


### PR DESCRIPTION
Unfortunately there is [no way to disable auto-linking in marked without overriding the renderer's `link` function][1].

Prevent the auto-linker from working by including an empty `<i>` tag within the email address, which is [consistent with how we've done it elsewhere, in the typography styles page][2].

Fixes #1316.

[1]: https://github.com/markedjs/marked/issues/882
[2]: https://github.com/alphagov/govuk-design-system/blob/d25b2f6407f86a8f4c168ea6604f935ae51cfe0c/src/styles/typography/index.md.njk#L86