### PR TITLE
Document row-no-border class

### DIFF
--- a/src/components/summary-list/index.md.njk
+++ b/src/components/summary-list/index.md.njk
@@ -51,6 +51,8 @@ If you do not include actions in your summary list and it would be better for yo
 
 {{ example({group: "components", item: "summary-list", example: "without-borders", html: true, nunjucks: true, open: false}) }}
 
+To remove borders on a single row, use the `govuk-summary-list__row--no-border` class.
+
 ## Research on this component
 
 This component was developed and tested by the Government Digital Services as part of the [check answers pattern](/patterns/check-answers).


### PR DESCRIPTION
I needed a summary list without a bottom border - the design system has a useful class for this, but it's not mentioned.

My use case is a summary list appearing inside of another block - in this case the bottom border is redundant.

![Screenshot 2020-08-11 at 13 25 22](https://user-images.githubusercontent.com/2204224/89896960-33fe2780-dbd6-11ea-9d77-427f5d7c2e78.png)
