### PR TITLE
Fix broken anchor link

### DIFF
--- a/src/components/fieldset/index.md.njk
+++ b/src/components/fieldset/index.md.njk
@@ -31,4 +31,4 @@ Read more about [why and how to set legends as headings](../../get-started/label
 
 On [question pages](../../patterns/question-pages) containing a group of inputs, including the question as the legend helps users of screen readers to understand that the inputs are all related to that&nbsp;question.
 
-Include any general help text which is important for filling in the form and cannot be written as [hint text](../../components/text-input#using-hint-text) in the legend, but try to keep it as concise as possible.
+Include any general help text which is important for filling in the form and cannot be written as [hint text](../../components/text-input#hint-text) in the legend, but try to keep it as concise as possible.


### PR DESCRIPTION
The heading was renamed from 'Using hint text' to 'Hint text' in fbe0c47.

Fixes #1326.