### PR TITLE
Add content about accessibility of Frontend docs

### DIFF
--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -38,11 +38,15 @@ The Equality and Human Rights Commission (EHRC) is responsible for enforcing the
 
 GDS is committed to making its websites accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
 
-This website is fully compliant with the Web Content Accessibility Guidelines version 2.1 AA standard.
+The Design System website at [https://design-system.service.gov.uk/](https://design-system.service.gov.uk/) is fully compliant with the Web Content Accessibility Guidelines version 2.1 AA standard.
+
+The GOV.UK Frontend documentation website at [http://frontend.design-system.service.gov.uk/](https://frontend.design-system.service.gov.uk/) is partially compliant with the Web Content Accessibility Guidelines version 2.1 AA standard, because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
+
+We plan to fix the issues with the Technical Documentation Template by the end of 2020.
 
 ### How this website has been tested for accessibility
 
-This website was last tested on 7 October. The test was carried out by the [Digital Accessibility Centre (DAC)](https://digitalaccessibilitycentre.org/).
+The Design System website was last tested on 7 October 2019. The test was carried out by the [Digital Accessibility Centre (DAC)](https://digitalaccessibilitycentre.org/).
 
 DAC tested a sample of pages to cover the different content types in the GOV.UK Design System website. They were:
 
@@ -54,9 +58,11 @@ DAC tested a sample of pages to cover the different content types in the GOV.UK 
 - [a component page](https://design-system.service.gov.uk/components/radios/)
 - [a pattern page](https://design-system.service.gov.uk/patterns/question-pages/)
 
-They also tested the global search functionality that appears in the header of every page in the Design System. 
+They also tested the global search functionality that appears in the header of every page in the Design System.
 
-### How the GOV.UK Design System team makes this website accessible 
+The [GOV.UK Frontend documentation website](http://frontend.design-system.service.gov.uk/) was last tested in July 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested all the website's pages.
+
+### How the GOV.UK Design System team makes this website accessible
 
 The GOV.UK Design System team works hard to ensure that this Design System and Frontend, the codebase it uses, are accessible.
 
@@ -64,7 +70,7 @@ Where possible, the team aims to research components and patterns with a represe
 
 It also tests components to ensure they work with a broad range of browsers, devices and assistive technologies - including screen magnifiers, screen readers and speech recognition tools.
 
-This statement was prepared on 23 October 2019. It was last updated on 23 October 2019.
+This statement was prepared on 23 October 2019. It was last updated on 2 September 2020.
 
 ## Using the Design System and Frontend in your service
 
@@ -84,7 +90,7 @@ The Design System and Frontend were introduced in June 2018 to replace the follo
 - GOV.UK Frontend Toolkit
 - GOV.UK Template
 
-The GOV.UK Design System team no longer supports these products and will not be making updates to help them meet level AA of WCAG 2.1. 
+The GOV.UK Design System team no longer supports these products and will not be making updates to help them meet level AA of WCAG 2.1.
 
 If you're using these products, you should start [updating your service to use the Design System and Frontend](https://design-system.service.gov.uk/get-started/updating-your-code/).
 


### PR DESCRIPTION
### Context
We're doing an overall accessibility audit of our Tech Docs Template technical documentation across GDS.

### Changes proposed in this pull request
Following the [audit and improvements](https://github.com/alphagov/govuk-frontend-docs/issues/65) to the Frontend docs July, we now need to publish accessibility content as part of the Design System accessibility statement.

I've made clarifications in the statement so it's clear when we're talking about the Design System website and when we're talking about the Frontend docs.

### Before we merge

- [ ] General TDT accessibility statement has been published
- [ ] Add missing date