### PR TITLE
Use PaaS-supplied nginx buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -12,12 +12,7 @@ applications:
   # from the default 1 GB allocated to containers by default to 64M.
   memory: 64M
   path: ./deploy
-  # PaaS don't currently support the nginx buildpack so we have to reference it
-  # by GitHub URL
-  #
-  # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
-  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.9
+  buildpack: nginx_buildpack
   # Run two instances to ensure availability
-  #
   # https://docs.cloud.service.gov.uk/managing_apps.html#scaling
   instances: 2


### PR DESCRIPTION
When we set the Design System up, PaaS did not support the nginx buildpack, so we had to reference the buildpack using its GitHub URL, pinning to a specific version.

PaaS now provide an nginx buildpack, so we can now use that instead. This means whenever PaaS update their buildpacks we'll automatically use the latest version when we next deploy.

The current version of the buildpack is 1.1.14, so this effectively bumps the buildpack version from 1.1.9 to 1.1.14, and the nginx version from v1.17.10 to v1.19.2 (verified by deploying a test app to the sandbox).