### PR TITLE
Make code blocks scrollable using the keyboard

### DIFF
--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -71,5 +71,6 @@
 }
 
 .app-example__code {
+  position: relative;
   @include govuk-font($size: 19);
 }

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -151,6 +151,7 @@
   padding: 0;
   border: 0;
   outline: 1px solid transparent;
+  color: $govuk-text-colour;
   background-color: govuk-colour("light-grey");
   font-size: inherit;
 

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -162,7 +162,7 @@
 }
 
 .app-tabs__container pre code {
-  display: block;
+  display: inline-block;
   padding: govuk-spacing(4);
 
   .js-enabled & {

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -146,7 +146,6 @@
 }
 
 .app-tabs__container pre {
-  position: relative;
   max-width: inherit;
   margin-bottom: 0;
   padding: 0;
@@ -154,12 +153,16 @@
   outline: 1px solid transparent;
   background-color: govuk-colour("light-grey");
   font-size: inherit;
+
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    box-shadow: inset 0 0 0 $govuk-focus-width;
+  }
 }
 
 .app-tabs__container pre code {
   display: block;
   padding: govuk-spacing(4);
-  overflow-x: auto;
 
   .js-enabled & {
     padding-top: 45px; // Allow extra space for the copy code button

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -65,7 +65,7 @@
   {% endif %}
   <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-html" role="tabpanel">
     <div class="app-example__code">
-      <pre data-module="app-copy"><code class="hljs html">
+      <pre data-module="app-copy" tabindex="0"><code class="hljs html">
         {{- getHTMLCode(examplePath) | highlight('html') | safe -}}
       </code></pre>
     </div>
@@ -147,7 +147,7 @@
       })}}
     {% endif %}
     <div class="app-example__code">
-      <pre data-module="app-copy"><code class="hljs js">
+      <pre data-module="app-copy" tabindex="0"><code class="hljs js">
         {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
       </code></pre>
     </div>


### PR DESCRIPTION
Allow the code blocks to be scrolled using the keyboard by including them in the tab order and giving them a visible focus state.

<img width="1392" alt="Example of a focused code block, with the focus state indicated by a thick black and yellow border around the code block" src="https://user-images.githubusercontent.com/121939/93102667-9948ab00-f6a3-11ea-9ba9-7e257c489edf.png">

This allows the user to tab to the code blocks, then use the arrow keys to scroll left to right.

Fixes #1343 