### PR TITLE
Clarify when not to use error messages

### DIFF
--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -21,7 +21,9 @@ Use standard messages for different components.
 
 ## When not to use this component
 
-Do not use error messages to tell users that they are not eligible or do not have permission to do something. Instead, take them to a page which tells them they’re not eligible and gives them useful information about what to do next.
+Do not use error messages to tell a user that they are not eligible or do not have permission to do something. Or to tell them about a lack of capacity or other problem the user cannot fix - because the problem is with the service rather than with the information the user has provided.
+
+Instead, take them to a page which explains the problem (for example, telling them why they’re not eligible) and provides useful information about what to do next.
 
 There are separate patterns for:
 

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -23,7 +23,7 @@ Use standard messages for different components.
 
 Do not use error messages to tell a user that they are not eligible or do not have permission to do something. Or to tell them about a lack of capacity or other problem the user cannot fix - because the problem is with the service rather than with the information the user has provided.
 
-Instead, take them to a page which explains the problem (for example, telling them why they’re not eligible) and provides useful information about what to do next.
+Instead, take the user to a page that explains the problem (for example, telling them why they’re not eligible) and provides useful information about what to do next.
 
 There are separate patterns for:
 


### PR DESCRIPTION
Make it clearer that the error message pattern is for highlighting problems with information the user provides rather than problems with the service.