### PR TITLE
Switch code block focus from box-shadow to border

### DIFF
--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -149,15 +149,15 @@
   max-width: inherit;
   margin-bottom: 0;
   padding: 0;
-  border: 0;
+  border: $govuk-focus-width solid transparent;
   outline: 1px solid transparent;
   color: $govuk-text-colour;
   background-color: govuk-colour("light-grey");
   font-size: inherit;
 
   &:focus {
+    border: $govuk-focus-width solid $govuk-input-border-colour;
     outline: $govuk-focus-width solid $govuk-focus-colour;
-    box-shadow: inset 0 0 0 $govuk-focus-width;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-design-system/issues/1356

## Before
![93597432-f5b50e80-f9b2-11ea-9835-7a584888348d](https://user-images.githubusercontent.com/29889908/93598713-0070a300-f9b5-11ea-8807-94156bf81502.png)

## After
<img width="834" alt="Screenshot 2020-09-18 at 13 46 03" src="https://user-images.githubusercontent.com/29889908/93598950-52b1c400-f9b5-11ea-98b5-274f262c3e6d.png">

