### PR TITLE
Applied to 'Address line x' format and modified guidance

### DIFF
--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -33,7 +33,7 @@ Use an address lookup when you’re asking users for a UK address.
 
 ### When not to use an address lookup
 
-Address lookups generally only work for UK addresses. Use a manual option such as  multiple text inputs or a textarea when you are collecting mostly or only international&nbsp;addresses
+Address lookups only work for UK addresses. Provide a manual option for addresses that are missing or not properly listed in the address lookup. Provide a manual option for addresses that are missing or not properly listed in the address lookup.
 
 ### How an address lookup works
 
@@ -43,13 +43,7 @@ When using an address lookup, you should:
 
 - make it clear that it will only work for UK addresses
 - provide a manual option for people with international addresses or addresses that are missing or not properly listed in the address lookup
-- let people enter their postcodes in upper or lower case and with or without spaces
-
-#### Allow different postcode formats
-
-It is easier for users if you accept and ignore unwanted characters. This is better than rejecting the input and telling a user they've not provided a valid postcode.
-
-You should allow postcodes that contain upper and lower case letters, no spaces, additional spaces at the beginning, middle or end and punctuation like hyphens, brackets, dashes and full stops.
+- allow postcodes that contain upper and lower case letters, no spaces, additional spaces at the beginning, middle or end and punctuation like hyphens, brackets, dashes and full stops. This is better than rejecting the input and telling a user they’ve not provided a valid postcode.
 
 ## Multiple text inputs
 

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -33,7 +33,10 @@ Use an address lookup when you’re asking users for a UK address.
 
 ### When not to use an address lookup
 
-Address lookups only work for UK addresses. Provide a manual option for addresses that are missing or not properly listed in the address lookup. Provide a manual option for addresses that are missing or not properly listed in the address lookup.
+Provide a manual option for addresses that are:
+
+- missing or not properly listed in the address lookup
+- international
 
 ### How an address lookup works
 

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -38,7 +38,6 @@ stylesheets:
     label: {
       html: 'Address line 3'
     },
-    classes: "govuk-!-width-two-thirds",
     id: "address-line-3",
     name: "address-line-3",
     autocomplete: "address-line3"

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -18,7 +18,7 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
+      html: 'Address line 1'
     },
     id: "address-line-1",
     name: "address-line-1",
@@ -27,7 +27,7 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
+      html: 'Address line 2'
     },
     id: "address-line-2",
     name: "address-line-2",
@@ -36,21 +36,12 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      text: "Town or city"
+      html: 'Address line 3'
     },
     classes: "govuk-!-width-two-thirds",
-    id: "address-town",
-    name: "address-town",
-    autocomplete: "address-level2"
-  }) }}
-
-  {{ govukInput({
-    label: {
-      text: "County"
-    },
-    classes: "govuk-!-width-two-thirds",
-    id: "address-county",
-    name: "address-county"
+    id: "address-line-3",
+    name: "address-line-3",
+    autocomplete: "address-line3"
   }) }}
 
   {{ govukInput({


### PR DESCRIPTION
1. Applied generic `Address line x` format:

- Replaced `Building and street` with `Address line 1` and `Address line 2`. This simplifies things because it makes screenreader interface the same as the visible interface. It also resolves some issues raised in the [github page for the address pattern](https://github.com/alphagov/govuk-design-system-backlog/issues/31)
- Replaced `Town or City` with `Address line 3`.

2. Removed `County` because it adds no value.