### PR TITLE
Update ID and name for conditional reveal examples

### DIFF
--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -44,8 +44,8 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukCheckboxes({
-  idPrefix: "citizenship-conditional",
-  name: "citizen",
+  idPrefix: "contact",
+  name: "contact",
   fieldset: {
     legend: {
       text: "How would you like to be contacted?",

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -44,8 +44,8 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukRadios({
-  idPrefix: "how-contacted-conditional",
-  name: "how-contacted",
+  idPrefix: "contact",
+  name: "contact",
   fieldset: {
     legend: {
       text: "How would you prefer to be contacted?",


### PR DESCRIPTION
The conditional reveals example for the checkboxes component uses an ID of `citizenship-conditional` but the question is about contact preferences – suspect this is either a copy and paste error or an error introduced when the content in the example was updated. Update it to use ‘contact’ as a prefix instead.

Update the corresponding example in the radios component to be consistent rather than the current more verbose `how-contacted-conditional`.