### PR TITLE
Explain why start buttons are output as HTML links, not buttons

### DIFF
--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -47,8 +47,7 @@ Avoid using multiple default buttons on a single page. Having more than one main
 ### Start buttons
 
 Use a start button for the main call to action on your service’s [start page](/patterns/start-pages/).
-Start buttons use the `<a>` element rather than the `<button>` element, because they don't submit any data.
-They are given button styling and behaviour because they are the main call to action on the page.
+Start buttons don't submit form data, so they use a link tag rather than a button tag.
 
 {{ example({group: "components", item: "button", example: "start", html: true, nunjucks: true, open: false}) }}
 

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -46,7 +46,9 @@ Avoid using multiple default buttons on a single page. Having more than one main
 
 ### Start buttons
 
-Use a start button for the main call to action on your service’s [start page](/patterns/start-pages/). Start buttons are rendered as links rather than inputs, because they don't submit any data.
+Use a start button for the main call to action on your service’s [start page](/patterns/start-pages/). 
+Start buttons use the <a> rather than the <button> element, because they don't submit any data. 
+They are given button styling and behaviour because they are the main call to action on the page.
 
 {{ example({group: "components", item: "button", example: "start", html: true, nunjucks: true, open: false}) }}
 

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -46,7 +46,7 @@ Avoid using multiple default buttons on a single page. Having more than one main
 
 ### Start buttons
 
-Use a start button for the main call to action on your service’s [start page](/patterns/start-pages/).
+Use a start button for the main call to action on your service’s [start page](/patterns/start-pages/). Start buttons are rendered as links rather than inputs, because they don't submit any data.
 
 {{ example({group: "components", item: "button", example: "start", html: true, nunjucks: true, open: false}) }}
 

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -46,8 +46,8 @@ Avoid using multiple default buttons on a single page. Having more than one main
 
 ### Start buttons
 
-Use a start button for the main call to action on your service’s [start page](/patterns/start-pages/). 
-Start buttons use the <a> element rather than the <button> element, because they don't submit any data. 
+Use a start button for the main call to action on your service’s [start page](/patterns/start-pages/).
+Start buttons use the `<a>` element rather than the `<button>` element, because they don't submit any data.
 They are given button styling and behaviour because they are the main call to action on the page.
 
 {{ example({group: "components", item: "button", example: "start", html: true, nunjucks: true, open: false}) }}

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -47,7 +47,7 @@ Avoid using multiple default buttons on a single page. Having more than one main
 ### Start buttons
 
 Use a start button for the main call to action on your service’s [start page](/patterns/start-pages/). 
-Start buttons use the <a> rather than the <button> element, because they don't submit any data. 
+Start buttons use the <a> element rather than the <button> element, because they don't submit any data. 
 They are given button styling and behaviour because they are the main call to action on the page.
 
 {{ example({group: "components", item: "button", example: "start", html: true, nunjucks: true, open: false}) }}


### PR DESCRIPTION
In response to this query in the backlog: https://github.com/alphagov/govuk-design-system-backlog/issues/34#issuecomment-399995390