### PR TITLE
Add guidance about using example dates in hint text

### DIFF
--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -33,6 +33,8 @@ If you’re asking [one question per page](../../patterns/question-pages/#start-
 
 Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings).
 
+Make sure that any example dates you use in hint text are valid for the question being asked. 
+
 There are 2 ways to use the date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}


### PR DESCRIPTION
Add the following sentence to the guidance for Date input:

_Make sure that any example dates you use in hint text are valid for the question being asked._ 

This came up in our support channels and is particularly relevant when the date you are asking for must fall with in a range relative to the current date (eg. 'within the last 2 weeks'). In cases like this example dates in hints would need to be programatically generated, to make sure they don't keep falling outside of the permissable date range.