### PR TITLE
removing 'Form input prefixes and suffixes' and 'Callout text'

### DIFF
--- a/src/community/backlog/index.md.njk
+++ b/src/community/backlog/index.md.njk
@@ -98,14 +98,6 @@ Here is a list of the components, patterns and updates currently on the Design S
     </tr>
     <tr>
       <td class="govuk-table__cell">
-        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/123">Callout text</a>
-      </td>
-      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
-        Proposed
-      </td>
-    </tr>
-    <tr>
-      <td class="govuk-table__cell">
         <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/113">Card</a>
       </td>
       <td class="govuk-table__cell govuk-body-s" style="text-align: right">
@@ -310,14 +302,6 @@ Here is a list of the components, patterns and updates currently on the Design S
       </td>
       <td class="govuk-table__cell govuk-body-s" style="text-align: right">
         To do
-      </td>
-    </tr>
-    <tr>
-      <td class="govuk-table__cell">
-        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/134">Form input prefixes and suffixes</a>
-      </td>
-      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
-        In progress
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
 'Callout text' is covered by [inset text](https://design-system.service.gov.uk/components/inset-text/)