### PR TITLE
Improve colour contrast of 'meta' syntax highlighting, and make comments look more like comments

### DIFF
--- a/src/stylesheets/components/_highlight.scss
+++ b/src/stylesheets/components/_highlight.scss
@@ -3,7 +3,7 @@
 
 .hljs-comment,
 .hljs-quote {
-  color: #0b0c0c;
+  color: #545555;
   font-style: italic;
 }
 

--- a/src/stylesheets/components/_highlight.scss
+++ b/src/stylesheets/components/_highlight.scss
@@ -67,7 +67,7 @@
 }
 
 .hljs-meta {
-  color: #999999;
+  color: #545555;
   font-weight: bold;
 }
 


### PR DESCRIPTION
Change the colour of ‘meta’ syntax highlighting from `#999999` to `#545555` (a 30% tint of `#0b0c0c`), improving the colour contrast against the background (`#f3f2f1`) from 2.55:1 (which fails [WCAG 2.1 1.4.3 Contrast (Minimum)](https://www.w3.org/TR/WCAG21/#contrast-minimum)) to 6.68:1 (which passes as it meets the minimum 4.5:1 ratio)

The ‘meta’ syntax highlighting is only used in a couple of places (the doctype definition in the page template and an `!important` rule in a code example from the ‘Extending and modifying components in production’ guidance.

| Before | After |
| -- | -- |
| ![Screenshot 2020-10-27 at 13 50 53](https://user-images.githubusercontent.com/121939/97310825-9b358a80-185b-11eb-9066-40b0333f93a8.png) | ![Screenshot 2020-10-27 at 13 51 02](https://user-images.githubusercontent.com/121939/97310830-9c66b780-185b-11eb-8ea5-a458cfdc4eed.png) |

Update the colour used for comments in syntax highlighting to match the updated style of ‘meta’ syntax, and to make them look more like comments whilst retaining a good colour contrast against the background.

| Before | After |
| -- | -- |
| ![Screenshot 2020-10-27 at 13 51 35](https://user-images.githubusercontent.com/121939/97310921-b43e3b80-185b-11eb-94be-559cf4e648eb.png) | ![Screenshot 2020-10-27 at 13 51 18](https://user-images.githubusercontent.com/121939/97310927-b4d6d200-185b-11eb-9c27-a408eb3edc83.png) |