### PR TITLE
Simplify language used in conditional reveals guidance

### DIFF
--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -59,7 +59,9 @@ You can add hints to checkbox items to provide additional information about the 
 
 ### Conditionally revealing content
 
-You can add conditionally revealing content to checkboxes, so users only see content when it’s relevant to them. For example, you could reveal a phone number input only when a user chooses to be contacted by phone.
+You can add conditionally revealing content to checkboxes, so users only see content when it’s relevant to them.
+
+For example, you could reveal a phone number input only when a user chooses to be contacted by phone.
 
 {{ example({group: "components", item: "checkboxes", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl"}) }}
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -59,9 +59,9 @@ You can add hints to checkbox items to provide additional information about the 
 
 ### Conditionally revealing content
 
-You can add conditionally revealing content to checkboxes, so users only see content when it’s relevant to them.
+You can conditionally reveal content when the user selects a particular checkbox, so they only see content when it’s relevant to them.
 
-For example, you could reveal a phone number input only when a user chooses to be contacted by phone.
+For example, you could reveal a phone number input when the user selects the 'Contact me by phone' option.
 
 {{ example({group: "components", item: "checkboxes", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl"}) }}
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -74,7 +74,7 @@ If one or more of your radio options is different from the others, it can help u
 
 ### Conditionally revealing content
 
-Using this component, you can add conditionally revealing content to stacked radios, so users only see content when it’s relevant to them.
+You can add conditionally revealing content to stacked radios, so users only see content when it’s relevant to them.
 
 For example, you could reveal an email address input only when a user chooses to be contacted by email.
 
@@ -82,7 +82,7 @@ For example, you could reveal an email address input only when a user chooses to
 
 Keep it simple. If you need to add a lot of content, consider showing it on the next page in the process instead.
 
-Do not use this component to add conditionally revealing content to inline radios.
+Do not add conditionally revealing content to inline radios.
 
 #### Known issues
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -74,9 +74,9 @@ If one or more of your radio options is different from the others, it can help u
 
 ### Conditionally revealing content
 
-You can add conditionally revealing content to stacked radios, so users only see content when it’s relevant to them.
+You can conditionally reveal content when the user selects a particular radio, so they only see content when it’s relevant to them.
 
-For example, you could reveal an email address input only when a user chooses to be contacted by email.
+For example, you could reveal a phone number input when the user selects the 'Contact me by phone' option.
 
 {{ example({group: "components", item: "radios", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl"}) }}
 


### PR DESCRIPTION
Simplify the guidance for radios so that it matches the language used for conditional reveals for checkboxes. You don’t ‘use a component’ to add conditionally revealing content to radios – radios _are_ the component.

Also break the equivalent guidance in the checkboxes guidance over two paragraphs to improve readability.