### PR TITLE
Archive the ‘Understand the impact of an emergency’ pattern

### DIFF
--- a/src/patterns/understand-the-impact-of-an-emergency/index.md.njk
+++ b/src/patterns/understand-the-impact-of-an-emergency/index.md.njk
@@ -1,25 +1,7 @@
 ---
 title: Understand the impact of an emergency on your service
-description: 
-section: Patterns
-theme: Help users to…
-aliases: coronavirus, covid
-backlog_issue_id: 212
-layout: layout-pane.njk
+layout: layout-archived.njk
+ignore_in_sitemap: true
 ---
 
-Do not use a red emergency banner or black global message banner to tell people about problems with a GOV.UK service, including problems related to coronavirus.
-
-These banner designs are only used for specific messages published through the central GOV.UK publishing platform, with the agreement of Cabinet Office.
-
-If your GOV.UK service is affected by an emergency, ask your department’s content team to [request a change to the service start page](https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#change-govuk-content).
-
-If your service is getting more demand than usual, check that you’ve set up [There is a problem with the service pages](https://design-system.service.gov.uk/patterns/problem-with-the-service-pages/) and [Service unavailable pages](https://design-system.service.gov.uk/patterns/service-unavailable-pages/), and the wording is up to date.
-
-## How it works
-
-Keep messages short. For example: 
-
-> “There may be a delay in processing your application because of the coronavirus outbreak. If you need help urgently, [add call to action].”
-
-You may also want to consider adding a notification banner to your service. This code is not yet in the GOV.UK Design System, but you can copy the design from the [notification banner used by Digital Marketplace](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/notification-banner.html).
+For up to date information, see [the notification banner component](/components/notification-banner/).


### PR DESCRIPTION
Archive the ‘Help users to understand the impact of an emergency on your service’ pattern.

This pattern is being replaced by the guidance in the notification banner component.

Closes https://github.com/alphagov/design-system-team-internal/issues/364