### PR TITLE
Treat hexadecimal colours codes as code

### DIFF
--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -46,7 +46,7 @@ use `govuk-colour("red")` rather than `$govuk-error-colour`.
           <code>{{colour.name}}</code>
         </th>
         <td class="app-colour-list-column app-colour-list-column--colour">
-          {{colour.colour}}
+          <code>{{colour.colour}}</code>
         </td>
         <td class="app-colour-list-column app-colour-list-column--notes">
           {{colour.notes}}
@@ -82,7 +82,7 @@ You can find departmental colours in the GOV.UK Frontend [_colours-organisations
         <code>govuk-colour("{{name}}")</code>
       </th>
       <td class="app-colour-list-column app-colour-list-column--colour">
-        {{colour}}
+        <code>{{colour}}</code>
       </td>
       <td class="app-colour-list-column app-colour-list-column--notes"></td>
     </tr>

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -233,6 +233,12 @@ $colour-list-breakpoint: 980px;
   @include govuk-media-query($from: $colour-list-breakpoint) {
     width: 15%;
   }
+
+  code {
+    padding: 0;
+    color: $govuk-text-colour;
+    background: none;
+  }
 }
 
 .app-colour-list-column--notes {


### PR DESCRIPTION
They are snippets of code, so semantically it makes sense to treat them as code.

This also has the benefit of styling them as code, which makes the individual digits easier to distinguish.

I’ve overridden the red text colour and grey background so they are styled the same as the colours’ variable names.

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/99659388-b3628900-2a58-11eb-8270-e70c111bdb73.png) | ![image](https://user-images.githubusercontent.com/355079/99659360-aba2e480-2a58-11eb-8dfd-2df5dc2084a8.png)
![image](https://user-images.githubusercontent.com/355079/99659447-cbd2a380-2a58-11eb-8138-f92269b8c415.png) | ![image](https://user-images.githubusercontent.com/355079/99659420-c2493b80-2a58-11eb-8634-96cd3e26e0a5.png)

