### PR TITLE
Update components with labels or legends to include examples without headings

### DIFF
--- a/src/components/character-count/default/index.njk
+++ b/src/components/character-count/default/index.njk
@@ -9,7 +9,9 @@ layout: layout-example.njk
   id: "with-hint",
   maxlength: 200,
   label: {
-    text: "Can you provide more detail?"
+    text: "Can you provide more detail?",
+    classes: "govuk-label--l",
+    isPageHeading: true
   },
   hint: {
     text: "Do not include personal or financial information like your National Insurance number or credit card details."

--- a/src/components/character-count/error/index.njk
+++ b/src/components/character-count/error/index.njk
@@ -11,7 +11,9 @@ layout: layout-example.njk
   maxlength: 350,
   value: "A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format.",
   label: {
-    text: "Enter a job description"
+    text: "Enter a job description",
+    classes: "govuk-label--l",
+    isPageHeading: true
   },
   errorMessage: {
     text: "Job description must be 350 characters or fewer"

--- a/src/components/character-count/index.md.njk
+++ b/src/components/character-count/index.md.njk
@@ -45,8 +45,13 @@ This component uses JavaScript. If JavaScript is not available, users will see a
 
 There are 2 ways to use the character count component. You can use HTML or, if you’re using Nunjucks or the GOV.UK Prototype Kit, you can use the Nunjucks macro.
 
-{% from "_example.njk" import example %}
-{{ example({group: "components", item: "character-count", example: "label-page-heading", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "character-count", example: "default", html: true, nunjucks: true, open: false}) }}
+
+###  If you’re asking more than one question on the page
+
+If you're asking [more than one question on the page](../../patterns/question-pages/#asking-multiple-questions-on-a-page), do not set the contents of the `<label>` as the page heading.
+
+{{ example({group: "components", item: "character-count", example: "without-heading", html: true, nunjucks: true, open: false}) }}
 
 ### Consider if a word count is more helpful
 

--- a/src/components/character-count/threshold/index.njk
+++ b/src/components/character-count/threshold/index.njk
@@ -12,6 +12,8 @@ layout: layout-example.njk
   threshold: 75,
   value: "Type another letter into this field after this message to see the threshold feature",
   label: {
-    text: "Can you provide more detail?"
+    text: "Can you provide more detail?",
+    classes: "govuk-label--l",
+    isPageHeading: true
   }
 }) }}

--- a/src/components/character-count/without-heading/index.njk
+++ b/src/components/character-count/without-heading/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Label page heading – Character count
+title: Character count without a heading
 layout: layout-example.njk
 ---
  {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
@@ -8,8 +8,6 @@ layout: layout-example.njk
   name: "label-as-page-heading",
   maxlength: 200,
   label: {
-    text: "Describe the nature of your event",
-    classes: "govuk-label--l",
-    isPageHeading: true
+    text: "Describe the nature of your event"
   }
 }) }}

--- a/src/components/character-count/word-count/index.njk
+++ b/src/components/character-count/word-count/index.njk
@@ -10,6 +10,8 @@ layout: layout-example.njk
   id: "word-count",
   maxwords: 150,
   label: {
-    text: "Enter a job description"
+    text: "Enter a job description",
+    classes: "govuk-label--l",
+    isPageHeading: true
   }
 }) }}

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -26,15 +26,9 @@ Do not use the checkboxes component if users can only choose one option from a s
 
 ## How it works
 
-Group checkboxes together in a `<fieldset>` with a `<legend>` that describes them, as shown in the examples on this page. This is usually a question, like ‘How would you like to be contacted?’.
-
-If you are asking just [one question per page](../../patterns/question-pages/#start-by-asking-one-question-per-page) as recommended, you can set the contents of the `<legend>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
-
-Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings).
-
 Always position checkboxes to the left of their labels. This makes them easier to find, especially for users of screen magnifiers.
 
-Unlike with radios, users can select multiple options from a list of checkboxes. Do not assume that users will know how many options they can select based on the visual difference between radios and checkboxes alone. 
+Unlike with radios, users can select multiple options from a list of checkboxes. Do not assume that users will know how many options they can select based on the visual difference between radios and checkboxes alone.
 
 If needed, add a hint explaining this, for example, 'Select all that apply'.
 
@@ -47,9 +41,23 @@ Order checkbox options alphabetically by default.
 
 In some cases, it can be helpful to order them from most-to-least common options. For example, you could order options for ‘What is your nationality?’ based on population size.
 
-There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+Group checkboxes together in a `<fieldset>` with a `<legend>` that describes them, as shown in the examples on this page. This is usually a question, like ‘How would you like to be contacted?’.
+
+###  If you’re asking one question on the page
+
+If you're asking just [one question per page](../../patterns/question-pages/#start-by-asking-one-question-per-page) as recommended, you can set the contents of the `<legend>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
+
+Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings).
+
+There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
+
+###  If you’re asking more than one question on the page
+
+If you're asking [more than one question on the page](../../patterns/question-pages/#asking-multiple-questions-on-a-page), do not set the contents of the `<legend>` as the page heading.
+
+{{ example({group: "components", item: "checkboxes", example: "without-heading", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ### Checkbox items with hints
 

--- a/src/components/checkboxes/without-heading/index.njk
+++ b/src/components/checkboxes/without-heading/index.njk
@@ -1,0 +1,33 @@
+---
+title: Checkboxes without a heading
+layout: layout-example.njk
+---
+
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  idPrefix: "waste",
+  name: "waste",
+  fieldset: {
+    legend: {
+      text: "Which types of waste do you transport?"
+    }
+  },
+  hint: {
+    text: "Select all that apply."
+  },
+  items: [
+    {
+      value: "carcasses",
+      text: "Waste from animal carcasses"
+    },
+    {
+      value: "mines",
+      text: "Waste from mines or quarries"
+    },
+    {
+      value: "farm",
+      text: "Farm or agricultural waste"
+    }
+  ]
+}) }}

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -41,6 +41,12 @@ There are 2 ways to use the date input component. You can use HTML or, if you’
 
 Never automatically tab users between the fields of the date input because this can be confusing and may clash with normal keyboard controls.
 
+###  If you’re asking more than one question on the page
+
+If you're asking [more than one question on the page](../../patterns/question-pages/#asking-multiple-questions-on-a-page), do not set the contents of the `<legend>` as the page heading.
+
+{{ example({group: "components", item: "date-input", example: "without-heading", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
+
 ### Use the autocomplete attribute for a date of birth
 
 Use the `autocomplete` attribute on the date input component when you're asking for a date of birth. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.

--- a/src/components/date-input/without-heading/index.njk
+++ b/src/components/date-input/without-heading/index.njk
@@ -1,0 +1,19 @@
+---
+title: Date input without a heading
+layout: layout-example.njk
+---
+
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+
+{{ govukDateInput({
+  id: "passport-issued",
+  namePrefix: "passport-issued",
+  fieldset: {
+    legend: {
+      text: "When was your passport issued?"
+    }
+  },
+  hint: {
+    text: "For example, 12 11 2007"
+  }
+}) }}

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -21,12 +21,6 @@ Do not use the radios component if users might need to select more than one opti
 
 ## How it works
 
-Group radios together in a `<fieldset>` with a `<legend>` that describes them, as shown in the examples on this page. This is usually a question, like ‘Where do you live?’.
-
-If you are asking just [one question per page](../../patterns/question-pages/#start-by-asking-one-question-per-page) as recommended, you can set the contents of the `<legend>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
-
-Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings).
-
 Always position radios to the left of their labels. This makes them easier to find, especially for users of screen magnifiers.
 
 Unlike with checkboxes, users can only select one option from a list of radios. Do not assume that users will know how many options they can select based on the visual difference between radios and checkboxes alone.
@@ -46,7 +40,23 @@ In some cases, it can be helpful to order them from most-to-least common options
 
 However you should do this with extreme caution as it can reinforce bias in your service. If in doubt, order alphabetically.
 
+Group radios together in a `<fieldset>` with a `<legend>` that describes them, as shown in the examples on this page. This is usually a question, like ‘Where do you live?’.
+
+###  If you’re asking one question on the page
+
+If you are asking just [one question per page](../../patterns/question-pages/#start-by-asking-one-question-per-page) as recommended, you can set the contents of the `<legend>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
+
+Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings).
+
 There are 2 ways to use the radios component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+
+{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
+
+###  If you’re asking more than one question on the page
+
+If you're asking [more than one question on the page](../../patterns/question-pages/#asking-multiple-questions-on-a-page), do not set the contents of the `<legend>` as the page heading.
+
+{{ example({group: "components", item: "radios", example: "without-heading", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ### Stacked radios
 
@@ -58,7 +68,7 @@ When there are more than 2 options, radios should be stacked, like so:
 
 If there are only 2 options, you can either stack the radios or display them inline, like so:
 
-{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
+{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "third"}) }}
 
 ### Radio items with hints
 

--- a/src/components/radios/without-heading/index.njk
+++ b/src/components/radios/without-heading/index.njk
@@ -1,0 +1,30 @@
+---
+title: Radios without a heading
+layout: layout-example.njk
+---
+
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  classes: "govuk-radios--inline",
+  idPrefix: "changed-name",
+  name: "changed-name",
+  fieldset: {
+    legend: {
+      text: "Have you changed your name?"
+    }
+  },
+  hint: {
+    text: "This includes changing your last name or spelling your name differently."
+  },
+  items: [
+    {
+      value: "yes",
+      text: "Yes"
+    },
+    {
+      value: "no",
+      text: "No"
+    }
+  ]
+}) }}

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -21,12 +21,6 @@ Do not use the text input component if you need to let users enter longer answer
 
 ## How it works
 
-There are 2 ways to use the text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
-
-{{ example({group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: dalse, size: "s", titleSuffix: "second"}) }}
-
-### Label text inputs
-
 All text inputs must have visible labels; placeholder text is not an acceptable replacement for a label as it vanishes when users start typing.
 
 Labels should be aligned above the text input they refer to. They should be short, direct and written in sentence case. Do not use colons at the end of labels.
@@ -34,6 +28,16 @@ Labels should be aligned above the text input they refer to. They should be shor
 If you’re asking just [one question per page](../../patterns/question-pages/#start-by-asking-one-question-per-page) as recommended, you can set the contents of the `<label>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
 
 Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings).
+
+There are 2 ways to use the text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+
+{{ example({group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
+
+###  If you’re asking more than one question on the page
+
+If you're asking [more than one question on the page](../../patterns/question-pages/#asking-multiple-questions-on-a-page), do not set the contents of the `<label>` as the page heading.
+
+{{ example({group: "components", item: "text-input", example: "without-heading", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ### Use appropriately-sized text inputs
 

--- a/src/components/text-input/without-heading/index.njk
+++ b/src/components/text-input/without-heading/index.njk
@@ -1,0 +1,14 @@
+---
+title: Text input without a heading
+layout: layout-example.njk
+---
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "What is the name of the event?"
+  },
+  id: "event-name",
+  name: "event-name"
+}) }}

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -25,15 +25,13 @@ Do not use the textarea component if you need to let users enter shorter answers
 
 ## How it works
 
-There are 2 ways to use the textarea component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
-
-{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
-
-### Label textareas
-
 You must label textareas. Placeholder text is not a suitable substitute for a label, as it disappears when users click inside the textarea.
 
 Labels must be aligned above the textarea they refer to. They should be short, direct and written in sentence case. Do not use colons at the end of labels.
+
+There are 2 ways to use the textarea component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+
+{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
 
 ### Use appropriately-sized textareas
 
@@ -45,10 +43,15 @@ Make the height of a textarea proportional to the amount of text you expect user
 
 Users will often need to copy and paste information into a textarea, so do not stop them from doing this.
 
+###  If you’re asking more than one question on the page
+
+If you're asking [more than one question on the page](../../patterns/question-pages/#asking-multiple-questions-on-a-page), do not set the contents of the `<label>` as the page heading.
+
+{{ example({group: "components", item: "textarea", example: "without-heading", html: true, nunjucks: true, open: false, size: "l"}) }}
+
 ### Limiting the number of characters
 
 If there’s a good reason to limit the number of characters users can enter, you can use the [character count](../character-count) component.
-
 
 ### Error messages
 

--- a/src/components/textarea/without-heading/index.njk
+++ b/src/components/textarea/without-heading/index.njk
@@ -1,0 +1,13 @@
+---
+title: Textarea without a heading
+layout: layout-example.njk
+---
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{{ govukTextarea({
+  name: "more-detail",
+  id: "more-detail",
+  label: {
+    text: "Can you provide more detail?"
+  }
+}) }}

--- a/src/get-started/labels-legends-headings/index.md.njk
+++ b/src/get-started/labels-legends-headings/index.md.njk
@@ -24,7 +24,7 @@ To avoid repetition, one option is to use a visually hidden `<label>` or `<legen
 
 However, this option only removes visual duplication and will not help users of screen readers. They will still hear both the page heading and the visually hidden `<label>` or `<legend>`.
 
-To prevent this, set the contents of the `<label>` or `<legend>` as the page heading.
+To prevent this, set the contents of the `<label>` or `<legend>` as the page heading (except if you're asking more than one question on the page).
 
 ## Labels as page headings
 
@@ -44,7 +44,7 @@ As with labels, you also need to apply classes to the `<legend>` to make it look
 
 ## Styling options for labels and legends
 
-As well as styling them as page headings, you can apply other classes to legends and labels to make them larger and bolder than the default.
+Instead of styling them as page headings, you can apply other classes to legends and labels to make them larger and bolder than the default.
 
 ### Styling labels
 


### PR DESCRIPTION
This PR updates components with labels or legends to include examples without headings. It aims to solve #1364 and apply the same principle to other relevant components.

It updates content and examples for the following components:
- Character count
- Checkboxes
- Date input
- Radios
- Text input 
- Text area

Would be good to get a review from @StephenGill – I went off your suggestion for the checkbox page and have tried to apply the same approach elsewhere. Should probs also have a developer make sure I haven't done anything wrong with the new examples.