### PR TITLE
Add 'flash message' alias to notification banner

### DIFF
--- a/src/components/notification-banner/index.md.njk
+++ b/src/components/notification-banner/index.md.njk
@@ -2,7 +2,7 @@
 title: Notification banner
 description: Use a notification banner to tell the user about something they need to know about, but that’s not directly related to the page content
 section: Components
-aliases: alert, warning, success message, important message
+aliases: alert, warning, success message, important message, flash message
 backlog_issue_id: 2
 layout: layout-pane.njk
 status: Experimental


### PR DESCRIPTION
Adds a new alias 'flash message' to the search that routes users to the notification banner:

<img width="339" alt="Screenshot 2020-11-25 at 12 14 05" src="https://user-images.githubusercontent.com/19834460/100226507-c1f8e680-2f17-11eb-8521-459a1ce04cd1.png">

Raised by @edwardhorsford on Slack