### PR TITLE
Link to a Miro version of GOVUK Design System Flow

### DIFF
--- a/src/community/resources-and-tools/index.md.njk
+++ b/src/community/resources-and-tools/index.md.njk
@@ -17,6 +17,9 @@ The GOV.UK Design System team is not responsible for these resources and tools a
 [GOV.UK Design System Flow Diagrams](https://github.com/dashouse/govuk-design-system-flow-diagrams) -
 A Sketch file for creating flow diagrams of GOV.UK services.
 
+[GOV.UK Design System Flow Diagrams for Miro](https://github.com/paulmsmith/govuk-designsystem-flow-diagram-miro) -
+A Miro file for creating flow diagrams of GOV.UK services.
+
 [GOV Flow](https://github.com/charlesrt/gov-flow) -
 A Sketch file for creating flow diagrams of GOV.UK services.
 


### PR DESCRIPTION
Adds a link to a Miro version of the GOV.UK Design System Flow Diagrams by @dashouse 