### PR TITLE
Removing deprecated govuk-frontend-diff tool

### DIFF
--- a/src/community/resources-and-tools/index.md.njk
+++ b/src/community/resources-and-tools/index.md.njk
@@ -85,8 +85,6 @@ You can download GOV.UK Frontend Nunjucks macro snippets for:
 - [Atom](https://atom.io/packages/govuk-design-system-snippets)
 - [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=simonwhatley.govuk-design-system-snippets)
 
-[govuk-frontend-diff](https://github.com/surevine/govuk-frontend-diff) -
-Command line tool to compare custom implementations of govuk-frontend templates with the reference Nunjucks.
 
 
 ## Help improve this page


### PR DESCRIPTION
Since the release of the fixtures in govuk-frontend@3.9.x the govuk-frontend-diff tool is no longer necessary - I have moved away from using it on my own repository and marked it as deprecated on the readme. I'll leave the repository up of course, but it wouldn't be my first choice for testing now that the fixtures are available.