### PR TITLE
Add the DfE's govuk-components to Rails resources list

### DIFF
--- a/src/community/resources-and-tools/index.md.njk
+++ b/src/community/resources-and-tools/index.md.njk
@@ -73,6 +73,9 @@ GOV.UK Frontend compatible React components.
 [GOV.UK Design System Formbuilder](https://github.com/DFE-Digital/govuk_design_system_formbuilder) -
 A Rails form builder using GOV.UK Frontend.
 
+[GOV.UK Components](https://github.com/DFE-Digital/govuk-components) -
+A lightweight set of Rails components using GOV.UK Frontend.
+
 [GOV.UK Frontend Rails](https://github.com/dxw/dxw_govuk_frontend_rails) -
 A Ruby gem that adds the GOV.UK Frontend to Rails applications.
 


### PR DESCRIPTION
The [govuk-components](https://github.com/dfe-digital/govuk-components) gem is a lightweight alternative to the [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components) library and provides all of the non-form components from the GOV.UK Design System.

Version 1.0.0 has recently been released and it's now used across several DfE projects.

It uses GitHub's ViewComponent framework.