### PR TITLE
Add Github Actions for build/lint/test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,29 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  run-build:
+    name: Build govuk-design-system
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Read node version from .nvmrc
+      id: nvm
+      run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+
+    - name: Setup node
+      uses: actions/setup-node@v1
+      with:
+        node-version: "${{ steps.nvm.outputs.NVMRC }}"
+
+    - name: Install dependencies
+      run: npm install --no-optional
+
+    - name: Build
+      run: npm run build
+
+    - name: Lint and test
+      run: npm test -- --runInBand


### PR DESCRIPTION
Part of https://github.com/alphagov/govuk-design-system/issues/1419

## What
Add Github Actions workflow for building the design system (includes running tests and linting). This is Part 1 of switching over to Github Actions - a second PR needs to be raised to switch deployment over to Github Actions before we can remove the Travis config.

## Why
Travis' changes to our plan means that builds are getting stuck in a queue, which means they can take around 30 minutes to run. Given that the direction of travel for the organisation seems to be towards GitHub Actions, and to be consistent with the approach we're taking with the Prototype Kit, move to GitHub Actions.