### PR TITLE
Improve visibility of focus state for search box

### DIFF
--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -60,7 +60,7 @@ $icon-size: 40px;
     margin-bottom: 0; // BUG: Safari 10 on macOS seems to add an implicit margin.
     padding: govuk-spacing(1);
     padding-left: $icon-size - govuk-spacing(1);
-    border: 2px solid govuk-colour("white");
+    border: $govuk-border-width-form-element solid govuk-colour("white");
     border-radius: 0; // Safari 10 on iOS adds implicit border rounding.
     -webkit-appearance: none;
   }
@@ -83,8 +83,10 @@ $icon-size: 40px;
   }
 
   .app-site-search__input--focused {
-    outline: 3px solid $govuk-focus-colour;
-    outline-offset: -2px;
+    border-color: $govuk-focus-text-colour;
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    outline-offset: 0;
+    box-shadow: inset 0 0 0 $govuk-border-width-form-element;
   }
 
   .app-site-search__input--show-all-values {


### PR DESCRIPTION
Prompted by discussions with the NHS Frontend team (https://github.com/nhsuk/nhsuk-frontend/issues/679), improve the visibility of the focus state for the search box by adding a black (#0b0c0c) border between the white text input and the yellow focus outline.

![Screenshot 2021-01-14 at 09 58 35](https://user-images.githubusercontent.com/121939/104575580-19315280-564f-11eb-8676-d9a5ccd2619b.png)

Without this change, the only part of the focus indicator that meets colour contrast is the outermost 1px which change from black to white as the input ‘grows’ – the other 2px of the 3px outline change from white to black.

After this change, the entire 7px comprised of the border, box shadow and outline meet contrast, as the border changes from a 2px white to a 4px (2px border + 2px box-shadow) black (19.58), and the 3px outline causes a change from black to yellow (14.54).

This change also improves the visibility of the focus state in High Contrast Mode as the outline no longer overlaps the border, so the effective border increases from 3px to 5px.

👉🏻 &nbsp;[Preview](https://deploy-preview-1444--govuk-design-system-preview.netlify.app/?utm_source=github&utm_campaign=bot_dp)

## Browser Testing

Tested in IE 11, Edge 87 (Windows), Google Chrome 87 (Mac / Windows), Mozilla Firefox 84 (Mac / Windows), Safari 12, Safari 14, iOS Safari (iOS 14.3), Google Chrome 87 (Android), Samsung Internet (Android)