### PR TITLE
Clarify guidance on image alt text

### DIFF
--- a/src/styles/images/index.md.njk
+++ b/src/styles/images/index.md.njk
@@ -43,7 +43,7 @@ Do not:
 - include the name of the photographer or person who created the image
 - start with ‘Image of’, ‘Graphic of’ or ‘Photo of’
 - repeat information from the page
-- include extra information not on the page
+- include extra information not in the image
 
 {{ example({group: "styles", item: "images", example: "alt-text", html: true, open: true, size: "l"}) }}
 


### PR DESCRIPTION
The following two lines under the "Do not" heading are mutually contradictory:

- repeat information from the page
- include extra information not on the page

What you should say is, don't include extra info that is **not in the image**