### PR TITLE
Add styling options to table header guidance

### DIFF
--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -31,6 +31,8 @@ Use the `<caption>` element to describe a table in the same way you would use a 
 
 Use table headers to tell users what the rows and columns represent. Use the `scope` attribute to help users of assistive technology distinguish between row and column headers.
 
+There are other styling options for table headers, you can apply other classes to make them larger than default.
+
 There are 2 ways to use the table component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}


### PR DESCRIPTION
This is an update to the guidance to include the additional table styles created in pull request [#2048](https://github.com/alphagov/govuk-frontend/pull/2048)