### PR TITLE
Add more detailed guidance about middle names

### DIFF
--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -37,7 +37,9 @@ A single name field can accommodate the broadest range of name types, but means 
 
 ### Labelling name fields
 
-Label single name fields ‘Full name’.
+Label single name fields:
+
+- ‘Full name’
 
 For multiple name fields, use:
 
@@ -49,9 +51,17 @@ If users are from outside the UK, use the labels:
 - ‘Given names’
 - ‘Family name’
 
-Make middle names optional.
-
 Make it clear whether you need someone’s common name, or their name as it's written on official documents such as a passport or driving licence.
+
+#### Middle names
+
+Only ask for middle names if your service requires them. 
+
+Use the label:
+
+- ’Middle names‘
+
+Make middle names optional as not all users have middle names. They do not need `(optional)` in the label as users should provide them if they have one - and will skip the field if they do not have one.
 
 ### Use the autocomplete attribute on name fields
 

--- a/src/patterns/names/index.md.njk
+++ b/src/patterns/names/index.md.njk
@@ -61,7 +61,9 @@ Use the label:
 
 - ’Middle names‘
 
-Make middle names optional as not all users have middle names. They do not need `(optional)` in the label as users should provide them if they have one - and will skip the field if they do not have one.
+Make sure middle names are optional, as not everyone has them.
+
+The label should not include `(optional)`. Users will enter their middle names if they have them and skip the field if they do not.
 
 ### Use the autocomplete attribute on name fields
 


### PR DESCRIPTION
Addressing #1354 at the request of @timpaul.

This makes clearer how to label middle names.

It does not address the issue I've seen frequently that the `Full name` field induces users to provide full legal names including middle name, when many services don't actually want this.