### PR TITLE
Make it clear that the heading class does not relate to the heading level

### DIFF
--- a/src/styles/typography/captions-inside/index.njk
+++ b/src/styles/typography/captions-inside/index.njk
@@ -3,7 +3,7 @@ title: Headings with captions nested – Typography
 layout: layout-example.njk
 ---
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl">govuk-caption-xl</span>
-  govuk-heading-xl
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l">govuk-caption-l</span>
+  govuk-heading-l
 </h1>

--- a/src/styles/typography/captions/index.njk
+++ b/src/styles/typography/captions/index.njk
@@ -7,7 +7,7 @@ layout: layout-example.njk
 <h1 class="govuk-heading-xl">govuk-heading-xl</h1>
 
 <span class="govuk-caption-l">govuk-caption-l</span>
-<h2 class="govuk-heading-l">govuk-heading-l</h2>
+<h1 class="govuk-heading-l">govuk-heading-l</h1>
 
 <span class="govuk-caption-m">govuk-caption-m</span>
-<h3 class="govuk-heading-m">govuk-heading-m</h3>
+<h1 class="govuk-heading-m">govuk-heading-m</h1>

--- a/src/styles/typography/headings-xl/index.njk
+++ b/src/styles/typography/headings-xl/index.njk
@@ -1,0 +1,9 @@
+---
+title: Headings for pages with long form content – Typography
+layout: layout-example.njk
+---
+
+<h1 class="govuk-heading-xl">govuk-heading-xl</h1>
+<h2 class="govuk-heading-l">govuk-heading-l</h2>
+<h3 class="govuk-heading-m">govuk-heading-m</h3>
+<h3 class="govuk-heading-s">govuk-heading-s</h3>

--- a/src/styles/typography/headings/index.njk
+++ b/src/styles/typography/headings/index.njk
@@ -3,7 +3,6 @@ title: Headings – Typography
 layout: layout-example.njk
 ---
 
-<h1 class="govuk-heading-xl">govuk-heading-xl</h1>
 <h1 class="govuk-heading-l">govuk-heading-l</h1>
-<h1 class="govuk-heading-m">govuk-heading-m</h1>
-<h1 class="govuk-heading-s">govuk-heading-s</h1>
+<h2 class="govuk-heading-m">govuk-heading-m</h2>
+<h3 class="govuk-heading-s">govuk-heading-s</h3>

--- a/src/styles/typography/headings/index.njk
+++ b/src/styles/typography/headings/index.njk
@@ -4,6 +4,6 @@ layout: layout-example.njk
 ---
 
 <h1 class="govuk-heading-xl">govuk-heading-xl</h1>
-<h2 class="govuk-heading-l">govuk-heading-l</h2>
-<h3 class="govuk-heading-m">govuk-heading-m</h3>
-<h4 class="govuk-heading-s">govuk-heading-s</h4>
+<h1 class="govuk-heading-l">govuk-heading-l</h1>
+<h1 class="govuk-heading-m">govuk-heading-m</h1>
+<h1 class="govuk-heading-s">govuk-heading-s</h1>

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -19,11 +19,11 @@ If you’re not sure whether you should be using GDS Transport, read the Service
 
 ## Headings
 
-Mark up headings semantically using the appropriate <h#> level HTML element and use a heading class to apply the GOV.UK styling. Style headings consistently to create a clear visual hierarchy throughout your service.
+Mark up headings semantically using the appropriate `<h#>` level HTML element and use a heading class to apply the GOV.UK styling. The heading class you use does not need to correspond to the heading level. Style headings consistently to create a clear visual hierarchy throughout your service.
 
-If your service has lots of long form content, use the corresponding size class. For example an `<h1>` should use `govuk-heading-xl`, an `<h2>` should use `govuk-heading-l` and so on. 
+If your page has lots of long form content, start with `govuk-heading-xl` for an `<h1>`, `govuk-heading-l` for an `<h2>`, and so on. 
 
-If your service has lots of [question pages](../../patterns/question-pages), short form content or pages with long headings, start with `govuk-heading-l` for an `<h1>`. But change it if your pages feel unbalanced – semantic and visual hierarchy do not always need to be the same.
+If your page is shorter - such a question page, or has long headings, start with `govuk-heading-l` for an `<h1>`, `govuk-heading-m` for an `<h2>` and so on. But change it if your pages feel unbalanced – semantic and visual hierarchy do not always need to be the same.
 
 Write all headings in sentence case.
 

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -19,23 +19,25 @@ If you’re not sure whether you should be using GDS Transport, read the Service
 
 ## Headings
 
-Mark up headings semantically using the appropriate `<h#>` level HTML element and use a heading class to apply the GOV.UK styling. The heading class you use does not need to correspond to the heading level. Style headings consistently to create a clear visual hierarchy throughout your service.
-
-If your page has lots of long form content, start with `govuk-heading-xl` for an `<h1>`, `govuk-heading-l` for an `<h2>`, and so on. 
-
-If your page is shorter - such a question page, or has long headings, start with `govuk-heading-l` for an `<h1>`, `govuk-heading-m` for an `<h2>` and so on. But change it if your pages feel unbalanced – semantic and visual hierarchy do not always need to be the same.
-
 Write all headings in sentence case.
+
+Mark up headings semantically using the appropriate `<h#>` level HTML element and use a heading class to apply the GOV.UK styling. Style headings consistently to create a clear visual hierarchy throughout your service.
+
+For a [question page](/patterns/question-pages), or pages with long headings, start with `govuk-heading-l` for an `<h1>`, `govuk-heading-m` for an `<h2>` and so on. But change it if your pages feel unbalanced – the heading class you use does not always need to correspond to the heading level.
 
 {{ example({group: "styles", item: "typography", example: "headings", html: true, open: true, size: "m"}) }}
 
+If your page has lots of long form content, start with `govuk-heading-xl` for an `<h1>`, `govuk-heading-l` for an `<h2>`, and so on. 
+
+{{ example({group: "styles", item: "typography", example: "headings-xl", html: true, open: true, size: "m"}) }}
+
 ### Headings with captions
 
-Sometimes you may need to make it clear that a heading is part of a larger section or group. To do this, you can use a heading with a caption.
+Sometimes you may need to make it clear that a page is part of a larger section or group. To do this, you can use a heading with a caption.
 
 {{ example({group: "styles", item: "typography", example: "captions", html: true, open: true, size: "l"}) }}
 
-If the caption should be considered part of the page heading, you can also nest the caption within the H1.
+If the caption should be considered part of the page heading, you can also nest the caption within the `<h1>`.
 
 {{ example({group: "styles", item: "typography", example: "captions-inside", html: true, open: true, size: "l"}) }}
 

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -21,7 +21,7 @@ If you’re not sure whether you should be using GDS Transport, read the Service
 
 Write all headings in sentence case.
 
-Mark up headings semantically using the appropriate `<h#>` level HTML element and use a heading class to apply the GOV.UK styling. Style headings consistently to create a clear visual hierarchy throughout your service.
+Use heading tags, such as `<h1>`, `<h2>` and so on, to tag the headings on a page. Apply a heading class, such as `govuk-heading-l`, to style them visually. Style headings consistently to create a clear content structure throughout your service.
 
 For a [question page](/patterns/question-pages), or pages with long headings, start with `govuk-heading-l` for an `<h1>`, `govuk-heading-m` for an `<h2>` and so on. But change it if your pages feel unbalanced – the heading class you use does not always need to correspond to the heading level.
 
@@ -33,7 +33,7 @@ If your page has lots of long form content, start with `govuk-heading-xl` for an
 
 ### Headings with captions
 
-Sometimes you may need to make it clear that a page is part of a larger section or group. To do this, you can use a heading with a caption.
+Sometimes you may need to make it clear that a page is part of a larger section or group. To do this, you can use a heading with a caption above it.
 
 {{ example({group: "styles", item: "typography", example: "captions", html: true, open: true, size: "l"}) }}
 


### PR DESCRIPTION
In #1201 the default heading size was changed to `govuk-heading-l` - however the typography page still gives the impression that `govuk-heading-xl` should be the default.

It says in words that the heading size should depend on the content - but all the examples continue to use `xl`.

Additionally the primary example showing the different heading classes also changes the heading level with each class. This gives the *very strong* impression that `govuk-heading-xl` is for `h1`, `govuk-heading-l` is for `h2`, etc.

<img width="847" alt="Screenshot 2021-01-13 at 16 15 29" src="https://user-images.githubusercontent.com/2204224/104479541-767bc400-55bb-11eb-8ece-9cd18031e999.png">

I've spoken with several teams across gov (both new starters and people who have worked with the design system for some time), and universally every one took the main example (screenshot above) as indicating a correlation between class and heading level - which is not at all intended. This pr removes that association by making them all `h1`.

The updated example is similar to the `Font size` example as only one variable is changing, not two.

Updated:
<img width="860" alt="Screenshot 2021-01-13 at 16 24 59" src="https://user-images.githubusercontent.com/2204224/104479951-e68a4a00-55bb-11eb-864f-715d4426c787.png">

The guidance also indicated you should pick one heading size and use the same throughout all pages of the service - which I don’t think is correct. _Most_ of the time teams will want `govuk-heading-l` - but for _some_ pages they may want `govuk-heading-xl`. Teams should vary it based on the page, not the service as a whole.