### PR TITLE
Add success colour

### DIFF
--- a/data/colours.json
+++ b/data/colours.json
@@ -44,6 +44,12 @@
       "notes": "Use for error messages"
     }
   ],
+  "Success state": [
+    {
+      "name": "$govuk-success-colour",
+      "notes": "Use for success messages"
+    }
+  ],
   "Brand colour": [
     {
       "name": "$govuk-brand-colour"


### PR DESCRIPTION
This PR is proposing we expose the `$govuk-success-colour` variable to be used for success messages [1][2], as we do for [error messages](https://design-system.service.gov.uk/styles/colour/).

[1] https://design-system.service.gov.uk/components/notification-banner/#reacting-to-something-the-user-has-done
[2] https://design-system.service.gov.uk/patterns/confirmation-pages/

I appreciate the timing of this PR might not be ideal and we might want to proceed with this at a more appropriate moment, but I personally find it valuable as it promotes a level of abstraction (on top of the raw `govuk-colour("green")`) that could prove to be beneficial on the long run.