### PR TITLE
Add guidance for button groups

### DIFF
--- a/src/components/button/button-group/index.njk
+++ b/src/components/button/button-group/index.njk
@@ -1,16 +1,13 @@
 ---
-title: Secondary button combo
+title: Button group
 layout: layout-example.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 <div class="govuk-button-group">
   {{ govukButton({
-    text: "Save and continue"
+    text: "Continue"
   }) }}
 
-  {{ govukButton({
-    text: "Save as draft",
-    classes: "govuk-button--secondary"
-  }) }}
+  <a class="govuk-link" href="#">Cancel</a>
 </div>

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -59,6 +59,8 @@ Pages with too many calls to action make it hard for users to know what to do ne
 
 {{ example({group: "components", item: "button", example: "secondary", html: true, nunjucks: true, open: false}) }}
 
+You can also [group default and secondary buttons together](#grouping-buttons).
+
 ### Warning buttons
 
 Warning buttons are designed to make users think carefully before they use them. They only work if used very sparingly. Most services should not need one.

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -59,10 +59,6 @@ Pages with too many calls to action make it hard for users to know what to do ne
 
 {{ example({group: "components", item: "button", example: "secondary", html: true, nunjucks: true, open: false}) }}
 
-You can use secondary buttons in combination with default buttons.
-
-{{ example({group: "components", item: "button", example: "secondary-combo", html: true, nunjucks: true, open: false}) }}
-
 ### Warning buttons
 
 Warning buttons are designed to make users think carefully before they use them. They only work if used very sparingly. Most services should not need one.
@@ -84,6 +80,16 @@ Disabled buttons have poor contrast and can confuse some users, so avoid them if
 Only use disabled buttons if research shows it makes the user interface easier to&nbsp;understand.
 
 {{ example({group: "components", item: "button", example: "disabled", html: true, nunjucks: true, open: false}) }}
+
+### Grouping buttons
+
+Use a button group when two or more buttons are placed together.
+
+{{ example({group: "components", item: "button", example: "secondary-combo", html: true, nunjucks: true, open: false}) }}
+
+Any links within a button group will automatically align with the buttons.
+
+{{ example({group: "components", item: "button", example: "button-group", html: true, nunjucks: true, open: false}) }}
 
 ### Stop users from accidentally sending information more than once
 


### PR DESCRIPTION
Add guidance about [button groups](https://github.com/alphagov/govuk-frontend/pull/2114) to the button component guidance.

Includes two examples:
- the current example of two buttons together, moved from the 'secondary buttons' section and updated to use the button group object rather than a margin override
- a new example that includes a button and a link together

👉🏻 &nbsp;[View preview](https://deploy-preview-1472--govuk-design-system-preview.netlify.app/components/button/#grouping-buttons)

Closes #1471 