### PR TITLE
Fix capitalisation in Get Started doc

### DIFF
--- a/src/get-started/index.md.njk
+++ b/src/get-started/index.md.njk
@@ -5,7 +5,7 @@ description: The following introductory guides will help you to get set up
 show_subnav: true
 ---
 
-The examples in the GOV.UK Design System come with code to make it easy for you to use them in your project. 
+The examples in the GOV.UK Design System come with code to make it easy for you to use them in your project.
 
 There are guides to getting started:
 
@@ -16,7 +16,7 @@ You may find the [guide on updating your code](updating-your-code) useful if you
 
 ## Using styles, components and patterns
 
-When something is published in the GOV.UK design system as a [style](/styles/), [component](/components/) or [pattern](/patterns/) we include details of how and when it’s been tested in user research. This should help you decide whether it’s something you can use or adapt for your service.
+When something is published in the GOV.UK Design System as a [style](/styles/), [component](/components/) or [pattern](/patterns/) we include details of how and when it’s been tested in user research. This should help you decide whether it’s something you can use or adapt for your service.
 
 You can ask questions or share your research by joining the discussion on GitHub. There are links at the end of each style, component and pattern page - under the ‘Help improve this page’ heading.
 


### PR DESCRIPTION
This is to correct lowercase instance of 'design system.'