### PR TITLE
Add clearer anchor links to guidance on multiple questions

### DIFF
--- a/src/components/character-count/index.md.njk
+++ b/src/components/character-count/index.md.njk
@@ -49,7 +49,7 @@ There are 2 ways to use the character count component. You can use HTML or, if y
 
 ###  If you’re asking more than one question on the page
 
-If you're asking [more than one question on the page](../../patterns/question-pages/#asking-multiple-questions-on-a-page), do not set the contents of the `<label>` as the page heading.
+If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "character-count", example: "without-heading", html: true, nunjucks: true, open: false}) }}
 


### PR DESCRIPTION
Adds clearer link text to 'multiple questions' guidance and signpost better that it's taking a user to the middle of a page.