### PR TITLE
Add clearer anchor link text to questions

### DIFF
--- a/src/components/character-count/index.md.njk
+++ b/src/components/character-count/index.md.njk
@@ -47,7 +47,7 @@ There are 2 ways to use the character count component. You can use HTML or, if y
 
 {{ example({group: "components", item: "character-count", example: "default", html: true, nunjucks: true, open: false}) }}
 
-###  If you’re asking more than one question on the page
+###  If you're asking more than one question on the page
 
 If you’re asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 

--- a/src/components/character-count/index.md.njk
+++ b/src/components/character-count/index.md.njk
@@ -49,7 +49,7 @@ There are 2 ways to use the character count component. You can use HTML or, if y
 
 ###  If you’re asking more than one question on the page
 
-If you're asking [more than one question on the page](../../patterns/question-pages/#asking-multiple-questions-on-a-page), do not set the contents of the `<label>` as the page heading.
+If you’re asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "character-count", example: "without-heading", html: true, nunjucks: true, open: false}) }}
 

--- a/src/components/character-count/index.md.njk
+++ b/src/components/character-count/index.md.njk
@@ -49,7 +49,7 @@ There are 2 ways to use the character count component. You can use HTML or, if y
 
 ###  If you’re asking more than one question on the page
 
-If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
+If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking multiple questions on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "character-count", example: "without-heading", html: true, nunjucks: true, open: false}) }}
 

--- a/src/components/character-count/index.md.njk
+++ b/src/components/character-count/index.md.njk
@@ -47,9 +47,9 @@ There are 2 ways to use the character count component. You can use HTML or, if y
 
 {{ example({group: "components", item: "character-count", example: "default", html: true, nunjucks: true, open: false}) }}
 
-###  If you're asking more than one question on the page
+###  If you’re asking more than one question on the page
 
-If you’re asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
+If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "character-count", example: "without-heading", html: true, nunjucks: true, open: false}) }}
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -45,9 +45,9 @@ Group checkboxes together in a `<fieldset>` with a `<legend>` that describes the
 
 ###  If you’re asking one question on the page
 
-If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once. 
+If you're asking just [one question per page](../../patterns/question-pages/#start-by-asking-one-question-per-page) as recommended, you can set the contents of the `<legend>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
 
-Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings) and [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
+Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings).
 
 There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs), you can use the Nunjucks macro.
 
@@ -55,7 +55,7 @@ There are 2 ways to use the checkboxes component. You can use HTML or, if you’
 
 ###  If you’re asking more than one question on the page
 
-If you're asking [more than one question on the page](../../patterns/question-pages/#asking-multiple-questions-on-a-page), do not set the contents of the `<legend>` as the page heading.
+If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "checkboxes", example: "without-heading", html: true, nunjucks: true, open: false, size: "m" }) }}
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -55,7 +55,7 @@ There are 2 ways to use the checkboxes component. You can use HTML or, if you’
 
 ###  If you’re asking more than one question on the page
 
-If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
+If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking multiple questions on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "checkboxes", example: "without-heading", html: true, nunjucks: true, open: false, size: "m" }) }}
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -45,9 +45,9 @@ Group checkboxes together in a `<fieldset>` with a `<legend>` that describes the
 
 ###  If you’re asking one question on the page
 
-If you're asking just [one question per page](../../patterns/question-pages/#start-by-asking-one-question-per-page) as recommended, you can set the contents of the `<legend>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
+If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once. 
 
-Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings).
+Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings) and [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs), you can use the Nunjucks macro.
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -55,7 +55,7 @@ There are 2 ways to use the checkboxes component. You can use HTML or, if you’
 
 ###  If you’re asking more than one question on the page
 
-If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
+If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "checkboxes", example: "without-heading", html: true, nunjucks: true, open: false, size: "m" }) }}
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -43,7 +43,7 @@ Never automatically tab users between the fields of the date input because this 
 
 ###  If you’re asking more than one question on the page
 
-If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
+If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "date-input", example: "without-heading", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -43,7 +43,7 @@ Never automatically tab users between the fields of the date input because this 
 
 ###  If you’re asking more than one question on the page
 
-If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
+If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking multiple questions on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "date-input", example: "without-heading", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -43,7 +43,7 @@ Never automatically tab users between the fields of the date input because this 
 
 ###  If you’re asking more than one question on the page
 
-If you're asking [more than one question on the page](../../patterns/question-pages/#asking-multiple-questions-on-a-page), do not set the contents of the `<legend>` as the page heading.
+If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "date-input", example: "without-heading", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -54,7 +54,7 @@ There are 2 ways to use the radios component. You can use HTML or, if you are us
 
 ###  If you’re asking more than one question on the page
 
-If you're asking [more than one question on the page](../../patterns/question-pages/#asking-multiple-questions-on-a-page), do not set the contents of the `<legend>` as the page heading.
+If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "radios", example: "without-heading", html: true, nunjucks: true, open: false, size: "s"}) }}
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -54,7 +54,7 @@ There are 2 ways to use the radios component. You can use HTML or, if you are us
 
 ###  If you’re asking more than one question on the page
 
-If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
+If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking multiple questions on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "radios", example: "without-heading", html: true, nunjucks: true, open: false, size: "s"}) }}
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -35,7 +35,7 @@ There are 2 ways to use the text input component. You can use HTML or, if you’
 
 ###  If you’re asking more than one question on the page
 
-If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
+If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking multiple questions on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "text-input", example: "without-heading", html: true, nunjucks: true, open: false, size: "s"}) }}
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -35,7 +35,7 @@ There are 2 ways to use the text input component. You can use HTML or, if you’
 
 ###  If you’re asking more than one question on the page
 
-If you're asking [more than one question on the page](../../patterns/question-pages/#asking-multiple-questions-on-a-page), do not set the contents of the `<label>` as the page heading.
+If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "text-input", example: "without-heading", html: true, nunjucks: true, open: false, size: "s"}) }}
 

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -45,7 +45,7 @@ Users will often need to copy and paste information into a textarea, so do not s
 
 ###  If you’re asking more than one question on the page
 
-If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
+If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking multiple questions on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "textarea", example: "without-heading", html: true, nunjucks: true, open: false, size: "l"}) }}
 

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -45,7 +45,7 @@ Users will often need to copy and paste information into a textarea, so do not s
 
 ###  If you’re asking more than one question on the page
 
-If you're asking [more than one question on the page](../../patterns/question-pages/#asking-multiple-questions-on-a-page), do not set the contents of the `<label>` as the page heading.
+If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking more than one question on question pages](../../patterns/question-pages/#asking-multiple-questions-on-a-page).
 
 {{ example({group: "components", item: "textarea", example: "without-heading", html: true, nunjucks: true, open: false, size: "l"}) }}
 

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -83,7 +83,7 @@ For example, ‘About you’
 
 You can also learn more about how starting with [one thing per page](https://www.gov.uk/service-manual/design/form-structure#start-with-one-thing-per-page) helps users in the GOV.UK Service Manual.
 
-#### Asking more than one question on the same page
+#### Asking multiple questions on a page
 
 Sometimes it makes sense to group a number of related questions on the same page.
 

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -83,7 +83,7 @@ For example, ‘About you’
 
 You can also learn more about how starting with [one thing per page](https://www.gov.uk/service-manual/design/form-structure#start-with-one-thing-per-page) helps users in the GOV.UK Service Manual.
 
-#### Asking multiple questions on a page
+#### Asking more than one question on the same page
 
 Sometimes it makes sense to group a number of related questions on the same page.
 


### PR DESCRIPTION
Adds clearer link text for anchor links to the 'Asking multiple questions on a page' section of the 'Question pages' page.