### PR TITLE
Minor: use straight quote marks in HTML fragments

### DIFF
--- a/src/components/cookie-banner/index.md.njk
+++ b/src/components/cookie-banner/index.md.njk
@@ -74,7 +74,7 @@ If you’re using JavaScript to manage cookie consent, write your own JavaScript
 - a replacement message is displayed in place of the cookie message
 - focus shifts to the replacement message
 
-Give the replacement message the `role=“alert”` and `tabindex=“-1”` attributes, to allow the focus to shift and so assistive technology can read the message.
+Give the replacement message the `role="alert"` and `tabindex="-1"` attributes, to allow the focus to shift and so assistive technology can read the message.
 
 Here’s an example:
 


### PR DESCRIPTION
(Curly quotation marks are invalid for HTML attributes)