### PR TITLE
Add cookie banner code example to page template

### DIFF
--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -7,6 +7,7 @@ ignore_in_sitemap: true
 {# Example that changes every setting in the template #}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 {% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
@@ -50,6 +51,34 @@ ignore_in_sitemap: true
 {% endblock %}
 
 {% block bodyStart %}
+  {{ govukCookieBanner({
+    ariaLabel: "Cookies on [name of service]",
+    messages: [
+      {
+        headingText: "Cookies on [name of service]",
+        html: "<p>We use some essential cookies to make this service work.</p>
+               <p>We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>",
+        actions: [
+          {
+            text: "Accept analytics cookies",
+            type: "button",
+            name: "cookies",
+            value: "accept"
+          },
+          {
+            text: "Reject analytics cookies",
+            type: "button",
+            name: "cookies",
+            value: "reject"
+          },
+          {
+            text: "View cookies",
+            href: "#"
+          }
+        ]
+      }
+    ]
+  }) }}
 {% endblock %}
 
 {% block skipLink %}

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -7,6 +7,7 @@ ignore_in_sitemap: true
 {# Example that changes every setting in the template #}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 {% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
@@ -45,6 +46,34 @@ ignore_in_sitemap: true
 {% endblock %}
 
 {% block bodyStart %}
+  {{ govukCookieBanner({
+    ariaLabel: "Cookies on [name of service]",
+    messages: [
+      {
+        headingText: "Cookies on [name of service]",
+        html: "<p>We use some essential cookies to make this service work.</p>
+               <p>We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>",
+        actions: [
+          {
+            text: "Accept analytics cookies",
+            type: "button",
+            name: "cookies",
+            value: "accept"
+          },
+          {
+            text: "Reject analytics cookies",
+            type: "button",
+            name: "cookies",
+            value: "reject"
+          },
+          {
+            text: "View cookies",
+            href: "#"
+          }
+        ]
+      }
+    ]
+  }) }}
 {% endblock %}
 
 {% block skipLink %}


### PR DESCRIPTION
Add the default cookie banner to the customised page template example as discussed in https://github.com/alphagov/govuk-design-system/issues/1475#issuecomment-775053243.

Partially fixes https://github.com/alphagov/govuk-design-system/issues/1475