### PR TITLE
Use typographic apostrophe in cookie banner

### DIFF
--- a/src/components/cookie-banner/default/index.njk
+++ b/src/components/cookie-banner/default/index.njk
@@ -7,7 +7,7 @@ layout: layout-example.njk
 
 {% set html %}
   <p>We use some essential cookies to make this service work.</p>
-  <p>We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+  <p>We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
 {% endset %}
 
 {{ govukCookieBanner({


### PR DESCRIPTION
> Straight quotes are a typewriter habit. In traditional printing, all quotation marks were curly. But typewriter character sets were limited by mechanical constraints and physical space.
>
> […]
>
> Compared to straight quotes, curly quotes are more legible on the page and match the other characters better.

– https://practicaltypography.com/straight-and-curly-quotes.html

This commit replaces the use of a straight single quotation mark as an apostrophe with the typographically-correct equivalent.