### PR TITLE
Disable cookie page notification banner autofocus

### DIFF
--- a/src/patterns/cookies-page/cookies-updated/code.njk
+++ b/src/patterns/cookies-page/cookies-updated/code.njk
@@ -13,6 +13,5 @@ layout: layout-example.njk
 
 {{ govukNotificationBanner({
   type: "success",
-  html: html,
-  disableAutoFocus: true
+  html: html
 }) }}

--- a/src/patterns/cookies-page/index.md.njk
+++ b/src/patterns/cookies-page/index.md.njk
@@ -89,7 +89,7 @@ Load the page with the radios set to ‘no’ on the user’s first visit. If th
 
 Use a green [notification banner](/components/notification-banner/) to confirm that you’ve updated the user’s cookie settings.
 
-{{ example({group: "patterns", item: "cookies-page", example: "cookies-updated", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "cookies-page", example: "cookies-updated", customCode: true, html: true, nunjucks: true, open: false}) }}
 
 ## If you depend on JavaScript to ask users to accept or reject cookies
 


### PR DESCRIPTION
Stop the notification banner used in the example from stealing focus when the iframe loads.

This is consistent with the approach used in other auto-focusing components in the Design System – for example, the ‘success’ example in the notification banner component guidance.