### PR TITLE
Make it possible to manually trigger a deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI Workflow
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 # Separate build and deploy jobs so we can build all branches and pull requests
 # but only deploy from master


### PR DESCRIPTION
Occasionally the webhook does not fire when a PR is merged to master – for example, if GitHub is having a partial outage.

Adding workflow_dispatch to the list of triggers [allows us to trigger this workflow manually from the Actions tab][1].

[1]: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually