### PR TITLE
Avoid implying we want people to use 'partner'

### DIFF
--- a/src/components/cookie-banner/index.md.njk
+++ b/src/components/cookie-banner/index.md.njk
@@ -60,7 +60,7 @@ Include the name of the service in the banner heading to help users understand t
 
 You’ll need to change the example cookie banner text if your service:
 
-- allows third parties to set cookies (tell the user that both you and your ‘partner’ or ‘partners’ will be setting cookies)
+- allows third parties to set cookies (tell the user that both your organisation and other organisations will be setting cookies)
 - uses cookies for reasons other than collecting analytics information or remembering the user’s settings
 
 Keep the text as short as possible while making sure it’s an accurate description of how you use cookies. For example, if you use more than one ‘functional’ cookie and there’s not enough space to mention what each of them does, you could ask for permission to set cookies so ‘you can use as many of the service’s features as possible’.


### PR DESCRIPTION
The fact that we've put the word 'partner' or 'partners' in quotes has led at least one person to think we want them to use that term in banner text. That's not the intent behind the guidance, so I've updated it to sound less prescriptive.