### PR TITLE
Add id to contact panel heading

### DIFF
--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -1,6 +1,6 @@
 {%- set fileEditURL = "https://github.com/alphagov/govuk-design-system/edit/master/src/" + path + "/index.md.njk" -%}
 {% if section === 'Styles' or section === 'Components' or section === 'Patterns'%}
-  <h2 class="govuk-heading-l govuk-!-padding-top-7">Help improve this page</h2>
+  <h2 class="govuk-heading-l govuk-!-padding-top-7" id="help-improve-this-page">Help improve this page</h2>
 
   {% if backlog_issue_id %}
     <p class="govuk-body">


### PR DESCRIPTION
### What

Add an `id` to the heading of the 'contact panel' shown at the bottom of guidance pages:


<img width="684" alt="Screenshot 2021-02-11 at 17 22 50" src="https://user-images.githubusercontent.com/19834460/107673324-cec2e600-6c8d-11eb-9115-7f56c2a671f2.png">

### Why

I wanted to send a link for this section to a user on support earlier. Also seems a bit inconsistent with the other headings on the pages.

The `id` content is hard coded cos the headings are the same on every page, happy to hear suggestions of better ways to do it if you think this would be a problem though.