### PR TITLE
Update notification banner example to use correct markup

### DIFF
--- a/src/components/notification-banner/success/code.njk
+++ b/src/components/notification-banner/success/code.njk
@@ -6,9 +6,9 @@ layout: layout-example.njk
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set html %}
-  <p class="govuk-notification-banner__heading">
+  <h3 class="govuk-notification-banner__heading">
     Training outcome recorded and trainee withdrawn
-  </p>
+  </h3>
   <p class="govuk-body">Contact <a class="govuk-notification-banner__link" href="#">example@department.gov.uk</a> if you think there's a problem.</p>
 {% endset %}
 


### PR DESCRIPTION
Updating one of the examples in the notification banner component so that the heading within the banner uses a `h3` instead of a `p`. 

I think that was our original intent, and reflects the hierarchy of the content more accurately. Let me know there's a reason it is the way it is!