### PR TITLE
Update multiple cookies example to be clearer

### DIFF
--- a/src/components/cookie-banner/multiple-cookies/index.njk
+++ b/src/components/cookie-banner/multiple-cookies/index.njk
@@ -7,7 +7,7 @@ layout: layout-example.njk
 
 {% set html %}
   <p>We use some essential cookies to make this service work.</p>
-  <p>We’d like to set additional cookies so we can remember your settings, understand how you use the service and make improvements.</p>
+  <p>We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
 {% endset %}
 
 {{ govukCookieBanner({


### PR DESCRIPTION
Single word change to avoid implying that analytics cookies track an individual user.

Checked with Stephen Gill for privacy concerns and it's fine.