### PR TITLE
Improve cookie banner research explanation

### DIFF
--- a/src/components/cookie-banner/index.md.njk
+++ b/src/components/cookie-banner/index.md.njk
@@ -127,6 +127,13 @@ When the user sets or changes their cookie preferences using the controls on the
 
 ## Research on this component
 
-We remove the visible focus indicator from when shifting focus to the cookie banner. We do this because the cookie banner is the first element on the page and the last thing the user interacted with prior to it being given focus.
+When the user accepts or rejects cookies, a replacement message will display. For example, "Your cookie preferences have been saved." The focus also shifts to this new message.
 
-So we’ve assumed that giving the cookie banner a visible focus indicator in these circumstances would be more likely to confuse users than to help them, especially as the element is not normally operable with a keyboard. However, more research is needed to find out if that assumption is right.
+However, a visible focus indicator does not appear around the replacement message. This is different from [what happens when a user does something in a notification banner](../notification-banner/#reacting-to-something-the-user-has-done).
+
+We decided to remove the visible focus indicator for a few reasons, as the replacement message:
+- is a `<div>`, so the user usually can’t interact with it using a keyboard
+- is the first element, at the very top of the page
+- displays in place of the cookie message, which is the last thing the user interacted with
+
+In this scenario, we assume that a visible focus indicator would be more likely to confuse users than to help them. However, we need more research to prove this.

--- a/src/components/cookie-banner/index.md.njk
+++ b/src/components/cookie-banner/index.md.njk
@@ -131,9 +131,9 @@ When the user accepts or rejects cookies, a replacement message will display. Fo
 
 However, a visible focus indicator does not display around the replacement message. This different from the notification banner, which does display a visible focus indicator.
 
-We decided to remove the visible focus indicator for a few reasons, as the replacement message:
-- is a `<div>`, so the user usually can’t interact with it using a keyboard
-- is the first element, at the very top of the page
-- displays in place of the cookie message, which is the last thing the user interacted with
+We decided to remove the visible focus indicator from the replacement message for a few reasons, as:
+- a user cannot interact with it
+- it's the first element, at the very top of the page
+- it displays in place of the cookie message, which is the last thing the user interacted with
 
 In this scenario, we assume that a visible focus indicator would be more likely to confuse users than to help them. However, we need more research to prove this.

--- a/src/components/cookie-banner/index.md.njk
+++ b/src/components/cookie-banner/index.md.njk
@@ -129,7 +129,7 @@ When the user sets or changes their cookie preferences using the controls on the
 
 When the user accepts or rejects cookies, a replacement message will display. For example, "Your cookie preferences have been saved." The focus also shifts to this new message.
 
-However, a visible focus indicator does not appear around the replacement message. This is different from [what happens when a user does something in a notification banner](../notification-banner/#reacting-to-something-the-user-has-done).
+However, a visible focus indicator does not display around the replacement message. This different from the notification banner, which does display a visible focus indicator.
 
 We decided to remove the visible focus indicator for a few reasons, as the replacement message:
 - is a `<div>`, so the user usually can’t interact with it using a keyboard


### PR DESCRIPTION
Reworked research section of the Cookie banner component page based on user feedback:
https://github.com/alphagov/govuk-design-system/issues/1502

User feedback 1 (example text)
> "I shared it with the designers...earlier today and it’s resulted in some interesting discussions, one in particular around the content in the banner. We wonder if “…understand how you use the service…” is potentially misleading, as analytics shouldn’t be able to track one user. Maybe something like “We’d also like to store cookies to track visits and find out how people use the website, so we can make improvements.” would be a better option?"