### PR TITLE
Add cookie banner legal disclaimer text

### DIFF
--- a/src/components/cookie-banner/index.md.njk
+++ b/src/components/cookie-banner/index.md.njk
@@ -22,7 +22,7 @@ You must tell users about any cookies you’re using - or any similar technologi
 This cookie banner and the [cookie page pattern](/patterns/cookies-page/) are based on the approach to getting cookie consent used on the GOV.UK website.
 
 You must not take this information as legal advice. Your organisation is responsible and accountable for what they do to comply with data protection legislation, such as:
-- [Privacy and Electronic Communications Regulations (PECR)
+- Privacy and Electronic Communications Regulations (PECR)
 - General Data Protection Regulation (GDPR)
  
 Check with your organisation's privacy expert to see how data protection legislation affects your website and service.

--- a/src/components/cookie-banner/index.md.njk
+++ b/src/components/cookie-banner/index.md.njk
@@ -21,6 +21,12 @@ You must tell users about any cookies you’re using - or any similar technologi
 
 This cookie banner and the [cookie page pattern](/patterns/cookies-page/) are based on the approach to getting cookie consent used on the GOV.UK website.
 
+You must not take this information as legal advice. Your organisation is responsible and accountable for what they do to comply with data protection legislation, such as:
+- [Privacy and Electronic Communications Regulations (PECR)
+- General Data Protection Regulation (GDPR)
+ 
+Check with your organisation's privacy expert to see how data protection legislation affects your website and service.
+
 ## How it works
 
 Show the cookie banner when the user accesses your service for the first time.


### PR DESCRIPTION
Add legal disclaimer text, as requested by privacy advisor, to make it clear this component does not automatically make services compliant with regulations.