### PR TITLE
Add GOV.UK Frontend WTForms package

### DIFF
--- a/src/community/resources-and-tools/index.md.njk
+++ b/src/community/resources-and-tools/index.md.njk
@@ -52,9 +52,11 @@ Guidance on [building a hapi service using GOV.UK Frontend](https://github.com/D
 
 ### Python
 
-[GOV.UK Frontend Jinja ](https://github.com/LandRegistry/govuk-frontend-jinja) -
+[GOV.UK Frontend Jinja](https://github.com/LandRegistry/govuk-frontend-jinja) -
 GOV.UK Frontend Jinja Macros.
 
+[GOV.UK Frontend WTForms](https://github.com/LandRegistry/govuk-frontend-wtf) -
+GOV.UK Frontend WTForms Widgets.
 
 ### R
 


### PR DESCRIPTION
Adding WTForms Widget package to generate GOV.UK compliant forms. Works in conjunction with the existing GOV.UK Frontend Jinja package.