### PR TITLE
Add guidance for divider and "none of these" to Checkboxes component

### DIFF
--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -65,6 +65,24 @@ You can add hints to checkbox items to provide additional information about the 
 
 {{ example({group: "components", item: "checkboxes", example: "hint", html: true, nunjucks: true, open: false, size: "s"}) }}
 
+### Add an option for ‘none’
+
+When 'none' would be a valid answer, give users the option to check a box to say none of the other options apply to them. Without this option, users would have to leave all of the boxes unchecked. This requirement also makes sure users do not skip the question by accident.
+
+Show the ‘none’ option last. Separate it from the other options using a divider. The text is usually the word ‘or’.
+
+Write a label that repeats the key part of the question.
+
+For example, for the question 'Will you be travelling to any of these countries?', say 'No, I will not be travelling to any of these countries.'
+
+To enable some JavaScript that unchecks all other checkboxes when the user clicks 'None', add the `exclusive` behaviour to the 'none' checkbox.
+
+{{ example({group: "components", item: "checkboxes", example: "with-none-option", html: true, nunjucks: true, open: false, size: "xl"}) }}
+
+If JavaScript is unavailable, and a user selects both the ‘none’ checkbox and another checkbox, display an error message.
+
+{{ example({group: "components", item: "checkboxes", example: "with-none-option-in-error", html: true, nunjucks: true, open: false, size: "xl"}) }}
+
 ### Conditionally revealing content
 
 You can conditionally reveal content when the user selects a particular checkbox, so they only see content when it’s relevant to them.
@@ -81,9 +99,9 @@ Users are not always notified when conditionally revealed content is expanded or
 
 ### Smaller checkboxes
 
-Use standard-sized checkboxes in nearly all cases. However, smaller versions work well on pages where it’s helpful to make them less visually prominent.  
+Use standard-sized checkboxes in most cases. However, smaller checkboxes work well on pages where it’s helpful to make them less visually prominent.
 
-For example, on a page of search results, the primary user need is to see the results. Using smaller checkboxes lets users see and change search filters without distracting them from the main content. 
+For example, on a page of search results, the main user need is to see the results. Using smaller checkboxes lets users see and change search filters without distracting them from the main content.
 
 {{ example({group: "components", item: "checkboxes", example: "small", html: true, nunjucks: true, open: false, size: "m"}) }}
 
@@ -108,6 +126,11 @@ For example, ‘Select if you are British, Irish or a citizen of a different cou
 
 Say ‘Select [whatever it is]’.<br>
 For example, ‘Select your nationality or nationalities’.
+
+#### If users check both a 'none' checkbox and another checkbox
+
+Say ‘Select [option label text] or select “[none of the above label text]”’<br>
+For example, ‘Select countries you will be travelling to, or select “No, I will not be travelling to any of these countries”’
 
 ## Research on this component
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -67,7 +67,7 @@ You can add hints to checkbox items to provide additional information about the 
 
 ### Add an option for ‘none’
 
-When 'none' would be a valid answer, give users the option to check a box to say none of the other options apply to them. Without this option, users would have to leave all of the boxes unchecked. This requirement also makes sure users do not skip the question by accident.
+When 'none' would be a valid answer, give users the option to check a box to say none of the other options apply to them — without this option, users would have to leave all of the boxes unchecked. Giving users this option also makes sure they do not skip the question by accident.
 
 Show the ‘none’ option last. Separate it from the other options using a divider. The text is usually the word ‘or’.
 

--- a/src/components/checkboxes/with-none-option-in-error/index.njk
+++ b/src/components/checkboxes/with-none-option-in-error/index.njk
@@ -1,0 +1,45 @@
+---
+title: Checkboxes with 'none' option showing an error
+layout: layout-example.njk
+---
+
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  idPrefix: "countries",
+  name: "countries",
+  fieldset: {
+    legend: {
+      text: "Will you be travelling to any of these countries?",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--l"
+    }
+  },
+  errorMessage: {
+    text: "Select countries you will be travelling to, or select “No, I will not be travelling to any of these countries”"
+  },
+  items: [
+    {
+      value: "france",
+      text: "France",
+      checked: true
+    },
+    {
+      value: "portugal",
+      text: "Portugal"
+    },
+    {
+      value: "spain",
+      text: "Spain"
+    },
+    {
+      divider: "or"
+    },
+    {
+      value: "none",
+      text: "No, I will not be travelling to any of these countries",
+      checked: true,
+      behaviour: "exclusive"
+    }
+  ]
+}) }}

--- a/src/components/checkboxes/with-none-option/index.njk
+++ b/src/components/checkboxes/with-none-option/index.njk
@@ -1,0 +1,43 @@
+---
+title: Checkboxes with 'none' option
+layout: layout-example.njk
+---
+
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  idPrefix: "countries",
+  name: "countries",
+  fieldset: {
+    legend: {
+      text: "Will you be travelling to any of these countries?",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--l"
+    }
+  },
+  hint: {
+    text: "Select all countries that apply"
+  },
+  items: [
+    {
+      value: "france",
+      text: "France"
+    },
+    {
+      value: "portugal",
+      text: "Portugal"
+    },
+    {
+      value: "spain",
+      text: "Spain"
+    },
+    {
+      divider: "or"
+    },
+    {
+      value: "none",
+      text: "No, I will not be travelling to any of these countries",
+      behaviour: "exclusive"
+    }
+  ]
+}) }}


### PR DESCRIPTION
This updates the GOV.UK Design System website with guidance on the use of a "None of these" option for the Checkboxes component.

➡️ [Preview of the Checkboxes component with new guidance](https://deploy-preview-1535--govuk-design-system-preview.netlify.app/components/checkboxes/)

Uses a pre-release version of `govuk-frontend`, currently open as [PR #2151](https://github.com/alphagov/govuk-frontend/pull/2151).

NOTE: Do not merge until the `govuk-frontend` PR has been merged and released, and then update this PR to use the released version.

