### PR TITLE
Add example to top of tag component

### DIFF
--- a/src/components/tag/default/index.njk
+++ b/src/components/tag/default/index.njk
@@ -6,5 +6,5 @@ layout: layout-example.njk
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 
 {{ govukTag({
-  text: "alpha"
+  text: "completed"
 }) }}

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -9,6 +9,8 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
+{{ example({group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: false }) }}
+
 ## When to use this component
 
 Use the tag component when it’s possible for something to have more than one status and it’s useful for the user to know about that status. For example, you can use a tag to show whether an item in a [task list](../../patterns/task-list-pages) has been ‘completed’.

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -9,6 +9,8 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
+Use the tag component to show users the status of something.
+
 {{ example({group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: false }) }}
 
 ## When to use this component


### PR DESCRIPTION
Just added an example here because there wasn't one there before, which is inconsistent with other components.

I used 'completed' as the example, taken from the task list pattern.

![Screenshot 2021-03-04 at 15 22 18](https://user-images.githubusercontent.com/19834460/109986345-8e3f1100-7cfd-11eb-8e6b-29661a25e3f9.png)
