### PR TITLE
Render additional component descriptions as markdown

### DIFF
--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -178,7 +178,7 @@ function getMacroOptions (componentName) {
     })
   ).concat(
     additionalComponents.map(name => {
-      const additionalComponentOptions = getMacroOptionsJson(name)
+      const additionalComponentOptions = getMacroOptionsJson(name).map(renderDescriptionsAsMarkdown)
       return {
         'name': 'Options for ' + name,
         'id': name,


### PR DESCRIPTION
## What
Make sure any additional components in the macro options are converted to markdown before displaying.

## Why
Issue raised by @EoinShaughnessy . We weren't converting all macro option descriptions to markdown, which meant some descriptions were displaying the backticks to highlight code rather than rendering as actual inline code blocks.

### Before
<img width="736" alt="Screenshot 2021-03-05 at 15 40 40" src="https://user-images.githubusercontent.com/29889908/110138046-76cd5a00-7dc9-11eb-9854-710ecbc9d0e1.png">

### After
<img width="744" alt="Screenshot 2021-03-05 at 15 40 48" src="https://user-images.githubusercontent.com/29889908/110138054-78971d80-7dc9-11eb-9c6b-1fc89097a7e7.png">
