### PR TITLE
Prevent full page examples from being indexed

### DIFF
--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -1,6 +1,7 @@
 {% extends "govuk/template.njk" %}
 {% block pageTitle %}{{ title }} – Example – GOV.UK Design System{% endblock %}
 {% block head %}
+  <meta name="robots" content="noindex, nofollow">
   <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
   {#- Include any additional stylesheets specified in the example frontmatter #}
   {% for stylesheet in stylesheets %}


### PR DESCRIPTION
We regularly get support requests from users who are having difficulty signing in to Universal Credit.

According to Google Search Console, on 1 Feb we saw a particularly high peak of 5,034 clicks from Google search results of which 2,349 related to Universal Credit. 2,633 clicks were to the ‘Service unavailable’ pattern, and another 1,223 clicks were to the ‘Problem with the service’ pattern.

These patterns both include full page examples which contain text that might appear in a service. They also contain the names of real-life services or concepts, including ‘tax credits’ and ‘Universal Credit’.

[Unlike partial examples][1], full page examples do not include a robots meta tag preventing indexing from search engines.

Prevent full page examples from being indexed by search engines by adding that missing robots meta tag, which we believe [will prevent the content being indexed as part of the parent page][2].

[1]: https://github.com/alphagov/govuk-design-system/blob/3af704f3f283d4f077658cc73eb1cfb7f540c93b/views/layouts/layout-example.njk#L5
[2]: https://webmasters.stackexchange.com/questions/77379/how-can-i-stop-google-from-indexing-embedded-iframes#:~:text=Based%20on%20pretty%20extensive%20experience%20with%20iframes%2C%20I%20can%20confirm%20that%20this%20prevents%20iframe%20pages%20from%20being%20indexed%2C%20while%20still%20allowing%20the%20parent%20page%20containing%20the%20iframe%20to%20be%20indexed.