### PR TITLE
Update expected fix dates in guidance

### DIFF
--- a/src/components/accordion/index.md.njk
+++ b/src/components/accordion/index.md.njk
@@ -85,7 +85,7 @@ The team made sure the component is accessible, for example that users can inter
 
 ### Known issues and gaps
 
-The section headings can be mistaken for links, but are treated as buttons. This fails [WCAG 2.1 success criterion 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships). We plan to fix this issue by the end of March 2021.
+The section headings can be mistaken for links, but are treated as buttons. This fails [WCAG 2.1 success criterion 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships). We plan to fix this issue by the end of June 2021.
 
 The plus and minus icon is on the right side of the component, which means users of screen magnifiers might not see it.
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -77,7 +77,7 @@ Keep it simple - if you need to add a lot of content, consider showing it on the
 
 #### Known issues
 
-Users are not always notified when conditionally revealed content is expanded or collapsed. This fails [WCAG 2.1 success criterion 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html). We plan to fix this issue by the end of March 2021.
+Users are not always notified when conditionally revealed content is expanded or collapsed. This fails [WCAG 2.1 success criterion 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html). We plan to fix this issue by the end of June 2021.
 
 ### Smaller checkboxes
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -96,7 +96,7 @@ Do not add conditionally revealing content to inline radios.
 
 #### Known issues
 
-Users are not always notified when conditionally revealed content is expanded or collapsed. This fails [WCAG 2.1 success criterion 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html). We plan to fix this issue by the end of March 2021.
+Users are not always notified when conditionally revealed content is expanded or collapsed. This fails [WCAG 2.1 success criterion 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html). We plan to fix this issue by the end of June 2021.
 
 ### Smaller radios
 


### PR DESCRIPTION
In #1549 we updated the date we plan to fix the 2 known accessibility issues from March 2021 to June 2021. However, the March dates also appear in the guidance for the affected components (radios, checkboxes, accordion) and these were missed.

Update the dates in the guidance to keep them in sync with the dates in the accessibility statement.