### PR TITLE
Add blogs, talks and podcasts to community pages

### DIFF
--- a/src/community/blogs-talks-podcasts/index.md.njk
+++ b/src/community/blogs-talks-podcasts/index.md.njk
@@ -6,7 +6,7 @@ layout: layout-pane.njk
 order: 8
 ---
 
-See blog posts, video talks, and podcasts about the GOV.UK Design System and Prototype Kit that our team and community have shared.
+To learn more about the GOV.UK Design System and Prototype Kit, check out these blog posts, video talks and podcasts that our team and community have shared.
 
 ## About the Design System
 

--- a/src/community/blogs-talks-podcasts/index.md.njk
+++ b/src/community/blogs-talks-podcasts/index.md.njk
@@ -1,0 +1,74 @@
+---
+title: Blog posts, videos and podcasts
+description: See blog posts, video talks, and podcasts about the GOV.UK Design System and Prototype Kit
+section: Community
+layout: layout-pane.njk
+order: 8
+---
+
+See blog posts, video talks, and podcasts about the GOV.UK Design System and Prototype Kit that our team and community have shared.
+
+## About the Design System
+
+Find out how the Design System and Prototype Kit work and what they do to make services more accessible and inclusive.
+
+[Inclusive Documentation](https://www.youtube.com/watch?v=dZOf973QzmE) (video) - 4 October 2019
+
+[Making the Design System more accessible](https://designnotes.blog.gov.uk/2019/07/29/weve-made-the-gov-uk-design-system-more-accessible/) (blog) - 29 July 2019
+
+[Inclusive forms, Anatomy of a (fictional) GOV.UK service](https://www.youtube.com/watch?v=JHaLzm-FGsc) (video) - 26 February 2019
+
+[Accessibility in the GOV.UK Design System](https://www.youtube.com/watch?v=OeyMEDPnPcE) (video) - 30 November 2018
+
+[Introducing the GOV.UK Design System](https://gds.blog.gov.uk/2018/06/22/introducing-the-gov-uk-design-system/) (blog) - 22 June 2018
+
+[Building Accessible Components and the GOV.UK Design System](https://www.youtube.com/watch?v=wprWuTvhec4) (video) - 11 June 2018
+
+[We've updated the radios and checkboxes on GOV.UK](https://designnotes.blog.gov.uk/2016/11/30/weve-updated-the-radios-and-checkboxes-on-gov-uk/) (blog) - 30 November 2016
+
+## Benefits of the Design System
+
+See how the Design System helps service teams across government.
+
+[Podcast, GOV.UK Design System](https://gds.blog.gov.uk/2020/02/28/podcast-gov-uk-design-system/) (podcast) - 28 February 2020
+
+[How the GOV.UK Design System can work alongside other government design resources](https://designnotes.blog.gov.uk/2019/02/14/how-the-gov-uk-design-system-can-work-alongside-other-government-design-resources/) (blog) - 14 February 2019
+
+[The benefits of migrating GOV.UK Pay’s codebase to the GOV.UK Design System](https://technology.blog.gov.uk/2018/12/21/the-benefits-of-migrating-gov-uk-pays-codebase-to-the-gov-uk-design-system/) (blog) - 21 December 2018
+
+## How to use the Design System
+
+Get some practical advice on how to use the Design System and Prototype Kit.
+
+[Building digital services that work for everyone](https://www.youtube.com/watch?v=1cuZnBqQYKQ&feature=youtu.be) (video) - 21 May 2020
+
+[Adapting the GOV.UK Design System for the NHS](https://gds.blog.gov.uk/2019/06/04/guest-post-adapting-the-gov-uk-design-system-for-the-nhs/) (blog) - 4 June 2019
+
+[How we document components and patterns in the GOV.UK Design System](https://designnotes.blog.gov.uk/2018/11/05/how-we-document-components-and-patterns-in-the-gov-uk-design-system/) (blog) - 5 November 2018
+
+[We’ve updated the prototype kit](https://designnotes.blog.gov.uk/2016/01/18/weve-updated-the-prototype-kit/) (blog) - 18 January 2016
+
+## Contributing to the community
+
+Find out how our community works and how to be a part of it.
+
+[Guest post, Adapting the GOV.UK Design System for the NHS](https://gds.blog.gov.uk/2019/06/04/guest-post-adapting-the-gov-uk-design-system-for-the-nhs/) (blog) - 4 June 2019
+
+[Opening up the GOV.UK Design System for contributions](https://designnotes.blog.gov.uk/2018/09/26/opening-up-the-gov-uk-design-system-for-contributions/) (blog) - 26 September 2018
+
+[Looking at design systems across government](https://designnotes.blog.gov.uk/2016/12/21/looking-at-design-systems-across-government/) (blog) - 21 December 2016
+
+## Add a link to this page
+
+To help us make this page better, you can [propose to add a link](https://github.com/alphagov/govuk-design-system/edit/master/src/community/blogs-talks-podcasts/index.md.njk) that you’ve created or think would be useful to the community. Links need to meet the [GOV.UK external link policy](https://www.gov.uk/guidance/content-design/links) and the Design System [community principles](/community/#community-principles).
+
+Before we publish a new link, we’ll make sure that:
+
+- it adds to the knowledge base of our community
+- it meets the Design System community principles
+- it shows the Design System or Prototype Kit as it currently works
+- the content is usable and accessible (especially on mobile) so everyone can use it
+- it does not endorse a particular product, platform or framework
+- it does not promote a product or service for commercial gain
+- users can access the content without having to pay or register to see it
+- it’s a safe place to send a user, based on site’s privacy and cookie policies

--- a/src/community/index.md.njk
+++ b/src/community/index.md.njk
@@ -13,36 +13,37 @@ Find out:
 - what people are currently working on in the [community backlog](/community/backlog)
 - how to [propose a component or pattern](/community/propose-a-component-or-pattern)
 - how to [develop a component or pattern](/community/develop-a-component-or-pattern)
+- about [blog posts, videos and podcasts](/community/blogs-talks-podcasts)
 
 Learn how the [Design System working group](/community/design-system-working-group) reviews and approves components and patterns to confirm they meet the [contribution criteria](/community/contribution-criteria).
 
-## Community principles 
+## Community principles
 
-These principles are for the community of people that create and contribute to government components and patterns. 
+These principles are for the community of people that create and contribute to government components and patterns.
 
 ### 1. Start with what exists
 
-Reuse as much as possible and iterate based on user needs. 
+Reuse as much as possible and iterate based on user needs.
 
-Start by checking what exists in the [GOV.UK Design System](/). 
+Start by checking what exists in the [GOV.UK Design System](/).
 
 If something is not in the Design System, check the [community backlog](/community/backlog/) and [community resources and tools](/community/resources-and-tools) to see what colleagues in other departments have done before.
 
 Reach out to the community to ask questions, gather examples and learn from others’ mistakes.
 
-### 2. Contribute back and help others 
+### 2. Contribute back and help others
 
-The GOV.UK Design System is for everyone. Anyone can contribute evidenced-based changes. 
+The GOV.UK Design System is for everyone. Anyone can contribute evidenced-based changes.
 
-Think beyond your service and aim to design components and patterns that are scalable, reusable and can evolve over time. 
+Think beyond your service and aim to design components and patterns that are scalable, reusable and can evolve over time.
 
-Share research findings and examples with others. Be open to feedback or changes to your work. 
+Share research findings and examples with others. Be open to feedback or changes to your work.
 
 Above all, be kind. Encourage others to contribute by being respectful when asking questions or giving feedback.
 
 ### 3. Prioritise openness and honesty
 
-Prioritise sharing components and patterns in the GOV.UK Design System and [community backlog](/community/backlog/). This makes them easier to find and reduces duplication of effort. 
+Prioritise sharing components and patterns in the GOV.UK Design System and [community backlog](/community/backlog/). This makes them easier to find and reduces duplication of effort.
 
 Share work in progress as early as possible. Be honest about the amount and nature of your research and findings. Share what works and what does not.
 

--- a/src/index.njk
+++ b/src/index.njk
@@ -68,6 +68,9 @@ description: Design your service using GOV.UK styles, components and patterns
           <a href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system" class="govuk-link" data-hsupport="slack">
             #govuk-design-system channel on cross-government Slack</a>
         </li>
+        <li>
+          see <a class="govuk-link" href="/community/blogs-talks-podcasts">blog posts, video talks, and podcasts about the GOV.UK Design System and Prototype Kit</a>
+        </li>
         </ul>
       </div>
 


### PR DESCRIPTION
This pull request adds a blog posts, talks, and podcasts page to the community section of the Design System website.

This closes #1470 