### PR TITLE
Add missing "is" to `Research on this component`

### DIFF
--- a/src/components/cookie-banner/index.md.njk
+++ b/src/components/cookie-banner/index.md.njk
@@ -129,7 +129,7 @@ When the user sets or changes their cookie preferences using the controls on the
 
 When the user accepts or rejects cookies, a replacement message will display. For example, "Your cookie preferences have been saved." The focus also shifts to this new message.
 
-However, a visible focus indicator does not display around the replacement message. This different from the notification banner, which does display a visible focus indicator.
+However, a visible focus indicator does not display around the replacement message. This is different from the notification banner, which does display a visible focus indicator.
 
 We decided to remove the visible focus indicator from the replacement message for a few reasons, as:
 - a user cannot interact with it


### PR DESCRIPTION
The `Research on this component` section is missing an "is", and is not clearly readable without it.