### PR TITLE
Add Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,30 @@
+---
+name: "🐛 Bug report"
+about: Report a bug or regression
+title: ''
+labels: "\U0001F41B bug, awaiting triage"
+assignees: ''
+
+---
+
+<!--
+    Please fill in as much of the template below as you’re able to. If you're unsure whether the issue already exists or how to fill in the template, open an issue anyway. Our team will help you to complete the rest.
+
+    Your issue might already exist. If so, add a comment to the existing issue instead of creating a new one. You can find existing issues here: https://github.com/alphagov/govuk-design-system/issues
+-->
+
+## Description of the issue
+<!-- A clear and concise summary of what the bug is. -->
+
+## Steps to reproduce the issue
+<!-- How can we reproduce this issue? If you think it will be helpful, please provide a small code snippet and/or screenshots. -->
+
+## Actual vs expected behaviour
+<!-- What is happening vs what would you expect to happen instead? -->
+
+## Environment (where applicable)
+<!-- Details of your operating system, browser and the version of GOVUK Frontend you’re using may help us to reproduce your issue. -->
+
+- Operating system:
+- Browser:
+- Browser version:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Get in touch another way
+    url: https://design-system.service.gov.uk/get-in-touch/
+    about: Find out how to get in touch via email or Slack

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,25 @@
+---
+name: "📖 Documentation"
+about: Add new documentation, or report missing, incorrect or unclear documentation
+title: ''
+labels: "documentation, awaiting triage"
+assignees: ''
+
+---
+
+<!--
+    Please fill in as much of the template below as you’re able to. If you're unsure whether the issue already exists or how to fill in the template, open an issue anyway. Our team will help you to complete the rest.
+
+    Your issue might already exist. If so, add a comment to the existing issue instead of creating a new one. You can find existing issues here: https://github.com/alphagov/govuk-design-system/issues
+
+    We also welcome pull requests from users, if you feel comfortable doing so.
+-->
+
+## Related documentation
+<!-- Does this issue refer to a gap or mistake in some existing documentation? Provide a link if possible. -->
+
+## Suggestion
+<!-- How could this documentation be improved? -->
+
+## Evidence (where applicable)
+<!-- Please provide any relevant user research or evidence to support this change. -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,27 @@
+---
+name: "✨ Feature request"
+about: Suggest a new feature or idea
+title: ''
+labels: "feature request, awaiting triage"
+assignees: ''
+
+---
+
+<!--
+  Please fill in as much of the template below as you’re able to. If you're unsure whether the issue already exists or how to fill in the template, open an issue anyway. Our team will help you to complete the rest.
+
+  Your issue might already exist. If so, add a comment to the existing issue instead of creating a new one. You can find existing issues here:
+  - the community backlog: https://design-system.service.gov.uk/community/backlog/
+  - an existing Github issue: https://github.com/alphagov/govuk-design-system/issues
+
+  If you are proposing a new component or pattern, please follow the instructions here: https://design-system.service.gov.uk/community/propose-a-component-or-pattern/
+-->
+
+## Context
+<!-- What are you trying to do? Is this something you think should behave differently, or something that you currently cannot do? Is this related to an existing issue/bug? -->
+
+## Alternatives
+<!-- Are you currently using a workaround / alternative solution instead? -->
+
+## Additional information (if applicable)
+<!-- What evidence do you have that this meets the needs of users? It’s useful for us to know of any user research/testing you’ve done with this feature. -->

--- a/.github/ISSUE_TEMPLATE/internal-story.md
+++ b/.github/ISSUE_TEMPLATE/internal-story.md
@@ -1,0 +1,24 @@
+---
+name: "Internal story template"
+about: For internal use only
+title: ''
+labels: "awaiting triage"
+assignees: ''
+
+---
+
+<!--
+
+  This is a template for any issues that aren’t bug reports or new feature requests. The headings in this section provide examples of the information you might want to include, but feel free to add/delete sections where appropriate.
+
+-->
+
+## What
+
+## Why
+
+## Who needs to know about this
+
+## Done when
+
+- [ ] Thing to do


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-design-system/issues/1570

Adds the following Github issue templates to the design system repo:
- bug report
- feature request
- internal card
- link to getting support

These issue templates match the templates already added to the govuk-frontend repo.

Given the nature of this repo, this PR also adds an additional documentation issue template too. Would be good for @EoinShaughnessy to take a look and see if having a separate template for this seems worthwhile.