### PR TITLE
Remove protected characteristics item

### DIFF
--- a/src/community/backlog/index.md.njk
+++ b/src/community/backlog/index.md.njk
@@ -562,14 +562,6 @@ Here is a list of the components, patterns and updates currently on the Design S
     </tr>
     <tr>
       <td class="govuk-table__cell">
-        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/180">Protected characteristics</a>
-      </td>
-      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
-        To do
-      </td>
-    </tr>
-    <tr>
-      <td class="govuk-table__cell">
         <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/213">Quick exit</a>
       </td>
       <td class="govuk-table__cell govuk-body-s" style="text-align: right">


### PR DESCRIPTION
Removes protected characteristics 'to do' line, as it's replaced by the Equality information pattern

https://github.com/alphagov/govuk-design-system/issues/1545