### PR TITLE
Correct typo

### DIFF
--- a/src/patterns/equality-information/index.md.njk
+++ b/src/patterns/equality-information/index.md.njk
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-Public sector organisations have a duty to consider the need to avoid discimination and advance equality of opportunity as part of what they do. This is part of what’s called the [public sector equality duty](https://www.gov.uk/guidance/equality-act-2010-guidance#public-sector-equality-duty).
+Public sector organisations have a duty to consider the need to avoid discrimination and advance equality of opportunity as part of what they do. This is part of what’s called the [public sector equality duty](https://www.gov.uk/guidance/equality-act-2010-guidance#public-sector-equality-duty).
 
 Public sector bodies often collect equality information about service users to help them meet this duty.
 


### PR DESCRIPTION
'Discrimination' is mis-spelled in opening sentence