### PR TITLE
Update accessibility statement after TDT fixes

### DIFF
--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -42,7 +42,7 @@ GDS is committed to making its websites accessible, in accordance with the Publi
 
 The Design System website at [https://design-system.service.gov.uk/](https://design-system.service.gov.uk/) is partially compliant with the Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard, due to the non-compliances listed below.
 
-The GOV.UK Frontend documentation website at [http://frontend.design-system.service.gov.uk/](https://frontend.design-system.service.gov.uk/) is partially compliant with the WCAG 2.1 AA standard, due to the non-compliances listed below.
+The GOV.UK Frontend documentation website at [http://frontend.design-system.service.gov.uk/](https://frontend.design-system.service.gov.uk/) is fully compliant with the WCAG 2.1 AA standard.
 
 ### Non-accessible content
 
@@ -56,10 +56,6 @@ The Design System website at [https://design-system.service.gov.uk/](https://des
 - the section headings in accordions can be mistaken for links, but are treated as buttons - this fails [WCAG 2.1 success criterion 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
 
 We plan to fix these accessibility issues by the end of June 2021.
-
-The GOV.UK Frontend documentation website is only partially compliant because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
-
-We plan to fix the issues with the Technical Documentation Template by the end of March 2021.
 
 ### How this website has been tested for accessibility
 
@@ -85,11 +81,13 @@ The GOV.UK Design System team works hard to ensure that this Design System and F
 
 Where possible, the team aims to research components and patterns with a representative range of users, including those with disabilities.
 
-It also tests components to ensure they work with a broad range of browsers, devices and assistive technologies - including screen magnifiers, screen readers and speech recognition tools.
+We also test components to ensure they work with a broad range of browsers, devices and assistive technologies - including screen magnifiers, screen readers and speech recognition tools.
+
+When we publish new content, we'll continue to make sure that it meets accessibility standards.
 
 ### Preparation of this accessibility statement
 
-This statement was prepared on 23 October 2019. It was last reviewed on 21 December 2020.
+This statement was prepared on 23 October 2019. It was last reviewed on 29 March 2021.
 
 ## Using the Design System and Frontend in your service
 

--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -73,7 +73,7 @@ DAC tested a sample of pages to cover the different content types in the GOV.UK 
 
 They also tested the global search functionality that appears in the header of every page in the Design System.
 
-The [GOV.UK Frontend documentation website](http://frontend.design-system.service.gov.uk/) was last tested in July 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested all the website's pages.
+The [GOV.UK Frontend documentation website](http://frontend.design-system.service.gov.uk/) was last tested for accessibility issues in March 2021.
 
 ### How the GOV.UK Design System team makes this website accessible
 


### PR DESCRIPTION
Fixes [#1569](https://github.com/alphagov/govuk-design-system/issues/1569) (Remove references to accessibility issues in Frontend Docs from accessibility statement [before 31 March]).

The [most recent update to the Tech Docs Template](https://github.com/alphagov/govuk-frontend-docs/pull/109) has fixed some accessibility issues. For example, users of assistive tech will now no longer be able to focus elements that should remain hidden on pages. So, we now need to update our accessibility statement to say that our Frontend docs site is fully compliant with the WCAG 2.1 AA standard.

This PR also contains:
- an updated review date for the accessibility statement
- deletions of outdated information (about WCAG only being partly met because of issues with the Template)