### PR TITLE
add figma resources to community resources and tools page

### DIFF
--- a/src/community/resources-and-tools/index.md.njk
+++ b/src/community/resources-and-tools/index.md.njk
@@ -41,6 +41,9 @@ Balsamiq wireframes based on the GOV.UK Design System.
 [Sketch Wireframing Kit](https://github.com/abbott567/sketch_wireframing_kit) -
 Sketch wireframes based on the GOV.UK Design System.
 
+[Figma resources](https://www.figma.com/file/NWuFffKvPQhl3aJ9nKU0p3/GOV.UK-Design-System) -
+Figma library of styles and components based on the GOV.UK Design System.
+
 
 ## Build front ends
 

--- a/src/community/resources-and-tools/index.md.njk
+++ b/src/community/resources-and-tools/index.md.njk
@@ -38,11 +38,11 @@ Adobe XD wireframes based on the GOV.UK Design System.
 [Balsamiq wireframes](https://github.com/enoranidi/govuk-design-system-balsamiq) -
 Balsamiq wireframes based on the GOV.UK Design System.
 
-[Sketch Wireframing Kit](https://github.com/abbott567/sketch_wireframing_kit) -
-Sketch wireframes based on the GOV.UK Design System.
-
 [Figma resources](https://www.figma.com/file/NWuFffKvPQhl3aJ9nKU0p3/GOV.UK-Design-System) -
 Figma library of styles and components based on the GOV.UK Design System.
+
+[Sketch Wireframing Kit](https://github.com/abbott567/sketch_wireframing_kit) -
+Sketch wireframes based on the GOV.UK Design System.
 
 
 ## Build front ends


### PR DESCRIPTION
This pull request closes #1533 

## What
Adding a Figma resource to the tools and resources page of the community section.

## Why
Some of our users use Figma to prototype their work. This resource will allow them to use Design System styles and components.