### PR TITLE
Replace negative contractions in guidance

### DIFF
--- a/src/community/contribution-criteria/index.md.njk
+++ b/src/community/contribution-criteria/index.md.njk
@@ -121,5 +121,5 @@ Before linking from the Design System to a [community resource or tool](/communi
 - it's no more than 3 months behind the latest version of GOV.UK Frontend
 - design resources are consistent with the styles, components and patterns in the GOV.UK Design System
 - development resources output the same markup as GOV.UK Frontend
-- it isn't being charged for or used to promote a private business
+- it is not being charged for or used to promote a private business
 - it's compatible with the [Service Standard](https://www.gov.uk/service-manual/service-standard) and [Technology code of practice](https://www.gov.uk/government/publications/technology-code-of-practice/technology-code-of-practice)

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -47,7 +47,7 @@ Avoid using multiple default buttons on a single page. Having more than one main
 ### Start buttons
 
 Use a start button for the main call to action on your service’s [start page](/patterns/start-pages/).
-Start buttons don't submit form data, so they use a link tag rather than a button tag.
+Start buttons do not submit form data, so they use a link tag rather than a button tag.
 
 {{ example({group: "components", item: "button", example: "start", html: true, nunjucks: true, open: false}) }}
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -33,7 +33,7 @@ If you’re asking [one question per page](../../patterns/question-pages/#start-
 
 Read more about [why and how to set legends as headings](../../get-started/labels-legends-headings).
 
-Make sure that any example dates you use in hint text are valid for the question being asked. 
+Make sure that any example dates you use in hint text are valid for the question being asked.
 
 There are 2 ways to use the date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
@@ -51,7 +51,7 @@ If you're asking more than one question on the page, do not set the contents of 
 
 Use the `autocomplete` attribute on the date input component when you're asking for a date of birth. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.
 
-To do this, set the `autocomplete` attribute on the 3 fields to `bday-day`, `bday-month` and `bday-year`. See how to do this in the HTML and Nunjucks tabs in the following example. 
+To do this, set the `autocomplete` attribute on the 3 fields to `bday-day`, `bday-month` and `bday-year`. See how to do this in the HTML and Nunjucks tabs in the following example.
 
 {{ example({group: "components", item: "date-input", example: "date-of-birth", html: true, nunjucks: true, open: true, size: "s", id: "default-2"}) }}
 
@@ -74,7 +74,7 @@ Make sure errors follow the guidance in [error message](/components/error-messag
 If there’s more than one error, show the highest priority error message. In order of priority, show error messages about:
 
 - missing or incomplete information
-- information that can’t be correct (for example, the number ‘13’ in the month field)
+- information that cannot be correct (for example, the number ‘13’ in the month field)
 - information that fails validation for another reason
 
 #### If nothing is entered
@@ -91,9 +91,9 @@ Say ‘[whatever it is] must include a [whatever is missing]’.<br>
 
 For example, ‘Date of birth must include a month’ or ‘Date of birth must include a day and month’.
 
-#### If the date entered can’t be correct
+#### If the date entered cannot be correct
 
-For example, ‘13’ in the month field can’t be correct.<br>
+For example, ‘13’ in the month field cannot be correct.<br>
 
 Highlight the day, month or year field with the incorrect information. Or highlight the date as a whole if there’s incorrect information in more than one field, or it's not clear which field is incorrect.<br>
 

--- a/src/components/notification-banner/index.md.njk
+++ b/src/components/notification-banner/index.md.njk
@@ -29,7 +29,7 @@ Use notification banners sparingly. There’s [evidence that people often miss t
 
 If the information is directly relevant to the thing the user is doing on that page, put the information in the main page content instead. Use [inset text](/components/inset-text/) or [warning text](/components/warning-text/) if it needs to stand out.
 
-Don’t use a notification banner to tell the user about validation errors (use an [error message](/components/error-message/) and [error summary](/components/error-summary/) instead).
+Do not use a notification banner to tell the user about validation errors (use an [error message](/components/error-message/) and [error summary](/components/error-summary/) instead).
 
 ## How it works
 
@@ -43,9 +43,9 @@ Do not show a notification banner and an [error summary](/components/error-summa
 
 ### Notification banner headings
 
-You can use `<h3>` headings in the `govuk-notification-banner__content` to help structure your content. 
+You can use `<h3>` headings in the `govuk-notification-banner__content` to help structure your content.
 
-Avoid using headings for single-line notifications that don't need them.
+Avoid using headings for single-line notifications that do not need them.
 
 ## Telling the user about a problem that affects the whole service
 
@@ -72,9 +72,9 @@ Use a ‘neutral’ notification banner if the user needs to know about somethin
 
 ## Reacting to something the user has done
 
-You can also use a notification banner to tell the user about the outcome of something they’ve just done - but they haven’t finished using the service, so it doesn’t make sense to use a [confirmation page](/patterns/confirmation-pages/).
+You can also use a notification banner to tell the user about the outcome of something they’ve just done - but they have not finished using the service, so it does not make sense to use a [confirmation page](/patterns/confirmation-pages/).
 
-Using a notification banner is unlikely to be the right approach in a linear service - for example, a service that lets the user register or apply for a thing. For a linear service, it will usually make sense to stick to the [‘one thing per page’ approach](https://www.gov.uk/service-manual/design/form-structure). Don’t use a notification banner to tell users that they’ve finished using a linear service. Use a [confirmation page](/patterns/confirmation-pages/) instead.
+Using a notification banner is unlikely to be the right approach in a linear service - for example, a service that lets the user register or apply for a thing. For a linear service, it will usually make sense to stick to the [‘one thing per page’ approach](https://www.gov.uk/service-manual/design/form-structure). Do not use a notification banner to tell users that they’ve finished using a linear service. Use a [confirmation page](/patterns/confirmation-pages/) instead.
 
 Use the green version of the notification banner to confirm that something they’re expecting to happen has happened.
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -100,15 +100,15 @@ Users are not always notified when conditionally revealed content is expanded or
 
 ### Smaller radios
 
-Use standard-sized radios in nearly all cases. However, smaller versions work well on pages where it’s helpful to make them less visually prominent.  
+Use standard-sized radios in nearly all cases. However, smaller versions work well on pages where it’s helpful to make them less visually prominent.
 
 For example, on a page of search results, the primary user need is to see the results. Using smaller radios lets users see and change search filters without distracting them from the main content.
 
 {{ example({group: "components", item: "radios", example: "small", html: true, nunjucks: true, open: false, size: "m"}) }}
 
-Small radios can work well on information dense screens in services designed for repeat use, like caseworking systems. 
+Small radios can work well on information dense screens in services designed for repeat use, like caseworking systems.
 
-In services like these, the risk that they will not be noticed is lower because users return to the screen multiple times. 
+In services like these, the risk that they will not be noticed is lower because users return to the screen multiple times.
 
 ### Error messages
 
@@ -124,7 +124,7 @@ Make sure errors follow the guidance in [error message](/components/error-messag
 
 Say ‘Select yes if [whatever it is is true]’. For example, ‘Select yes if Sarah normally lives with you’.
 
-#### If there are two options which aren’t ‘yes’ and ‘no’
+#### If there are two options which are not ‘yes’ and ‘no’
 
 Say ‘Select if [whatever it is]’. For example, ‘Select if you are employed or self-employed’.
 

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -25,7 +25,7 @@ Tags are just used to indicate a status, so do not add links. Use adjectives rat
 
 ## Showing one or two statuses
 
-Sometimes a single status is enough. For example if you need to tell users which parts of an application they’ve finished and which they haven’t, you may only need a ‘Completed’ tag. Because the user understands that if something doesn’t have a tag, that means it’s incomplete.
+Sometimes a single status is enough. For example if you need to tell users which parts of an application they’ve finished and which they have not, you may only need a ‘Completed’ tag. Because the user understands that if something does not have a tag, that means it’s incomplete.
 
 The [task list pattern](/patterns/task-list-pages/) has an example of how to show one status using tags.
 

--- a/src/patterns/cookies-page/index.md.njk
+++ b/src/patterns/cookies-page/index.md.njk
@@ -26,7 +26,7 @@ A cookies page helps you to be transparent about the cookies you’re using. The
 
 ## Preparing your cookies page
 
-You must publish a cookie page by the time your service goes into public beta. The cookie page must be unique to your service: don’t link to the cookie policy for the main GOV.UK website.
+You must publish a cookie page by the time your service goes into public beta. The cookie page must be unique to your service: do not link to the cookie policy for the main GOV.UK website.
 
 Follow the steps below to create a cookie policy.
 
@@ -39,7 +39,7 @@ Follow the steps below to create a cookie policy.
 List all the cookies you’re using in the service. Divide the list into:
 
 - essential cookies - these are cookies you need to set so the service will work
-- functional cookies - the service will work without them, but the user won’t be able to take advantage of some functionality (for example, remembering the settings they’ve chosen between different visits)
+- functional cookies - the service will work without them, but the user will not be able to take advantage of some functionality (for example, remembering the settings they’ve chosen between different visits)
 - analytics cookies - cookies that let you collect analytics data to use within your own organisation
 - any other types of cookie you’re using
 
@@ -58,13 +58,13 @@ List the cookies individually on the cookie page, under the relevant category. F
 
 You can see an example on the [GOV.UK Notify cookie page](https://www.notifications.service.gov.uk/cookies).
 
-Don’t bury your cookie policy in a ‘terms and conditions’ page.
+Do not bury your cookie policy in a ‘terms and conditions’ page.
 
 Have an agreed process for updating the cookie policy when you add or remove a cookie. Make sure the relevant people on your team know what the process is.
 
 ## Which cookies you need consent for
 
-You do not need the user’s consent to set essential or ‘strictly necessary’ cookies. A cookie is ‘strictly necessary’ if the service won’t work without it.
+You do not need the user’s consent to set essential or ‘strictly necessary’ cookies. A cookie is ‘strictly necessary’ if the service will not work without it.
 
 The Information Commissioner’s Office (ICO) has [guidance on what types of cookie are likely to be considered ‘strictly necessary’](https://ico.org.uk/for-organisations/guide-to-pecr/guidance-on-the-use-of-cookies-and-similar-technologies/what-are-the-rules-on-cookies-and-similar-technologies/). For example, load balancing cookies are likely to be strictly necessary - but cookies that collect analytics data are not.
 
@@ -108,7 +108,7 @@ Update your cookies page when you change the cookies you’re using. Check with 
 
 It’s likely you’ll need to ask for new consent if:
 
-- you start using a type of non-essential cookie you haven’t used before (for example, if you start using functional cookies for the first time)
+- you start using a type of non-essential cookie you have not used before (for example, if you start using functional cookies for the first time)
 - you start using cookies which could be considered intrusive (for example because they collect sensitive information which could be associated with an individual, like health information)
 - you start doing something with the data you’re collecting through cookies which is significantly different to what the user originally consented to
 

--- a/src/patterns/equality-information/index.md.njk
+++ b/src/patterns/equality-information/index.md.njk
@@ -96,7 +96,7 @@ If the user answers ‘yes’, ask about the impact of their condition or illnes
 
 The ethnic groups used here are for England. The Government Statistical Service harmonised standard for ethnicity uses [different categories for Wales, Scotland and Northern Ireland](https://gss.civilservice.gov.uk/policy-store/ethnicity/). This is to reflect differences in local populations.
 
-If your service covers more than one of England, Wales, Scotland or Northern Ireland, you should accommodate these differences in your design. For example, by changing the ethnic groups shown depending on where the user is based. Where this isn’t possible, use the English categories.
+If your service covers more than one of England, Wales, Scotland or Northern Ireland, you should accommodate these differences in your design. For example, by changing the ethnic groups shown depending on where the user is based. Where this is not possible, use the English categories.
 
 First ask about the user’s broad ethnic group.
 
@@ -120,7 +120,7 @@ Use this approach to ask about marriage or civil partnership status.
 
 The categories used here are for England. The Government Statistical Service harmonised standard for religion uses [different categories for Wales, Scotland and Northern Ireland](https://gss.civilservice.gov.uk/policy-store/religion/). This is to reflect differences in local populations.
 
-If your service covers more than one of England, Wales, Scotland or Northern Ireland, you should accommodate these differences in your design. For example, by changing the categories shown depending on where the user is based. Where this isn’t possible, use the English categories.
+If your service covers more than one of England, Wales, Scotland or Northern Ireland, you should accommodate these differences in your design. For example, by changing the categories shown depending on where the user is based. Where this is not possible, use the English categories.
 
 {{ example({group: "patterns", item: "equality-information", example: "religion", html: true, nunjucks: true, open: false}) }}
 

--- a/src/patterns/gender-or-sex/index.md.njk
+++ b/src/patterns/gender-or-sex/index.md.njk
@@ -34,7 +34,7 @@ You may not always be able to use ‘you’. For example, if your service allows
 
 Do not guess someone's gender based on a title because:
 
-- some people use titles that aren’t gendered - for example Dr, Rev, Major or Mx
+- some people use titles that are not gendered - for example Dr, Rev, Major or Mx
 - people can decide what title they want to use, without going through a formal process
 
 ## Research on this pattern

--- a/src/patterns/payment-card-details/index.md.njk
+++ b/src/patterns/payment-card-details/index.md.njk
@@ -35,7 +35,7 @@ Use Issuer Identification Number (IIN) lookups to validate the card number as th
     <source src="card-number.mp4" type="video/mp4">
   </video>
   <p class="app-video__description" id="card-number-video-description">
-    This video shows the card number validation in practice. It doesn't have any audio.
+    This video shows the card number validation in practice. It does not have any audio.
   </p>
 </div>
 

--- a/src/patterns/step-by-step-navigation/index.md.njk
+++ b/src/patterns/step-by-step-navigation/index.md.njk
@@ -30,7 +30,7 @@ GOV.UK uses step by step navigation to represent end to end journeys:
 
 Do not use the step by step pattern:
 
-+ when most of the guidance or services that make up the journey aren’t on GOV.UK
++ when most of the guidance or services that make up the journey are not on GOV.UK
 + when the user only needs to read guidance and not take an action
 + when there’s no logical or helpful order to complete the tasks - for example, when you’re mostly presenting the user with a series of options
 + inside a transactional service – use the [task list pattern](/patterns/task-list-pages/) instead
@@ -44,7 +44,7 @@ A step by step navigation journey can:
 + link to content and services outside government
 + include both online and offline actions
 
-When you prototype a step by step journey, don’t customise the design. If you did, it wouldn’t be a realistic representation of the pattern as it would eventually appear on the GOV.UK live site.
+When you prototype a step by step journey, do not customise the design. If you did, it would not be a realistic representation of the pattern as it would eventually appear on the GOV.UK live site.
 
 Step by step navigation is displayed in 2 ways.
 
@@ -73,7 +73,7 @@ This is a short statement describing what the step by step helps the user to do.
 
 You can also use it to tell users when this step by step navigation is not relevant to them. For example, if the process is different in another region.
 
-Users don’t see the introduction in the sidebar, so don’t add anything vital there.
+Users do not see the introduction in the sidebar, so do not add anything vital there.
 
 ![A screenshot showing an example of the step by step navigation summary](step-by-step-summary.png)
 

--- a/src/patterns/task-list-pages/index.md.njk
+++ b/src/patterns/task-list-pages/index.md.njk
@@ -61,7 +61,7 @@ Make it clear to users which tasks they’ve completed and which still need thei
 
 Use the following labels to describe the different states of a task:
 
-- 'Not started' (in grey) if the user can start work on the task, but hasn't done so yet
+- 'Not started' (in grey) if the user can start work on the task, but has not done so yet
 - 'Cannot start yet' (in grey) if the user cannot start the task yet - for example because another task must be completed first
 - 'In progress' (in light blue) if the user has started but not completed the task
 - 'Completed' (in blue) if the user has completed the task
@@ -85,7 +85,7 @@ The pattern was iterated after each round of testing.
 
 You can read more about [testing and iterating the task list page pattern](https://designnotes.blog.gov.uk/2017/04/04/weve-published-the-task-list-pattern/).
 
-In the original pattern only completed tasks were labelled. Some users did not realise they had to complete all the tasks before they could continue, or [thought that they had completed the whole transaction](https://github.com/alphagov/govuk-design-system-backlog/issues/72#issuecomment-413159884). 
+In the original pattern only completed tasks were labelled. Some users did not realise they had to complete all the tasks before they could continue, or [thought that they had completed the whole transaction](https://github.com/alphagov/govuk-design-system-backlog/issues/72#issuecomment-413159884).
 
 The pattern has now been iterated to include labels for all statuses and a summary above the list.
 

--- a/src/patterns/validation/index.md.njk
+++ b/src/patterns/validation/index.md.njk
@@ -33,11 +33,11 @@ There are separate patterns for:
 
 Validation should refuse to accept:
 
-+ information that can’t be correct
++ information that cannot be correct
 + information that’s too ambiguous for you to use
 + missing information, if the information is required
 
-For example, if you’re asking for someone’s date of birth you shouldn’t accept ‘13’ in the month field.
+For example, if you’re asking for someone’s date of birth you should not accept ‘13’ in the month field.
 
 ### How to tell the user about validation errors
 
@@ -77,7 +77,7 @@ If you do use client side validation, make sure your client side and server side
 
 HTML5 validation is a type of client side validation built into browsers. Do not use it because:
 
-+ the visual style, placement and content of HTML5 error messages can’t be made consistent with the GOV.UK Design System
++ the visual style, placement and content of HTML5 error messages cannot be made consistent with the GOV.UK Design System
 + we know that the GOV.UK Design System error message and error summary components are accessible
 
 To turn off HTML5 validation, add ‘[novalidate](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-novalidate)’ to your form tags.

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -27,7 +27,7 @@ For a [question page](/patterns/question-pages), or pages with long headings, st
 
 {{ example({group: "styles", item: "typography", example: "headings", html: true, open: true, size: "m"}) }}
 
-If your page has lots of long form content, start with `govuk-heading-xl` for an `<h1>`, `govuk-heading-l` for an `<h2>`, and so on. 
+If your page has lots of long form content, start with `govuk-heading-xl` for an `<h1>`, `govuk-heading-l` for an `<h2>`, and so on.
 
 {{ example({group: "styles", item: "typography", example: "headings-xl", html: true, open: true, size: "m"}) }}
 
@@ -105,7 +105,7 @@ If it's an external link to a non-government website, make that clear in the lin
 
 ### Opening links in a new tab
 
-Avoid opening links in a new tab or window. It can be disorienting - and [can cause accessibility problems for people who aren't able to visually perceive that the new tab has opened](https://www.w3.org/TR/WCAG20-TECHS/G200.html).
+Avoid opening links in a new tab or window. It can be disorienting - and [can cause accessibility problems for people who cannot visually perceive that the new tab has opened](https://www.w3.org/TR/WCAG20-TECHS/G200.html).
 
 If you need a link to open in a new tab - for example, to stop the user losing information they’ve entered into a form - then include the words ‘opens in new tab’ as part of the link. There's no need to say 'tab or window', since opening in a new tab is the default behaviour for most browsers.
 
@@ -125,7 +125,7 @@ Only remove underlines from links if:
 * the number or placement of links makes them difficult to scan or interact with the element they're part of, and
 * it’s clear to the user from the context that they’re links, even without the underline
 
-For example, navigation links in a header won’t necessarily need underlines. Users will understand that they’re links because of their position on the page.
+For example, navigation links in a header will not necessarily need underlines. Users will understand that they’re links because of their position on the page.
 
 ## Lists
 


### PR DESCRIPTION
The GOV.UK style guide says that some users find negative contractions hard to read, or else misread them.
So, we should write "have not" instead of "haven't," and so on.
This PR replaces the negative contractions I've found in our components guidance.