### PR TITLE
Exclude ethnic group pattern from sitemap and nav

### DIFF
--- a/src/patterns/ethnic-group/index.md.njk
+++ b/src/patterns/ethnic-group/index.md.njk
@@ -1,8 +1,7 @@
 ---
 title: Ethnic groups
-description: This pattern explains how to ask users their ethnic group
-backlog_issue_id: 83
 layout: layout-archived.njk
+ignore_in_sitemap: true
 ---
 
 In March 2021, we published a new pattern to [ask users for equality information](../equality-information/), based on data standards set by the Government Statistical Service (GSS).


### PR DESCRIPTION
The ‘asking users for ethnic groups’ pattern was archived in #1582 and redirected to the new ‘asking users for equality information’ pattern.

However, the Design System currently relies on the `ignore_in_sitemap` flag in the frontmatter when deciding whether the page should appear in the sitemap and the site navigation.

This means that the pattern is still appearing in the sitemap, and also at the very bottom of the Patterns navigation.

![Screenshot 2021-04-16 at 14 05 10](https://user-images.githubusercontent.com/121939/115029905-64613880-9ebe-11eb-8bf0-344b6d9fc44f.png)

Add the `ignore_in_sitemap` flag to the archived page to remove it from both places.

Fixes #1592.