### PR TITLE
Add criteria for community resources

### DIFF
--- a/src/community/contribution-criteria/index.md.njk
+++ b/src/community/contribution-criteria/index.md.njk
@@ -7,6 +7,7 @@ order: 6
 ---
 
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 The contents of the Design System must be of a high quality and meet user needs. To guarantee this, all components and patterns need to meet certain criteria.
 
@@ -114,7 +115,7 @@ Before a new component or pattern is published the working group reviews the imp
 Before linking from the Design System to a [community resource or tool](/community/resources-and-tools) the Design System team will review it to make sure that:
 
 - it has a clear owner
-- it cannot be mistaken for an official resource
+- it cannot be mistaken for an official part of the Design System
 - it has documentation explaining how to use it, contribute to it and get support for it
 - support tickets are answered within 1 month
 - it's clearly documented which version of GOV.UK Frontend it supports
@@ -123,3 +124,9 @@ Before linking from the Design System to a [community resource or tool](/communi
 - development resources output the same markup as GOV.UK Frontend
 - it is not being charged for or used to promote a private business
 - it's compatible with the [Service Standard](https://www.gov.uk/service-manual/service-standard) and [Technology code of practice](https://www.gov.uk/government/publications/technology-code-of-practice/technology-code-of-practice)
+
+To help users decide whether to use your resource or tool and tell them how to get support for it, add this message to the resource README and after any website links:
+
+{{ govukInsetText({
+  text: "[Name of resource or tool] is a community [resource/tool] of the GOV.UK Design System. The Design System team is not responsible for it and cannot support you with using it. Contact [contributor] directly if you need help or you want to request a feature."
+}) }}


### PR DESCRIPTION
Adds suggested message so community resources cannot be mistaken for official parts of the Design System.
Fixes https://github.com/alphagov/design-system-team-internal/issues/430