### PR TITLE
Fix grammar in step by step navigation pattern

### DIFF
--- a/src/patterns/step-by-step-navigation/index.md.njk
+++ b/src/patterns/step-by-step-navigation/index.md.njk
@@ -8,7 +8,7 @@ backlog_issue_id: 171
 layout: layout-pane.njk
 ---
 
-The step by step navigation pattern presents an end to end journey in logical steps, providing links users out to the content that helps them complete each step.
+The step by step navigation pattern presents an end to end journey in logical steps, with links to content to help users complete each step.
 
 The Government Digital Service (GDS) works with departments to build step by step navigation journeys on GOV.UK. You will not be able to publish step by step navigation you’ve created yourself on the live GOV.UK site: this pattern is for use in your prototype only.
 

--- a/src/patterns/step-by-step-navigation/index.md.njk
+++ b/src/patterns/step-by-step-navigation/index.md.njk
@@ -8,7 +8,7 @@ backlog_issue_id: 171
 layout: layout-pane.njk
 ---
 
-The step by step navigation pattern presents an end to end journey in logical steps, with links to content to help users complete each step.
+The step by step navigation pattern presents an end to end journey in logical steps, with links to content that helps users complete each step.
 
 The Government Digital Service (GDS) works with departments to build step by step navigation journeys on GOV.UK. You will not be able to publish step by step navigation you’ve created yourself on the live GOV.UK site: this pattern is for use in your prototype only.
 


### PR DESCRIPTION
This PR fixes an unclear expression in the [guidance page for our step by step navigation pattern](https://design-system.service.gov.uk/patterns/step-by-step-navigation/).