### PR TITLE
Specify lang attributes on Welsh link in footer

### DIFF
--- a/src/components/footer/full/index.njk
+++ b/src/components/footer/full/index.njk
@@ -127,7 +127,11 @@ layout: layout-example.njk
       },
       {
         href: "#",
-        text: "Rhestr o Wasanaethau Cymraeg"
+        text: "Rhestr o Wasanaethau Cymraeg",
+        attributes: {
+          lang: "cy",
+          hreflang: "cy"
+        }
       }
     ],
     html: 'Built by the <a href="#" class="govuk-footer__link">Government Digital Service</a>'


### PR DESCRIPTION
Set [`lang`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) and [`hreflang`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-hreflang) attributes on the ‘Rhestr o Wasanaethau Cymraeg’ (‘List of Welsh Language Services’) link in the [Footer with secondary navigation and links to meta information](https://design-system.service.gov.uk/components/footer/#footer-with-secondary-navigation-and-links-to-meta-information) example:

```html
<a class="govuk-footer__link" href="#" lang="cy" hreflang="cy">
    Rhestr o Wasanaethau Cymraeg
</a>
```

This matches the current HTML used in the footer on GOV.UK:

```html
<a class="govuk-link" href="/cymraeg" lang="cy" hreflang="cy">Rhestr o Wasanaethau Cymraeg</a>
```

Fixes #1631 