### PR TITLE
Fix typos on team page

### DIFF
--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -14,15 +14,15 @@ If you want to contact the team you can
 
 ## Members
 
-- Calvin Lau - Content Designer
-- Charlotte Downs – Interaction Designer
-- Chris Thomas – Senior Interaction Designer
+- Calvin Lau – Content Designer
+- Charlotte Downs – Interaction Designer
+- Chris Thomas – Senior Interaction Designer
 - Eoin Shaughnessy – Technical Writer
 - Hanna Laakso – Senior Frontend Developer
-- Imran Hussain - Community Manager
+- Imran Hussain – Community Manager
 - Joe Lanman – Lead Interaction Designer
 - Kelly Lee – Delivery Manager
-- Laurence de Bruxelles - Developer
+- Laurence de Bruxelles – Developer
 - Oliver Byford – Senior Developer (Tech Lead)
 - Rosie Clayton – User Researcher
 - Sara Cox – Senior Performance Analyst


### PR DESCRIPTION
- Replace dashes with en-dashes
- Replace non-breaking spaces with spaces