### PR TITLE
Implement the new link and hover styles in the Design System website

### DIFF
--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -41,8 +41,6 @@
 
 .app-mobile-nav-subnav-toggler__link,
 .app-mobile-nav__link {
-  text-decoration: none;
-
   // Expand the touch area of the link to the full menu width
   &:after {
     content: "";

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -36,10 +36,6 @@ $navigation-height: 50px;
 .app-navigation__link {
   @include govuk-typography-weight-bold;
 
-  &:not(:focus):visited {
-    color: $govuk-link-colour;
-  }
-
   &:not(:focus):hover {
     color: $govuk-link-colour;
   }

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -35,7 +35,6 @@ $navigation-height: 50px;
 
 .app-navigation__link {
   @include govuk-typography-weight-bold;
-  text-decoration: none;
 
   &:not(:focus):visited {
     color: $govuk-link-colour;
@@ -43,7 +42,6 @@ $navigation-height: 50px;
 
   &:not(:focus):hover {
     color: $govuk-link-colour;
-    text-decoration: underline;
   }
 
   // Extend the touch area of the link to the list

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -16,11 +16,9 @@
 
   .app-subnav__link {
     padding: 2px 0;
-    text-decoration: none;
 
     &:not(:focus):hover {
       color: $govuk-link-colour;
-      text-decoration: underline;
     }
   }
 

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -77,7 +77,7 @@
   a {
     .app-prose-scope & {
       color: $govuk-text-colour;
-      text-decoration: none;
+      @include govuk-link-style-no-underline;
     }
   }
 }
@@ -122,7 +122,7 @@
   border-bottom: 0;
 
   a {
-    text-decoration: none;
+    @include govuk-link-style-no-underline;
   }
 }
 

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -1,3 +1,5 @@
+$govuk-new-link-styles: true;
+
 @import "govuk-frontend/govuk/all";
 
 // App-specific variables

--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -3,14 +3,14 @@
     {% for item in navigation %}
       <li>
         <div class="app-mobile-nav-subnav-toggler{% if path.startsWith(item.url) %} app-mobile-nav__subnav-toggler--active{% endif %}">
-          <a class="govuk-link govuk-link--no-visited-state app-mobile-nav-subnav-toggler__link js-mobile-nav-subnav-toggler" href="/{{ item.url }}/">
+          <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-mobile-nav-subnav-toggler__link js-mobile-nav-subnav-toggler" href="/{{ item.url }}/">
             {{ item.label }}
           </a>
         </div>
         {% if item.items %}
           <ul class="app-mobile-nav__list app-mobile-nav__subnav js-app-mobile-nav-subnav {% if path.startsWith(item.url) %}app-mobile-nav__subnav--active{% endif %}" aria-label="{{ item.label }}">
             <li class="app-mobile-nav__subnav-item{% if path == item.url %} app-mobile-nav__subnav-item--current{% endif %}">
-              <a class="govuk-link govuk-link--no-visited-state app-mobile-nav__link" href="/{{ item.url }}/">
+              <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-mobile-nav__link" href="/{{ item.url }}/">
                 {{ item.label }} overview
               </a>
             </li>
@@ -22,7 +22,7 @@
                 <ul class="app-mobile-nav__list">
                   {% for subitem in items %}
                     <li class="app-mobile-nav__subnav-item{% if path == subitem.url %} app-mobile-nav__subnav-item--current{% endif %}">
-                      <a class="govuk-link govuk-link--no-visited-state app-mobile-nav__link" href="/{{ subitem.url }}/">
+                      <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-mobile-nav__link" href="/{{ subitem.url }}/">
                         {{ subitem.label }}
                       </a>
                     </li>

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -2,7 +2,7 @@
   <ul class="app-navigation__list app-width-container">
     {% for item in navigation %}
     <li class="app-navigation__list-item{% if path == item.url or item.url and path.startsWith(item.url) %} app-navigation__list-item--current{% endif %}">
-      <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/{{ item.url }}/" data-topnav="{{ item.label }}">{{ item.label }}</a>
+      <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link" href="/{{ item.url }}/" data-topnav="{{ item.label }}">{{ item.label }}</a>
     </li>
     {% endfor %}
   </ul>

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -9,13 +9,13 @@
           <ul class="app-subnav__section">
           {% for subitem in items %}
             <li class="app-subnav__section-item{% if subitem.url == path %} app-subnav__section-item--current{% endif %}">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/{{ subitem.url }}/">{{ subitem.label }}</a>
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/">{{ subitem.label }}</a>
               {% if (subitem.headings) and (subitem.url == path) %}
                 <ul class="app-subnav__section app-subnav__section--nested">
                   {% for link in subitem.headings %}
                     {% if link.depth == 2 %}
                       <li class="app-subnav__section-item">
-                        <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/{{ subitem.url }}/#{{ link.url }}" >
+                        <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/#{{ link.url }}" >
                           {{ link.text }}
                         </a>
                       </li>


### PR DESCRIPTION
The new link and hover styles due to be published in GOV.UK Frontend v3.12.0 will be opt-in until the next major release. However, we'd like the Design System website itself to take advantage of the new styles in order to showcase the most up-to-date version of GOV.UK Frontend, and to have an example we can show users of making custom link styles compatible with the new styles.

This PR:
- opts into the new styles
- makes the navigation, mobile navigation, subnav and tabs compatible with the new styles by using the `govuk-link-style-no-underline` mixin which will handle the text decoration and use the new hover styles.

## Browser testing
- [x] IE 11
- [x] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Safari (iOS)
- [x] Chrome (iOS)
- [x] Chrome (Android)
- [x] Samsung Internet (Android)
- [x] Firefox (Forced colours)

As the new link styles don't support IE8, the current navigation item will have a double underline. The navigation is still functional.

## Additional exploration
~Optionally, I've had a go at making the current page indicators in the navigation and subnav aligned with the new border widths - comment out the specific lines in https://github.com/alphagov/govuk-design-system/commit/7bdfce1b52d52346153f12f8635be3ba4f13551a to view this.~

Fixes https://github.com/alphagov/govuk-design-system/issues/1635