### PR TITLE
Add mobile tabs issue to Accessibility Statement

### DIFF
--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -52,8 +52,9 @@ The content listed below is non-accessible for the following reasons.
 
 The Design System website at [https://design-system.service.gov.uk/](https://design-system.service.gov.uk/) is partially compliant due to the following non-compliances:
 
-- users are not always notified when conditionally revealed content associated with a radio button or checkbox is expanded or collapsed - this fails [WCAG 2.1 success criterion 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
 - the section headings in accordions can be mistaken for links, but are treated as buttons - this fails [WCAG 2.1 success criterion 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
+- on mobile, assistive technologies might interpret our guidance's HTML and Nunjucks tabs as plain text because the tabs are not contained within a tab list - this fails [WCAG 2.1 success criterion 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)
+- users are not always notified when conditionally revealed content associated with a radio button or checkbox is expanded or collapsed - this fails [WCAG 2.1 success criterion 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
 
 We plan to fix these accessibility issues by the end of June 2021.
 


### PR DESCRIPTION
Fixes [#1654](https://github.com/alphagov/govuk-design-system/issues/1654) (Update accessibility statement to say that mobile tabs are not in a tablist).

This PR is to tell users of our [Accessibility Statement](https://design-system.service.gov.uk/accessibility/) about an issue that fails [WCAG 2.1 success criterion 1.3.1 (Info and Relationships)](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).

On mobile, our guidance's HTML and Nunjucks tabs are not contained in a `tablist`.

This means that assistive tech might interpret the tabs as plain text, instead of as the 'control' we've built them to be.

This PR also redisplays the accessibility issues in numerical order of WCAG fail.