### PR TITLE
Fix URL in link to sass-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ npm run build
 
 ## Run the Sass linter
 
-We are using the [sass-lint][sass-lint] plugin to lint the Sass files in
+We are using the tool [sass-lint][sass-lint] to lint the Sass files in
 `source/stylesheets`. You can run the linter from command line by running:
 
 ```
 npm run lint
 ```
 
-[sass-lint]: https://github.com/juanfran/gulp-scss-lint
+[sass-lint]: https://github.com/sasstools/sass-lint
 
 ## GOV.UK Frontend packages
 


### PR DESCRIPTION
The link in the readme to sass-lint was pointing to a similar but different tool, gulp-scss-lint. This commit fixes the link so that it points to the tool we are actually using according to the package maniftests.