### PR TITLE
Add example of summary list with missing information

### DIFF
--- a/src/components/summary-list/index.md
+++ b/src/components/summary-list/index.md
@@ -70,9 +70,12 @@ To remove borders on a single row, use the `govuk-summary-list__row--no-border` 
 
 ### Showing missing information
 
-There may be some contexts where users see a summary list where there is some missing information, for instance if they are returning to a partially-completed form, or if you have added some additional questions since they first answered.
+In some contexts, you might need to show rows that have missing information. This can happen when: 
 
-Where there are missing answers, display a link to the question page within the `value` column instead of as a "Change" action:
+- a user returns to an incomplete journey
+- you've added or changed the questions in a service.
+
+Show a link to the appropriate question page in the `value` column so the user can enter the missing information, instead of showing a 'change' link on that row.
 
 {{ example({group: "components", item: "summary-list", example: "with-missing-information", html: true, nunjucks: true, open: false}) }}
 

--- a/src/components/summary-list/index.md
+++ b/src/components/summary-list/index.md
@@ -68,6 +68,15 @@ If your summary list does not have any actions, you can choose to remove the sep
 
 To remove borders on a single row, use the `govuk-summary-list__row--no-border` class.
 
+### Showing missing information
+
+There may be some contexts where users see a summary list where there is some missing information, for instance if they are returning to a partially-completed form, or if you have added some additional questions since they first answered.
+
+Where there are missing answers, display a link to the question page within the `value` column instead of as a "Change" action:
+
+{{ example({group: "components", item: "summary-list", example: "with-missing-information", html: true, nunjucks: true, open: false}) }}
+
+
 ## Summary cards
 
 
@@ -131,6 +140,6 @@ The summary card is also used in services run by other departments, such us:
 
 ### Next steps
 
-We still want to learn more about when this component works well. 
+We still want to learn more about when this component works well.
 
 If you use this component in your service, we'd like to hear about how you use the summary list and summary card, as well as any research findings you might have.

--- a/src/components/summary-list/with-missing-information/index.njk
+++ b/src/components/summary-list/with-missing-information/index.njk
@@ -1,0 +1,61 @@
+---
+title: Summary list with missing information
+layout: layout-example.njk
+---
+
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{{ govukSummaryList({
+  rows: [
+    {
+      key: {
+        text: "Name"
+      },
+      value: {
+        text: "Sarah Philips"
+      },
+      actions: {
+        items: [
+          {
+            href: "#",
+            text: "Change",
+            visuallyHiddenText: "name"
+          }
+        ]
+      }
+    },
+    {
+      key: {
+        text: "Date of birth"
+      },
+      value: {
+        text: "5 January 1978"
+      },
+      actions: {
+        items: [
+          {
+            href: "#",
+            text: "Change",
+            visuallyHiddenText: "date of birth"
+          }
+        ]
+      }
+    },
+    {
+      key: {
+        text: "Contact information"
+      },
+      value: {
+        html: '<a href="#" class="govuk-link">Enter contact information</a>'
+      }
+    },
+    {
+      key: {
+        text: "Contact details"
+      },
+      value: {
+        html: '<a href="#" class="govuk-link">Enter contact details</a>'
+      }
+    }
+  ]
+}) }}


### PR DESCRIPTION
This shows how you can use the summary list when there is some missing information. There’s a few scenarios when this can occur:

* if a user returns to a partially-completed application
* if additional questions have been added since the user first completed the task (for example, in a case working system)
* optional questions
* where the summary list is shown before the user starts answering the questions. Digital Marketplace adopted this pattern, in order to make it clearer up-front what all the questions were, and because multiple users might collaborate on a single application.

One option for tackling this is to leave the `value` column blank, or with some placeholder text such as "Not entered", whilst keeping a "Change" link in the `actions` column. However "Change" makes sense sense when there’s no existing value to change. The link could be renamed to "Add" or similar, but the wording is a bit awkward. Having a "Not entered" placeholder text can be harder to spot when scanning, or be mis-interpreted as words literally entered by a user. The placeholder text could be a different colour such as a dark grey, but this is quite subtle and relying upon colour should be avoided. A blank space is arguably easier to spot, but might be mis-interpreted as being an optional question.

To solve these issues, a more apparent way to make missing (and required) information apparent is to put a link in the `value` column, instead of a "Change" link. The link text could be a question, or the information required preceded by a verb such as "Enter" or "Select" (depending on context).

This pattern/component is being tested by different teams at the Department for Education. Feedback from other teams using similar patterns is welcome.

## Screenshot

<img width="873" alt="Screenshot 2021-05-13 at 16 04 49" src="https://user-images.githubusercontent.com/30665/118146804-de75d600-b406-11eb-9121-edc55f64f29c.png">

## Alternatives

It may make sense to add further highlighting using a blue border, either left of the key or the link text:

<img width="893" alt="Screenshot 2021-05-13 at 16 07 59" src="https://user-images.githubusercontent.com/30665/118147017-13822880-b407-11eb-8f6e-bc96449c2105.png">

<img width="886" alt="Screenshot 2021-05-13 at 16 09 59" src="https://user-images.githubusercontent.com/30665/118147041-18df7300-b407-11eb-830f-b6e61e6dcced.png">
