### PR TITLE
Make Equality Info example question accessible

### DIFF
--- a/src/patterns/equality-information/sexual-orientation/index.njk
+++ b/src/patterns/equality-information/sexual-orientation/index.njk
@@ -24,7 +24,7 @@ layout: layout-example.njk
   name: "sexual-orientation",
   fieldset: {
     legend: {
-      text: "Which of the following options best describes how you think of yourself?",
+      text: "Which of the following best describes your sexual orientation?",
       isPageHeading: true,
       classes: "govuk-fieldset__legend--l"
     }


### PR DESCRIPTION
## What
Addresses [#1624](https://github.com/alphagov/govuk-design-system/issues/1624).

This PR changes an example question in the [Equality information pattern](https://design-system.service.gov.uk/patterns/equality-information/) from:

> Which of the following options best describes how you think of yourself?

to

> Which of the following best describes your sexual orientation?

## Why
This change is because of an issue raised by a designer at the Office of National Statistics (ONS). The original question was inaccessible - when screen readers read it out, what was being asked was unclear to users.

The revised wording is in line with what was asked in the Census and signed off by the ONS.