### PR TITLE
Add correct usage to hint text guidance

### DIFF
--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -67,9 +67,17 @@ Fluid width inputs will resize with the viewport.
 
 ### Hint text
 
-Use hint for help that’s relevant to the majority of users, like how their information will be used, or where to find it.
+Use hint text for help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
 {{ example({group: "components", item: "text-input", example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s"}) }}
+
+#### When not to use hint text
+
+Do not use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+
+#### Avoid links
+
+Do not include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ### Numbers
 


### PR DESCRIPTION
Addresses [#1671](https://github.com/alphagov/govuk-design-system/issues/1671).

This PR updates our [hint text guidance](https://design-system.service.gov.uk/components/text-input/#hint-text) to:
- explain why users should not use hint text for long paragraphs and lists
- suggest an alternative way to display complex questions