### PR TITLE
Add cookie consent functions

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "test": {
+      "plugins": ["@babel/plugin-transform-modules-commonjs"]
+    }
+  }
+}

--- a/__tests__/cookie-functions.test.js
+++ b/__tests__/cookie-functions.test.js
@@ -119,5 +119,13 @@ describe('Cookie settings', () => {
         expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":true}')
       })
     })
+
+    describe('default', () => {
+      it('sets consent cookie to default if no options are provided', async () => {
+        CookieHelpers.setConsentCookie()
+
+        expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":false}')
+      })
+    })
   })
 })

--- a/__tests__/cookie-functions.test.js
+++ b/__tests__/cookie-functions.test.js
@@ -27,7 +27,7 @@ describe('Cookie settings', () => {
     afterEach(() => {
       // Delete test cookies
       document.cookie = 'myCookie=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
-      document.cookie = 'dm_cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+      document.cookie = 'cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
     })
 
     it('doesnt set a cookie with a value if not a recognised name', async () => {
@@ -43,23 +43,23 @@ describe('Cookie settings', () => {
     })
 
     it('sets allowed cookie with no options', async () => {
-      CookieHelpers.setCookie('dm_cookies_policy', '{"analytics":false}')
+      CookieHelpers.setCookie('cookies_policy', '{"analytics":false}')
 
-      expect(document.cookie).toEqual('dm_cookies_policy={"analytics":false}')
+      expect(document.cookie).toEqual('cookies_policy={"analytics":false}')
     })
 
     it('sets allowed cookie with options', async () => {
-      CookieHelpers.setCookie('dm_cookies_policy', '{"analytics":false}', { days: 100 })
+      CookieHelpers.setCookie('cookies_policy', '{"analytics":false}', { days: 100 })
 
       // Annoyingly JS can't retrieve expiry date directly from document.cookie, this is all we can assert
-      expect(document.cookie).toEqual('dm_cookies_policy={"analytics":false}')
+      expect(document.cookie).toEqual('cookies_policy={"analytics":false}')
     })
   })
 
   describe('getConsentCookie', () => {
     afterEach(() => {
       // Delete consent cookie
-      document.cookie = 'dm_cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+      document.cookie = 'cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
     })
 
     it('returns null if consent cookie not present', async () => {
@@ -67,7 +67,7 @@ describe('Cookie settings', () => {
     })
 
     it('returns consent cookie object if present', async () => {
-      document.cookie = 'dm_cookies_policy={"analytics":false}'
+      document.cookie = 'cookies_policy={"analytics":false}'
 
       expect(CookieHelpers.getConsentCookie()).toEqual({ analytics: false })
     })
@@ -76,16 +76,16 @@ describe('Cookie settings', () => {
   describe('setConsentCookie', () => {
     afterEach(() => {
       // Delete consent cookie
-      document.cookie = 'dm_cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+      document.cookie = 'cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
     })
 
     describe('to false', () => {
       it('changes existing cookie value to false', async () => {
-        document.cookie = 'dm_cookies_policy={"analytics":true};'
+        document.cookie = 'cookies_policy={"analytics":true};'
 
         CookieHelpers.setConsentCookie({ analytics: false })
 
-        expect(document.cookie).toEqual('dm_cookies_policy={"analytics":false}')
+        expect(document.cookie).toEqual('cookies_policy={"analytics":false}')
       })
 
       it('deletes existing analytics cookies', async () => {
@@ -93,7 +93,7 @@ describe('Cookie settings', () => {
 
         CookieHelpers.setConsentCookie({ analytics: false })
 
-        expect(document.cookie).toEqual('dm_cookies_policy={"analytics":false}')
+        expect(document.cookie).toEqual('cookies_policy={"analytics":false}')
         // Make sure those analytics cookies are definitely gone
         expect(CookieHelpers.getCookie('_ga')).toEqual(null)
         expect(CookieHelpers.getCookie('_gid')).toEqual(null)
@@ -103,11 +103,11 @@ describe('Cookie settings', () => {
 
     describe('to true', () => {
       it('sets existing cookie policy cookie to true', async () => {
-        document.cookie = 'dm_cookies_policy={"analytics":false};'
+        document.cookie = 'cookies_policy={"analytics":false};'
 
         CookieHelpers.setConsentCookie({ analytics: true })
 
-        expect(document.cookie).toEqual('dm_cookies_policy={"analytics":true}')
+        expect(document.cookie).toEqual('cookies_policy={"analytics":true}')
       })
     })
   })

--- a/__tests__/cookie-functions.test.js
+++ b/__tests__/cookie-functions.test.js
@@ -37,9 +37,12 @@ describe('Cookie settings', () => {
     })
 
     it('allows deletion of any cookie even if not recognised', async () => {
-      CookieHelpers.Cookie('myCookie', null)
+      document.cookie = 'myCookie=hello; path=/'
+      document.cookie = 'otherCookie=world; path=/'
 
-      expect(document.cookie).toEqual('myCookie=null')
+      CookieHelpers.Cookie('otherCookie', null)
+
+      expect(document.cookie).toEqual('myCookie=hello')
     })
 
     it('sets allowed cookie with no options', async () => {

--- a/__tests__/cookie-functions.test.js
+++ b/__tests__/cookie-functions.test.js
@@ -16,7 +16,7 @@ describe('Cookie settings', () => {
     afterEach(() => {
       // Delete test cookies
       document.cookie = '_ga=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
-      document.cookie = 'cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+      document.cookie = 'design_system_cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
     })
 
     it('returns null if no cookie present', async () => {
@@ -33,7 +33,7 @@ describe('Cookie settings', () => {
     afterEach(() => {
       // Delete test cookies
       document.cookie = 'myCookie=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
-      document.cookie = 'cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+      document.cookie = 'design_system_cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
     })
 
     it('doesnt set a cookie with a value if not a recognised name', async () => {
@@ -52,23 +52,23 @@ describe('Cookie settings', () => {
     })
 
     it('sets allowed cookie with no options', async () => {
-      CookieHelpers.Cookie('cookies_policy', '{"analytics":false}')
+      CookieHelpers.Cookie('design_system_cookies_policy', '{"analytics":false}')
 
-      expect(document.cookie).toEqual('cookies_policy={"analytics":false}')
+      expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":false}')
     })
 
     it('sets allowed cookie with options', async () => {
-      CookieHelpers.Cookie('cookies_policy', '{"analytics":false}', { days: 100 })
+      CookieHelpers.Cookie('design_system_cookies_policy', '{"analytics":false}', { days: 100 })
 
       // Annoyingly JS can't retrieve expiry date directly from document.cookie, this is all we can assert
-      expect(document.cookie).toEqual('cookies_policy={"analytics":false}')
+      expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":false}')
     })
   })
 
   describe('getConsentCookie', () => {
     afterEach(() => {
       // Delete consent cookie
-      document.cookie = 'cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+      document.cookie = 'design_system_cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
     })
 
     it('returns null if consent cookie not present', async () => {
@@ -76,7 +76,7 @@ describe('Cookie settings', () => {
     })
 
     it('returns consent cookie object if present', async () => {
-      document.cookie = 'cookies_policy={"analytics":false}'
+      document.cookie = 'design_system_cookies_policy={"analytics":false}'
 
       expect(CookieHelpers.getConsentCookie()).toEqual({ analytics: false })
     })
@@ -85,16 +85,16 @@ describe('Cookie settings', () => {
   describe('setConsentCookie', () => {
     afterEach(() => {
       // Delete consent cookie
-      document.cookie = 'cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+      document.cookie = 'design_system_cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
     })
 
     describe('to false', () => {
       it('changes existing cookie value to false', async () => {
-        document.cookie = 'cookies_policy={"analytics":true};'
+        document.cookie = 'design_system_cookies_policy={"analytics":true};'
 
         CookieHelpers.setConsentCookie({ analytics: false })
 
-        expect(document.cookie).toEqual('cookies_policy={"analytics":false}')
+        expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":false}')
       })
 
       it('deletes existing analytics cookies', async () => {
@@ -102,7 +102,7 @@ describe('Cookie settings', () => {
 
         CookieHelpers.setConsentCookie({ analytics: false })
 
-        expect(document.cookie).toEqual('cookies_policy={"analytics":false}')
+        expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":false}')
         // Make sure those analytics cookies are definitely gone
         expect(CookieHelpers.Cookie('_ga')).toEqual(null)
         expect(CookieHelpers.Cookie('_gid')).toEqual(null)
@@ -112,11 +112,11 @@ describe('Cookie settings', () => {
 
     describe('to true', () => {
       it('sets existing cookie policy cookie to true', async () => {
-        document.cookie = 'cookies_policy={"analytics":false};'
+        document.cookie = 'design_system_cookies_policy={"analytics":false};'
 
         CookieHelpers.setConsentCookie({ analytics: true })
 
-        expect(document.cookie).toEqual('cookies_policy={"analytics":true}')
+        expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":true}')
       })
     })
   })

--- a/__tests__/cookie-functions.test.js
+++ b/__tests__/cookie-functions.test.js
@@ -1,7 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-import * as CookieHelpers from '../../helpers/cookie/cookie-functions'
+
+/* eslint-env jest */
+
+import * as CookieHelpers from '../src/javascripts/cookie-functions'
 
 describe('Cookie settings', () => {
   describe('getCookie', () => {

--- a/__tests__/cookie-functions.test.js
+++ b/__tests__/cookie-functions.test.js
@@ -7,23 +7,23 @@
 import * as CookieHelpers from '../src/javascripts/cookie-functions'
 
 describe('Cookie settings', () => {
-  describe('getCookie', () => {
+  describe('Reading a cookie', () => {
     afterEach(() => {
       // Delete _ga cookie
       document.cookie = '_ga=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
     })
 
     it('returns null if no cookie present', async () => {
-      expect(CookieHelpers.getCookie('_ga')).toEqual(null)
+      expect(CookieHelpers.Cookie('_ga')).toEqual(null)
     })
 
     it('returns cookie if present', async () => {
-      CookieHelpers.setCookie('_ga', 'foo')
-      expect(CookieHelpers.getCookie('_ga')).toEqual('foo')
+      CookieHelpers.Cookie('_ga', 'foo')
+      expect(CookieHelpers.Cookie('_ga')).toEqual('foo')
     })
   })
 
-  describe('setCookie', () => {
+  describe('Setting a cookie', () => {
     afterEach(() => {
       // Delete test cookies
       document.cookie = 'myCookie=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
@@ -31,25 +31,25 @@ describe('Cookie settings', () => {
     })
 
     it('doesnt set a cookie with a value if not a recognised name', async () => {
-      CookieHelpers.setCookie('myCookie', 'myValue')
+      CookieHelpers.Cookie('myCookie', 'myValue')
 
       expect(document.cookie).toEqual('')
     })
 
     it('allows deletion of any cookie even if not recognised', async () => {
-      CookieHelpers.setCookie('myCookie', null)
+      CookieHelpers.Cookie('myCookie', null)
 
       expect(document.cookie).toEqual('myCookie=null')
     })
 
     it('sets allowed cookie with no options', async () => {
-      CookieHelpers.setCookie('cookies_policy', '{"analytics":false}')
+      CookieHelpers.Cookie('cookies_policy', '{"analytics":false}')
 
       expect(document.cookie).toEqual('cookies_policy={"analytics":false}')
     })
 
     it('sets allowed cookie with options', async () => {
-      CookieHelpers.setCookie('cookies_policy', '{"analytics":false}', { days: 100 })
+      CookieHelpers.Cookie('cookies_policy', '{"analytics":false}', { days: 100 })
 
       // Annoyingly JS can't retrieve expiry date directly from document.cookie, this is all we can assert
       expect(document.cookie).toEqual('cookies_policy={"analytics":false}')
@@ -95,9 +95,9 @@ describe('Cookie settings', () => {
 
         expect(document.cookie).toEqual('cookies_policy={"analytics":false}')
         // Make sure those analytics cookies are definitely gone
-        expect(CookieHelpers.getCookie('_ga')).toEqual(null)
-        expect(CookieHelpers.getCookie('_gid')).toEqual(null)
-        expect(CookieHelpers.getCookie('_gat_govuk_shared')).toEqual(null)
+        expect(CookieHelpers.Cookie('_ga')).toEqual(null)
+        expect(CookieHelpers.Cookie('_gid')).toEqual(null)
+        expect(CookieHelpers.Cookie('_gat_govuk_shared')).toEqual(null)
       })
     })
 

--- a/__tests__/cookie-functions.test.js
+++ b/__tests__/cookie-functions.test.js
@@ -8,9 +8,15 @@ import * as CookieHelpers from '../src/javascripts/cookie-functions'
 
 describe('Cookie settings', () => {
   describe('Reading a cookie', () => {
+    beforeEach(() => {
+      // Allow setting _ga cookie
+      CookieHelpers.setConsentCookie({ analytics: true })
+    })
+
     afterEach(() => {
-      // Delete _ga cookie
+      // Delete test cookies
       document.cookie = '_ga=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+      document.cookie = 'cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
     })
 
     it('returns null if no cookie present', async () => {

--- a/__tests__/cookie-functions.test.js
+++ b/__tests__/cookie-functions.test.js
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as CookieHelpers from '../../helpers/cookie/cookie-functions'
+
+describe('Cookie settings', () => {
+  describe('getCookie', () => {
+    afterEach(() => {
+      // Delete _ga cookie
+      document.cookie = '_ga=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+    })
+
+    it('returns null if no cookie present', async () => {
+      expect(CookieHelpers.getCookie('_ga')).toEqual(null)
+    })
+
+    it('returns cookie if present', async () => {
+      CookieHelpers.setCookie('_ga', 'foo')
+      expect(CookieHelpers.getCookie('_ga')).toEqual('foo')
+    })
+  })
+
+  describe('setCookie', () => {
+    afterEach(() => {
+      // Delete test cookies
+      document.cookie = 'myCookie=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+      document.cookie = 'dm_cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+    })
+
+    it('doesnt set a cookie with a value if not a recognised name', async () => {
+      CookieHelpers.setCookie('myCookie', 'myValue')
+
+      expect(document.cookie).toEqual('')
+    })
+
+    it('allows deletion of any cookie even if not recognised', async () => {
+      CookieHelpers.setCookie('myCookie', null)
+
+      expect(document.cookie).toEqual('myCookie=null')
+    })
+
+    it('sets allowed cookie with no options', async () => {
+      CookieHelpers.setCookie('dm_cookies_policy', '{"analytics":false}')
+
+      expect(document.cookie).toEqual('dm_cookies_policy={"analytics":false}')
+    })
+
+    it('sets allowed cookie with options', async () => {
+      CookieHelpers.setCookie('dm_cookies_policy', '{"analytics":false}', { days: 100 })
+
+      // Annoyingly JS can't retrieve expiry date directly from document.cookie, this is all we can assert
+      expect(document.cookie).toEqual('dm_cookies_policy={"analytics":false}')
+    })
+  })
+
+  describe('getConsentCookie', () => {
+    afterEach(() => {
+      // Delete consent cookie
+      document.cookie = 'dm_cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+    })
+
+    it('returns null if consent cookie not present', async () => {
+      expect(CookieHelpers.getConsentCookie()).toEqual(null)
+    })
+
+    it('returns consent cookie object if present', async () => {
+      document.cookie = 'dm_cookies_policy={"analytics":false}'
+
+      expect(CookieHelpers.getConsentCookie()).toEqual({ analytics: false })
+    })
+  })
+
+  describe('setConsentCookie', () => {
+    afterEach(() => {
+      // Delete consent cookie
+      document.cookie = 'dm_cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+    })
+
+    describe('to false', () => {
+      it('changes existing cookie value to false', async () => {
+        document.cookie = 'dm_cookies_policy={"analytics":true};'
+
+        CookieHelpers.setConsentCookie({ analytics: false })
+
+        expect(document.cookie).toEqual('dm_cookies_policy={"analytics":false}')
+      })
+
+      it('deletes existing analytics cookies', async () => {
+        document.cookie = '_ga=test;_gid=test;_gat_govuk_shared=test'
+
+        CookieHelpers.setConsentCookie({ analytics: false })
+
+        expect(document.cookie).toEqual('dm_cookies_policy={"analytics":false}')
+        // Make sure those analytics cookies are definitely gone
+        expect(CookieHelpers.getCookie('_ga')).toEqual(null)
+        expect(CookieHelpers.getCookie('_gid')).toEqual(null)
+        expect(CookieHelpers.getCookie('_gat_govuk_shared')).toEqual(null)
+      })
+    })
+
+    describe('to true', () => {
+      it('sets existing cookie policy cookie to true', async () => {
+        document.cookie = 'dm_cookies_policy={"analytics":false};'
+
+        CookieHelpers.setConsentCookie({ analytics: true })
+
+        expect(document.cookie).toEqual('dm_cookies_policy={"analytics":true}')
+      })
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -416,6 +416,255 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.14.0.tgz",
+      "integrity": "sha512-EX4QePlsTaRZQmw9BsoPeyh5OCtRGIhwfLquhxGp5e32w+dyL8htOcDwamlitmNFK6xBZYlygjdye9dbd9rUlQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.14.0",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-simple-access": "^7.13.12",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.12.13"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.14.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
+          "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.2",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.14.2",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
+          "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.12.13",
+            "@babel/template": "^7.12.13",
+            "@babel/types": "^7.14.2"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+          "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.13.12"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+          "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.13.12"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.14.2",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
+          "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.13.12",
+            "@babel/helper-replace-supers": "^7.13.12",
+            "@babel/helper-simple-access": "^7.13.12",
+            "@babel/helper-split-export-declaration": "^7.12.13",
+            "@babel/helper-validator-identifier": "^7.14.0",
+            "@babel/template": "^7.12.13",
+            "@babel/traverse": "^7.14.2",
+            "@babel/types": "^7.14.2"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+          "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+          "dev": true
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.14.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.3.tgz",
+          "integrity": "sha512-Rlh8qEWZSTfdz+tgNV/N4gz1a0TMNwCUcENhMjHTHKp3LseYH5Jha0NSlyTQWMnjbYcwFt+bqAMqSLHVXkQ6UA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.13.12",
+            "@babel/helper-optimise-call-expression": "^7.12.13",
+            "@babel/traverse": "^7.14.2",
+            "@babel/types": "^7.14.2"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+          "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.13.12"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+          "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+          "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.0",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.14.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.3.tgz",
+          "integrity": "sha512-7MpZDIfI7sUC5zWo2+foJ50CSI5lcqDehZ0lVgIhSi4bFEk94fLAKlF3Q0nzSQQ+ca0lm+O6G9ztKVBeu8PMRQ==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@babel/parser": "^7.12.13",
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.14.2",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
+          "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@babel/generator": "^7.14.2",
+            "@babel/helper-function-name": "^7.14.2",
+            "@babel/helper-split-export-declaration": "^7.12.13",
+            "@babel/parser": "^7.14.2",
+            "@babel/types": "^7.14.2",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.14.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.2.tgz",
+          "integrity": "sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.0",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
@@ -2218,6 +2467,15 @@
         }
       }
     },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -2630,6 +2888,16 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "caller-path": {
@@ -5093,6 +5361,25 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        }
+      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -10030,6 +10317,32 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "slugger": "^1.0.1"
   },
   "devDependencies": {
+    "@babel/plugin-transform-modules-commonjs": "^7.14.0",
     "accessible-autocomplete": "^2.0.2",
     "axe-puppeteer": "^1.0.0",
     "fs-extra": "^7.0.1",

--- a/src/javascripts/cookie-functions.js
+++ b/src/javascripts/cookie-functions.js
@@ -1,0 +1,161 @@
+// used by the cookie banner component
+const DEFAULT_COOKIE_CONSENT = {
+  analytics: false
+}
+
+const COOKIE_CATEGORIES = {
+  _ga: 'analytics',
+  _gid: 'analytics',
+  _gat_govuk_shared: 'analytics'
+}
+
+export function getCookie (name) {
+  var nameEQ = name + '='
+  var cookies = document.cookie.split(';')
+  for (var i = 0, len = cookies.length; i < len; i++) {
+    var cookie = cookies[i]
+    while (cookie.charAt(0) === ' ') {
+      cookie = cookie.substring(1, cookie.length)
+    }
+    if (cookie.indexOf(nameEQ) === 0) {
+      return decodeURIComponent(cookie.substring(nameEQ.length))
+    }
+  }
+  return null
+}
+/*
+Cookie methods
+==============
+
+Usage:
+
+  Setting a cookie:
+  setCookie('hobnob', 'tasty', { days: 30 })
+
+  Reading a cookie:
+  getCookie('hobnob')
+
+  Deleting a cookie:
+  Cookie('hobnob', null)
+*/
+
+function Cookie (name, value, options) {
+  if (typeof value !== 'undefined') {
+    if (value === false || value === null) {
+      return setCookie(name, '', { days: -1 })
+    } else {
+      // Default expiry date of 30 days
+      if (typeof options === 'undefined') {
+        options = { days: 30 }
+      }
+      return setCookie(name, value, options)
+    }
+  } else {
+    return getCookie(name)
+  }
+}
+
+export function getConsentCookie () {
+  var consentCookie = getCookie('dm_cookies_policy')
+  var consentCookieObj
+
+  if (consentCookie) {
+    try {
+      consentCookieObj = JSON.parse(consentCookie)
+    } catch (err) {
+      return null
+    }
+
+    if (typeof consentCookieObj !== 'object' && consentCookieObj !== null) {
+      consentCookieObj = JSON.parse(consentCookieObj)
+    }
+  } else {
+    return null
+  }
+
+  return consentCookieObj
+}
+
+export function setConsentCookie (options) {
+  var cookieConsent = getConsentCookie()
+
+  if (!cookieConsent) {
+    cookieConsent = JSON.parse(JSON.stringify(DEFAULT_COOKIE_CONSENT))
+  }
+
+  for (var cookieType in options) {
+    cookieConsent[cookieType] = options[cookieType]
+
+    // Delete cookies of that type if consent being set to false
+    if (!options[cookieType]) {
+      for (var cookie in COOKIE_CATEGORIES) {
+        if (COOKIE_CATEGORIES[cookie] === cookieType) {
+          Cookie(cookie, null)
+
+          if (Cookie(cookie)) {
+            document.cookie = cookie + '=;expires=' + new Date() + ';domain=' + window.location.hostname.replace(/^www\./, '.') + ';path=/'
+          }
+        }
+      }
+    }
+  }
+
+  setCookie('dm_cookies_policy', JSON.stringify(cookieConsent), { days: 365 })
+}
+
+function checkConsentCookieCategory (cookieName, cookieCategory) {
+  var currentConsentCookie = getConsentCookie()
+
+  // If the consent cookie doesn't exist, but the cookie is in our known list, return true
+  if (!currentConsentCookie && COOKIE_CATEGORIES[cookieName]) {
+    return true
+  }
+
+  currentConsentCookie = getConsentCookie()
+
+  // Sometimes currentConsentCookie is malformed in some of the tests, so we need to handle these
+  try {
+    return currentConsentCookie[cookieCategory]
+  } catch (e) {
+    console.error(e)
+    return false
+  }
+}
+
+function checkConsentCookie (cookieName, cookieValue) {
+  // If we're setting the consent cookie OR deleting a cookie, allow by default
+  if (cookieName === 'dm_cookies_policy' || (cookieValue === null || cookieValue === false)) {
+    return true
+  }
+
+  if (COOKIE_CATEGORIES[cookieName]) {
+    var cookieCategory = COOKIE_CATEGORIES[cookieName]
+
+    return checkConsentCookieCategory(cookieName, cookieCategory)
+  } else {
+    // Deny the cookie if it is not known to us
+    return false
+  }
+}
+
+// Usage :
+// Setting a cookie:
+// Cookie('hobnob', 'tasty', { days: 30 })
+
+export function setCookie (name, value, options) {
+  if (checkConsentCookie(name, value)) {
+    if (typeof options === 'undefined') {
+      options = {}
+    }
+    var cookieString = name + '=' + value + '; path=/'
+    if (options.days) {
+      var date = new Date()
+      date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000))
+      cookieString = cookieString + '; expires=' + date.toGMTString()
+    }
+    if (document.location.protocol === 'https:') {
+      cookieString = cookieString + '; Secure'
+    }
+    document.cookie = cookieString
+  }
+}

--- a/src/javascripts/cookie-functions.js
+++ b/src/javascripts/cookie-functions.js
@@ -13,20 +13,6 @@ const COOKIE_CATEGORIES = {
   _gat_govuk_shared: 'analytics'
 }
 
-export function getCookie (name) {
-  var nameEQ = name + '='
-  var cookies = document.cookie.split(';')
-  for (var i = 0, len = cookies.length; i < len; i++) {
-    var cookie = cookies[i]
-    while (cookie.charAt(0) === ' ') {
-      cookie = cookie.substring(1, cookie.length)
-    }
-    if (cookie.indexOf(nameEQ) === 0) {
-      return decodeURIComponent(cookie.substring(nameEQ.length))
-    }
-  }
-  return null
-}
 /*
 Cookie methods
 ==============
@@ -34,16 +20,16 @@ Cookie methods
 Usage:
 
   Setting a cookie:
-  setCookie('hobnob', 'tasty', { days: 30 })
+  Cookie('hobnob', 'tasty', { days: 30 })
 
   Reading a cookie:
-  getCookie('hobnob')
+  Cookie('hobnob')
 
   Deleting a cookie:
   Cookie('hobnob', null)
 */
 
-function Cookie (name, value, options) {
+export function Cookie (name, value, options) {
   if (typeof value !== 'undefined') {
     if (value === false || value === null) {
       return setCookie(name, '', { days: -1 })
@@ -138,11 +124,22 @@ function checkConsentCookie (cookieName, cookieValue) {
   }
 }
 
-// Usage :
-// Setting a cookie:
-// Cookie('hobnob', 'tasty', { days: 30 })
+function getCookie (name) {
+  var nameEQ = name + '='
+  var cookies = document.cookie.split(';')
+  for (var i = 0, len = cookies.length; i < len; i++) {
+    var cookie = cookies[i]
+    while (cookie.charAt(0) === ' ') {
+      cookie = cookie.substring(1, cookie.length)
+    }
+    if (cookie.indexOf(nameEQ) === 0) {
+      return decodeURIComponent(cookie.substring(nameEQ.length))
+    }
+  }
+  return null
+}
 
-export function setCookie (name, value, options) {
+function setCookie (name, value, options) {
   if (checkConsentCookie(name, value)) {
     if (typeof options === 'undefined') {
       options = {}

--- a/src/javascripts/cookie-functions.js
+++ b/src/javascripts/cookie-functions.js
@@ -143,13 +143,8 @@ function userAllowsCookie (cookieName) {
   if (COOKIE_CATEGORIES[cookieName]) {
     var cookieCategory = COOKIE_CATEGORIES[cookieName]
 
-    // Get the current cookie preferences
-    var cookiePreferences = getConsentCookie()
-
-    // If the consent cookie doesn't exist, but the cookie is in our known list, return true
-    if (!cookiePreferences) {
-      return true
-    }
+    // Get the current cookie preferences, or the default if no preferences set
+    var cookiePreferences = getConsentCookie() || DEFAULT_COOKIE_CONSENT
 
     return userAllowsCookieCategory(cookieCategory, cookiePreferences)
   } else {

--- a/src/javascripts/cookie-functions.js
+++ b/src/javascripts/cookie-functions.js
@@ -1,4 +1,8 @@
 // used by the cookie banner component
+
+// name of the cookie to save users cookie preferences to
+const CONSENT_COOKIE_NAME = 'cookies_policy'
+
 const DEFAULT_COOKIE_CONSENT = {
   analytics: false
 }
@@ -56,7 +60,7 @@ function Cookie (name, value, options) {
 }
 
 export function getConsentCookie () {
-  var consentCookie = getCookie('dm_cookies_policy')
+  var consentCookie = getCookie(CONSENT_COOKIE_NAME)
   var consentCookieObj
 
   if (consentCookie) {
@@ -100,7 +104,7 @@ export function setConsentCookie (options) {
     }
   }
 
-  setCookie('dm_cookies_policy', JSON.stringify(cookieConsent), { days: 365 })
+  setCookie(CONSENT_COOKIE_NAME, JSON.stringify(cookieConsent), { days: 365 })
 }
 
 function checkConsentCookieCategory (cookieName, cookieCategory) {
@@ -124,7 +128,7 @@ function checkConsentCookieCategory (cookieName, cookieCategory) {
 
 function checkConsentCookie (cookieName, cookieValue) {
   // If we're setting the consent cookie OR deleting a cookie, allow by default
-  if (cookieName === 'dm_cookies_policy' || (cookieValue === null || cookieValue === false)) {
+  if (cookieName === CONSENT_COOKIE_NAME || (cookieValue === null || cookieValue === false)) {
     return true
   }
 

--- a/src/javascripts/cookie-functions.js
+++ b/src/javascripts/cookie-functions.js
@@ -15,7 +15,6 @@ const CONSENT_COOKIE_NAME = 'design_system_cookies_policy'
 const COOKIE_CATEGORIES = {
   _ga: 'analytics',
   _gid: 'analytics',
-  _gat_govuk_shared: 'analytics',
 
   /* Essential cookies
    *

--- a/src/javascripts/cookie-functions.js
+++ b/src/javascripts/cookie-functions.js
@@ -69,10 +69,6 @@ export function getConsentCookie () {
     } catch (err) {
       return null
     }
-
-    if (typeof consentCookieObj !== 'object' && consentCookieObj !== null) {
-      consentCookieObj = JSON.parse(consentCookieObj)
-    }
   } else {
     return null
   }

--- a/src/javascripts/cookie-functions.js
+++ b/src/javascripts/cookie-functions.js
@@ -1,12 +1,22 @@
-// used by the cookie banner component
+/**
+ * Cookie functions
+ * ================
+ *
+ * Used by the cookie banner component and cookies page pattern.
+ *
+ * Includes function `Cookie()` for getting, setting, and deleting cookies, and
+ * functions to manage the users' consent to cookies.
+ */
 
-// name of the cookie to save users cookie preferences to
+/* Name of the cookie to save users cookie preferences to. */
 const CONSENT_COOKIE_NAME = 'cookies_policy'
 
+/* Default cookie preferences if user has no cookie preferences. */
 const DEFAULT_COOKIE_CONSENT = {
   analytics: false
 }
 
+/* Users can (dis)allow different groups of cookies. */
 const COOKIE_CATEGORIES = {
   _ga: 'analytics',
   _gid: 'analytics',
@@ -14,21 +24,19 @@ const COOKIE_CATEGORIES = {
 }
 
 /*
-Cookie methods
-==============
-
-Usage:
-
-  Setting a cookie:
-  Cookie('hobnob', 'tasty', { days: 30 })
-
-  Reading a cookie:
-  Cookie('hobnob')
-
-  Deleting a cookie:
-  Cookie('hobnob', null)
-*/
-
+ * Set, get, and delete cookies.
+ *
+ * Usage:
+ *
+ *   Setting a cookie:
+ *   Cookie('hobnob', 'tasty', { days: 30 })
+ *
+ *   Reading a cookie:
+ *   Cookie('hobnob')
+ *
+ *   Deleting a cookie:
+ *   Cookie('hobnob', null)
+ */
 export function Cookie (name, value, options) {
   if (typeof value !== 'undefined') {
     if (value === false || value === null) {
@@ -45,6 +53,7 @@ export function Cookie (name, value, options) {
   }
 }
 
+/** Return the user's cookie preferences. */
 export function getConsentCookie () {
   var consentCookie = getCookie(CONSENT_COOKIE_NAME)
   var consentCookieObj
@@ -62,6 +71,7 @@ export function getConsentCookie () {
   return consentCookieObj
 }
 
+/** Update the user's cookie preferences. */
 export function setConsentCookie (options) {
   var cookieConsent = getConsentCookie()
 
@@ -70,6 +80,7 @@ export function setConsentCookie (options) {
   }
 
   for (var cookieType in options) {
+    // Update existing user cookie consent preferences
     cookieConsent[cookieType] = options[cookieType]
 
     // Delete cookies of that type if consent being set to false
@@ -89,7 +100,7 @@ export function setConsentCookie (options) {
   setCookie(CONSENT_COOKIE_NAME, JSON.stringify(cookieConsent), { days: 365 })
 }
 
-function checkConsentCookieCategory (cookieName, cookieCategory) {
+function checkConsentForCookieCategory (cookieName, cookieCategory) {
   var currentConsentCookie = getConsentCookie()
 
   // If the consent cookie doesn't exist, but the cookie is in our known list, return true
@@ -117,7 +128,7 @@ function checkConsentCookie (cookieName) {
   if (COOKIE_CATEGORIES[cookieName]) {
     var cookieCategory = COOKIE_CATEGORIES[cookieName]
 
-    return checkConsentCookieCategory(cookieName, cookieCategory)
+    return checkConsentForCookieCategory(cookieName, cookieCategory)
   } else {
     // Deny the cookie if it is not known to us
     return false

--- a/src/javascripts/cookie-functions.js
+++ b/src/javascripts/cookie-functions.js
@@ -32,7 +32,7 @@ Usage:
 export function Cookie (name, value, options) {
   if (typeof value !== 'undefined') {
     if (value === false || value === null) {
-      return setCookie(name, '', { days: -1 })
+      return deleteCookie(name)
     } else {
       // Default expiry date of 30 days
       if (typeof options === 'undefined') {
@@ -108,9 +108,9 @@ function checkConsentCookieCategory (cookieName, cookieCategory) {
   }
 }
 
-function checkConsentCookie (cookieName, cookieValue) {
-  // If we're setting the consent cookie OR deleting a cookie, allow by default
-  if (cookieName === CONSENT_COOKIE_NAME || (cookieValue === null || cookieValue === false)) {
+function checkConsentCookie (cookieName) {
+  // Always allow setting the consent cookie
+  if (cookieName === CONSENT_COOKIE_NAME) {
     return true
   }
 
@@ -140,7 +140,7 @@ function getCookie (name) {
 }
 
 function setCookie (name, value, options) {
-  if (checkConsentCookie(name, value)) {
+  if (checkConsentCookie(name)) {
     if (typeof options === 'undefined') {
       options = {}
     }
@@ -155,4 +155,9 @@ function setCookie (name, value, options) {
     }
     document.cookie = cookieString
   }
+}
+
+function deleteCookie (name) {
+  document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT'
+  return null
 }

--- a/src/javascripts/cookie-functions.js
+++ b/src/javascripts/cookie-functions.js
@@ -9,7 +9,7 @@
  */
 
 /* Name of the cookie to save users cookie preferences to. */
-const CONSENT_COOKIE_NAME = 'cookies_policy'
+const CONSENT_COOKIE_NAME = 'design_system_cookies_policy'
 
 /* Users can (dis)allow different groups of cookies. */
 const COOKIE_CATEGORIES = {


### PR DESCRIPTION
Closes #1614.

This PR adds copies of the [cookie consent functions from digitalmarketplace-govuk-frontend](https://github.com/alphagov/digitalmarketplace-govuk-frontend/tree/d24e7f1dc6e94fb9f173aebf46aed5f1051af59c/src/digitalmarketplace/helpers/cookie), and refactors them slightly.

---

We wanted a cookie module to provide the following functionality:

- accept and reject cookies
- save consent in a cookie, with an expiry of 1 year
- delete cookies when a user changes their preference to reject
- look up a user's consent
- be able to map a cookie name to it's category, e.g: `_ga` -> `analytics`

I reviewed existing code in other alphagov projects and found the Digital Marketplace GOV.UK Frontend code fit all of our needs and was the best fit for our existing codebase. See issue #1615 for more details of the analysis done. I also ran the analysis past @vanitabarrett for a sense check.

---

This commit copies `cookie-functions.js` and `cookie-functions.test.js` to `src/javascripts` where it can be used by future code for the cookie banner and cookie page. Currently the code is unused and is not sent to browsers.

[1]: https://github.com/alphagov/digitalmarketplace-govuk-frontend/tree/d24e7f1dc6e94fb9f173aebf46aed5f1051af59c/src/digitalmarketplace/helpers/cookie