### PR TITLE
Add content about using step-by-step only on GOVUK

### DIFF
--- a/src/patterns/step-by-step-navigation/index.md.njk
+++ b/src/patterns/step-by-step-navigation/index.md.njk
@@ -61,6 +61,8 @@ You can use the following examples in the GOV.UK Prototype Kit to prototype a st
 - [Step by step page](https://govuk-prototype-kit.herokuapp.com/docs/templates/step-by-step-navigation)
 - [Start page with step by step navigation as a sidebar](https://govuk-prototype-kit.herokuapp.com/docs/templates/start-with-step-by-step)
 
+Remember that step by step navigation is not for use within transactional services. We have included it in the Prototype Kit only so you can prototype your end to end journeys. Unlike most other components and patterns in the Design System, we do not provide the code for step by step navigation in `govuk-frontend`.
+
 Content pages that are part of the step by step navigation always have a link at the top that goes to the standalone step by step page.
 
 ![A screenshot showing an example of the link at the top of a page to the step by step page](step-by-step-content-header.png)


### PR DESCRIPTION
Partly addresses [#1426](https://github.com/alphagov/govuk-design-system/issues/1426).

This PR updates the [guidance for the step by step navigation pattern](https://design-system.service.gov.uk/patterns/step-by-step-navigation/) to make it clear that:
- the pattern is only for use on GOV.UK 
- the pattern is only included in the Prototype Kit so users can prototype their journeys
- we do not actually provide the code for the pattern (unlike most of our other components and patterns)