### PR TITLE
Add `cspNonce` option to Page template guidance

### DIFF
--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -158,6 +158,14 @@ To change the components that are included in the page template by default, set 
     </tr>
 
     <tr class="govuk-table__row">
+      <td class="govuk-table__cell">cspNonce</td>
+      <td class="govuk-table__cell">Variable</td>
+      <td class="govuk-table__cell">
+        Add a <code>nonce</code> attribute to the script for your Content Security Policy (CSP). Provide a nonce that hostile actors cannot guess, as otherwise they can easily find a way around your CSP. However, you should use this attribute only if you’re not able to <a class="govuk-link" href="https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-is-not-working-properly">include the hash for the inline scripts in your service’s CSP</a>.
+      </td>
+    </tr>
+
+    <tr class="govuk-table__row">
       <td class="govuk-table__cell">footer</td>
       <td class="govuk-table__cell">Block</td>
       <td class="govuk-table__cell">


### PR DESCRIPTION
Fixes [#1709](https://github.com/alphagov/govuk-design-system/issues/1709).

This PR adds a `scriptNonce` option to the [options table in our Page template guidance](https://design-system.service.gov.uk/styles/page-template/#options).

We've added this option because users need to know what else to use, if they cannot follow our recommended approach and [include the SHA hash in their Content Security Policy (CSP)](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#select-and-initialise-part-of-a-page).

This PR also adds content to remind users they should provide nonces that are hard to guess. Otherwise, hostile actors can easily bypass the nonce.