### PR TITLE
Clarify when a service needs a phase banner

### DIFF
--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -15,9 +15,7 @@ Use the phase banner component to show users your service is still being worked 
 
 ## When to use this component
 
-You must use the phase banner component if your service:
-- still needs to complete a live service assessment
-- is hosted on the service.gov.uk subdomain
+Services hosted on a service.gov.uk domain must use the phase banner until they pass a live assessment.
 
 Use an alpha banner when your service is in alpha, and a beta banner if your service is in private or public beta.
 

--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -15,7 +15,10 @@ Use the phase banner component to show users your service is still being worked 
 
 ## When to use this component
 
-You must use the phase banner component if your service is still being developed and is hosted on the service.gov.uk subdomain.
+You must use the phase banner component if your service:
+- still needs to complete a live service assessment
+- is hosted on the service.gov.uk subdomain
+
 Use an alpha banner when your service is in alpha, and a beta banner if your service is in private or public beta.
 
 ## How it works


### PR DESCRIPTION
Minor update to clarify that a service needs to complete a live assessment before they can remove a phase banner.

In response to a support query from Head of Service Assessments in CDDO.
https://govuk.zendesk.com/agent/tickets/4587581