### PR TITLE
Add guidance on using longer supporting text for questions

### DIFF
--- a/src/patterns/question-pages/explanatory-text/index.njk
+++ b/src/patterns/question-pages/explanatory-text/index.njk
@@ -1,0 +1,72 @@
+---
+title: Explanatory text – Question pages
+layout: layout-example-full-page.njk
+---
+
+{% extends "example-wrappers/full-page.njk" %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        Interview needs
+      </h1>
+
+      <p class="govuk-body">
+        Providers do not usually have much flexibility when setting a date and time for interview unless you need adjustments due to a <a href="#" class="govuk-link">health condition or disability</a>.
+      </p>
+
+      <p class="govuk-body">
+        However, if you need flexibility for other reasons you can tell us about it here.
+      </p>
+
+      <p class="govuk-body">
+        For example, you have commitments like caring responsibilites or employment.
+      </p>
+
+      <p class="govuk-body">
+        Contact your provider if you're concerned about the interview process.
+      </p>
+
+      <form action="/form-handler" method="post" novalidate>
+
+        {{ govukRadios({
+          idPrefix: "interview-needs",
+          name: "interview-needs",
+          fieldset: {
+            legend: {
+              text: "Do you have any interview needs?",
+              isPageHeading: false,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes"
+            },
+            {
+              value: "no",
+              text: "No"
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -83,11 +83,18 @@ For example, ‘About you’
 
 You can also learn more about how starting with [one thing per page](https://www.gov.uk/service-manual/design/form-structure#start-with-one-thing-per-page) helps users in the GOV.UK Service Manual.
 
-#### Asking filter questions to simplify a complex question
+#### Asking complex questions without using hint text
 
-A series of simple questions can be easier to answer than one complex question. Especially if parts of it are not relevant to all users. A 'filter question' will let the user skip parts of a question that do not apply to them so they do not get confused.
+Do not use hint text if you need to give a lengthy explanation with lists and paragraphs. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-For example, you could ask the user if they've travelled outside the UK before you ask them which countries they've travelled to. This would let the user skip looking at a list of countries when they do not need to.
+Do not use links in hint text. While screen readers will read out the link text when describing the field, they will not tell users the text is a link.
+
+If you're asking a question that needs a detailed explanation, use:
+* a `h1` heading that's a statement (for example, 'Interview needs') rather than a question
+* whatever mix of text, paragraphs, lists and examples best explains your question to users
+* a label, above the form input, that asks users a specific question – for example, 'Do you have any interview needs?'
+
+{{ example({group: "patterns", item: "question-pages", example: "explanatory-text", html: true, nunjucks: true, open: false}) }}
 
 #### Asking multiple questions on a page
 


### PR DESCRIPTION
## What

New guidance to explain how to structure a question page when you need to explain the question in more depth than is appropriate for hint text. 

## Why

We've seen this come up as a discussion point on Slack a few times. We've also seen lots of examples of hint text that is too long to be read out by a screen reader every time a user focuses on the related input.

## Questions

The example we used was from 'apply from teacher training'. It's quite a good one, although the explanatory text is arguably a bit on the short side. Could those sentences reasonably be hint text?

![Screenshot 2021-06-10 at 10 56 18](https://user-images.githubusercontent.com/19834460/121511122-3ab91f00-c9e0-11eb-99c9-ca784d5eed36.png)

I think it's borderline. If anyone's found an example that might explain the approach better, please suggest one!
