### PR TITLE
Avoid confusing IDs in error summary examples

### DIFF
--- a/src/components/error-summary/default/index.njk
+++ b/src/components/error-summary/default/index.njk
@@ -10,11 +10,11 @@ layout: layout-example.njk
   errorList: [
     {
       text: "The date your passport was issued must be in the past",
-      href: "#passport-issued-error"
+      href: "#passport-issued-day"
     },
     {
       text: "Enter a postcode, like AA1 1AA",
-      href: "#postcode-error"
+      href: "#postcode-input"
     }
   ]
 }) }}

--- a/src/components/error-summary/linking-checkboxes-radios/index.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/index.njk
@@ -38,8 +38,7 @@ layout: layout-example.njk
       text: "British",
       hint: {
         text: "including English, Scottish, Welsh and Northern Irish"
-      },
-      id: "nationality"
+      }
     },
     {
       value: "irish",

--- a/src/components/error-summary/linking/index.njk
+++ b/src/components/error-summary/linking/index.njk
@@ -11,7 +11,7 @@ layout: layout-example.njk
   "errorList": [
     {
       "text": "Enter your full name",
-      "href": "#name"
+      "href": "#full-name-input"
     }
   ]
 }) }}
@@ -22,7 +22,7 @@ layout: layout-example.njk
   label: {
     "text": 'Full name'
   },
-  id: "name",
+  id: "full-name-input",
   name: "name",
   errorMessage: {
     "text": "Enter your full name"


### PR DESCRIPTION
We’ve had feedback that the IDs used in these examples might suggest that the links should go to the error message rather than the input.

To make this clearer, avoid suffixing the link targets with the word ‘error’, and use `input` where it’d be realistic a user might do so, like for simple text inputs.

In the case of date inputs, the date input component uses the field name as a suffix, so it’s likely the field ID will end with e.g. ‘-day’, so don’t add a further suffix there.

For the checkbox example, simplify the code as use the auto-generated ID for the first checkbox will be ‘nationality’ anyway, so we don’t need to set it explicitly.

Closes #1696 