### PR TITLE
Add versioning to consent cookie

### DIFF
--- a/__tests__/cookie-functions.test.js
+++ b/__tests__/cookie-functions.test.js
@@ -78,9 +78,9 @@ describe('Cookie settings', () => {
     })
 
     it('returns consent cookie object if present', async () => {
-      document.cookie = 'design_system_cookies_policy={"analytics":false}'
+      document.cookie = 'design_system_cookies_policy={"analytics":false,"version":1}'
 
-      expect(CookieHelpers.getConsentCookie()).toEqual({ analytics: false })
+      expect(CookieHelpers.getConsentCookie()).toEqual({ analytics: false, version: 1 })
     })
   })
 
@@ -101,7 +101,7 @@ describe('Cookie settings', () => {
 
         CookieHelpers.setConsentCookie({ analytics: false })
 
-        expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":false}')
+        expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":false,"version":1}')
       })
 
       it('does not load the analytics script', async () => {
@@ -115,7 +115,7 @@ describe('Cookie settings', () => {
 
         CookieHelpers.setConsentCookie({ analytics: false })
 
-        expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":false}')
+        expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":false,"version":1}')
         // Make sure those analytics cookies are definitely gone
         expect(CookieHelpers.Cookie('_ga')).toEqual(null)
         expect(CookieHelpers.Cookie('_gid')).toEqual(null)
@@ -129,7 +129,7 @@ describe('Cookie settings', () => {
 
         CookieHelpers.setConsentCookie({ analytics: true })
 
-        expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":true}')
+        expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":true,"version":1}')
       })
 
       it('loads analytics script if consenting to analytics cookies', async () => {
@@ -143,8 +143,49 @@ describe('Cookie settings', () => {
       it('sets consent cookie to default if no options are provided', async () => {
         CookieHelpers.setConsentCookie()
 
-        expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":false}')
+        expect(document.cookie).toEqual('design_system_cookies_policy={"analytics":false,"version":1}')
       })
+    })
+  })
+
+  describe('consent cookie version', () => {
+    it('version is an integer property of the consent cookie object', async () => {
+      CookieHelpers.setConsentCookie()
+
+      expect(CookieHelpers.getConsentCookie().version).toEqual(1)
+    })
+
+    it('Cookie will not set cookies if consent cookie is old version', async () => {
+      document.cookie = 'design_system_cookies_policy={"analytics":true,"version":0}'
+
+      CookieHelpers.Cookie('_ga', 'foo')
+      expect(CookieHelpers.Cookie('_ga')).toEqual(null)
+    })
+  })
+
+  describe('isValidConsentCookie', () => {
+    it('isValidConsentCookie returns true if consent cookie is current version', async () => {
+      var cookieOptions = { analytics: true, version: 1 }
+
+      expect(CookieHelpers.isValidConsentCookie(cookieOptions)).toEqual(true)
+    })
+
+    it('isValidConsentCookie returns true if consent cookie is newer than current version', async () => {
+      var cookieOptions = { analytics: true, version: 2 }
+
+      expect(CookieHelpers.isValidConsentCookie(cookieOptions)).toEqual(true)
+    })
+
+    it('isValidConsentCookie returns false if consent cookie is older than current version', async () => {
+      var cookieOptions = { analytics: true, version: 0 }
+
+      expect(CookieHelpers.isValidConsentCookie(cookieOptions)).toEqual(false)
+    })
+
+    it('isValidConsentCookie returns false if consent cookie version is not a number', async () => {
+      var cookieOptions = { analytics: true, version: 'foobar' }
+
+      expect(CookieHelpers.isValidConsentCookie(cookieOptions)).toEqual(false)
     })
   })
 })

--- a/src/javascripts/cookie-functions.js
+++ b/src/javascripts/cookie-functions.js
@@ -13,6 +13,16 @@ import Analytics from './components/analytics.js'
 /* Name of the cookie to save users cookie preferences to. */
 const CONSENT_COOKIE_NAME = 'design_system_cookies_policy'
 
+/* If cookie policy changes and/or the user preferences object format needs to
+ * change, bump this version up afterwards. The user should then be shown the
+ * banner again to consent to the new policy.
+ *
+ * Note that because isValidCookieConsent checks that the version in the user's
+ * cookie is equal to or greater than this number, you should be careful to
+ * check backwards compatibility when changing the object format.
+ */
+const CONSENT_COOKIE_VERSION = 1
+
 /* Users can (dis)allow different groups of cookies. */
 const COOKIE_CATEGORIES = {
   _ga: 'analytics',
@@ -68,7 +78,11 @@ export function Cookie (name, value, options) {
   }
 }
 
-/** Return the user's cookie preferences. */
+/** Return the user's cookie preferences.
+ *
+ * If the consent cookie is malformed, or not present,
+ * returns null.
+ */
 export function getConsentCookie () {
   var consentCookie = getCookie(CONSENT_COOKIE_NAME)
   var consentCookieObj
@@ -84,6 +98,15 @@ export function getConsentCookie () {
   }
 
   return consentCookieObj
+}
+
+/** Check the cookie preferences object.
+ *
+ * If the consent object is not present, malformed, or incorrect version,
+ * returns false, otherwise returns true.
+ */
+export function isValidConsentCookie (options) {
+  return (options && options.version >= CONSENT_COOKIE_VERSION)
 }
 
 /** Update the user's cookie preferences. */
@@ -122,6 +145,8 @@ export function setConsentCookie (options) {
     }
   }
 
+  cookieConsent.version = CONSENT_COOKIE_VERSION
+
   // Set consent cookie
   setCookie(CONSENT_COOKIE_NAME, JSON.stringify(cookieConsent), { days: 365 })
 }
@@ -150,8 +175,13 @@ function userAllowsCookie (cookieName) {
   if (COOKIE_CATEGORIES[cookieName]) {
     var cookieCategory = COOKIE_CATEGORIES[cookieName]
 
-    // Get the current cookie preferences, or the default if no preferences set
-    var cookiePreferences = getConsentCookie() || DEFAULT_COOKIE_CONSENT
+    // Get the current cookie preferences
+    var cookiePreferences = getConsentCookie()
+
+    // If no preferences or old version use the default
+    if (!isValidConsentCookie(cookiePreferences)) {
+      cookiePreferences = DEFAULT_COOKIE_CONSENT
+    }
 
     return userAllowsCookieCategory(cookieCategory, cookiePreferences)
   } else {


### PR DESCRIPTION
Closes #1615.

Why
---

If we are likely to move to a sub-domain consent approach in the future, we will need to 'reset' the cookie banner and consent cookie for users who have previously consented as what they have consented to has now
changed. This also applies if in the future we add a new cookie category or important new cookie.

What
-----

This PR adds a version number as a property to the cookie preferences object, and the function `resetCookies`.

The theory is that consumers of this code will check the cookie preferences object version on load, and if the version is incorrect, delete all cookies using `resetCookies`.