### PR TITLE
Update index.md.njk

### DIFF
--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -92,7 +92,7 @@ General errors are not helpful to everyone. They do not make sense out of contex
 
 - ‘An error occurred’
 - ‘Answer the question’
-- ‘Select an option’
+- ‘Choose an option’
 - ‘Fill in the field’
 - ‘This field is required’
 


### PR DESCRIPTION
The word 'Select' should not be used in error messages (probably elsewhere) as it is a key word used in voice recognition software as a result it prevents the voice recognition software performing as required.
e.g speak the command 'Click "Select an option"' 
will hear the word "Select" and will search the page for the 'an option' element