### PR TITLE
Check for Back to top link before initialising it

### DIFF
--- a/src/javascripts/components/back-to-top.js
+++ b/src/javascripts/components/back-to-top.js
@@ -5,6 +5,10 @@ function BackToTop ($module) {
 }
 
 BackToTop.prototype.init = function () {
+  if (!this.$module) {
+    return
+  }
+
   // Check if we can use Intersection Observers
   if (!('IntersectionObserver' in window)) {
     // If there's no support fallback to regular behaviour


### PR DESCRIPTION
Fixes JavaScript error `Unable to get property 'classList' of undefined or null reference` in IE11 on the few pages we have that don't have a back to top link.