### PR TITLE
Remove role="tab" from mobile tabs and progressively enhance to button

### DIFF
--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -11,10 +11,11 @@ var tabsItemJsClass = 'js-tabs__item'
 var headingItemClass = 'app-tabs__heading'
 var headingItemCurrentClass = headingItemClass + '--current'
 var headingItemJsClass = 'js-tabs__heading'
+var headingItemJsLinkSelector = '.js-tabs__heading a'
 var tabContainerHiddenClass = 'app-tabs__container--hidden'
 var tabContainerJsClass = '.js-tabs__container'
 var tabContainerNoTabsJsClass = 'js-tabs__container--no-tabs'
-var allTabTogglers = '.' + tabsItemJsClass + ' a, ' + '.' + headingItemJsClass + ' a'
+var allTabTogglers = '.' + tabsItemJsClass + ' a'
 var tabTogglersMarkedOpenClass = '.js-tabs__item--open a'
 
 function AppTabs ($module) {
@@ -22,12 +23,17 @@ function AppTabs ($module) {
   this.$allTabContainers = this.$module.querySelectorAll(tabContainerJsClass)
   this.$allTabTogglers = this.$module.querySelectorAll(allTabTogglers)
   this.$allTabTogglersMarkedOpen = this.$module.querySelectorAll(tabTogglersMarkedOpenClass)
+  this.$mobileTabs = this.$module.querySelectorAll(headingItemJsLinkSelector)
 }
 
 AppTabs.prototype.init = function () {
   if (!this.$module) {
     return
   }
+
+  // Enhance tab links to buttons on mobile if JS enabled
+  this.enhanceMobileButtons(this.$mobileTabs)
+
   // reset all tabs
   this.resetTabs()
   // add close to each tab
@@ -42,11 +48,11 @@ AppTabs.prototype.init = function () {
 AppTabs.prototype.activateAndToggle = function (event) {
   event.preventDefault()
   var $currentToggler = event.target
-  var $currentTogglerSiblings = this.$module.querySelectorAll('[href="' + $currentToggler.hash + '"]')
+  var $currentTogglerSiblings = this.$module.querySelectorAll('[aria-controls="' + $currentToggler.getAttribute('aria-controls') + '"]')
   var $tabContainer
 
   try {
-    $tabContainer = this.$module.querySelector($currentToggler.hash)
+    $tabContainer = this.$module.querySelector('#' + $currentToggler.getAttribute('aria-controls'))
   } catch (exception) {
     throw new Error('Invalid example ID given: ' + exception)
   }
@@ -81,6 +87,22 @@ AppTabs.prototype.activateAndToggle = function (event) {
     })
   }
 }
+
+// We progressively enhance the mobile tab links to buttons
+// to make sure we're using semantic HTML to describe the behaviour of the tabs
+AppTabs.prototype.enhanceMobileButtons = function (mobileTabs) {
+  nodeListForEach(mobileTabs, function (mobileTab) {
+    var button = document.createElement('button')
+    button.setAttribute('aria-controls', mobileTab.getAttribute('aria-controls'))
+    button.setAttribute('data-track', mobileTab.getAttribute('data-track'))
+    button.innerHTML = mobileTab.innerHTML
+    mobileTab.parentNode.appendChild(button)
+    mobileTab.parentNode.removeChild(mobileTab)
+  })
+
+  this.$allTabTogglers = this.$module.querySelectorAll(allTabTogglers)
+}
+
 // reset aria attributes to default and close the tab content container
 AppTabs.prototype.resetTabs = function () {
   nodeListForEach(this.$allTabContainers, function ($tabContainer) {

--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -95,6 +95,7 @@ AppTabs.prototype.enhanceMobileButtons = function (mobileTabs) {
     var button = document.createElement('button')
     button.setAttribute('aria-controls', mobileTab.getAttribute('aria-controls'))
     button.setAttribute('data-track', mobileTab.getAttribute('data-track'))
+    button.classList = 'app-tabs__heading-button'
     button.innerHTML = mobileTab.innerHTML
     mobileTab.parentNode.appendChild(button)
     mobileTab.parentNode.removeChild(mobileTab)

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -97,7 +97,16 @@
     display: block;
   }
 
-  a {
+  button {
+    @include govuk-link-common;
+    @include govuk-font($size: 19);
+    @include govuk-link-decoration;
+
+    border: 0;
+    outline: 0;
+    color: $govuk-link-colour;
+    background: none;
+
     // Extend the touch area of the <a> to fill the entire heading
     &:after {
       content: "";

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -97,7 +97,7 @@
     display: block;
   }
 
-  button {
+  .app-tabs__heading-button {
     @include govuk-link-common;
     @include govuk-font($size: 19);
     @include govuk-link-decoration;
@@ -106,7 +106,10 @@
     outline: 0;
     color: $govuk-link-colour;
     background: none;
+  }
 
+  .app-tabs__heading-link,
+  .app-tabs__heading-button {
     // Extend the touch area of the <a> to fill the entire heading
     &:after {
       content: "";

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -74,7 +74,7 @@
 
   {%- if (params.nunjucks) %}
   {%- if (multipleTabs) %}
-  <div class="app-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
+  <div class="app-tabs__heading js-tabs__heading"><a class="app-tabs__heading-link" href="#{{ exampleId }}-nunjucks" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
   {% elif not (params.hideTab) %}
 	<div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
   {% endif %}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -61,7 +61,7 @@
 
   {%- if (params.html) %}
   {%- if (multipleTabs) or (not params.hideTab) %}
-  <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
+  <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
   {% endif %}
   <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-html" role="tabpanel">
     <div class="app-example__code">
@@ -74,7 +74,7 @@
 
   {%- if (params.nunjucks) %}
   {%- if (multipleTabs) %}
-  <div class="app-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
+  <div class="app-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
   {% elif not (params.hideTab) %}
 	<div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
   {% endif %}


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-design-system/issues/1653

## What

- Removes the `role="tab"` attribute from the code example "tabs" (actually more of an accordion) on mobile
- Progressively enhances the mobile accordion links into buttons when JavaScript is available
- Replace CSS element selectors with classes for the mobile accordion links/buttons

## Why
When running the Lighthouse accessibility audit, the tabs for HTML and Nunjucks on mobile were flagged because they
used `role="tab"` without being nested within a parent element with `role="tablist"`.

The 'tabs' on mobile actually behave more like an accordion and it's not possible to nest them within `ul` and `li` elements,
so it made more sense to remove `role="tab"`.

Because the 'tabs' on mobile don't actually link anywhere when JavaScript is enabled, we should progressively enhance
the links to become buttons. When JavaScript is disabled, the tabs remain as links and link directly to each code example.

<img width="218" alt="Screenshot 2021-06-18 at 11 16 41" src="https://user-images.githubusercontent.com/29889908/122546294-b6414e80-d026-11eb-829e-d7f5323ad897.png"><img width="219" alt="Screenshot 2021-06-18 at 11 16 55" src="https://user-images.githubusercontent.com/29889908/122546297-b6d9e500-d026-11eb-8660-0079a4d593be.png">

## Testing
[Full testing spreadsheet here](https://docs.google.com/spreadsheets/d/1_0lC0v21yHEkoSzNg_iPkYvU_CzEohYM1CLbhkGGRfQ/edit#gid=701019914)

Note: if anyone wants to test on iOS please feel free!

✅ JAWS 2020 / Chrome
✅ JAWS 2020 / IE 11
✅ NVDA 2020.3 / Firefox 81
✅ NVDA 2020.3 / Chrome 86
✅ Voiceover / Safari (macOS Catalina)
✅  Voiceover / Safari (iOS 12)
✅ Talkback / Chrome 86 (Android 10)
