### PR TITLE
Add sign up journey

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -4,6 +4,10 @@ description: Design your service using GOV.UK styles, components and patterns
 ---
 
 {% include "_masthead.njk" %}
+
+{% include "_whats-new.njk" %}
+
+
 <div class="app-width-container">
   <div class="govuk-main-wrapper govuk-main-wrapper--l">
     <div class="govuk-grid-row">

--- a/src/stylesheets/components/_masthead.scss
+++ b/src/stylesheets/components/_masthead.scss
@@ -1,6 +1,7 @@
 .app-masthead {
   @include govuk-responsive-padding(6, "top");
   @include govuk-responsive-padding(6, "bottom");
+  border-bottom: 1px solid govuk-colour("blue");
   color: govuk-colour("white");
   background-color: govuk-colour("blue");
 }

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -344,3 +344,10 @@ p code {
     margin-bottom: 0;
   }
 }
+
+// Add styling for 'what's new' banner
+.app-whats-new {
+  border-top: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid $govuk-border-colour;
+  background-color: $app-light-grey;
+}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -347,7 +347,6 @@ p code {
 
 // Add styling for 'what's new' banner
 .app-whats-new {
-  border-top: 1px solid $govuk-border-colour;
   border-bottom: 1px solid $govuk-border-colour;
   background-color: $app-light-grey;
 }

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -1,0 +1,15 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+<div class="app-whats-new" style="background-color:#f8f8f8; border-bottom:1px solid #b1b4b6">
+  <div class="app-width-container">
+    <div class="govuk-main-wrapper govuk-main-wrapper--l">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h2 id="whats-new" class="govuk-heading-l">What's new</h2>
+        <p class="govuk-body">We’ve released GOV.UK Frontend v3.12.0, which includes changes to make text links easer to see and read. <a href="https://github.com/alphagov/govuk-frontend/releases" class="govuk-link">Read the full release notes</a></p>
+        <p class="govuk-body"><a href="http://eepurl.com/hye639" class="govuk-link">Sign up to get emails when the Design System is updated</a> and find out what’s happening in the community</p>
+      </div>
+    </div>
+    </div>
+  </div>
+</div>

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -1,13 +1,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-<div class="app-whats-new" style="background-color:#f8f8f8; border-bottom:1px solid #b1b4b6">
+<div class="app-whats-new">
   <div class="app-width-container">
     <div class="govuk-main-wrapper govuk-main-wrapper--l">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds-from-desktop">
+      <div class="govuk-grid-column-full-from-desktop">
         <h2 id="whats-new" class="govuk-heading-l">What's new</h2>
-        <p class="govuk-body">We’ve released GOV.UK Frontend v3.12.0, which includes changes to make text links easer to see and read. <a href="https://github.com/alphagov/govuk-frontend/releases" class="govuk-link">Read the full release notes</a></p>
-        <p class="govuk-body"><a href="http://eepurl.com/hye639" class="govuk-link">Sign up to get emails when the Design System is updated</a> and find out what’s happening in the community</p>
+        <p class="govuk-body">24 June 2021: We’ve released GOV.UK Frontend v3.13.0 and added <a href="https://design-system.service.gov.uk/components/checkboxes/#add-an-option-for-none-" class="govuk-link">a new ‘none’ option</a> to the checkboxes component. <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v3.13.0" class="govuk-link">Read the release notes to see what’s changed</a>.</p>
+        <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design System</a>.</p>
       </div>
     </div>
     </div>


### PR DESCRIPTION
Add a what's new banner and a sign-up form journey to the GOV.UK Design System homepage. Replaces pull request #1670 