### PR TITLE
Bump govuk-frontend from 3.12.0 to 3.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5515,9 +5515,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.12.0.tgz",
-      "integrity": "sha512-+mM8BqEUqsBVSV/ud0dEhE8OmMdhkK53eEUp5YyPN+y3mwcdRnwwP2A2B5qFdFi6E6j/2AYuCG8l5kXD+JXNxA=="
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.0.tgz",
+      "integrity": "sha512-JiPCeasuHZ+9m1VyqhsfE81PhWIW4Sweoe6Jvn6oMjQNr75ZpupiytN3DGwA+WKOoESHZibIG+heAzlkdZ/MhA=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clipboard": "^2.0.4",
     "connect": "^3.6.6",
     "eslint": "^5.16.0",
-    "govuk-frontend": "^3.12.0",
+    "govuk-frontend": "^3.13.0",
     "gray-matter": "^4.0.2",
     "highlight.js": "^10.4.1",
     "html5shiv": "^3.7.3",


### PR DESCRIPTION
Closes #1730.

Bumps [govuk-frontend](https://github.com/alphagov/govuk-frontend/) from 3.12.0 to 3.13.0:
  - [Release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v3.13.0)
  - [Changelog](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md)
  - [Commits](https://github.com/alphagov/govuk-frontend/compare/v3.12.0...v3.13.0)