### PR TITLE
Remove mobile tabs issue from accessibility statement

### DIFF
--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -53,7 +53,6 @@ The content listed below is non-accessible for the following reasons.
 The Design System website at [https://design-system.service.gov.uk/](https://design-system.service.gov.uk/) is partially compliant due to the following non-compliances:
 
 - the section headings in accordions can be mistaken for links, but are treated as buttons - this fails [WCAG 2.1 success criterion 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
-- on mobile, assistive technologies might interpret our guidance's HTML and Nunjucks tabs as plain text because the tabs are not contained within a tab list - this fails [WCAG 2.1 success criterion 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)
 - users are not always notified when conditionally revealed content associated with a radio button or checkbox is expanded or collapsed - this fails [WCAG 2.1 success criterion 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
 
 We plan to fix these accessibility issues by the end of June 2021.


### PR DESCRIPTION
As part of https://github.com/alphagov/govuk-design-system/pull/1728 we remove the role="tab"
from our mobile HTML/Nunjucks sections to better reflect their behaviour as an accordion and,
when JavaScript is enabled, enhance the links to be buttons with `aria-controls` and `aria-expanded`
attributes to help screenreader users understand the behaviour.

This fixes the accessibility issue listed in our accessibility statement, so we can remove it.