### PR TITLE
Mention alternatives to 'none' checkbox option

### DIFF
--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -69,6 +69,8 @@ You can add hints to checkbox items to provide additional information about the 
 
 When 'none' would be a valid answer, give users the option to check a box to say none of the other options apply to them — without this option, users would have to leave all of the boxes unchecked. Giving users this option also makes sure they do not skip the question by accident.
 
+Remember to [start by asking one question per page](https://design-system.service.gov.uk/patterns/question-pages/#start-by-asking-one-question-per-page). You might be able to remove the need for a 'none' option by asking the user a better question or filtering them out with a ‘filter question’ beforehand. The GOV.UK Service Manual has guidance on [designing good questions](https://www.gov.uk/service-manual/design/designing-good-questions).
+
 Show the ‘none’ option last. Separate it from the other options using a divider. The text is usually the word ‘or’.
 
 Write a label that repeats the key part of the question.

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -83,6 +83,12 @@ For example, ‘About you’
 
 You can also learn more about how starting with [one thing per page](https://www.gov.uk/service-manual/design/form-structure#start-with-one-thing-per-page) helps users in the GOV.UK Service Manual.
 
+#### Asking filter questions to simplify a complex question
+
+A series of simple questions can be easier to answer than one complex question. Especially if parts of it aren’t relevant to all users. A 'filter question' will let the user skip parts of a question that do not apply to them so they do not get confused.
+
+For example, you could ask the user if they've travelled outside the UK before you ask them which countries they've travelled to. This would let the user skip looking at a list of countries when they do not need to.
+
 #### Asking multiple questions on a page
 
 Sometimes it makes sense to group a number of related questions on the same page.


### PR DESCRIPTION
## What

Add a sentence to Checkboxes components to tell service teams to consider alternatives to the 'None of these' component, as it may not be the best option for some questions.

1/7/2021: Decision to add an explanation of a 'guard' question and link to it as part of this message.

## Why

Community and working group says that it is important to acknowledge that there are several ways of dealing with the 'none of the above' case and we ought to urge designers to consider different options.

## Who needs to know about this

Content designer, Designer

## Further detail

Discussions in the backlog for [Checkboxes](https://github.com/alphagov/govuk-design-system-backlog/issues/37) component.

## Done when

- [x] Draft sentence in checkboxes component
- [x] Draft explanation of guard question in question page pattern 
- [x] Add example of guard question
- [ ] 2i with team, check with people concerned
- [ ] Publish