### PR TITLE
Fix apostrophe in what's new

### DIFF
--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -5,7 +5,7 @@
     <div class="govuk-main-wrapper govuk-main-wrapper--l">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full-from-desktop">
-        <h2 id="whats-new" class="govuk-heading-l">What's new</h2>
+        <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
         <p class="govuk-body">24 June 2021: We’ve released GOV.UK Frontend v3.13.0 and added <a href="https://design-system.service.gov.uk/components/checkboxes/#add-an-option-for-none-" class="govuk-link">a new ‘none’ option</a> to the checkboxes component. <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v3.13.0" class="govuk-link">Read the release notes to see what’s changed</a>.</p>
         <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design System</a>.</p>
       </div>


### PR DESCRIPTION
Replace straight apostrophe with curly apostrophe.

This doesn't happen automatically here because smart quotes are handled by the Markdown parser in our pipeline, which treats this block as HTML and doesn't touch it.

Thanks to @joelanman for spotting this bug.