### PR TITLE
Change width of what's new column

### DIFF
--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -4,7 +4,7 @@
   <div class="app-width-container">
     <div class="govuk-main-wrapper govuk-main-wrapper--l">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full-from-desktop">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
         <p class="govuk-body">24 June 2021: We’ve released GOV.UK Frontend v3.13.0 and added <a href="https://design-system.service.gov.uk/components/checkboxes/#add-an-option-for-none-" class="govuk-link">a new ‘none’ option</a> to the checkboxes component. <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v3.13.0" class="govuk-link">Read the release notes to see what’s changed</a>.</p>
         <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design System</a>.</p>


### PR DESCRIPTION
## Why

This change constrains the Whats new section to a 2/3 column, which follows the [guidance we recommend for main content](https://design-system.service.gov.uk/styles/layout/#grid-system).

> Your main content should always be in a two-thirds column even if you’re not using a corresponding one-third column for secondary content.