### PR TITLE
Add headings to subnav and mobile navigation

### DIFF
--- a/__tests__/mobile-navigation.test.js
+++ b/__tests__/mobile-navigation.test.js
@@ -25,6 +25,16 @@ describe('Homepage', () => {
       const isMobileNavigationVisible = await page.waitForSelector('.js-app-mobile-nav', { visible: true, timeout: 1000 })
       expect(isMobileNavigationVisible).toBeTruthy()
     })
+
+    it('does not wrap the navigation links in a heading element', async () => {
+      await page.setJavaScriptEnabled(false)
+      await page.goto(baseUrl, { waitUntil: 'load' })
+      const isMobileNavigationLinkVisible = await page.waitForSelector('.app-mobile-nav-subnav-toggler__link', { visible: true, timeout: 1000 })
+      expect(isMobileNavigationLinkVisible).toBeTruthy()
+
+      const mobileNavigationWrappingHeading = await page.evaluate(() => document.body.querySelector('.app-mobile-nav-subnav__link-heading'))
+      expect(mobileNavigationWrappingHeading).toBeNull()
+    })
   })
 
   describe('when JavaScript is available', () => {
@@ -64,6 +74,18 @@ describe('Homepage', () => {
 
         const navigationAriaHidden = await page.evaluate(() => document.body.querySelector('.app-mobile-nav').getAttribute('aria-hidden'))
         expect(navigationAriaHidden).toBe('false')
+      })
+
+      it('should wrap the navigation links in a heading element', async () => {
+        await page.goto(baseUrl, { waitUntil: 'load' })
+
+        await page.click('.js-app-mobile-nav-toggler')
+
+        const isMobileNavigationLinkVisible = await page.waitForSelector('.app-mobile-nav-subnav-toggler__link', { visible: true, timeout: 1000 })
+        expect(isMobileNavigationLinkVisible).toBeTruthy()
+
+        const isMobileNavigationWrappingHeading = await page.waitForSelector('.app-mobile-nav-subnav__link-heading', { visible: true, timeout: 1000 })
+        expect(isMobileNavigationWrappingHeading).toBeTruthy()
       })
     })
   })

--- a/src/javascripts/components/mobile-navigation.js
+++ b/src/javascripts/components/mobile-navigation.js
@@ -63,6 +63,17 @@ MobileNav.prototype.bindUIEvents = function () {
   })
 }
 
+MobileNav.prototype.addHeadings = function () {
+  var $headings = this.$nav.querySelectorAll('.js-app-mobile-nav-subnav__link-heading')
+
+  nodeListForEach($headings, function ($headingText) {
+    var $heading = document.createElement('h3')
+    $heading.classList.add('app-mobile-nav-subnav__link-heading')
+    $headingText.parentNode.appendChild($heading)
+    $heading.appendChild($headingText)
+  })
+}
+
 MobileNav.prototype.includeAria = function () {
   this.$nav.setAttribute('aria-hidden', 'true')
 
@@ -102,6 +113,7 @@ MobileNav.prototype.init = function () {
     return
   }
 
+  this.addHeadings()
   this.includeAria()
   this.bindUIEvents()
 }

--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -30,26 +30,13 @@
 }
 
 .app-mobile-nav-subnav-toggler__link,
-.app-mobile-nav-subnav-toggler__link-heading {
+.app-mobile-nav-subnav__link-heading {
   @include govuk-typography-weight-bold; // Override .govuk-link weight
   font-size: 19px; // We do not have a font mixin that produces 19px on mobile
   font-size: govuk-px-to-rem(19px); // sass-lint:disable-line no-duplicate-properties
 
   &:not(:focus):hover {
     color: $govuk-link-colour;
-  }
-}
-
-.js-enabled .app-mobile-nav-subnav-toggler__link-text {
-  display: none;
-}
-
-.app-mobile-nav-subnav-toggler__link-heading {
-  display: none;
-
-  .js-enabled & {
-    display: inline-block;
-    margin: 0;
   }
 }
 
@@ -64,6 +51,11 @@
     bottom: 0;
     left: 0;
   }
+}
+
+.app-mobile-nav-subnav__link-heading {
+  display: inline-block;
+  margin: 0;
 }
 
 .app-mobile-nav__subnav {

--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -29,13 +29,27 @@
   background-color: $app-light-grey;
 }
 
-.app-mobile-nav-subnav-toggler__link {
+.app-mobile-nav-subnav-toggler__link,
+.app-mobile-nav-subnav-toggler__link-heading {
   @include govuk-typography-weight-bold; // Override .govuk-link weight
   font-size: 19px; // We do not have a font mixin that produces 19px on mobile
   font-size: govuk-px-to-rem(19px); // sass-lint:disable-line no-duplicate-properties
 
   &:not(:focus):hover {
     color: $govuk-link-colour;
+  }
+}
+
+.js-enabled .app-mobile-nav-subnav-toggler__link-text {
+  display: none;
+}
+
+.app-mobile-nav-subnav-toggler__link-heading {
+  display: none;
+
+  .js-enabled & {
+    display: inline-block;
+    margin: 0;
   }
 }
 

--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -4,7 +4,14 @@
       <li>
         <div class="app-mobile-nav-subnav-toggler{% if path.startsWith(item.url) %} app-mobile-nav__subnav-toggler--active{% endif %}">
           <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-mobile-nav-subnav-toggler__link js-mobile-nav-subnav-toggler" href="/{{ item.url }}/">
-            {{ item.label }}
+            {% if item.items %}
+              <!-- When JavaScript is enabled, the menu links expand a section below with more content, so we should make them headings -->
+              <h2 class="app-mobile-nav-subnav-toggler__link-heading">{{ item.label }}</h2>
+              <span class="app-mobile-nav-subnav-toggler__link-text">{{ item.label }}</span>
+            {% else %}
+              {{ item.label }}
+            {% endif %}
+
           </a>
         </div>
         {% if item.items %}
@@ -17,7 +24,7 @@
             {% for theme, items in item.items | groupby("theme") %}
               <li>
                 {% if theme != 'undefined' %}
-                  <h4 class="app-mobile-nav__theme">{{ theme }}</h4>
+                  <h3 class="app-mobile-nav__theme">{{ theme }}</h3>
                 {% endif %}
                 <ul class="app-mobile-nav__list">
                   {% for subitem in items %}

--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -1,4 +1,5 @@
-<nav id="app-mobile-nav" class="app-mobile-nav js-app-mobile-nav" role="navigation">
+<nav id="app-mobile-nav" class="app-mobile-nav js-app-mobile-nav" role="navigation" aria-labelledby="app-mobile-navigation-heading">
+  <h2 class="govuk-visually-hidden" id="app-mobile-navigation-heading">Menu</h2>
   <ul class="app-mobile-nav__list">
     {% for item in navigation %}
       <li>
@@ -6,7 +7,7 @@
           <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-mobile-nav-subnav-toggler__link js-mobile-nav-subnav-toggler" href="/{{ item.url }}/">
             {% if item.items %}
               <!-- When JavaScript is enabled, the menu links expand a section below with more content, so we should make them headings -->
-              <h2 class="app-mobile-nav-subnav-toggler__link-heading">{{ item.label }}</h2>
+              <h3 class="app-mobile-nav-subnav-toggler__link-heading">{{ item.label }}</h3>
               <span class="app-mobile-nav-subnav-toggler__link-text">{{ item.label }}</span>
             {% else %}
               {{ item.label }}
@@ -24,7 +25,7 @@
             {% for theme, items in item.items | groupby("theme") %}
               <li>
                 {% if theme != 'undefined' %}
-                  <h3 class="app-mobile-nav__theme">{{ theme }}</h3>
+                  <h4 class="app-mobile-nav__theme">{{ theme }}</h4>
                 {% endif %}
                 <ul class="app-mobile-nav__list">
                   {% for subitem in items %}

--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -7,8 +7,7 @@
           <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-mobile-nav-subnav-toggler__link js-mobile-nav-subnav-toggler" href="/{{ item.url }}/">
             {% if item.items %}
               <!-- When JavaScript is enabled, the menu links expand a section below with more content, so we should make them headings -->
-              <h3 class="app-mobile-nav-subnav-toggler__link-heading">{{ item.label }}</h3>
-              <span class="app-mobile-nav-subnav-toggler__link-text">{{ item.label }}</span>
+              <span class="js-app-mobile-nav-subnav__link-heading">{{ item.label }}</span>
             {% else %}
               {{ item.label }}
             {% endif %}

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -5,7 +5,7 @@
     {% if item.items %}
       {% for theme, items in item.items | groupby("theme") %}
         {% if theme != 'undefined' %}
-          <h4 class="app-subnav__theme">{{ theme }}</h4>
+          <h3 class="app-subnav__theme">{{ theme }}</h3>
         {% endif %}
         <ul class="app-subnav__section">
         {% for subitem in items %}

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -1,33 +1,34 @@
-<nav class="app-subnav">
-    {% for item in navigation %}
-      {% if path.startsWith(item.url) %}
-      {% if item.items %}
-        {% for theme, items in item.items | groupby("theme") %}
-          {% if theme != 'undefined' %}
-            <h4 class="app-subnav__theme">{{ theme }}</h4>
-          {% endif %}
-          <ul class="app-subnav__section">
-          {% for subitem in items %}
-            <li class="app-subnav__section-item{% if subitem.url == path %} app-subnav__section-item--current{% endif %}">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/">{{ subitem.label }}</a>
-              {% if (subitem.headings) and (subitem.url == path) %}
-                <ul class="app-subnav__section app-subnav__section--nested">
-                  {% for link in subitem.headings %}
-                    {% if link.depth == 2 %}
-                      <li class="app-subnav__section-item">
-                        <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/#{{ link.url }}" >
-                          {{ link.text }}
-                        </a>
-                      </li>
-                    {% endif %}
-                  {% endfor %}
-                </ul>
-              {% endif %}
-            </li>
-          {% endfor %}
-          </ul>
+<nav class="app-subnav" aria-labelledby="app-subnav-heading">
+  <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
+  {% for item in navigation %}
+    {% if path.startsWith(item.url) %}
+    {% if item.items %}
+      {% for theme, items in item.items | groupby("theme") %}
+        {% if theme != 'undefined' %}
+          <h4 class="app-subnav__theme">{{ theme }}</h4>
+        {% endif %}
+        <ul class="app-subnav__section">
+        {% for subitem in items %}
+          <li class="app-subnav__section-item{% if subitem.url == path %} app-subnav__section-item--current{% endif %}">
+            <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/">{{ subitem.label }}</a>
+            {% if (subitem.headings) and (subitem.url == path) %}
+              <ul class="app-subnav__section app-subnav__section--nested">
+                {% for link in subitem.headings %}
+                  {% if link.depth == 2 %}
+                    <li class="app-subnav__section-item">
+                      <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/#{{ link.url }}" >
+                        {{ link.text }}
+                      </a>
+                    </li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </li>
         {% endfor %}
-      {% endif %}
-      {% endif %}
-    {% endfor %}
+        </ul>
+      {% endfor %}
+    {% endif %}
+    {% endif %}
+  {% endfor %}
 </nav>


### PR DESCRIPTION
## What

Restructure the sub navigation and mobile navigation heading structure so that it still makes sense with the addition of a cookie banner to the site (being added in https://github.com/alphagov/govuk-design-system/compare/cookie-banner?expand=1)

This PR:

- Changes the existing sub navigation and mobile navigation headings from `h4` to `h3` - there is no visual change
- On desktop, add a visually hidden `h2` so that the sub navigation `h3` headings are nested beneath it. 
- On mobile with JavaScript enabled, the existing mobile navigation has links which expand to reveal more content underneath (including `h3` headings). Wrap the mobile navigation link text within a `h2` heading.
- On mobile with JavaScript disabled, the existing mobile navigation does not expand to reveal more content - it simply links straight to the page. This PR does not change this behaviour and the links are *not* wrapped in headings in this instance.

Adding `h2` headings helps the existing heading structure make sense once a cookie banner is added.

Note: I’ve chosen ‘Menu’ as the text for the visually hidden heading on desktop, to mimic the ‘Menu’ button which appears on mobile - but this is up for debate.

## Why

When [adding the cookie banner to the design system](https://github.com/alphagov/govuk-design-system/compare/cookie-banner?expand=1) site, our accessibility tests were failing with the following error:

```
"description": "Ensures the order of headings is semantically correct",
    +     "help": "Heading levels should only increase by one",
    +     "helpUrl": "https://dequeuniversity.com/rules/axe/3.1/heading-order?application=axe-puppeteer",
```

There are two intertwined issues here:

1. The heading level is skipping from a h2 in the cookie banner to a h4 in the sub navigation
2. The headings within the sub navigation section look like they’re nested within the cookie banner content, which is misleading and confusing

Other approaches I considered to fixing the issue have downsides:

1. Make the cookie banner heading a h3 - this fixes the jump from h2 -> h4 and appeases our accessibility tests, but it still leaves a confusing heading structure where the sub navigation looks like part of the cookie banner to a user navigating by headings / in a heading map
2. Make the sub navigation headings a h2 - this fixes both issues mentioned above, but perhaps mistakenly adds importance to the sub navigation headings and makes it more difficult to distinguish from the main page content

## Heading Map differences
**Note: these screenshots show the result of testing this change on the cookie banner branch, so we can see it works with the addition of the cookie banner**

### Before - sub navigation (addresses pattern page)
The sub navigation looks like it is part of the cookie banner content
<img width="326" alt="Screenshot 2021-06-29 at 12 10 55" src="https://user-images.githubusercontent.com/29889908/123797082-bae6ec00-d8dd-11eb-8da9-66656eacea72.png">


### After - sub navigation (addresses pattern page)
The sub navigation is clearly distinct from the cookie banner, and is part of the Menu navigation
<img width="323" alt="Screenshot 2021-06-29 at 12 09 58" src="https://user-images.githubusercontent.com/29889908/123797116-c20dfa00-d8dd-11eb-9bda-a3930e5dfd29.png">


### Before - sub navigation (components page)
The components page has no headings in its sub navigation - the sub navigation doesn't show up if navigating by headings
<img width="330" alt="Screenshot 2021-06-29 at 12 04 19" src="https://user-images.githubusercontent.com/29889908/123796798-6a6f8e80-d8dd-11eb-96e8-b28673f080bf.png">

### After - sub navigation (components page)
The components page now has a Menu heading for its sub navigation links
<img width="329" alt="Screenshot 2021-06-29 at 12 08 34" src="https://user-images.githubusercontent.com/29889908/123796864-7d825e80-d8dd-11eb-9853-ac6e960bb31a.png">


### Before - mobile navigation (patterns page)
The mobile navigation headings look like they are nested within the cookie banner content
<img width="333" alt="Screenshot 2021-06-29 at 13 28 49" src="https://user-images.githubusercontent.com/29889908/123797330-fc779700-d8dd-11eb-9c62-1f839771cfe0.png">

### After - mobile navigation (patterns page)
The mobile navigation headings are clearly distinct from the cookie banner. Each expanding section in the mobile navigation has its own heading.
<img width="330" alt="Screenshot 2021-06-29 at 12 09 03" src="https://user-images.githubusercontent.com/29889908/123797400-0bf6e000-d8de-11eb-8f14-32407402bc9c.png">


