### PR TITLE
Align the phase banner content to app-width-container on mobile

### DIFF
--- a/src/stylesheets/components/_phase-banner.scss
+++ b/src/stylesheets/components/_phase-banner.scss
@@ -2,8 +2,6 @@
   @include govuk-media-query($until: tablet) {
     margin-right: 0;
     margin-left: 0;
-    padding-right: govuk-spacing(3);
-    padding-left: govuk-spacing(3);
   }
 
   @include govuk-media-query($from: tablet) {


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-design-system/issues/1595

## What
Remove left and right padding from the phase banner on mobile.

## Why
The content within the phase banner on mobile has left and right padding applied. This means the content within the banner does not line up with other content on the page that is within an app-width-container element.

The app-width-container class means the padding isn't actually needed, so we can remove it on mobile. There is already no padding on desktop.

## Screenshots
### Before
<img width="339" alt="Screenshot 2021-06-29 at 14 48 58" src="https://user-images.githubusercontent.com/29889908/123809048-2d10fe00-d8e9-11eb-940e-0fd2c468117a.png">

### After
<img width="335" alt="Screenshot 2021-06-29 at 14 49 09" src="https://user-images.githubusercontent.com/29889908/123809068-313d1b80-d8e9-11eb-9d10-a5860002a716.png">
