### PR TITLE
Fix title case on layout page

### DIFF
--- a/src/styles/layout/common-two-thirds-one-third/index.njk
+++ b/src/styles/layout/common-two-thirds-one-third/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Common two-thirds / One-third – Layout
+title: Common two-thirds / one-third – Layout
 layout: layout-example.njk
 ---
 

--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -32,7 +32,7 @@ The default maximum page width is 1020px, but you can make it wider if your cont
 {{ example({group: "styles", item: "layout", example: "common-two-thirds-one-third", html: true, open: true, size: "m"}) }}
 
 
-### Row 1: Two-thirds <br>Row 2: Two-thirds / One-third
+### Row 1: Two-thirds <br>Row 2: Two-thirds / one-third
 
 {{ example({group: "styles", item: "layout", example: "common-two-thirds-two-thirds-one-third", html: true, open: true, size: "l"}) }}
 


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-design-system/issues/741

## What
Changes "Row 2: Two-thirds / One-third" to "Row 2: Two-thirds / one-third"

## Why
It should be sentence case to be consistent with other instances on the page and generally with other Design System content 

## Before
<img width="350" alt="Screenshot 2021-06-29 at 15 26 08" src="https://user-images.githubusercontent.com/29889908/123815669-92b3b900-d8ee-11eb-8638-6ce7bd524c6d.png">

## After
<img width="338" alt="Screenshot 2021-06-29 at 15 26 02" src="https://user-images.githubusercontent.com/29889908/123815705-99dac700-d8ee-11eb-8349-39c397969030.png">
