### PR TITLE
Replace example email address

### DIFF
--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -85,7 +85,7 @@ As with the font size, you can add a font weight override class to any other typ
 
 You can use bold to emphasise particular words in a transaction. Use it to highlight critical information that users need to refer to or you’ve seen them miss.
 
-For example, "Your reference number is **ABC12345678**. Use this to track your application. Updates will be sent to **this.person<i></i>@email.com**"
+For example, "Your reference number is **ABC12345678**. Use this to track your application. Updates will be sent to **name<i></i>@example.com**"
 
 Use bold sparingly. Overuse will make it difficult for users to know which parts of your content they need to pay the most attention to.
 


### PR DESCRIPTION
email.com is a real domain, so shouldn't be used in documentation, as any example email address could actually be real. example.com is reserved for documentation, per https://www.iana.org/domains/reserved. name@example.com is already used on the email addresses pattern page