### PR TITLE
Remove conditional reveals as a WCAG 2.1 non-compliance

### DIFF
--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -53,9 +53,8 @@ The content listed below is non-accessible for the following reasons.
 The Design System website at [https://design-system.service.gov.uk/](https://design-system.service.gov.uk/) is partially compliant due to the following non-compliances:
 
 - the section headings in accordions can be mistaken for links, but are treated as buttons - this fails [WCAG 2.1 success criterion 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
-- users are not always notified when conditionally revealed content associated with a radio button or checkbox is expanded or collapsed - this fails [WCAG 2.1 success criterion 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
 
-We plan to fix these accessibility issues by the end of June 2021.
+We plan to fix this accessibility issue by the end of September 2021.
 
 ### How this website has been tested for accessibility
 
@@ -87,7 +86,7 @@ When we publish new content, we'll continue to make sure that it meets accessibi
 
 ### Preparation of this accessibility statement
 
-This statement was prepared on 23 October 2019. It was last reviewed on 29 March 2021.
+This statement was prepared on 23 October 2019. It was last reviewed on 30 June 2021.
 
 ## Using the Design System and Frontend in your service
 


### PR DESCRIPTION
Update accessibility statement, after research and added guidance to mitigate issues with conditional reveals.

Added guidance in:
- [checkboxes component](https://design-system.service.gov.uk/components/checkboxes/#conditionally-revealing-a-related-question)
- [radios component](https://design-system.service.gov.uk/components/radios/#conditionally-revealing-a-related-question)