### PR TITLE
Audit autocomplete attribute use in examples

### DIFF
--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -11,6 +11,7 @@ layout: layout-example.njk
   id: "contact-by-email",
   name: "contact-by-email",
   type: "email",
+  autocomplete: "email",
   spellcheck: false,
   classes: "govuk-!-width-one-third",
   label: {
@@ -24,6 +25,7 @@ layout: layout-example.njk
   id: "contact-by-phone",
   name: "contact-by-phone",
   type: "tel",
+  autocomplete: "tel",
   classes: "govuk-!-width-one-third",
   label: {
     text: "Phone number"
@@ -36,6 +38,7 @@ layout: layout-example.njk
   id: "contact-by-text",
   name: "contact-by-text",
   type: "tel",
+  autocomplete: "tel",
   classes: "govuk-!-width-one-third",
   label: {
     text: "Mobile phone number"

--- a/src/components/error-summary/linking/index.njk
+++ b/src/components/error-summary/linking/index.njk
@@ -24,6 +24,7 @@ layout: layout-example.njk
   },
   id: "full-name-input",
   name: "name",
+  autocomplete: "name",
   errorMessage: {
     "text": "Enter your full name"
   }

--- a/src/components/fieldset/address-group/index.njk
+++ b/src/components/fieldset/address-group/index.njk
@@ -21,7 +21,8 @@ stylesheets:
       html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
     },
     id: "address-line-1",
-    name: "address-line-1"
+    name: "address-line-1",
+    autocomplete: "address-line1"
   }) }}
 
   {{ govukInput({
@@ -29,7 +30,8 @@ stylesheets:
       html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
     },
     id: "address-line-2",
-    name: "address-line-2"
+    name: "address-line-2",
+    autocomplete: "address-line2"
   }) }}
 
   {{ govukInput({
@@ -38,7 +40,8 @@ stylesheets:
     },
     classes: "govuk-!-width-two-thirds",
     id: "address-town",
-    name: "address-town"
+    name: "address-town",
+    autocomplete: "address-level2"
   }) }}
 
   {{ govukInput({
@@ -56,7 +59,8 @@ stylesheets:
     },
     classes: "govuk-input--width-10",
     id: "address-postcode",
-    name: "address-postcode"
+    name: "address-postcode",
+    autocomplete: "postal-code"
   }) }}
 
 {% endcall %}

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -11,6 +11,7 @@ layout: layout-example.njk
   id: "contact-by-email",
   name: "contact-by-email",
   type: "email",
+  autocomplete: "email",
   spellcheck: false,
   classes: "govuk-!-width-one-third",
   label: {
@@ -24,6 +25,7 @@ layout: layout-example.njk
   id: "contact-by-phone",
   name: "contact-by-phone",
   type: "tel",
+  autocomplete: "tel",
   classes: "govuk-!-width-one-third",
   label: {
     text: "Phone number"
@@ -36,6 +38,7 @@ layout: layout-example.njk
   id: "contact-by-text",
   name: "contact-by-text",
   type: "tel",
+  autocomplete: "tel",
   classes: "govuk-!-width-one-third",
   label: {
     text: "Mobile phone number"

--- a/src/get-started/labels-legends-headings/legend-h1/index.njk
+++ b/src/get-started/labels-legends-headings/legend-h1/index.njk
@@ -3,8 +3,6 @@ title: Legends as page headings - Making labels and legends headings
 layout: layout-example.njk
 ---
 
-{% from "govuk/components/input/macro.njk" import govukInput %}
-
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({

--- a/src/get-started/labels-legends-headings/legend-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/legend-m-s/index.njk
@@ -3,9 +3,6 @@ title: Styling legends - Making labels and legends headings
 layout: layout-example.njk
 ---
 
-
-{% from "govuk/components/input/macro.njk" import govukInput %}
-
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({

--- a/src/patterns/bank-details/default/index.njk
+++ b/src/patterns/bank-details/default/index.njk
@@ -14,6 +14,7 @@ layout: layout-example.njk
   },
   id: "name-on-the-account",
   name: "name-on-the-account",
+  autocomplete: "name",
   spellcheck: false
 }) }}
 

--- a/src/patterns/equality-information/date-of-birth/index.njk
+++ b/src/patterns/equality-information/date-of-birth/index.njk
@@ -18,7 +18,24 @@ layout: layout-example.njk
   },
   hint: {
     text: "For example, 31 3 1980. If you prefer not to say, continue without entering any information."
-  }
+  },
+  items: [
+    {
+      name: "day",
+      classes: "govuk-input--width-2",
+      autocomplete: "bday-day"
+    },
+    {
+      name: "month",
+      classes: "govuk-input--width-2",
+      autocomplete: "bday-month"
+    },
+    {
+      name: "year",
+      classes: "govuk-input--width-4",
+      autocomplete: "bday-year"
+    }
+  ]
 }) }}
 
 {{ govukButton({

--- a/src/patterns/equality-information/error-date-of-birth/index.njk
+++ b/src/patterns/equality-information/error-date-of-birth/index.njk
@@ -21,7 +21,24 @@ layout: layout-example.njk
   },
   hint: {
     text: "For example, 31 3 1980. If you prefer not to say, continue without entering any information."
-  }
+  },
+  items: [
+    {
+      name: "day",
+      classes: "govuk-input--width-2",
+      autocomplete: "bday-day"
+    },
+    {
+      name: "month",
+      classes: "govuk-input--width-2",
+      autocomplete: "bday-month"
+    },
+    {
+      name: "year",
+      classes: "govuk-input--width-4",
+      autocomplete: "bday-year"
+    }
+  ]
 }) }}
 
 {{ govukButton({

--- a/src/patterns/question-pages/date-of-birth/index.njk
+++ b/src/patterns/question-pages/date-of-birth/index.njk
@@ -31,7 +31,24 @@ layout: layout-example-full-page.njk
           },
           hint: {
             text: "For example, 31 3 1980"
-          }
+          },
+          items: [
+            {
+              name: "day",
+              classes: "govuk-input--width-2",
+              autocomplete: "bday-day"
+            },
+            {
+              name: "month",
+              classes: "govuk-input--width-2",
+              autocomplete: "bday-month"
+            },
+            {
+              name: "year",
+              classes: "govuk-input--width-4",
+              autocomplete: "bday-year"
+            }
+          ]
         }) }}
 
         {{ govukButton({

--- a/src/patterns/question-pages/postcode/index.njk
+++ b/src/patterns/question-pages/postcode/index.njk
@@ -27,7 +27,8 @@ layout: layout-example-full-page.njk
         },
         classes: "govuk-input--width-10",
         id: "postcode",
-        name: "postcode"
+        name: "postcode",
+        autocomplete: "postal-code"
       }) }}
 
       {{ govukButton({

--- a/src/styles/spacing/input-width/index.njk
+++ b/src/styles/spacing/input-width/index.njk
@@ -13,7 +13,8 @@ layout: layout-example.njk
   },
   classes: "govuk-!-width-full",
   id: "full-name",
-  name: "full-name"
+  name: "full-name",
+  autocomplete: "name"
 }) }}
 
 <h3 class="govuk-heading-m">Three-quarters</h3>
@@ -24,7 +25,8 @@ layout: layout-example.njk
   },
   classes: "govuk-!-width-three-quarters",
   id: "full-name",
-  name: "full-name"
+  name: "full-name",
+  autocomplete: "name"
 }) }}
 
 <h3 class="govuk-heading-m">Two-thirds</h3>
@@ -35,7 +37,8 @@ layout: layout-example.njk
   },
   classes: "govuk-!-width-two-thirds",
   id: "full-name",
-  name: "full-name"
+  name: "full-name",
+  autocomplete: "name"
 }) }}
 
 <h3 class="govuk-heading-m">One-half</h3>
@@ -46,7 +49,8 @@ layout: layout-example.njk
   },
   classes: "govuk-!-width-one-half",
   id: "full-name",
-  name: "full-name"
+  name: "full-name",
+  autocomplete: "name"
 }) }}
 
 <h3 class="govuk-heading-m">One-third</h3>
@@ -57,7 +61,8 @@ layout: layout-example.njk
   },
   classes: "govuk-!-width-one-third",
   id: "full-name",
-  name: "full-name"
+  name: "full-name",
+  autocomplete: "name"
 }) }}
 
 <h3 class="govuk-heading-m">One-quarter</h3>
@@ -68,5 +73,6 @@ layout: layout-example.njk
   },
   classes: "govuk-!-width-one-quarter",
   id: "full-name",
-  name: "full-name"
+  name: "full-name",
+  autocomplete: "name"
 }) }}

--- a/src/styles/spacing/input-width/index.njk
+++ b/src/styles/spacing/input-width/index.njk
@@ -5,74 +5,56 @@ layout: layout-example.njk
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-<h3 class="govuk-heading-m">Full</h3>
-
 {{ govukInput({
   label: {
-    text: "Full name"
+    text: "Full width"
   },
   classes: "govuk-!-width-full",
-  id: "full-name",
-  name: "full-name",
-  autocomplete: "name"
+  id: "full",
+  name: "full"
 }) }}
-
-<h3 class="govuk-heading-m">Three-quarters</h3>
 
 {{ govukInput({
   label: {
-    text: "Full name"
+    text: "Three-quarters width"
   },
   classes: "govuk-!-width-three-quarters",
-  id: "full-name",
-  name: "full-name",
-  autocomplete: "name"
+  id: "three-quarters",
+  name: "three-quarters"
 }) }}
-
-<h3 class="govuk-heading-m">Two-thirds</h3>
 
 {{ govukInput({
   label: {
-    text: "Full name"
+    text: "Two-thirds width"
   },
   classes: "govuk-!-width-two-thirds",
-  id: "full-name",
-  name: "full-name",
-  autocomplete: "name"
+  id: "two-thirds",
+  name: "two-thirds"
 }) }}
-
-<h3 class="govuk-heading-m">One-half</h3>
 
 {{ govukInput({
   label: {
-    text: "Full name"
+    text: "One-half width"
   },
   classes: "govuk-!-width-one-half",
-  id: "full-name",
-  name: "full-name",
-  autocomplete: "name"
+  id: "one-half",
+  name: "one-half"
 }) }}
-
-<h3 class="govuk-heading-m">One-third</h3>
 
 {{ govukInput({
   label: {
-    text: "Full name"
+    text: "One-third width"
   },
   classes: "govuk-!-width-one-third",
-  id: "full-name",
-  name: "full-name",
-  autocomplete: "name"
+  id: "one-third",
+  name: "one-third"
 }) }}
-
-<h3 class="govuk-heading-m">One-quarter</h3>
 
 {{ govukInput({
   label: {
-    text: "Full name"
+    text: "One-quarter width"
   },
   classes: "govuk-!-width-one-quarter",
-  id: "full-name",
-  name: "full-name",
-  autocomplete: "name"
+  id: "one-quarter",
+  name: "one-quarter"
 }) }}


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-design-system/issues/1151

## What
Audit of the following components in examples in the design system, to make sure they have appropriate autocomplete attributes:

- govukInput
- govukTextarea
- govukDateInput

## Why
We recommend using the `autocomplete` attribute in our [guidance](https://design-system.service.gov.uk/components/text-input/#use-the-autocomplete-attribute), so we should use it (where appropriate) in our examples.