### PR TITLE
Updated a typo in the spelling of Caribbean

### DIFF
--- a/src/patterns/equality-information/error-ethnicity/index.njk
+++ b/src/patterns/equality-information/error-ethnicity/index.njk
@@ -34,7 +34,7 @@ layout: layout-example.njk
     },
     {
       value: "black",
-      text: "Black, African, Carribean or Black British"
+      text: "Black, African, Caribbean or Black British"
     },
     {
       value: "other",

--- a/src/patterns/equality-information/ethnic-group/index.njk
+++ b/src/patterns/equality-information/ethnic-group/index.njk
@@ -31,7 +31,7 @@ layout: layout-example.njk
     },
     {
       value: "black",
-      text: "Black, African, Carribean or Black British"
+      text: "Black, African, Caribbean or Black British"
     },
     {
       value: "other",


### PR DESCRIPTION
**What**

Fixed typo in the spelling of `Caribbean` on the Equality Information page

**Why**
Because it is a typo.
