### PR TITLE
Add TDT issues to accessibility statement

### DIFF
--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -42,7 +42,7 @@ GDS is committed to making its websites accessible, in accordance with the Publi
 
 The Design System website at [https://design-system.service.gov.uk/](https://design-system.service.gov.uk/) is partially compliant with the Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard, due to the non-compliances listed below.
 
-The GOV.UK Frontend documentation website at [http://frontend.design-system.service.gov.uk/](https://frontend.design-system.service.gov.uk/) is fully compliant with the WCAG 2.1 AA standard.
+The GOV.UK Frontend documentation website at [http://frontend.design-system.service.gov.uk/](https://frontend.design-system.service.gov.uk/) is partially compliant with the WCAG 2.1 AA standard. We know some parts of this website are not fully accessible as there are issues caused by our Technical Documentation Template.
 
 ### Non-accessible content
 
@@ -55,6 +55,10 @@ The Design System website at [https://design-system.service.gov.uk/](https://des
 - the section headings in accordions can be mistaken for links, but are treated as buttons - this fails [WCAG 2.1 success criterion 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
 
 We plan to fix this accessibility issue by the end of September 2021.
+
+The GOV.UK Frontend documentation website at http://frontend.design-system.service.gov.uk/ is partially compliant because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
+
+We plan to fix these accessibility issues by the end of July 2021.
 
 ### How this website has been tested for accessibility
 


### PR DESCRIPTION
Fixes [#1770](https://github.com/alphagov/govuk-design-system/issues/1770).

A DAC audit of GovWifi tech docs has identified some WCAG-related issues with the Technical Documentation Template (TDT).

So, this PR updates [our accessibility statement](https://design-system.service.gov.uk/accessibility/) to:

- say we're aware of accessibility issues caused by the TDT
- link to the [TDT accessibility statement](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation), where users can read about the issues in detail
