### PR TITLE
Remove border from banner on homepage

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -1,12 +1,11 @@
 ---
 title: Home
 description: Design your service using GOV.UK styles, components and patterns
+masthead: true
 ---
 
 {% include "_masthead.njk" %}
-
 {% include "_whats-new.njk" %}
-
 
 <div class="app-width-container">
   <div class="govuk-main-wrapper govuk-main-wrapper--l">

--- a/src/stylesheets/components/_phase-banner.scss
+++ b/src/stylesheets/components/_phase-banner.scss
@@ -8,3 +8,7 @@
     border-bottom: 0;
   }
 }
+
+.app-phase-banner--no-border {
+  border-bottom: 0;
+}

--- a/views/partials/_banner.njk
+++ b/views/partials/_banner.njk
@@ -1,4 +1,9 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% set phaseBannerClasses = "app-phase-banner app-width-container" %}
+{% if masthead %}
+  {% set phaseBannerClasses = phaseBannerClasses + " app-phase-banner--no-border" %}
+{% endif %}
+
 <div class="app-phase-banner__wrapper">
 {% if PULL_REQUEST %}
   {% set phaseBannerText %}
@@ -16,7 +21,7 @@
       "text": "preview",
       "classes": "app-tag--review"
     },
-    "classes": "app-phase-banner app-width-container",
+    "classes": phaseBannerClasses,
     "html": phaseBannerText
   }) }}
 {% else %}
@@ -24,7 +29,7 @@
       "tag": {
         "text": "beta"
       },
-      "classes": "app-phase-banner app-width-container",
+      "classes": phaseBannerClasses,
       "html": "This is a new service – your <a class=\"govuk-link\" href=\"/get-in-touch\">feedback</a> will help us to improve it."
     }) }}
   {% endif %}


### PR DESCRIPTION
The bottom border on the banner ends up butting up against the top of the masthead on the homepage at the mobile viewport. As it’s inset with the grid gutter it does not span the full width of the masthead, so this looks a bit odd.

Remove the bottom border from the phase banner from the homepage page only, by setting a `masthead` boolean in the frontmatter.

## Before

![Screenshot 2021-07-05 at 14 32 50](https://user-images.githubusercontent.com/121939/124479186-ea926a00-dd9d-11eb-91f7-a1b4953f75de.png)

## After

![Screenshot 2021-07-05 at 14 32 55](https://user-images.githubusercontent.com/121939/124479164-e5351f80-dd9d-11eb-8ce9-1083c485d0d7.png)

Fixes #1612 