### PR TITLE
Make sure we use classlist.add

### DIFF
--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -95,7 +95,7 @@ AppTabs.prototype.enhanceMobileButtons = function (mobileTabs) {
     var button = document.createElement('button')
     button.setAttribute('aria-controls', mobileTab.getAttribute('aria-controls'))
     button.setAttribute('data-track', mobileTab.getAttribute('data-track'))
-    button.classList = 'app-tabs__heading-button'
+    button.classList.add('app-tabs__heading-button')
     button.innerHTML = mobileTab.innerHTML
     mobileTab.parentNode.appendChild(button)
     mobileTab.parentNode.removeChild(mobileTab)


### PR DESCRIPTION
## What
Replaces one instance of `classlist = ` with `classlist.add()` in tabs.js

## Why
Assignment to read-only properties is not allowed in strict mode
https://developer.mozilla.org/en-US/docs/Web/API/Element/classList