### PR TITLE
Link Backlog page to GitHub Community Backlog

### DIFF
--- a/src/community/backlog/index.md.njk
+++ b/src/community/backlog/index.md.njk
@@ -10,7 +10,7 @@ The Design System is built upon the research and experience of teams across the 
 
 Anyone can propose, develop or contribute to new patterns and components, or improvements to existing ones.
 
-Here is a list of the components, patterns and updates currently on the Design System community backlog. They can be:
+Here is a list of the components, patterns and updates currently on the [GOV.UK Design System Community Backlog](https://github.com/alphagov/govuk-design-system-backlog/projects/1). They can be:
 
 - **Proposed** - someone has suggested a new component or pattern
 - **To do** - the proposed component or pattern has been agreed and is ready to work on


### PR DESCRIPTION
Fixes [#1778](https://github.com/alphagov/govuk-design-system/issues/1778).

This PR adds a link from the [Design System site's Community Backlog page](https://design-system.service.gov.uk/community/backlog/) to [our Community Backlog board on GitHub](https://github.com/alphagov/govuk-design-system-backlog/projects/1).

Hopefully, this will make it easier for users to navigate between both of these places.