### PR TITLE
Add IE8 sentence to cookies page

### DIFF
--- a/src/cookies.njk
+++ b/src/cookies.njk
@@ -33,6 +33,10 @@ layout: layout-single-page.njk
 
       <p class="govuk-body">We only set cookies when JavaScript is running in your browser and you’ve accepted them. If you choose not to run Javascript, the information on this page will not apply to you.</p>
 
+      <!--[if lt IE 9]>
+        <p class="govuk-body">If you use an older browser, such as Internet Explorer 8 or earlier, the cookies we use will not affect you.</p>
+      <![endif]-->
+
       <p class="govuk-body">Find out <a href="https://ico.org.uk/for-the-public/online/cookies" class="govuk-link">how to manage cookies</a> from the Information Commissioner's Office.</p>
 
       <form class="js-cookies-page-form">


### PR DESCRIPTION
## What
Add a sentence to the cookies page that is only shown when users visit the page using IE8 or below

## Why
The cookie banner and cookies form is hidden on IE8 and below. We want to add a sentence to the cookies page when users are using these versions, to explain that the information on the page doesn't apply to them.

Note: we're hiding the cookie banner and cookies form on IE8 and below, because the Google Tag Manager script is officially not supported on these versions.

<img width="973" alt="Screenshot 2021-07-27 at 15 41 43" src="https://user-images.githubusercontent.com/29889908/127174399-c44fb8cb-200b-4ba9-af51-03107a04c8d6.png">
