### PR TITLE
Analytics cookies are deleted and disabled when consent removed

### DIFF
--- a/__tests__/cookie-functions.test.js
+++ b/__tests__/cookie-functions.test.js
@@ -179,6 +179,25 @@ describe('Cookie settings', () => {
 
       expect(Analytics.default).toHaveBeenCalledTimes(1)
     })
+
+    it('disables analytics by setting a window property', async () => {
+      document.cookie = '_ga=test'
+      document.cookie = '_gid=test'
+
+      CookieHelpers.resetCookies()
+
+      expect(window['ga-disable-UA-26179049-17']).toEqual(true)
+      expect(window['ga-disable-UA-116229859-1']).toEqual(true)
+    })
+
+    it('re-enables analytics by setting a window property', async () => {
+      document.cookie = 'design_system_cookies_policy={"analytics":true,"version":1}'
+
+      CookieHelpers.resetCookies()
+
+      expect(window['ga-disable-UA-26179049-17']).toEqual(false)
+      expect(window['ga-disable-UA-116229859-1']).toEqual(false)
+    })
   })
 
   describe('consent cookie version', () => {

--- a/__tests__/cookie-functions.test.js
+++ b/__tests__/cookie-functions.test.js
@@ -15,8 +15,11 @@ describe('Cookie settings', () => {
 
   afterEach(() => {
     // Delete test cookies
-    document.cookie = '_ga=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
-    document.cookie = 'design_system_cookies_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC'
+    var cookies = document.cookie.split(';')
+    cookies.forEach(function (cookie) {
+      var name = cookie.split('=')[0]
+      document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;domain=' + window.location.hostname + ';path=/'
+    })
   })
 
   describe('Reading a cookie', () => {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "preset": "jest-puppeteer",
     "setupFilesAfterEnv": [
       "./jest.setup.js"
-    ]
+    ],
+    "testURL": "https://design-system.service.gov.uk"
   },
   "browserslist": [
     "last 2 versions",

--- a/src/cookies.njk
+++ b/src/cookies.njk
@@ -96,7 +96,7 @@ layout: layout-single-page.njk
               { text: "24 hours" }
             ],
             [
-              { text: "_dc_gtm_UA-[random number]" },
+              { text: "_gat_UA-[random number]" },
               { text: "Used to reduce the number of requests." },
               { text: "1 minute" }
             ]

--- a/src/javascripts/components/cookie-functions.js
+++ b/src/javascripts/components/cookie-functions.js
@@ -59,13 +59,13 @@ var DEFAULT_COOKIE_CONSENT = {
 export function Cookie (name, value, options) {
   if (typeof value !== 'undefined') {
     if (value === false || value === null) {
-      return deleteCookie(name)
+      deleteCookie(name)
     } else {
       // Default expiry date of 30 days
       if (typeof options === 'undefined') {
         options = { days: 30 }
       }
-      return setCookie(name, value, options)
+      setCookie(name, value, options)
     }
   } else {
     return getCookie(name)
@@ -161,11 +161,8 @@ export function resetCookies () {
     if (!options[cookieType]) {
       for (var cookie in COOKIE_CATEGORIES) {
         if (COOKIE_CATEGORIES[cookie] === cookieType) {
+          // Delete cookie
           Cookie(cookie, null)
-
-          if (Cookie(cookie)) {
-            document.cookie = cookie + '=;expires=' + new Date() + ';domain=' + window.location.hostname.replace(/^www\./, '.') + ';path=/'
-          }
         }
       }
     }
@@ -246,5 +243,10 @@ function setCookie (name, value, options) {
 
 function deleteCookie (name) {
   document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT'
-  return null
+
+  // If the cookie still exists, let's try a more thorough way of deleting it,
+  // by specifying the domain and path
+  if (Cookie(name)) {
+    document.cookie = name + '=;expires=' + new Date() + ';domain=' + window.location.hostname.replace(/^www\./, '.') + ';path=/'
+  }
 }

--- a/src/javascripts/components/cookie-functions.js
+++ b/src/javascripts/components/cookie-functions.js
@@ -242,11 +242,8 @@ function setCookie (name, value, options) {
 }
 
 function deleteCookie (name) {
-  document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT'
-
-  // If the cookie still exists, let's try a more thorough way of deleting it,
-  // by specifying the domain and path
   if (Cookie(name)) {
-    document.cookie = name + '=;expires=' + new Date() + ';domain=' + window.location.hostname.replace(/^www\./, '.') + ';path=/'
+    document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;domain=' + window.location.hostname + ';path=/'
+    document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;domain=.' + window.location.hostname + ';path=/'
   }
 }

--- a/src/javascripts/components/cookie-functions.js
+++ b/src/javascripts/components/cookie-functions.js
@@ -156,7 +156,14 @@ export function resetCookies () {
 
     // Initialise analytics if allowed
     if (cookieType === 'analytics' && options[cookieType]) {
+      // Enable GA if allowed
+      window['ga-disable-UA-' + TRACKING_PREVIEW_ID] = false
+      window['ga-disable-UA-' + TRACKING_LIVE_ID] = false
       Analytics()
+    } else {
+      // Disable GA if not allowed
+      window['ga-disable-UA-' + TRACKING_PREVIEW_ID] = true
+      window['ga-disable-UA-' + TRACKING_LIVE_ID] = true
     }
 
     if (!options[cookieType]) {

--- a/src/javascripts/components/cookies-page.js
+++ b/src/javascripts/components/cookies-page.js
@@ -43,7 +43,7 @@ CookiesPage.prototype.savePreferences = function (event) {
     preferences[cookieType] = selectedItem === 'yes'
   }.bind(this))
 
-  // otherwise save preferences to cookie and show success notification
+  // Save preferences to cookie and show success notification
   setConsentCookie(preferences)
   this.showSuccessNotification()
 }


### PR DESCRIPTION
## What
There are a couple of related changes included in this PR:

- Make sure all code that deletes cookies sets the expiry to `Thu, 01 Jan 1970 00:00:00 GMT` rather than using `new Date()` which does not consistently work
- Move the above logic for cookie deletion to the `deleteCookie()` function, to be consistent
- Refactor `COOKIE_CATEGORIES` to lookup via category (e.g: 'analytics') rather than by cookie name (see individual commit for more details)
- Add `_gat_UA` cookies to the allow list
- Fixes to test setup to support the above changes: setting the testURL to a value other than localhost; making the logic which deletes cookies in the `afterEach` more generic so we don't need to manually update it each time a new cookie is added to the allow list.

## Why
Analytics cookies were being set to empty or blank values rather than being completely removed from the browser. This seemed to be related to us deleting the cookie using `new Date()` when we specify the domain, rather than manually setting it to a date in 1970.

Analytics cookies were also re-appearing after being deleted in some scenarios (see steps below). This was happening because we weren't disabling Google Analytics when we deleted the cookies, so it was re-creating them. We now set an object on the window to `true` or `false` depending on if the user has consented to analytics, following [Google's documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out)

Scenario where analytics cookies were reappearing (this should now be fixed):

1. Accept analytics cookies
2. Navigate to the cookies page and reject analytics cookies
3. Click a link to another page in the design system - as soon as the link is clicked, it triggers an analytics event (because analytics haven't been disabled) and re-creates the cookies