### PR TITLE
Replaced 'telephone' with 'phone' where I could. It needs further review

### DIFF
--- a/src/components/text-input/index.md
+++ b/src/components/text-input/index.md
@@ -59,7 +59,7 @@ If you want to make the input smaller, you can either use a fixed width input, o
 
 #### Fixed width inputs
 
-Use fixed width inputs for content that has a specific, known length. Postcode inputs should be postcode-sized, telephone number inputs should be telephone number-sized.
+Use fixed width inputs for content that has a specific, known length. Postcode inputs should be postcode-sized, phone number inputs should be phone number-sized.
 
 The widths are designed for specific character lengths and to be consistent across a range of browsers. They include extra padding to fit icons that some browsers might insert into the input (for example to show or generate a password).
 

--- a/src/patterns/contact-a-department-or-service-team/all-contact-information/index.njk
+++ b/src/patterns/contact-a-department-or-service-team/all-contact-information/index.njk
@@ -5,12 +5,12 @@ layout: layout-example.njk
 
 <h2 class="govuk-heading-m">Get help with your application</h2>
 
-<h3 class="govuk-heading-s">Telephone</h3>
+<h3 class="govuk-heading-s">Phone</h3>
 
 <p class="govuk-body">If you have a unique reference number, have it with you when you call.</p>
 
 <ul class="govuk-list">
-  <li>Telephone: 020 7946 0101</li>
+  <li>Phone: 020 7946 0101</li>
   <li>Textphone: 020 7946 0102</li>
   <li>Monday to Friday, 8am to 6pm</li>
   <li>Saturday and Sunday, 10am to 4pm</li>

--- a/src/patterns/contact-a-department-or-service-team/default/index.njk
+++ b/src/patterns/contact-a-department-or-service-team/default/index.njk
@@ -6,7 +6,7 @@ layout: layout-example.njk
 <h2 class="govuk-heading-m">Get help with your application</h2>
 
 <ul class="govuk-list">
-  <li>Telephone: 020 7946 0101</li>
+  <li>Phone: 020 7946 0101</li>
   <li>Monday to Friday, 9am to 5pm (except public holidays)</li>
 </ul>
 <p class="govuk-body">

--- a/src/patterns/contact-a-department-or-service-team/expanding-contact-information/index.njk
+++ b/src/patterns/contact-a-department-or-service-team/expanding-contact-information/index.njk
@@ -7,7 +7,7 @@ layout: layout-example.njk
 
 {% set contactInformation %}
   <ul class="govuk-list">
-    <li>Telephone: 020 7946 0101</li>
+    <li>Phone: 020 7946 0101</li>
     <li>Monday to Friday, 8am to 6pm (except public holidays)</li>
     <li>Saturday and Sunday, 10am to 4pm</li>
   </ul>

--- a/src/patterns/contact-a-department-or-service-team/index.md
+++ b/src/patterns/contact-a-department-or-service-team/index.md
@@ -40,15 +40,15 @@ If you have social media channels:
 - do not include a link to the social media sites you're using - read more about this in [GOV.UK’s external linking policy](https://www.gov.uk/guidance/content-design/links#linking-policy)
 - tell users not to share personal information with you
 
-### Write telephone numbers in the GOV.UK style
+### Write phone numbers in the GOV.UK style
 
-See the [GOV.UK style for writing telephone numbers](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#telephone-numbers).
+See the [GOV.UK style for writing phone numbers](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#telephone-numbers).
 
 ### Explain any charges
 
 Tell users if they might have to pay to use any of your contact channels.
 
-For telephone call charges, link to the GOV.UK page on [call charges](https://www.gov.uk/call-charges). Include the link after the contact channels list and opening hours.
+For phone call charges, link to the GOV.UK page on [call charges](https://www.gov.uk/call-charges). Include the link after the contact channels list and opening hours.
 
 {{ example({group: "patterns", item: "contact-a-department-or-service-team", example: "default", html: true, open: false, size: "s", titleSuffix: "second"}) }}
 

--- a/src/patterns/contact-a-department-or-service-team/inset-contact-information/index.njk
+++ b/src/patterns/contact-a-department-or-service-team/inset-contact-information/index.njk
@@ -8,7 +8,7 @@ layout: layout-example.njk
 {% set contactInformation %}
   <h2 class="govuk-heading-m">Talk to an advisor</h2>
   <ul class="govuk-list">
-    <li>Telephone: 020 7946 0101</li>
+    <li>Phone: 020 7946 0101</li>
     <li>Textphone: 020 7946 0102</li>
     <li>Monday to Friday, 9am to 5pm (except public holidays)</li>
   </ul>

--- a/src/patterns/problem-with-the-service-pages/offline-support/index.njk
+++ b/src/patterns/problem-with-the-service-pages/offline-support/index.njk
@@ -18,7 +18,7 @@ layout: layout-example-full-page.njk
         Contact the Tax Credits Helpline if you have any questions.
       </p>
       <p class="govuk-body">
-        Telephone:<br>
+        Phone:<br>
         <strong class="govuk-!-font-weight-bold">0808 157 3900</strong>
       </p>
       <p class="govuk-body">

--- a/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
+++ b/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
@@ -16,7 +16,7 @@ layout: layout-example-full-page.njk
     <p class="govuk-body">
       Contact us if you need to speak to someone about the service and your reports.
     </p>
-    <p class="govuk-body">Telephone:<br>
+    <p class="govuk-body">Phone:<br>
       <strong class="govuk-!-font-weight-bold">0808 157 3900</strong>
     </p>
     <p class="govuk-body">Opening times:<br>

--- a/src/patterns/start-using-a-service/index.md
+++ b/src/patterns/start-using-a-service/index.md
@@ -24,7 +24,7 @@ A service's start point should:
 - include a ‘button’ linking into the service, with text that’s consistent with the action you’re asking users to take — for example, ‘Start now’, ‘Sign in’ or ‘Register or update your details’ (if you need a secondary call to action, use a standard link)
 - let users sign in, resume an application they’ve already started or update their details (if relevant)
 - include any other information that most users are likely to need before they start using the service online — for example, how much it costs to use the service and roughly how long it will take
-- include details of other ways to access the service — for example, by telephone or by completing a paper form
+- include details of other ways to access the service — for example, by phone or by completing a paper form
 
 You’ll also need to list any documents or information the user will need to help them complete the service (there’s no need to list information that a user is likely to know from memory — for example, their own date of birth).
 

--- a/src/patterns/telephone-numbers/default/index.njk
+++ b/src/patterns/telephone-numbers/default/index.njk
@@ -1,13 +1,13 @@
 ---
 layout: layout-example.njk
-title: Default – Telephone numbers
+title: Default – Phone numbers
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {{ govukInput({
   label: {
-    text: "UK telephone number"
+    text: "UK phone number"
   },
   id: "telephone-number",
   name: "telephone-number",

--- a/src/patterns/telephone-numbers/error-empty-field/index.njk
+++ b/src/patterns/telephone-numbers/error-empty-field/index.njk
@@ -1,16 +1,16 @@
 ---
 layout: layout-example.njk
-title: Error, empty field – Telephone numbers
+title: Error, empty field – Phone numbers
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {{ govukInput({
   label: {
-    text: "UK telephone number"
+    text: "UK phone number"
   },
   errorMessage: {
-    text: "Enter a UK telephone number"
+    text: "Enter a UK phone number"
   },
   id: "telephone-number",
   name: "telephone-number",

--- a/src/patterns/telephone-numbers/index.md
+++ b/src/patterns/telephone-numbers/index.md
@@ -1,6 +1,6 @@
 ---
-title: Telephone numbers
-description: Help users enter a valid telephone number
+title: Phone numbers
+description: Help users enter a valid phone number
 section: Patterns
 theme: Ask users for…
 aliases: phone numbers
@@ -17,19 +17,19 @@ This guidance is for government teams that build online services. [To find infor
 
 ## When to use this pattern
 
-Only collect telephone numbers from people if you genuinely need them. Not everyone has or can use a telephone, so make sure you give users a choice about how they can be contacted.
+Only collect phone numbers from people if you genuinely need them. Not everyone has or can use a phone, so make sure you give users a choice about how they can be contacted.
 
 ## How it works
 
 ### Allow different formats
-Let users enter telephone numbers in whatever format is familiar to them. Allow for additional spaces, hyphens, dashes and brackets, and be able to accommodate country and area codes.
+Let users enter phone numbers in whatever format is familiar to them. Allow for additional spaces, hyphens, dashes and brackets, and be able to accommodate country and area codes.
 
-### Validate telephone numbers
-You should validate telephone numbers so you can let users know if they have entered one incorrectly. Google’s [libphonenumber](https://github.com/googlei18n/libphonenumber) library can validate telephone numbers from most countries.
+### Validate phone numbers
+You should validate phone numbers so you can let users know if they have entered one incorrectly. Google’s [libphonenumber](https://github.com/googlei18n/libphonenumber) library can validate phone numbers from most countries.
 
 ### Use the autocomplete attribute
 
-Use the `autocomplete` attribute on telephone number inputs. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.
+Use the `autocomplete` attribute on phone number inputs. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.
 
 To do this, set the `autocomplete` attribute to `tel`, as shown in the HTML and Nunjucks tabs in the examples on this page.
 
@@ -45,47 +45,47 @@ Error messages should be styled like this:
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
-#### If the telephone number is not in the correct format and there is no example
+#### If the phone number is not in the correct format and there is no example
 
-Say ‘Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192’.
+Say ‘Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192’.
 
-#### If the telephone number is not in the correct format and there is an example
+#### If the phone number is not in the correct format and there is an example
 
-Say ‘Enter a telephone number in the correct format’.
+Say ‘Enter a phone number in the correct format’.
 
-### Make it clear what type of telephone number you need
-Use the form label or hint text to tell users if you specifically need a UK, international or mobile telephone number.
+### Make it clear what type of phone number you need
+Use the form label or hint text to tell users if you specifically need a UK, international or mobile phone number.
 
 {{ example({group: "patterns", item: "telephone-numbers", example: "international", html: true, nunjucks: true, open: false, size: "s"}) }}
 
-### Using example telephone numbers
-If you wish to include an example telephone number (in hint text for example), [Ofcom maintains a list of numbers](https://www.ofcom.org.uk/phones-telecoms-and-internet/information-for-industry/numbering/numbers-for-drama) that are reserved for use in media. These are:
+### Using example phone numbers
+If you wish to include an example phone number (in hint text for example), [Ofcom maintains a list of numbers](https://www.ofcom.org.uk/phones-telecoms-and-internet/information-for-industry/numbering/numbers-for-drama) that are reserved for use in media. These are:
 
 - UK non-geographic: 01632 960000 to 960999
 - UK London:  020 7946 0000 to 7946 0999
 - UK mobile: 07700 900000 to 900999
 
-### Explain why you need a telephone number
+### Explain why you need a phone number
 Tell users why you might contact them and when.
 
-### Do not display telephone numbers as links on devices that cannot make calls
+### Do not display phone numbers as links on devices that cannot make calls
 
-It’s possible to mark up telephone numbers as links, like this:
+It’s possible to mark up phone numbers as links, like this:
 
 ```html
 <a href="tel:+442079476330">020 7947 6330</a>
 ```
 
-However, doing this will style telephone numbers as links, which is confusing on devices that do not support telephone calls.
+However, doing this will style phone numbers as links, which is confusing on devices that do not support phone calls.
 
-It might also not be necessary - some modern mobile browsers automatically detect telephone numbers and display them as links anyway.
+It might also not be necessary - some modern mobile browsers automatically detect phone numbers and display them as links anyway.
 
-If you do need to mark up your telephone numbers as links, for example, to support a device that cannot automatically detect them, make sure they do not display as links on devices that cannot make calls.
+If you do need to mark up your phone numbers as links, for example, to support a device that cannot automatically detect them, make sure they do not display as links on devices that cannot make calls.
 
-When you look at your service's user journey, remember that telephone numbers as links might behave in unexpected ways for the user. For example, unless the user sets a default app to handle `tel:` links, some browsers and operating systems will automatically start a setup process.
+When you look at your service's user journey, remember that phone numbers as links might behave in unexpected ways for the user. For example, unless the user sets a default app to handle `tel:` links, some browsers and operating systems will automatically start a setup process.
 
-### Write telephone numbers in the GOV.UK style
-See the [GOV.UK style for writing telephone numbers](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#telephone-numbers).
+### Write phone numbers in the GOV.UK style
+See the [GOV.UK style for writing phone numbers](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#telephone-numbers).
 
 ### Avoid input masking
 
@@ -94,9 +94,9 @@ Avoid [input masking](https://css-tricks.com/input-masking/) because it makes it
 - type a number in their preferred way
 - transcribe a number from another place and check that they’ve got it right
 
-### Avoid reformatting telephone numbers
+### Avoid reformatting phone numbers
 
-The GOV.UK Notify team have observed some users becoming confused when presented with a reformatted version of a telephone number that they provided, for example, with the +44 country code added.
+The GOV.UK Notify team have observed some users becoming confused when presented with a reformatted version of a phone number that they provided, for example, with the +44 country code added.
 
 
 ## Research on this pattern

--- a/src/patterns/telephone-numbers/international/index.njk
+++ b/src/patterns/telephone-numbers/international/index.njk
@@ -1,13 +1,13 @@
 ---
 layout: layout-example.njk
-title: International – Telephone numbers
+title: International – Phone numbers
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {{ govukInput({
   label: {
-    text: "Telephone number"
+    text: "Phone number"
   },
   hint: {
     text: "For international numbers include the country code"


### PR DESCRIPTION
The Design System and content guidance use both 'telephone' and 'phone' as synonyms. Guidance can be made consistent by using one term throughout. Google ngram viewer indicates 'phone' is dominant (https://books.google.com/ngrams/graph?content=phone%2Ctelephone&year_start=1800&year_end=2019&corpus=29&smoothing=3). Discussions on Slack and on github (https://github.com/alphagov/govuk-design-system-backlog/issues/101#issuecomment-509659599) indicate the single term 'phone' can be used throughout.