### PR TITLE
Update accessibility statement re last TDT issue

### DIFF
--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -56,9 +56,9 @@ The Design System website at [https://design-system.service.gov.uk/](https://des
 
 We plan to fix this accessibility issue by the end of September 2021.
 
-The GOV.UK Frontend documentation website at http://frontend.design-system.service.gov.uk/ is partially compliant because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
+The GOV.UK Frontend documentation website at http://frontend.design-system.service.gov.uk/ is partially compliant because of [an issue caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
 
-We plan to fix these accessibility issues by the end of July 2021.
+We plan to fix this issue by 30 September 2021.
 
 ### How this website has been tested for accessibility
 


### PR DESCRIPTION
Fixes [#1792](https://github.com/alphagov/govuk-design-system/issues/1792).

Following the [release of the latest version of the Tech Docs Template](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md#240), there is only one remaining issue making our Frontend docs site non-compliant with WCAG:

- When a user searches, the search results dialogue hides the main page region from assistive technology. This fails [WCAG 2.1 success criterion 2.4.3 Focus Order.](https://www.w3.org/TR/WCAG21/#focus-order) and [WCAG 2.1 success criterion 3.2.2 - On Input](https://www.w3.org/TR/WCAG21/#on-input).

This PR updates our [accessibility statement](https://design-system.service.gov.uk/accessibility/#non-accessible-content) to say:

- there is a non-compliant issue (instead of issues)
- when we plan to fix the outstanding issue