### PR TITLE
Replace absolute links to self with relative links

### DIFF
--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -40,7 +40,7 @@ GDS is committed to making its websites accessible, in accordance with the Publi
 
 ### Compliance status
 
-The Design System website at [https://design-system.service.gov.uk/](https://design-system.service.gov.uk/) is partially compliant with the Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard, due to the non-compliances listed below.
+The Design System website at [https://design-system.service.gov.uk/](/) is partially compliant with the Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard, due to the non-compliances listed below.
 
 The GOV.UK Frontend documentation website at [http://frontend.design-system.service.gov.uk/](https://frontend.design-system.service.gov.uk/) is partially compliant with the WCAG 2.1 AA standard. We know some parts of this website are not fully accessible as there are issues caused by our Technical Documentation Template.
 
@@ -50,7 +50,7 @@ The content listed below is non-accessible for the following reasons.
 
 #### Non-compliance with the accessibility regulations
 
-The Design System website at [https://design-system.service.gov.uk/](https://design-system.service.gov.uk/) is partially compliant due to the following non-compliances:
+The Design System website at [https://design-system.service.gov.uk/](/) is partially compliant due to the following non-compliances:
 
 - the section headings in accordions can be mistaken for links, but are treated as buttons - this fails [WCAG 2.1 success criterion 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
 
@@ -66,13 +66,13 @@ The Design System website was last tested on 7 October 2019. The test was carrie
 
 DAC tested a sample of pages to cover the different content types in the GOV.UK Design System website. They were:
 
-- [the homepage](https://design-system.service.gov.uk/)
-- [a short content page](https://design-system.service.gov.uk/community/design-system-working-group)
-- [a long content page](https://design-system.service.gov.uk/styles/layout/)
-- [an overview page](https://design-system.service.gov.uk/community/)
-- [a styles page](https://design-system.service.gov.uk/styles/typography/)
-- [a component page](https://design-system.service.gov.uk/components/radios/)
-- [a pattern page](https://design-system.service.gov.uk/patterns/question-pages/)
+- [the homepage](/)
+- [a short content page](/community/design-system-working-group)
+- [a long content page](/styles/layout/)
+- [an overview page](/community/)
+- [a styles page](/styles/typography/)
+- [a component page](/components/radios/)
+- [a pattern page](/patterns/question-pages/)
 
 They also tested the global search functionality that appears in the header of every page in the Design System.
 
@@ -112,7 +112,7 @@ The Design System and Frontend were introduced in June 2018 to replace the follo
 
 The GOV.UK Design System team no longer supports these products and will not be making updates to help them meet level AA of WCAG 2.1.
 
-If you're using these products, you should start [updating your service to use the Design System and Frontend](https://design-system.service.gov.uk/get-started/updating-your-code/).
+If you're using these products, you should start [updating your service to use the Design System and Frontend](/get-started/updating-your-code/).
 
 If you have any questions or need help, contact the GOV.UK Design System team:
 

--- a/src/community/resources-and-tools/index.md.njk
+++ b/src/community/resources-and-tools/index.md.njk
@@ -104,6 +104,6 @@ You can download GOV.UK Frontend Nunjucks macro snippets for:
 
 ## Help improve this page
 
-To help make sure that this page is useful, relevant and up to date, you can [propose a change](https://github.com/alphagov/govuk-design-system/edit/main/src/community/resources-and-tools/index.md.njk) – read more about [how to propose changes in GitHub](https://design-system.service.gov.uk/community/propose-a-content-change-using-github/).
+To help make sure that this page is useful, relevant and up to date, you can [propose a change](https://github.com/alphagov/govuk-design-system/edit/main/src/community/resources-and-tools/index.md.njk) – read more about [how to propose changes in GitHub](/community/propose-a-content-change-using-github/).
 
 If you want to submit a resource or tool, check that it meets the [contribution criteria for resources](/community/contribution-criteria/#developing-a-community-resource-or-tool) first.

--- a/src/components/character-count/index.md.njk
+++ b/src/components/character-count/index.md.njk
@@ -30,7 +30,7 @@ If your users keep hitting the character limit imposed by the backend of your se
 
 ## How it works
 
-It tells users how many characters they have remaining as they type into a [textarea](https://design-system.service.gov.uk/components/textarea/) with a character limit.
+It tells users how many characters they have remaining as they type into a [textarea](/components/textarea/) with a character limit.
 
 Sighted users will see a count message that updates as they type. Screen reader users will hear the count message when they stop typing.
 
@@ -85,7 +85,7 @@ If a user tries to send their response with too many characters, you must show a
 
 The error message tells users what went wrong and how to fix it. The count message provides live feedback and updates as a user types.
 
-Make sure errors follow GOV.UK guidance on [writing error messages](https://design-system.service.gov.uk/components/error-message/#be-clear-and-concise) and have specific error messages for specific error states.
+Make sure errors follow GOV.UK guidance on [writing error messages](/components/error-message/#be-clear-and-concise) and have specific error messages for specific error states.
 
 #### If the input is empty
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -69,7 +69,7 @@ You can add hints to checkbox items to provide additional information about the 
 
 When 'none' would be a valid answer, give users the option to check a box to say none of the other options apply to them — without this option, users would have to leave all of the boxes unchecked. Giving users this option also makes sure they do not skip the question by accident.
 
-Remember to [start by asking one question per page](https://design-system.service.gov.uk/patterns/question-pages/#start-by-asking-one-question-per-page). You might be able to remove the need for a 'none' option by asking the user a better question or filtering them out with a ‘filter question’ beforehand. The GOV.UK Service Manual has guidance on [designing good questions](https://www.gov.uk/service-manual/design/designing-good-questions).
+Remember to [start by asking one question per page](/patterns/question-pages/#start-by-asking-one-question-per-page). You might be able to remove the need for a 'none' option by asking the user a better question or filtering them out with a ‘filter question’ beforehand. The GOV.UK Service Manual has guidance on [designing good questions](https://www.gov.uk/service-manual/design/designing-good-questions).
 
 Show the ‘none’ option last. Separate it from the other options using a divider. The text is usually the word ‘or’.
 

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -53,6 +53,6 @@ You can use the [width override classes](../../styles/spacing#width-override-cla
 
 If the [width override classes](../../styles/spacing#width-override-classes) do not meet your needs you can create your own width classes and apply them to the cells in the table head. These can be added using the `classes` option in the Nunjucks macro or adding the class directly to the individual cells within `govuk-table__head` as below.
 
-To learn more about this, read guidance on [extending and modifying components in production](https://design-system.service.gov.uk/get-started/extending-and-modifying-components/).
+To learn more about this, read guidance on [extending and modifying components in production](/get-started/extending-and-modifying-components/).
 
 {{ example({group: "components", item: "table", example: "column-widths-custom-classes", html: true, nunjucks: true, open: false, size: "m"}) }}

--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -10,7 +10,7 @@ The GOV.UK Design System team at the
 [Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service) maintains this design system.
 
 If you want to contact the team you can
-[get in touch via email or Slack](https://design-system.service.gov.uk/get-in-touch/).
+[get in touch via email or Slack](/get-in-touch/).
 
 ## Members
 

--- a/src/get-started/extending-and-modifying-components/index.md.njk
+++ b/src/get-started/extending-and-modifying-components/index.md.njk
@@ -144,6 +144,6 @@ For example, a large modification of an existing component is the [step by step 
 
 If you’ve extended something and you think it’s useful for the wider government community you can propose an improvement.
 
-You can do this by proposing your change to a component on the [community backlog](https://design-system.service.gov.uk/community/backlog).
+You can do this by proposing your change to a component on the [community backlog](/community/backlog).
 
 [prefix]: #use-a-unique-prefix-for-component-names

--- a/src/patterns/bank-details/index.md.njk
+++ b/src/patterns/bank-details/index.md.njk
@@ -86,7 +86,7 @@ Error messages should be styled like this:
 
 {{ example({group: "patterns", item: "bank-details", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
 
-Make sure errors follow the guidance in [error message](https://design-system.service.gov.uk/components/error-message/) and have specific error messages for specific error states.
+Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
 #### If the name on the account is empty
 

--- a/src/patterns/contact-a-department-or-service-team/index.md.njk
+++ b/src/patterns/contact-a-department-or-service-team/index.md.njk
@@ -71,13 +71,13 @@ For example, tell users how long it'll usually take to:
 
 ### Inset contact information
 
-Use [inset text](https://design-system.service.gov.uk/components/inset-text/) to display contact information when you want to differentiate it from the content that surrounds it.
+Use [inset text](/components/inset-text/) to display contact information when you want to differentiate it from the content that surrounds it.
 
 {{ example({group: "patterns", item: "contact-a-department-or-service-team", example: "inset-contact-information", html: true, nunjucks: true, open: false, size: "m"}) }}
 
 ### Expanding contact information
 
-If contact information is less important than other content on a page, you can enclose contact information inside the [details](https://design-system.service.gov.uk/components/details/) component to avoid distracting users.
+If contact information is less important than other content on a page, you can enclose contact information inside the [details](/components/details/) component to avoid distracting users.
 
 For example, if you need to provide contact information at the bottom of a form page for users who need help completing the form.
 

--- a/src/privacy-policy.md.njk
+++ b/src/privacy-policy.md.njk
@@ -7,7 +7,7 @@ layout: layout-single-page-prose.njk
 
 # Privacy notice: how we use your data
 
-The [GOV.UK Design System](https://design-system.service.gov.uk/) brings together the latest research, design and development from across government to make sure it’s representative and relevant for its users. 
+The [GOV.UK Design System](/) brings together the latest research, design and development from across government to make sure it’s representative and relevant for its users. 
 
 To add to and improve the Design System, the team reviews proposals and works with contributors to publish new entries and improve existing ones.  
 
@@ -17,7 +17,7 @@ The GOV.UK Design System is provided by the [Government Digital Service (GDS)](h
 
 ## Why we need your data
 
-For a number of the activities that we undertake to complete our function, we need to process personal data. The purposes are to manage and coordinate the [GOV.UK Design System](https://design-system.service.gov.uk/) and contributions from the community. 
+For a number of the activities that we undertake to complete our function, we need to process personal data. The purposes are to manage and coordinate the [GOV.UK Design System](/) and contributions from the community. 
 
 This includes:
 - contribution process, including working with you on contributions, where you’ve proposed to add or improve part of the Design System
@@ -27,7 +27,7 @@ This includes:
 
 ## What data we collect from you
 
-We collect certain information and data about you when you use the [GOV.UK Design System](https://design-system.service.gov.uk/). 
+We collect certain information and data about you when you use the [GOV.UK Design System](/). 
 
 We collect your:
 - name
@@ -60,7 +60,7 @@ Your personal data may be transferred outside the United Kingdom while being pro
 
 ## Who we share your data with 
 
-As part of [GOV.UK Design System](https://design-system.service.gov.uk/) we share your personal data with data processors who provide us with:
+As part of [GOV.UK Design System](/) we share your personal data with data processors who provide us with:
 - software collaboration platforms when you share research, feedback or make a contribution
 - mailing list providers when you sign up to receive emails from us
 - support providers when you contact us for assistance


### PR DESCRIPTION
We should try and use relative URLs in links where possible, so that review apps don't send users to the production app.

A few absolute links to the Design System website have snuck in over time, this PR replaces them with relative links by removing the `https://design-system.service.gov.uk` part.