### PR TITLE
Replace use of FormElements.elements and RadioNodeList.value to support IE

### DIFF
--- a/__tests__/cookie-banner.test.js
+++ b/__tests__/cookie-banner.test.js
@@ -7,18 +7,25 @@ const PORT = configPaths.testPort
 let page
 let baseUrl = 'http://localhost:' + PORT
 
-beforeEach(async () => {
-  page = await setupPage()
-})
-
-afterEach(async () => {
-  await page.deleteCookie({ name: 'design_system_cookies_policy', url: baseUrl })
-  await page.close()
-})
-
 const COOKIE_BANNER_SELECTOR = '[data-module="govuk-cookie-banner"]'
 
 describe('Cookie banner', () => {
+  beforeEach(async () => {
+    page = await setupPage()
+  })
+
+  afterEach(async () => {
+    await page.evaluate(() => {
+      // Delete test cookies
+      var cookies = document.cookie.split(';')
+      cookies.forEach(function (cookie) {
+        var name = cookie.split('=')[0]
+        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;domain=' + window.location.hostname + ';path=/'
+      })
+    })
+    await page.close()
+  })
+
   it('is hidden on the cookies page', async () => {
     await page.setCookie({ name: 'design_system_cookies_policy', value: '{"analytics":true, "version":1}', url: baseUrl })
     await page.goto(`${baseUrl}/cookies/`, { waitUntil: 'load' })

--- a/__tests__/cookies-page.test.js
+++ b/__tests__/cookies-page.test.js
@@ -9,24 +9,17 @@ const baseUrl = 'http://localhost:' + PORT
 
 const cookiesPageSelector = '[data-module="app-cookies-page"]'
 
-beforeAll(async () => {
+beforeEach(async () => {
   page = await setupPage()
+  await page.setJavaScriptEnabled(true)
+  await page.goto(`${baseUrl}/cookies`)
 })
 
-afterAll(async () => {
+afterEach(async () => {
   await page.close()
 })
 
 describe('Cookies page', () => {
-  beforeEach(async () => {
-    await page.goto(`${baseUrl}/cookies`)
-  })
-
-  afterEach(async () => {
-    await page.deleteCookie({ name: 'design_system_cookies_policy' })
-    await page.setJavaScriptEnabled(true)
-  })
-
   it('without JavaScript it has no visible inputs', async () => {
     await page.setJavaScriptEnabled(false)
     await page.goto(`${baseUrl}/cookies`)

--- a/__tests__/cookies-page.test.js
+++ b/__tests__/cookies-page.test.js
@@ -9,17 +9,25 @@ const baseUrl = 'http://localhost:' + PORT
 
 const cookiesPageSelector = '[data-module="app-cookies-page"]'
 
-beforeEach(async () => {
-  page = await setupPage()
-  await page.setJavaScriptEnabled(true)
-  await page.goto(`${baseUrl}/cookies`)
-})
-
-afterEach(async () => {
-  await page.close()
-})
-
 describe('Cookies page', () => {
+  beforeEach(async () => {
+    page = await setupPage()
+    await page.setJavaScriptEnabled(true)
+    await page.goto(`${baseUrl}/cookies`)
+  })
+
+  afterEach(async () => {
+    await page.evaluate(() => {
+      // Delete test cookies
+      var cookies = document.cookie.split(';')
+      cookies.forEach(function (cookie) {
+        var name = cookie.split('=')[0]
+        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;domain=' + window.location.hostname + ';path=/'
+      })
+    })
+    await page.close()
+  })
+
   it('without JavaScript it has no visible inputs', async () => {
     await page.setJavaScriptEnabled(false)
     await page.goto(`${baseUrl}/cookies`)

--- a/src/javascripts/components/cookies-page.js
+++ b/src/javascripts/components/cookies-page.js
@@ -37,8 +37,7 @@ CookiesPage.prototype.savePreferences = function (event) {
 
   nodeListForEach(this.$cookieFormFieldsets, function ($cookieFormFieldset) {
     var cookieType = this.getCookieType($cookieFormFieldset)
-    var radios = this.$cookieForm.elements[cookieType]
-    var selectedItem = radios.value
+    var selectedItem = $cookieFormFieldset.querySelector('input[name=' + cookieType + ']:checked').value
 
     preferences[cookieType] = selectedItem === 'yes'
   }.bind(this))
@@ -50,14 +49,15 @@ CookiesPage.prototype.savePreferences = function (event) {
 
 CookiesPage.prototype.showUserPreference = function ($cookieFormFieldset, preferences) {
   var cookieType = this.getCookieType($cookieFormFieldset)
-  var radios = this.$cookieForm.elements[cookieType]
   var preference = false
 
   if (cookieType && preferences && preferences[cookieType] !== undefined) {
     preference = preferences[cookieType]
   }
 
-  radios.value = preference ? 'yes' : 'no'
+  var radioValue = preference ? 'yes' : 'no'
+  var radio = $cookieFormFieldset.querySelector('input[name=' + cookieType + '][value=' + radioValue + ']')
+  radio.checked = true
 }
 
 CookiesPage.prototype.showSuccessNotification = function () {


### PR DESCRIPTION
The [MDN page for FormElement.elements](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/elements) states that it is fully supported by IE. However, in IE, FormElement.elements returns a HTMLCollection rather than a RadioNodeList, which means we can't use RadioNodeList.value to check or set the radio button values.

This was leading to a bug where the radio buttons in the cookies forms were not being preselected, and the values were not being correctly set.

Instead of relying on the elements being returned as a RadioNodeList:

- use `querySelector` and the `:checked` selector to find radio buttons which have been selected already
- use `querySelector` and the `[name]` and `[value]` selectors to find the right radio button to select