### PR TITLE
Fix excludes for accessibility audit tests

### DIFF
--- a/__tests__/accessiblity_audit.test.js
+++ b/__tests__/accessiblity_audit.test.js
@@ -9,12 +9,17 @@ const PORT = configPaths.testPort
 let page
 let baseUrl = 'http://localhost:' + PORT
 
-const thingsToExclude = [
-  // axe reports there is "no label associated with the text field", when there is one.
-  ['#app-site-search__input'],
-  // axe reports that the phase banner is not inside a landmark, which is intentional.
-  ['.app-phase-banner__wrapper']
-]
+async function audit (page) {
+  const axe = new AxePuppeteer(page)
+    .include('body')
+    .exclude('#app-site-search__input') // axe reports there is "no label associated with the text field", when there is one.
+    .exclude('.app-phase-banner__wrapper') // axe reports that the phase banner is not inside a landmark, which is intentional.
+
+  const results = await axe.analyze()
+
+  return results.violations
+}
+
 beforeAll(async () => {
   page = await setupPage()
 })
@@ -27,64 +32,40 @@ describe('Accessibility Audit', () => {
   describe('Home page - layout.njk', () => {
     it('validates', async () => {
       await page.goto(baseUrl + '/', { waitUntil: 'load' })
-      const results =
-        await new AxePuppeteer(page)
-          .include(['body'])
-          .exclude(...thingsToExclude)
-          .analyze()
-      expect(results.violations).toEqual([])
+      const violations = await audit(page)
+      expect(violations).toEqual([])
     })
   })
 
   describe('Component page - layout-pane.njk', () => {
     it('validates', async () => {
       await page.goto(baseUrl + '/components/radios/', { waitUntil: 'load' })
-      const results =
-        await new AxePuppeteer(page)
-          .include(['body'])
-          .exclude(...thingsToExclude)
-          .analyze()
-
-      expect(results.violations).toEqual([])
+      const violations = await audit(page)
+      expect(violations).toEqual([])
     })
   })
 
   describe('Patterns page - layout-pane.njk', () => {
     it('validates', async () => {
       await page.goto(baseUrl + '/patterns/gender-or-sex/', { waitUntil: 'load' })
-      const results =
-        await new AxePuppeteer(page)
-          .include(['body'])
-          .exclude(...thingsToExclude)
-          .analyze()
-
-      expect(results.violations).toEqual([])
+      const violations = await audit(page)
+      expect(violations).toEqual([])
     })
   })
 
   describe('Get in touch page - layout-single-page.njk', () => {
     it('validates', async () => {
       await page.goto(baseUrl + '/get-in-touch/', { waitUntil: 'load' })
-      const results =
-        await new AxePuppeteer(page)
-          .include(['body'])
-          .exclude(...thingsToExclude)
-          .analyze()
-
-      expect(results.violations).toEqual([])
+      const violations = await audit(page)
+      expect(violations).toEqual([])
     })
   })
 
   describe('Site Map page - layout-sitemap.njk', () => {
     it('validates', async () => {
       await page.goto(baseUrl + '/sitemap/', { waitUntil: 'load' })
-      const results =
-        await new AxePuppeteer(page)
-          .include(['body'])
-          .exclude(...thingsToExclude)
-          .analyze()
-
-      expect(results.violations).toEqual([])
+      const violations = await audit(page)
+      expect(violations).toEqual([])
     })
   })
 })


### PR DESCRIPTION
Fixes the accessibility audit tests so we can exclude multiple different selectors from tests. Previously the selector
`.app-phase-banner__wrapper` was in the list of things to exclude, but was not being excluded (see [comment from @hannalaakso in PR #784][1]).

This change is needed to be able to bump `axe-core` or `@axe-core/puppeteer`.

### Details

It isn't clear from the `axe-puppeteer` documentation, but `AxePuppeteer.exclude` accepts only one argument, which is either a string or a list of strings. If a list of strings is provided, this is used to select an element within an iframe [[2]]. So to exclude several different elements, we need to call `.exclude` multiple times.

The easiest way to call `.exclude` multiple times for each test is to create a function (replacing the `thingsToExclude` object), which this commit does.

This is required to upgrade `axe-core` to version 3.5.0 or greater. The tests we passing before this commit because the rule ['all page content must be contained by landmarks'][3] was not working fully: it treated regions as being part of the `html` element (and thus not covered by `.include('body')`) [[4]].

[1]: https://github.com/alphagov/govuk-design-system/pull/784/files#r260285048
[2]: https://deque.com/axe/core-documentation/api-documentation/#context-parameter
[3]: https://dequeuniversity.com/rules/axe/4.3/region
[4]: https://github.com/dequelabs/axe-core/pull/1980