### PR TITLE
Wrap the cookie banner inline script in an IE conditional

### DIFF
--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -28,7 +28,9 @@
 
 {% block main %}
 <div class="app-pane {% block appPaneClasses %}{% endblock %}" id="top">
-  {% include "_cookie-banner.njk" %}
+  <!--[if gte IE 9]><!-->
+    {% include "_cookie-banner.njk" %}
+  <!--<![endif]-->
   {% include "_header.njk" %}
   {% include "_mobile-navigation.njk" %}
   {% include "_banner.njk" %}


### PR DESCRIPTION
## What
The [addition of an inline script](https://github.com/alphagov/govuk-design-system/pull/1775/commits/6858861f4f599176160359cd5927420fd0cc0e2a) to the `cookie-banner.njk` file to help with Cumulative Layout Shift means that the banner is still being shown in Internet Explorer 8 and below.

This PR wraps the inline script in a conditional which checks the browser is Internet Explorer 9 or above before running the inline script, to hide the banner on IE8 and below. This uses a "downlevel" conditional comment ([read more here](https://www.sitepoint.com/internet-explorer-conditional-comments/)) which means the HTML content inside the conditional is revealed to browsers that don’t support conditional comments, because the conditional statements - and only the conditional statements - are ignored.

## Why
The Google Analytics script does not support Internet Explorer 8 or below, so we hide the cookie banner completely for users on IE8 and below.