### PR TITLE
Add app-width-container to cookie confirmation

### DIFF
--- a/views/partials/_cookie-banner.njk
+++ b/views/partials/_cookie-banner.njk
@@ -51,7 +51,7 @@
           classes: "js-cookie-banner-hide js-cookie-banner-hide--accept"
         }
       ],
-      classes: "js-cookie-banner-confirmation-accept"
+      classes: "js-cookie-banner-confirmation-accept app-width-container"
     },
     {
       html: rejectHtml,
@@ -63,7 +63,7 @@
           classes: "js-cookie-banner-hide js-cookie-banner-hide--reject"
         }
       ],
-      classes: "js-cookie-banner-confirmation-reject"
+      classes: "js-cookie-banner-confirmation-reject app-width-container"
     }
   ]
 }) }}


### PR DESCRIPTION
## What
Add app-width-container to cookie confirmation to ensure that the confirmation message lines up with the crown in the header. The app-width-container class has already been applied to the cookie message

## Before
<img width="1144" alt="Screenshot 2021-08-03 at 16 54 58" src="https://user-images.githubusercontent.com/29889908/128047177-acb1e96d-578f-4a71-8266-53253ed85d52.png">

## After
<img width="1134" alt="Screenshot 2021-08-03 at 16 54 34" src="https://user-images.githubusercontent.com/29889908/128047199-ae160c53-e2f5-4371-b428-9b72dddf5272.png">
