### PR TITLE
Correct the cookie consent name on /cookies

### DIFF
--- a/src/cookies.njk
+++ b/src/cookies.njk
@@ -55,7 +55,7 @@ layout: layout-single-page.njk
           ],
           rows: [
             [
-              {text: "design-system-cookie-policy"},
+              {text: "design_system_cookies_policy"},
               {text: "Saves your cookie consent settings"},
               {text: "1 year"}
             ]


### PR DESCRIPTION
## What
Correct the name of our design_system_cookies_policy cookie on the cookies page.