### PR TITLE
Corrected phone number

### DIFF
--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -28,9 +28,9 @@ You should validate telephone numbers so you can let users know if they have ent
 
 ### Use the autocomplete attribute
 
-Use the `autocomplete` attribute on telephone number inputs. This lets browsers autofill the information on a user's behalf if they’ve entered it previously. 
+Use the `autocomplete` attribute on telephone number inputs. This lets browsers autofill the information on a user's behalf if they’ve entered it previously.
 
-To do this, set the `autocomplete` attribute to `tel`, as shown in the HTML and Nunjucks tabs in the examples on this page. 
+To do this, set the `autocomplete` attribute to `tel`, as shown in the HTML and Nunjucks tabs in the examples on this page.
 
 If you are working in production you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
 
@@ -46,7 +46,7 @@ Make sure errors follow the guidance in [error message](/components/error-messag
 
 #### If the telephone number is not in the correct format and there is no example
 
-Say ‘Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192’.
+Say ‘Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192’.
 
 #### If the telephone number is not in the correct format and there is an example
 


### PR DESCRIPTION
A UK country code cannot be followed by zero. Number has now been corrected. The standard followed by BT is https://www.itu.int/rec/T-REC-E.123-200102-I/en