### PR TITLE
Add MIT license and GitHub info to Components page

### DIFF
--- a/src/components/index.md.njk
+++ b/src/components/index.md.njk
@@ -6,6 +6,8 @@ show_subnav: true
 
 Components are reusable parts of the user interface that have been made to support a variety of applications.
 
-Individual components can be used in multiple different [patterns](../patterns) and contexts. For example, the [text input](../components/text-input) component can be used to ask for an email address, a National Insurance number or someone’s name.
+You can use individual components in many different [patterns](../patterns) and contexts. For example, you can use the [text input](../components/text-input) component to ask for an email address, a National Insurance number or someone’s name.
 
-If you are using the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com) or have [GOV.UK Frontend](https://frontend.design-system.service.gov.uk/) included in your build, the coded examples provided will render exactly as they do inside the Design&nbsp;System.
+Each component in the GOV.UK Design System has coded examples. If you're using the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), or have included [GOV.UK Frontend](https://frontend.design-system.service.gov.uk/) in your build, coded examples will render the same as in the Design System.
+
+The GOV.UK Design System's code is public and freely available under a [Massachusetts Institute of Technology (MIT) license](https://github.com/alphagov/govuk-frontend/blob/main/LICENSE.txt). You can [find our code repositories on GitHub](https://github.com/topics/govuk-design-system-team), where we [code in the open](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/).


### PR DESCRIPTION
## What we've changed

Fixes [#1810](https://github.com/alphagov/govuk-design-system/issues/1810).

This PR adds info to the [Components page on the main Design System site](https://design-system.service.gov.uk/components/).

It tells users:

- that our code is public and available under an MIT license
- where they can find our repos

I also replaced some instances of the passive voice, to make the text more direct.

## Why we've changed it

We're adding this info because a user reported they'd had to dig around before they found out we use MIT. See [#1810](https://github.com/alphagov/govuk-design-system/issues/1810) for full details.

Other gov teams have previously added similar info to their sites. For example, [data.gov.uk](https://guidance.data.gov.uk/support/contribute/) and [Verify](https://www.docs.verify.service.gov.uk/open-components/).