### PR TITLE
Delete cookies with and without domain

### DIFF
--- a/__tests__/cookie-banner.test.js
+++ b/__tests__/cookie-banner.test.js
@@ -20,6 +20,7 @@ describe('Cookie banner', () => {
       var cookies = document.cookie.split(';')
       cookies.forEach(function (cookie) {
         var name = cookie.split('=')[0]
+        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/'
         document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;domain=' + window.location.hostname + ';path=/'
       })
     })

--- a/__tests__/cookie-functions.test.js
+++ b/__tests__/cookie-functions.test.js
@@ -18,6 +18,7 @@ describe('Cookie settings', () => {
     var cookies = document.cookie.split(';')
     cookies.forEach(function (cookie) {
       var name = cookie.split('=')[0]
+      document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/'
       document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;domain=' + window.location.hostname + ';path=/'
     })
   })
@@ -251,6 +252,24 @@ describe('Cookie settings', () => {
       var cookieOptions = { analytics: true, version: 'foobar' }
 
       expect(CookieHelpers.isValidConsentCookie(cookieOptions)).toEqual(false)
+    })
+  })
+
+  describe('deleteCookie', () => {
+    it('deletes cookies set with a domain attribute', async () => {
+      document.cookie = 'my_cookie=test;domain=design-system.service.gov.uk'
+
+      CookieHelpers.Cookie('my_cookie', null)
+
+      expect(document.cookie).toEqual('')
+    })
+
+    it('deletes cookies set without a domain attribute', async () => {
+      document.cookie = 'my_cookie_2=test'
+
+      CookieHelpers.Cookie('my_cookie_2', null)
+
+      expect(document.cookie).toEqual('')
     })
   })
 })

--- a/__tests__/cookies-page.test.js
+++ b/__tests__/cookies-page.test.js
@@ -22,6 +22,7 @@ describe('Cookies page', () => {
       var cookies = document.cookie.split(';')
       cookies.forEach(function (cookie) {
         var name = cookie.split('=')[0]
+        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/'
         document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;domain=' + window.location.hostname + ';path=/'
       })
     })

--- a/src/javascripts/components/cookie-functions.js
+++ b/src/javascripts/components/cookie-functions.js
@@ -254,6 +254,11 @@ function setCookie (name, value, options) {
 
 function deleteCookie (name) {
   if (Cookie(name)) {
+    // Cookies need to be deleted in the same level of specificity in which they were set
+    // If a cookie was set with a specified domain, it needs to be specified when deleted
+    // If a cookie wasn't set with the domain attribute, it shouldn't be there when deleted
+    // You can't tell if a cookie was set with a domain attribute or not, so try both options
+    document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/'
     document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;domain=' + window.location.hostname + ';path=/'
     document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;domain=.' + window.location.hostname + ';path=/'
   }


### PR DESCRIPTION
## What
Changes the deleteCookie function to handle deleting cookies with and without the domain specified. This is to make sure the deleteCookies function continues to work even if changes are made to the way we set cookies (for example: in Google Tag Manager - see below)
 
## Why 
Cookies need to be deleted in the same level of specificity in which they were set.
You can't tell if a cookie was set with a domain attribute or not, so try both options

Previously, we set the Google Analytics cookieDomain property to 'auto' which caused
an issue in Internet Explorer where the cookies were set on service.gov.uk. We then set
the cookieDomain property to 'design-system.service.gov.uk' or the output of {{Page Hostname}}
in Google Tag Manager for preview apps. However, this actually means the analytics cookies are
set on the specified domain *and any of it's subdomains*, which isn't the behaviour we want at
the moment.

So we now set the cookieDomain property to "none", which effectively sets the analytics cookies
without any specified domain, meaning the cookies apply to that domain and that domain only. This
is the behaviour we want, but it means our deletion code doesn't work because we're specifying the domain.

https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#cookieDomain