### PR TITLE
Remove graph mentions from Colour guidance

### DIFF
--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -25,7 +25,7 @@ whenever you update.
 
 Only use the variables in the context they're designed for. In all other cases,
 you should reference the [colour palette](#colour-palette) directly. For
-example, if you wanted to use red to represent some data in a graph you should
+example, if you wanted to use red, you should
 use `govuk-colour("red")` rather than `$govuk-error-colour`.
 
 <table class="govuk-body app-colour-list" summary="Table of main colours">
@@ -59,7 +59,7 @@ use `govuk-colour("red")` rather than `$govuk-error-colour`.
 
 ## Colour palette
 
-Use these colours for graphs and supporting material.
+Use these colours for supporting materials like illustrations, or in custom components where appropriate.
 
 To reference colours from the palette directly you should use the `govuk-colour`
 function. For example, `color: govuk-colour("blue")`.


### PR DESCRIPTION
## What we've changed

Fixes [#1816](https://github.com/alphagov/govuk-design-system/issues/1816).

This PR removes mentions of "graphs" from our [Colour guidance](https://design-system.service.gov.uk/styles/colour/).

We've also given examples (illustrations, custom components) of what users should use colour for.

## Why we've changed it

A user (see [#1814](https://github.com/alphagov/govuk-design-system/issues/1814)) asked if we designed the palette with graphs in mind. The guidance suggests we have:

> Use these colours for graphs and supporting material.

> For example, if you wanted to use red to represent some data in a graph you should use govuk-colour("red")` rather than `$govuk-error-colour`.

It is possible to use the colours for graphs, but we have not provided them for that purpose.  That's why they do not have enough contrast with each other if used (for example) to colour bars in a bar chart. So, we should remove any mentions that could mislead users.