### PR TITLE
Update team page with recent changes

### DIFF
--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -7,7 +7,7 @@ layout: layout-single-page-prose.njk
 # GOV.UK Design System team
 
 The GOV.UK Design System team at the
-[Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service) maintains this design system.
+[Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service) (GDS) maintains this design system.
 
 If you want to contact the team you can
 [get in touch via email or Slack](/get-in-touch/).
@@ -25,9 +25,9 @@ If you want to contact the team you can
 - Kelly Lee – Delivery Manager
 - Laurence de Bruxelles – Developer
 - Nora Brodian – Content Designer
-- Oliver Byford – Senior Developer (Tech Lead)
+- Oliver Byford – Lead Frontend Developer, Government as a Platform
 - Rosie Clayton – User Researcher
 - Sara Cox – Senior Performance Analyst
-- Tim Paul – Head of Interaction Design at GDS
+- Tim Paul – Head of Interaction Design, GDS
 - Trang Erskine – Senior Product Manager
-- Vanita Barrett – Senior Frontend Developer
+- Vanita Barrett – Senior Frontend Developer (Tech Lead)


### PR DESCRIPTION
- Update my role
- Mark Vanita as the tech lead 🎉 
- Tweak Tim's role description for consistency
- Ensure the GDS acronym is defined before it's used in Tim's role