### PR TITLE
Delete accordion issue in accessibility statement

### DIFF
--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -42,21 +42,9 @@ GDS is committed to making its websites accessible, in accordance with the Publi
 
 ### Compliance status
 
-The Design System website at [https://design-system.service.gov.uk/](/) is partially compliant with the Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard, due to the non-compliances listed below.
+The Design System website at [https://design-system.service.gov.uk/](/) is fully compliant with the Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard.
 
 The GOV.UK Frontend documentation website at [http://frontend.design-system.service.gov.uk/](https://frontend.design-system.service.gov.uk/) is fully compliant with the WCAG 2.1 AA standard.
-
-### Non-accessible content
-
-The content listed below is non-accessible for the following reasons.
-
-#### Non-compliance with the accessibility regulations
-
-The Design System website at [https://design-system.service.gov.uk/](/) is partially compliant due to the following non-compliances:
-
-- the section headings in accordions can be mistaken for links, but are treated as buttons - this fails [WCAG 2.1 success criterion 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
-
-We plan to fix this accessibility issue by 31 December 2021.
 
 ### How this website has been tested for accessibility
 


### PR DESCRIPTION
Fixes [#1823](https://github.com/alphagov/govuk-design-system/issues/1823).

### What we've changed

This PR removes mention of an accordion-affecting [WCAG issue](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships) from the [non-compliance section of our accessibility statement](https://design-system.service.gov.uk/accessibility/#non-compliance-with-the-accessibility-regulations).

We've also removed some redundant text to avoid a clumsy repetition.

### Why we've changed it

The iterated accordion component will fix the accessibility issue.