### PR TITLE
Replace negative contractions in Patterns guidance

### DIFF
--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -23,7 +23,7 @@ Help users provide an address using one of the following:
     <source src="passports-address-lookup.mp4" type="video/mp4">
   </video>
   <p class="app-video__description" id="passports-address-lookup-video-description">
-    This video shows the address lookup in practice. It doesn't have any audio.
+    This video shows the address lookup in practice. It does not have any audio.
   </p>
 </div>
 

--- a/src/patterns/equality-information/explainer-screen/index.njk
+++ b/src/patterns/equality-information/explainer-screen/index.njk
@@ -9,7 +9,7 @@ layout: layout-example.njk
 
 {% set hintHtml %}
   <p class="govuk-!-margin-top-0">These questions are optional. [Add a couple of sentences explaining why you’re asking the questions and what you’ll do with the information].</p>
-  <p>Your answers won’t affect your application.</p>
+  <p>Your answers will not affect your application.</p>
 {% endset -%}
 
 <h1 class="govuk-heading-l">We have received your application</h1>

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -43,7 +43,7 @@ If research shows it’s helpful for users, you can also include a [progress ind
 
 ### Back link
 
-Some users do not trust browser back buttons when they’re entering data. 
+Some users do not trust browser back buttons when they’re entering data.
 
 Always include a [back link](../../components/back-link) at the top of question pages to reassure them it’s possible to go back and change previous answers.
 
@@ -85,7 +85,7 @@ You can also learn more about how starting with [one thing per page](https://www
 
 #### Asking filter questions to simplify a complex question
 
-A series of simple questions can be easier to answer than one complex question. Especially if parts of it aren’t relevant to all users. A 'filter question' will let the user skip parts of a question that do not apply to them so they do not get confused.
+A series of simple questions can be easier to answer than one complex question. Especially if parts of it are not relevant to all users. A 'filter question' will let the user skip parts of a question that do not apply to them so they do not get confused.
 
 For example, you could ask the user if they've travelled outside the UK before you ask them which countries they've travelled to. This would let the user skip looking at a list of countries when they do not need to.
 


### PR DESCRIPTION
This PR is (probably) the last instalment in my quest to rid Design System content of negative contractions.

We avoid negative contractions in content because [some users struggle with them](https://readabilityguidelines.co.uk/grammar-points/contractions/#1-avoid-negative-contractions).