### PR TITLE
Write out accordion guidance numbers in full

### DIFF
--- a/src/components/accordion/index.md.njk
+++ b/src/components/accordion/index.md.njk
@@ -49,7 +49,7 @@ You should also take into account the number of sections of content – accordio
 
 Tabs may work better for users who need to switch quickly between 2 sections. Accordions push other sections down the page when they open, but tabs do not move which makes it easier to switch.
 
-Consider using an accordion instead of the [details](/components/details/) component if there are multiple related sections of content. The details component might be better if you only have one or 2 sections of content. The details component is less visually prominent than an accordion, so tends to work better for content which is not as important to users.
+Consider using an accordion instead of the [details](/components/details/) component if there are multiple related sections of content. The details component might be better if you only have one or two sections of content. The details component is less visually prominent than an accordion, so tends to work better for content which is not as important to users.
 
 ## How it works
 


### PR DESCRIPTION
Fixes [#747](https://github.com/alphagov/govuk-design-system/issues/747).

### What we've changed

In the [Accordion, tabs and details section of our accordion guidance](https://design-system.service.gov.uk/components/accordion/#accordions-tabs-and-details), we've changed:

> The details component might be better if you only have one or 2 sections of content.

to

> The details component might be better if you only have one or two sections of content.

### Why we've changed it

The ['Numbers' section of the style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#numbers) states:

> Write all other numbers in numerals (including 2 to 9) except where it’s part of a common expression like ‘one or two of them’ where numerals would look strange.