### PR TITLE
Link Colour guidance to Frontend Sass docs

### DIFF
--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -17,7 +17,7 @@ your service meets [level AA of the Web Content Accessibility Guidelines
 ## Main colours
 
 If you are using GOV.UK Frontend or the GOV.UK Prototype Kit, use the [Sass
-variables](https://sass-lang.com/guide#topic-2) provided rather than copying the
+variables](https://frontend.design-system.service.gov.uk/sass-api-reference/#colours) provided rather than copying the
 hexadecimal (hex) colour values. For example, use `$govuk-brand-colour` rather
 than `{{ colours.applied['Brand colour'][0]['colour'] | trim }}`.
 This means that your service will always use the most recent colour palette


### PR DESCRIPTION
Addresses [#1304](https://github.com/alphagov/govuk-design-system/issues/1304).

### What we've changed

We've replaced a link to an external site with a link to our [Sass API Reference docs](https://frontend.design-system.service.gov.uk/sass-api-reference/).

### Why we've changed it

Three users on Slack (convo now unavailable) told us they'd had difficulty navigating to our Sass docs from the Design System site.

They also pointed out that the link from the text "[Sass variables](https://sass-lang.com/guide#topic-2)" is to Sass' own content on variables - and not, as they'd expected, to our Sass docs.