### PR TITLE
Remove email address from homepage

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -57,24 +57,11 @@ masthead: true
         <h2 id="support" class="govuk-heading-l">Support</h2>
         <p class="govuk-body">
           The GOV.UK Design System is <a class="govuk-link" href="/design-system-team">maintained by a team at the Government Digital Service</a>.
-          If you’ve got a question, idea or suggestion you can:
+          If you’ve got a question, idea or suggestion you can <a class="govuk-link" href="/get-in-touch/">contact the team</a>.
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
-        <li>
-          email
-          <a href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" class="govuk-link" data-hsupport="email">
-            govuk-design-system-support@digital.cabinet-office.gov.uk
-          </a>
-        </li>
-        <li>
-          get in touch using the
-          <a href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system" class="govuk-link" data-hsupport="slack">
-            #govuk-design-system channel on cross-government Slack</a>
-        </li>
-        <li>
-          see <a class="govuk-link" href="/community/blogs-talks-podcasts">blog posts, video talks, and podcasts about the GOV.UK Design System and Prototype Kit</a>
-        </li>
-        </ul>
+       <p class="govuk-body"> 
+        See <a class="govuk-link" href="/community/blogs-talks-podcasts">blog posts, video talks, and podcasts about the GOV.UK Design System and Prototype Kit</a>.
+</p>
       </div>
 
       <div class="govuk-grid-column-full">


### PR DESCRIPTION
Replaces email address on homepage with link to 'Get in touch' page