### PR TITLE
Add user need to Back link page

### DIFF
--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -11,6 +11,8 @@ layout: layout-pane.njk
 
 Use the back link component to help users go back to the previous page in a multi-page transaction.
 
+Although browsers have a back button, some sites break when you use it - so many users avoid it, instead of losing their progress in a service. Also, not all users are aware of the back button.
+
 {{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this component


### PR DESCRIPTION
Fixes [#1847](https://github.com/alphagov/govuk-design-system/issues/1847).

This PR tells users why they should use a back link component, even though browsers already contain a back button.