### PR TITLE
Tell users when not to use GDS Transport font

### DIFF
--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -13,9 +13,14 @@ show_page_nav: true
 
 If your service is on the service.gov.uk subdomain you must use the GDS Transport font.
 
-You should use an alternative typeface like Helvetica or Arial for services that are publicly available on different domains.
+### When not to use the GDS Transport font
 
-If you’re not sure whether you should be using GDS Transport, read the Service Manual guide on [making your service look like GOV.UK](https://www.gov.uk/service-manual/design/making-your-service-look-like-govuk) or [contact the Design System team](../../get-in-touch/).
+If your service is publicly available on a subdomain other than service.gov.uk, use an alternative typeface like Helvetica or Arial.
+
+If you’re not sure whether you should use GDS Transport, do one of the following:
+
+  - [read the 'If your service is not on GOV.UK' section on 'Making your service look like GOV.UK'](https://www.gov.uk/service-manual/design/making-your-service-look-like-govuk#if-your-service-isnt-on-govuk)
+  - [contact the Design System team](../../get-in-touch/)
 
 ## Headings
 
@@ -130,7 +135,7 @@ Make sure all users can see the links — the white links and background colour 
 
 Use the `govuk-link--no-underline` modifier class to remove underlines from links.
 
-Only do this if the context tells the user that the text is a link, even without the underline. 
+Only do this if the context tells the user that the text is a link, even without the underline.
 
 For example, links in a header or side navigation might not need underlines. Users will understand that they’re links because of where they are, at the same place, across different pages.
 


### PR DESCRIPTION
Fixes [#1076](https://github.com/alphagov/govuk-design-system/issues/1076).

### What we've added

This PR adds a 'When not to use the GDS Transport font' heading to our [Typography content](https://design-system.service.gov.uk/styles/typography/#font). It also replaces an old link with a more helpful link.

### Why we've added it

Currently, if users want to find out about restrictions, we direct them to the [Service Manual's 'Making your service look like GOV.UK' guidance](https://www.gov.uk/service-manual/design/making-your-service-look-like-govuk). However, the correct location is actually the same page's ['If your service isn't on GOV.UK' subsection](https://www.gov.uk/service-manual/design/making-your-service-look-like-govuk#if-your-service-isnt-on-govuk). Several users have struggled to find this info.