### PR TITLE
Update to govuk-frontend 3.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5515,9 +5515,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.0.tgz",
-      "integrity": "sha512-JiPCeasuHZ+9m1VyqhsfE81PhWIW4Sweoe6Jvn6oMjQNr75ZpupiytN3DGwA+WKOoESHZibIG+heAzlkdZ/MhA=="
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.1.tgz",
+      "integrity": "sha512-OlbAVVpJfZ8tEhkScVoNFA+27RUfMDslN4uxtJyASfXwg4QZYHTX8RqmKBbgVJWaybpa5RsYDuRKQNJe3qN8gw=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clipboard": "^2.0.4",
     "connect": "^3.6.6",
     "eslint": "^5.16.0",
-    "govuk-frontend": "^3.13.0",
+    "govuk-frontend": "^3.13.1",
     "gray-matter": "^4.0.2",
     "highlight.js": "^10.4.1",
     "html5shiv": "^3.7.3",


### PR DESCRIPTION
Changelog from govuk-frontend:

> Fixes
> We’ve made fixes to GOV.UK Frontend in the following pull requests:
> 
> #2264: Improve focus state for radio and checkbox controls in forced colors mode (for example, Windows High Contrast Mode) – thanks to @adamliptrot-oc for reporting this issue
> #2265: Do not remove focus outline from disabled link buttons in forced colors mode
> #2273: Fix invisible footer on Open Government Licence logo in forced colors mode – thanks to @oscarduignan for reporting this issue
> #2277: Fix invisible start button chevron in forced colors mode
> #2290: Improve support for Internet Explorer 11 with Windows High Contrast Mode
> #2306: Add max-width to file upload component
> #2312: Remove padding-right from details component