### PR TITLE
Update deploy job to use production environment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,9 @@ jobs:
 
   # Deploy the Design System to production when the main branch is changed
   # Github Actions is not involved in deploying PR or branch previews – these are handled by Netlify
+  # Only runs if the production environment protection rules are fulfilled
   deploy:
+    environment: production
     name: Deploy
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
Should close https://github.com/alphagov/design-system-team-internal/issues/446 (hopefully).

We want to make sure only merges to main can deploy to PaaS, so we've created a [GitHub Actions environment][1] that contains the production secrets with the necessary protection rules.

This commit sets the job environment to the new `production` environment, so the job can use the new secret.

[1]: https://docs.github.com/en/actions/reference/environments