### PR TITLE
fixup! Bump default Node.js to 14.17.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "standard": "^12.0.1"
   },
   "engines": {
-    "node": "14.17.0"
+    "node": "~14.17.6"
   },
   "jest": {
     "preset": "jest-puppeteer",


### PR DESCRIPTION
I missed this from #1865 :disappointed:

We need to also bump and relax the constraint on Node in the package.json file, to avoid command line warnings.