### PR TITLE
Fix error message text in equality info example

### DIFF
--- a/src/patterns/equality-information/error-date-of-birth/index.njk
+++ b/src/patterns/equality-information/error-date-of-birth/index.njk
@@ -17,7 +17,7 @@ layout: layout-example.njk
     }
   },
   errorMessage: {
-    text: "Enter a real date of birth, or leave it blank"
+    text: "Enter your date of birth or leave blank"
   },
   hint: {
     text: "For example, 31 3 1980. If you prefer not to say, continue without entering any information."


### PR DESCRIPTION
Fixes [#1867](https://github.com/alphagov/govuk-design-system/issues/1867).

This PR updates the error message's text in the 'What is your date of birth?' example on our [equality information page](https://design-system.service.gov.uk/patterns/equality-information/).

We're replacing the previous text, "Enter a real date of birth, or leave it blank," because:

- a user pointed out that any valid date would be accepted, even if it was not the user's actual date of birth
- referring to the entry boxes as "it" is vague