### PR TITLE
Explain page content in notification banner guide

### DIFF
--- a/src/components/notification-banner/index.md.njk
+++ b/src/components/notification-banner/index.md.njk
@@ -33,7 +33,7 @@ Do not use a notification banner to tell the user about validation errors (use a
 
 ## How it works
 
-Position a notification banner immediately before the page `h1`. The notification banner should be the same width as the page content.
+Position a notification banner immediately before the page `h1`. The notification banner should be the same width as the page's other content, such as components, headings and body text. For example, if the other content takes up two-thirds of the screen on desktop devices, then the notification banner should also take up two-thirds. [Read about how to lay out pages](https://design-system.service.gov.uk/styles/layout/). 
 
 Use `role ="region"` and `aria-labelledby="govuk-notification-banner-title"` (with `id="govuk-notification-banner-title"` on `<govuk-notification-banner__title>`) so that screen reader users can navigate to the notification banner.
 


### PR DESCRIPTION
Fixes [#1411](https://github.com/alphagov/govuk-design-system/issues/1411).

This PR updates our [notification banner guidance](https://design-system.service.gov.uk/components/notification-banner/) to:

- give examples of what we mean by 'page content'
- specify what we mean when we say the notification banner should be the same width as the page content
- include a link to our [layout guidance](https://design-system.service.gov.uk/styles/layout/)

We've made these changes because a user told us the previous wording was ambiguous.