### PR TITLE
Add preselected setting info to select guidance

### DIFF
--- a/src/components/select/index.md.njk
+++ b/src/components/select/index.md.njk
@@ -15,11 +15,17 @@ layout: layout-pane.njk
 
 The select component should only be used as a last resort in public-facing services because research shows that some users find selects very difficult to use.
 
-## How it works
+## When not to use this component
 
 The select component allows users to choose an option from a long list. Before using the select component, try asking users questions which will allow you to present them with fewer options.
 
 Asking questions means you’re less likely to need to use the select component, and can consider using a different solution, such as [radios](../radios/).
+
+## How it works
+
+If you use the component for settings, you can make an option pre-selected by default when users first see it.
+
+If you use the component for questions, you should not pre-select any of the options in case it influences users' answers.
 
 There are 2 ways to use the select component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com),  you can use the Nunjucks macro.
 


### PR DESCRIPTION
Fixes [#1565](https://github.com/alphagov/govuk-design-system/issues/1565).

This PR updates our [select guidance](https://design-system.service.gov.uk/components/select/) with info about the difference between select's options and the options on [radios](https://design-system.service.gov.uk/components/radios/) and [checkboxes](https://design-system.service.gov.uk/components/checkboxes/).

We've added this info because of feedback from a user. It confused them that the select examples display pre-selected options, when the radios guidance advises against pre-selection.