### PR TITLE
Link Design System site to accessibility criteria

### DIFF
--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -10,6 +10,8 @@ The GOV.UK Design System website and the codebase it uses, GOV.UK Frontend, is m
 
 This page explains how the team works to ensure the Design System and Frontend are accessible.
 
+[Read about how to test components using accessibility acceptance criteria.](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/test-components-using-accessibility-acceptance-criteria.md)
+
 ## Accessibility statement for the GOV.UK Design System website
 
 This accessibility statement applies to the GOV.UK Design System at https://design-system.service.gov.uk/, and the components and patterns from the GOV.UK Frontend codebase which appear in the examples throughout the Design System.

--- a/src/community/develop-a-component-or-pattern/index.md.njk
+++ b/src/community/develop-a-component-or-pattern/index.md.njk
@@ -19,7 +19,6 @@ After you’ve emailed them, a member of the Design System team will get in touc
 
 During the meeting, the team will help you to:
 
-
 - agree the scope of your contribution
 - plan what design, content, code and guidance needs working on
 - agree timings
@@ -30,19 +29,29 @@ If you’re happy to go ahead, the team will assign you to the issue as a contri
 
 ## Research and develop your contribution
 
-While you’re working on your contribution, the Design System team will arrange a weekly catch up to find out how you’re getting on and if you need any help. 
+While you’re working on your contribution, the Design System team will arrange a weekly catch up to find out how you’re getting on and if you need any support.
+
+The following principles will help you research and develop your contribution.
+
+### Start with what exists
 
 Find examples of the component or pattern already in use. The best way to do this is to ask the government design community on the [digital service designers mailing list](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en-GB#!forum/digital-service-designers) or the [#design channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=design).
 
 Examples and research from government services are usually most relevant. But look at how other organisations solve the problem too.
 
-Involve people from the [government design community](https://www.gov.uk/service-manual/communities/design-community) in any work you’re doing. This makes it less likely that you’ll spend time doing work or research that’s already been done. 
+### Work with the community
+
+Involve people from the [government design community](https://www.gov.uk/service-manual/communities/design-community) in any work you’re doing. This makes it less likely that you’ll spend time doing work or research that’s already been done.
 
 By finding people who are working on similar solutions, you can benefit from progress they’ve made and relevant research they’ve done.
 
 Once you have collected some examples and research findings, you should start designing a specific implementation of the component or pattern to research with.
 
-Ideally you’ll research as part of an actual service, but it’s possible to test using prototypes as long as they are realistic. Work with your own team or find a team to work with through the design community. 
+Ideally you’ll research as part of an actual service, but it’s possible to test using prototypes as long as they are realistic. Work with your own team or find a team to work with through the design community.
+
+### Test for accessibility
+
+If you're making a component, you'll also need to [make sure it's accessible by testing it against both general and specific acceptance criteria](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/test-components-using-accessibility-acceptance-criteria.md).
 
 Once you have researched the component or pattern and shown it works for users, the [Design System working group](/community/design-system-working-group/) will review it.
 
@@ -50,7 +59,7 @@ Once you have researched the component or pattern and shown it works for users, 
 
 All components and patterns must meet the [contribution criteria](/community/contribution-criteria/) before they can be published. The Design System working group will use the criteria to review your contribution.
 
-To arrange a review, tell the Design System team your contribution is ready. The team will check your work before letting the working group know it’s ready to review. 
+To arrange a review, tell the Design System team your contribution is ready. The team will check your work before letting the working group know it’s ready to review.
 
 The working group will vote if your contribution:
 
@@ -68,5 +77,3 @@ If the working group recommended some changes to make before publishing, the Des
 If the working group agree your contribution meets the criteria, the Design System team will help you get ready to publish. This includes organising any final checks or updates to the design, content, code and guidance.
 
 Most new components and patterns will be published as experimental at first. The Design System team will remove the experimental status once research proves the component or pattern meets user needs. The research must be from different services and with different types of users.
-
-


### PR DESCRIPTION
Fixes [#1798](https://github.com/alphagov/govuk-design-system/issues/1798).

This PR adds links from the Design System site to our [accessibility acceptance criteria doc](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/test-components-using-accessibility-acceptance-criteria.md).

Hopefully, these links will help contributors find the doc more easily.

We've also added some H3 headings to make the doc easier to scan.