### PR TITLE
Update backlog on website

### DIFF
--- a/src/community/backlog/index.md.njk
+++ b/src/community/backlog/index.md.njk
@@ -282,6 +282,14 @@ Here is a list of the components, patterns and updates currently on the [GOV.UK 
     </tr>
     <tr>
       <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/225">Freepost addresses</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
         <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/144">Geolocation design</a>
       </td>
       <td class="govuk-table__cell govuk-body-s" style="text-align: right">
@@ -326,6 +334,14 @@ Here is a list of the components, patterns and updates currently on the [GOV.UK 
       </td>
       <td class="govuk-table__cell govuk-body-s" style="text-align: right">
         Proposed
+      </td>
+    </tr>
+    <tr>
+      <td class="govuk-table__cell">
+        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/213">Hide this page</a>
+      </td>
+      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
+        In progress
       </td>
     </tr>
     <tr>
@@ -413,7 +429,7 @@ Here is a list of the components, patterns and updates currently on the [GOV.UK 
         <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/75">Maps</a>
       </td>
       <td class="govuk-table__cell govuk-body-s" style="text-align: right">
-        To do
+        In progress
       </td>
     </tr>
     <tr>
@@ -429,7 +445,7 @@ Here is a list of the components, patterns and updates currently on the [GOV.UK 
         <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/30">Modal dialogue</a>
       </td>
       <td class="govuk-table__cell govuk-body-s" style="text-align: right">
-        In progress
+        To do
       </td>
     </tr>
     <tr>
@@ -562,14 +578,6 @@ Here is a list of the components, patterns and updates currently on the [GOV.UK 
     </tr>
     <tr>
       <td class="govuk-table__cell">
-        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/213">Quick exit</a>
-      </td>
-      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
-        In progress
-      </td>
-    </tr>
-    <tr>
-      <td class="govuk-table__cell">
         <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/84">Recover an account</a>
       </td>
       <td class="govuk-table__cell govuk-body-s" style="text-align: right">
@@ -646,14 +654,6 @@ Here is a list of the components, patterns and updates currently on the [GOV.UK 
       </td>
       <td class="govuk-table__cell govuk-body-s" style="text-align: right">
         To do
-      </td>
-    </tr>
-    <tr>
-      <td class="govuk-table__cell">
-        <a href="https://github.com/alphagov/govuk-design-system-backlog/issues/175">Service timeout</a>
-      </td>
-      <td class="govuk-table__cell govuk-body-s" style="text-align: right">
-        Proposed
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Updated to reflect current community backlog. 

Summary of changes:
- updated status of Modal dialogue from 'in progress' to 'to do'
- updated Maps to 'in progress'
- renamed Quick exit to 'Hide this page'
- removed Service timeout as duplicate of Timeout
- added Freepost addresses