### PR TITLE
Add missing `govuk-body` classes to cookie banner 

### DIFF
--- a/src/components/cookie-banner/client-side-accepted/index.njk
+++ b/src/components/cookie-banner/client-side-accepted/index.njk
@@ -6,16 +6,16 @@ layout: layout-example.njk
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
 {% set html %}
-  <p>We use some essential cookies to make this service work.</p>
-  <p>We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+  <p class="govuk-body">We use some essential cookies to make this service work.</p>
+  <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
 {% endset %}
 
 {% set acceptHtml %}
-  <p>You’ve accepted analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You’ve accepted analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 {% set rejectHtml %}
-  <p>You’ve rejected analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You’ve rejected analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 {{ govukCookieBanner({

--- a/src/components/cookie-banner/client-side-rejected/index.njk
+++ b/src/components/cookie-banner/client-side-rejected/index.njk
@@ -6,16 +6,16 @@ layout: layout-example.njk
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
 {% set html %}
-  <p>We use some essential cookies to make this service work.</p>
-  <p>We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+  <p class="govuk-body">We use some essential cookies to make this service work.</p>
+  <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
 {% endset %}
 
 {% set acceptHtml %}
-  <p>You’ve accepted analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You’ve accepted analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 {% set rejectHtml %}
-  <p>You’ve rejected analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You’ve rejected analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 {{ govukCookieBanner({

--- a/src/components/cookie-banner/client-side/index.njk
+++ b/src/components/cookie-banner/client-side/index.njk
@@ -6,16 +6,16 @@ layout: layout-example.njk
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
 {% set html %}
-  <p>We use some essential cookies to make this service work.</p>
-  <p>We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+  <p class="govuk-body">We use some essential cookies to make this service work.</p>
+  <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
 {% endset %}
 
 {% set acceptHtml %}
-  <p>You’ve accepted analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You’ve accepted analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 {% set rejectHtml %}
-  <p>You’ve rejected analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You’ve rejected analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 {{ govukCookieBanner({

--- a/src/components/cookie-banner/default/index.njk
+++ b/src/components/cookie-banner/default/index.njk
@@ -6,8 +6,8 @@ layout: layout-example.njk
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
 {% set html %}
-  <p>We use some essential cookies to make this service work.</p>
-  <p>We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+  <p class="govuk-body">We use some essential cookies to make this service work.</p>
+  <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
 {% endset %}
 
 {{ govukCookieBanner({

--- a/src/components/cookie-banner/multiple-cookies/index.njk
+++ b/src/components/cookie-banner/multiple-cookies/index.njk
@@ -6,8 +6,8 @@ layout: layout-example.njk
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
 {% set html %}
-  <p>We use some essential cookies to make this service work.</p>
-  <p>We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
+  <p class="govuk-body">We use some essential cookies to make this service work.</p>
+  <p class="govuk-body">We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
 {% endset %}
 
 {{ govukCookieBanner({

--- a/src/components/cookie-banner/server-side-confirmation/index.njk
+++ b/src/components/cookie-banner/server-side-confirmation/index.njk
@@ -6,7 +6,7 @@ layout: layout-example.njk
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
 {% set acceptHtml %}
-  <p>You’ve accepted additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You’ve accepted additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 <form method="POST">

--- a/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
@@ -6,16 +6,16 @@ layout: layout-example.njk
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
 {% set html %}
-  <p>We use some essential cookies to make this service work.</p>
-  <p>We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
+  <p class="govuk-body">We use some essential cookies to make this service work.</p>
+  <p class="govuk-body">We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
 {% endset %}
 
 {% set acceptHtml %}
-  <p>You’ve accepted additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You’ve accepted additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 {% set rejectedHtml %}
-  <p>You’ve rejected additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You’ve rejected additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 <form method="POST">

--- a/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
@@ -6,16 +6,16 @@ layout: layout-example.njk
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
 {% set html %}
-  <p>We use some essential cookies to make this service work.</p>
-  <p>We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
+  <p class="govuk-body">We use some essential cookies to make this service work.</p>
+  <p class="govuk-body">We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
 {% endset %}
 
 {% set acceptHtml %}
-  <p>You’ve accepted additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You’ve accepted additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 {% set rejectedHtml %}
-  <p>You’ve rejected additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You’ve rejected additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 <form method="POST">

--- a/src/components/cookie-banner/server-side/index.njk
+++ b/src/components/cookie-banner/server-side/index.njk
@@ -6,8 +6,8 @@ layout: layout-example.njk
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
 {% set html %}
-  <p>We use some essential cookies to make this service work.</p>
-  <p>We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
+  <p class="govuk-body">We use some essential cookies to make this service work.</p>
+  <p class="govuk-body">We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
 {% endset %}
 
 <form method="POST">

--- a/views/partials/_cookie-banner.njk
+++ b/views/partials/_cookie-banner.njk
@@ -1,16 +1,16 @@
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
 {% set html %}
-  <p>We’d like to use analytics cookies so we can understand how you use the Design System and make improvements.</p>
-  <p>We also use essential cookies to remember if you’ve accepted analytics cookies.</p>
+  <p class="govuk-body">We’d like to use analytics cookies so we can understand how you use the Design System and make improvements.</p>
+  <p class="govuk-body">We also use essential cookies to remember if you’ve accepted analytics cookies.</p>
 {% endset %}
 
 {% set acceptHtml %}
-  <p>You’ve accepted analytics cookies. You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You’ve accepted analytics cookies. You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 {% set rejectHtml %}
-  <p>You’ve rejected analytics cookies. You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You’ve rejected analytics cookies. You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 {{ govukCookieBanner({


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-design-system/issues/1886

## What
Adds missing `govuk-body` classes to the design system cookie banner and the component examples.

## Why
Previously we were relying on default colour and margins for the text content within the cookie banner, when html was passed to the banner. In the yaml examples in govuk-frontend, we assume a user will add govuk-body classes to any html they pass in. However, this was missed when adding the cookie banner to the design system site and when implementing the examples shown in the cookie banner component guidance.

## Notes
Adding the `govuk-body` class is an easy thing to miss because the cookie banner component adds some default text styling. We could remove this default styling to make it more obvious if a user forgets to add the `govuk-body` class, but this would be a breaking change so we should do this as a separate piece of work in v4.0.0.

## Before
<img width="796" alt="Screenshot 2021-09-21 at 15 04 08" src="https://user-images.githubusercontent.com/29889908/134185591-889c12b8-d932-4ad7-9fa4-0026f0eaccb6.png">

## After
<img width="860" alt="Screenshot 2021-09-21 at 15 04 57" src="https://user-images.githubusercontent.com/29889908/134185615-5ced7ccd-d151-458f-9dfc-f0de15140ced.png">
