### PR TITLE
Update Images guidance and example of alt text

### DIFF
--- a/src/styles/images/index.md.njk
+++ b/src/styles/images/index.md.njk
@@ -28,6 +28,8 @@ If your image represents something physical, such as a letter, document or credi
 
 ## Alternative text
 
+This guidance is for government teams that build online services. [To learn about publishing alternative text in GOV.UK mainstream content, go to GOV.UK's 'Images' guidance.](https://www.gov.uk/guidance/content-design/images)
+
 Alternative text, or alt text, is read out by screen readers or displayed if an image does not load or if images have been switched off.
 
 All images, except decorative images, must have alt text that:


### PR DESCRIPTION
Fixes [#1887](https://github.com/alphagov/govuk-design-system/issues/1887).

This PR updates our [Images guidance's section about alt text](https://design-system.service.gov.uk/styles/images/#alternative-text) to specify:

- who our guidance is for
- redirect users who want guidance about publishing mainstream content on GOV.UK

We've suggested these changes because our Images guidance did not mirror the [recently updated GDS guidance on alt text](https://www.gov.uk/guidance/content-design/images#alt-text)