### PR TITLE
Fix wording in check answers pattern example

### DIFF
--- a/src/patterns/check-answers/default/index.njk
+++ b/src/patterns/check-answers/default/index.njk
@@ -177,7 +177,7 @@ layout: layout-example-full-page.njk
 
       <h2 class="govuk-heading-m">Now send your application</h2>
 
-      <p class="govuk-body">By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>
+      <p class="govuk-body">By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>
 
       <form action="/form-handler" method="post" novalidate>
 


### PR DESCRIPTION
This PR replaces the word 'notification' with 'application' in the example on our [check answers page](https://design-system.service.gov.uk/patterns/check-answers/).