### PR TITLE
Make layout names consistent

### DIFF
--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -13,7 +13,7 @@ show_page_nav: true
 
 Design for small screens first, starting with a single-column layout.
 
-For most types of page, we recommend using either a 'two-thirds' or a 'two-thirds and one third layout'. That stops lines of text getting so long that the page becomes difficult to read on desktop devices. This would usually mean no more than 75 characters per line.
+For most types of page, we recommend using either a 'two-thirds' or a 'two-thirds / one-third' layout. That stops lines of text getting so long that the page becomes difficult to read on desktop devices. This would usually mean no more than 75 characters per line.
 
 Never make assumptions about what devices people are using. Design for different screen sizes rather than specific devices.
 


### PR DESCRIPTION
Updated 'two-thirds and one-third' to 'two-thirds / one-third' to make it consistent with how the layout is named on the rest of the page.
Moved "layout" out of the quotes because it applies to both options, not just the second one