### PR TITLE
Add guidance for text align override classes

### DIFF
--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -70,6 +70,15 @@ The majority of your body copy should use the standard 19px paragraph size.
 
 {{ example({group: "styles", item: "typography", example: "small", html: true, open: true}) }}
 
+## Text alignment override classes
+
+If you need to align text differently to how it usually displays on the page, you can use text alignment override classes.
+
+Use:
+- `govuk-!-text-align-left` to align text to the left
+- `govuk-!-text-align-right` to align text to the right
+- `govuk-!-text-align-centre` to align text to the centre
+
 ## Font override classes
 
 You might need to set the font size or font weight of an element outside of the predefined heading and paragraph classes. For this you can use the font override classes in your HTML or reference the typography mixins in your own components.


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-design-system/issues/1863

Add guidance for newly-added text override classes in Frontend: https://github.com/alphagov/govuk-frontend/pull/2339

Co-authored-by: @hannalaakso 