### PR TITLE
Add heading text info to Panel guidance

### DIFF
--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -28,3 +28,11 @@ Never use the panel component to highlight important information within body con
 There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
+
+### How to write heading text
+
+Keep your heading text brief, as it's only meant for a high-level explanation of what has happened. For example, 'Application complete'.
+
+If you can, use shorter words instead of longer ones. Shorter words are less likely to wrap around the panel, which can happen when users on mobile zoom in.
+
+If you need to give detailed information, or more context, use the description text under the heading text.


### PR DESCRIPTION
Fixes [#1901](https://github.com/alphagov/govuk-design-system/issues/1901).

This PR adds content about heading text to our [Panel guidance](https://design-system.service.gov.uk/components/panel/).

We're adding this info to help users keep their heading text punchy. If they use long words, it could result in the text 'wrapping' to avoid overflowing its container.