### PR TITLE
Add info about when to add 'optional' to legend

### DIFF
--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -22,7 +22,12 @@ You should make sure you know why you’re asking every question and only ask us
 
 To help you work out what to ask, you can carry out a [question protocol](https://www.uxmatters.com/mt/archives/2010/06/the-question-protocol-how-to-make-sure-every-form-field-is-necessary.php).
 
-If you ask for optional information, mark the labels of optional fields with ‘(optional)’. Never mark mandatory fields with asterisks.
+If you ask for optional information:
+
+- in most contexts, add ‘(optional)’ to the labels of optional fields
+- for [radios](/components/radios/) and [checkboxes](/components/checkboxes/), add ‘(optional)’ to the legend
+
+Never mark mandatory fields with asterisks.
 
 On every question page you should:
 


### PR DESCRIPTION
Fixes [#1726](https://github.com/alphagov/govuk-design-system/issues/1726).

This PR adds content to our [question pages pattern](https://design-system.service.gov.uk/patterns/question-pages/).

We're adding this content because of a user-reported issue. The current wording suggests that, in contexts where a whole question is optional, users need to mark each label as ‘(optional)’. However, it's the legend they need to mark.