### PR TITLE
Add archive banner

### DIFF
--- a/views/partials/_banner.njk
+++ b/views/partials/_banner.njk
@@ -5,14 +5,10 @@
 {% endif %}
 
 <div class="app-phase-banner__wrapper">
-{% if PULL_REQUEST %}
+{% if PULL_REQUEST === "true" %}
   {% set phaseBannerText %}
     This is a preview of
-    {% if REVIEW_ID %}
-      a <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/pull/{{ REVIEW_ID  }}">proposed change</a> to the
-    {% else %}
-      the <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/tree/{{ BRANCH }}">{{ BRANCH }}</a> branch for the
-    {% endif %}
+    a <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/pull/{{ REVIEW_ID  }}">proposed change</a> to the
     <a class="govuk-link" href="https://design-system.service.gov.uk">Design System</a>.
   {% endset %}
 
@@ -24,13 +20,28 @@
     "classes": phaseBannerClasses,
     "html": phaseBannerText
   }) }}
-{% else %}
-    {{ govukPhaseBanner({
-      "tag": {
-        "text": "beta"
-      },
-      "classes": phaseBannerClasses,
-      "html": "This is a new service – your <a class=\"govuk-link\" href=\"/get-in-touch\">feedback</a> will help us to improve it."
-    }) }}
-  {% endif %}
+{% elif PULL_REQUEST === "false" %}
+  {% set phaseBannerText %}
+    This is an archived version of
+    the <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/tree/{{ BRANCH }}">{{ BRANCH }}</a> branch for the
+    <a class="govuk-link" href="https://design-system.service.gov.uk">Design System</a>.
+  {% endset %}
+
+  {{ govukPhaseBanner({
+    "tag": {
+      "text": "archive",
+      "classes": "app-tag--review"
+    },
+    "classes": phaseBannerClasses,
+    "html": phaseBannerText
+  }) }}
+{% else %} {# in production the envvar PULL_REQUEST is not set #}
+  {{ govukPhaseBanner({
+    "tag": {
+      "text": "beta"
+    },
+    "classes": phaseBannerClasses,
+    "html": "This is a new service – your <a class=\"govuk-link\" href=\"/get-in-touch\">feedback</a> will help us to improve it."
+  }) }}
+{% endif %}
 </div>


### PR DESCRIPTION
Part of https://github.com/alphagov/design-system-team-internal/issues/332.

We want it to be clear to users that when they visit v2--govuk-design-system-preview.netlify.com (or 'v3--' etc.) that what they are seeing is an old version of the Design System website.

This commit changes the phase banner for [Netlify branch deploys][1] to state that the website is an archive (rather than a preview).

Note that this applies to all branch deploys, so it might potentially cover branches that are for pull requests, but I think we only usually share branch deploys for old versions of the website.

[1]: https://docs.netlify.com/site-deploys/overview/

### Screenshot

<img width="799" alt="Screenshot 2021-09-28 at 17 35 28" src="https://user-images.githubusercontent.com/503614/135128844-d4862c2c-e503-4bb3-87ff-34863e246512.png">


