### PR TITLE
Link Design System repo README to security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,9 @@ interface.
 
 - [How the Design System is deployed to production](docs/deployment/production.md)
 - [How branch and PR previews are deployed](docs/deployment/previews.md)
+
+## Security
+
+GDS is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, we would like to know so we can fix it.
+
+To learn how to report a security vulnerability, [see our security policy](https://github.com/alphagov/govuk-design-system/security/policy).


### PR DESCRIPTION
Partly addresses [#1692](https://github.com/alphagov/govuk-design-system/issues/1692).

This PR updates the [repo README](https://github.com/alphagov/govuk-design-system/blob/main/README.md) with info and link text for our [security policy](https://github.com/alphagov/govuk-design-system/security/policy).

Hopefully this will make the security policy more visible to researchers who want to report vulnerabilities.