### PR TITLE
Update What's New message on DS homepage

### DIFF
--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -6,8 +6,8 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
-        <p class="govuk-body">6 September 2021: We’ve released GOV.UK Frontend v3.13.1. This ‘fix release’ contains bug fixes and minor visual improvements, particularly for users in forced colors mode and high contrast mode. <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v3.13.1" class="govuk-link">Read the release notes to see what’s changed.</a>
-        </p>
+        <p class="govuk-body">4 October 2021: We’ve released GOV.UK Frontend v3.14.0. This ‘feature release’ contains new override classes for text alignment and a better way to add negative spacing using the <code>govuk-spacing</code> Sass function.</p>
+        <p class="govuk-body"><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v3.14.0" class="govuk-link">Read the release notes to see what’s changed</a>.</p>
         <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design System</a>.</p>
       </div>
     </div>


### PR DESCRIPTION
Partly addresses [#2363](https://github.com/alphagov/govuk-frontend/issues/2363).

This PR updates the ['What's New' message on the Design System homepage](https://design-system.service.gov.uk/#:~:text=Get%20started-,What%E2%80%99s%20new).

It adds info about the contents of our v3.14.0 release of GOV.UK Frontend.