### PR TITLE
Updating the hint text on the "Date Input" examples to match the "Dates" pattern guidance

### DIFF
--- a/src/components/date-input/default/index.njk
+++ b/src/components/date-input/default/index.njk
@@ -16,6 +16,6 @@ layout: layout-example.njk
     }
   },
   hint: {
-    text: "For example, 12 11 2007"
+    text: "For example, 27 3 2007"
   }
 }) }}

--- a/src/components/date-input/error/index.njk
+++ b/src/components/date-input/error/index.njk
@@ -16,7 +16,7 @@ layout: layout-example.njk
     }
   },
   hint: {
-    text: "For example, 12 11 2007"
+    text: "For example, 27 3 2007"
   },
   errorMessage: {
     text: "The date your passport was issued must be in the past"

--- a/src/components/date-input/without-heading/index.njk
+++ b/src/components/date-input/without-heading/index.njk
@@ -14,6 +14,6 @@ layout: layout-example.njk
     }
   },
   hint: {
-    text: "For example, 12 11 2007"
+    text: "For example, 27 3 2007"
   }
 }) }}

--- a/src/components/error-message/default/index.njk
+++ b/src/components/error-message/default/index.njk
@@ -14,7 +14,7 @@ layout: layout-example.njk
     }
   },
   hint: {
-    text: "For example, 12 11 2007"
+    text: "For example, 27 3 2007"
   },
   errorMessage: {
     text: "The date your passport was issued must be in the past"


### PR DESCRIPTION
The "Dates" pattern gives specific guidance about giving user example dates: https://design-system.service.gov.uk/patterns/dates/#how-to-write-dates

However I noticed that the examples on the 'Date Input' component don't follow that guidance, so this PR updates the examples to match the guidance from the pattern.