### PR TITLE
Cache npm dependencies between builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,10 @@ jobs:
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
 
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm install --no-optional


### PR DESCRIPTION
Use the built-in functionality provided by the setup-node GitHub Action[^1] to cache and restore dependencies.

This will enable quicker builds[^2] by caching the node_modules folder between builds, as long as the package-lock.json file hasn't changed (a hash of the file is used as part of the cache key).

[^1]: https://github.com/actions/setup-node#caching-packages-dependencies
[^2]: https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows