### PR TITLE
Only save build folder as artifact if deploying

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
       # Upload the deploy folder as an artifact so it can be downloaded and used in the deploy job
       - name: Upload artifact
         uses: actions/upload-artifact@v2
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
             name: build
             path: deploy/**


### PR DESCRIPTION
We currently upload the build folder as an artifact as the last step of every successful build, so that we can use it in the deploy job.

However, the deploy job only happens if the build is running against the main branch.

We can therefore save some time for builds for pull requests and branches other than main [^1] by applying the same if condition to the step, so we only upload the build folder if we expect to be running the deploy job.

[^1]: a quick scan of the last few builds shows that uploading the artifact seems to take about 15-35 seconds, out of a total build time of 1m 30s - 2m 30s, so we'd expect to see a 15-20% reduction in build times.