### PR TITLE
Update phase banner for v2 deploy

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -1,9 +1,11 @@
 ---
 title: Home
 description: Design your service using GOV.UK styles, components and patterns
+masthead: true
 ---
 
 {% include "_masthead.njk" %}
+
 <div class="govuk-width-container app-site-width-container">
   <div class="govuk-main-wrapper govuk-main-wrapper--l">
     <div class="govuk-grid-row">

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -10,3 +10,7 @@
     border-bottom: 0;
   }
 }
+
+.app-phase-banner--no-border {
+  border-bottom: 0;
+}

--- a/views/partials/_banner.njk
+++ b/views/partials/_banner.njk
@@ -5,14 +5,10 @@
 {% endif %}
 
 <div class="app-phase-banner__wrapper">
-{% if PULL_REQUEST %}
+{% if PULL_REQUEST === "true" %}
   {% set phaseBannerText %}
     This is a preview of
-    {% if REVIEW_ID %}
-      a <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/pull/{{ REVIEW_ID  }}">proposed change</a> to the
-    {% else %}
-      the <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/tree/{{ BRANCH }}">{{ BRANCH }}</a> branch for the
-    {% endif %}
+    a <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/pull/{{ REVIEW_ID  }}">proposed change</a> to the
     <a class="govuk-link" href="https://design-system.service.gov.uk">Design System</a>.
   {% endset %}
 
@@ -24,13 +20,28 @@
     "classes": phaseBannerClasses,
     "html": phaseBannerText
   }) }}
-{% else %}
-    {{ govukPhaseBanner({
-      "tag": {
-        "text": "beta"
-      },
-      "classes": phaseBannerClasses,
-      "html": "This is a new service – your <a class=\"govuk-link\" href=\"/get-in-touch\">feedback</a> will help us to improve it."
-    }) }}
-  {% endif %}
+{% elif PULL_REQUEST === "false" %}
+  {% set phaseBannerText %}
+    This is an archived version of
+    the <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/tree/{{ BRANCH }}">{{ BRANCH }}</a> branch for the
+    <a class="govuk-link" href="https://design-system.service.gov.uk">Design System</a>.
+  {% endset %}
+
+  {{ govukPhaseBanner({
+    "tag": {
+      "text": "archive",
+      "classes": "app-tag--review"
+    },
+    "classes": phaseBannerClasses,
+    "html": phaseBannerText
+  }) }}
+{% else %} {# in production the envvar PULL_REQUEST is not set #}
+  {{ govukPhaseBanner({
+    "tag": {
+      "text": "beta"
+    },
+    "classes": phaseBannerClasses,
+    "html": "This is a new service – your <a class=\"govuk-link\" href=\"/get-in-touch\">feedback</a> will help us to improve it."
+  }) }}
+{% endif %}
 </div>

--- a/views/partials/_banner.njk
+++ b/views/partials/_banner.njk
@@ -1,4 +1,9 @@
 {% from "phase-banner/macro.njk" import govukPhaseBanner %}
+{% set phaseBannerClasses = "app-phase-banner govuk-width-container" %}
+{% if masthead %}
+  {% set phaseBannerClasses = phaseBannerClasses + " app-phase-banner--no-border" %}
+{% endif %}
+
 <div class="app-phase-banner__wrapper">
 {% if PULL_REQUEST %}
   {% set phaseBannerText %}
@@ -16,7 +21,7 @@
       "text": "preview",
       "classes": "app-tag--review"
     },
-    "classes": "app-phase-banner govuk-width-container",
+    "classes": phaseBannerClasses,
     "html": phaseBannerText
   }) }}
 {% else %}
@@ -24,7 +29,7 @@
       "tag": {
         "text": "beta"
       },
-      "classes": "app-phase-banner govuk-width-container",
+      "classes": phaseBannerClasses,
       "html": "This is a new service – your <a class=\"govuk-link\" href=\"/get-in-touch\">feedback</a> will help us to improve it."
     }) }}
   {% endif %}


### PR DESCRIPTION
Pulls in changes to phase banner from main branch, so that the v2 deployment uses the new archive banner from https://github.com/alphagov/design-system-team-internal/issues/332.