### PR TITLE
Update to GOV.UK Frontend 3.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4935,9 +4935,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.1.tgz",
-      "integrity": "sha512-OlbAVVpJfZ8tEhkScVoNFA+27RUfMDslN4uxtJyASfXwg4QZYHTX8RqmKBbgVJWaybpa5RsYDuRKQNJe3qN8gw=="
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
+      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clipboard": "^2.0.4",
     "connect": "^3.6.6",
     "eslint": "^5.16.0",
-    "govuk-frontend": "^3.13.1",
+    "govuk-frontend": "^3.14.0",
     "gray-matter": "^4.0.2",
     "highlight.js": "^10.4.1",
     "html5shiv": "^3.7.3",


### PR DESCRIPTION
### New features

#### Set text alignment with override classes

You can now use the `govuk-!-text-align-left`, `govuk-!-text-align-centre` and `govuk-!-text-align-right` CSS classes to set text alignment on elements.

This was added in [pull request #2368: Add `text-align` override classes](https://github.com/alphagov/govuk-frontend/pull/2368). Thanks to [Ed Horsford](https://github.com/edwardhorsford) for reporting this issue.

#### Define negative spacing using the `govuk-spacing` function

You can now pass the negative equivalent of a point from the spacing scale to the `govuk-spacing` function to get negative spacing.

For example, `govuk-spacing(1)` returns `5px`, and `govuk-spacing(-1)` returns `-5px`.

This was added in [pull request #2367: Allow `govuk-spacing` to output negative spacing](https://github.com/alphagov/govuk-frontend/pull/2367). Thanks to [Chris Hill-Scott](https://github.com/quis) for reporting this issue.

### Fixes

- [#2366: Prevent panel text overflowing when zoomed in on mobile](https://github.com/alphagov/govuk-frontend/pull/2366) - thanks to [Phil Sherry](https://github.com/philsherry) for reporting this issue.