### PR TITLE
Update accessibility statement to reflect TDT fix

### DIFF
--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -44,7 +44,7 @@ GDS is committed to making its websites accessible, in accordance with the Publi
 
 The Design System website at [https://design-system.service.gov.uk/](/) is partially compliant with the Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard, due to the non-compliances listed below.
 
-The GOV.UK Frontend documentation website at [http://frontend.design-system.service.gov.uk/](https://frontend.design-system.service.gov.uk/) is partially compliant with the WCAG 2.1 AA standard. We know some parts of this website are not fully accessible as there are issues caused by our Technical Documentation Template.
+The GOV.UK Frontend documentation website at [http://frontend.design-system.service.gov.uk/](https://frontend.design-system.service.gov.uk/) is fully compliant with the WCAG 2.1 AA standard.
 
 ### Non-accessible content
 
@@ -57,10 +57,6 @@ The Design System website at [https://design-system.service.gov.uk/](/) is parti
 - the section headings in accordions can be mistaken for links, but are treated as buttons - this fails [WCAG 2.1 success criterion 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
 
 We plan to fix this accessibility issue by 31 December 2021.
-
-The GOV.UK Frontend documentation website at http://frontend.design-system.service.gov.uk/ is partially compliant because of [an issue caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
-
-We plan to fix this issue by 30 September 2021.
 
 ### How this website has been tested for accessibility
 


### PR DESCRIPTION
This PR removes outdated content from our [accessibility statement](https://design-system.service.gov.uk/accessibility/).

The [new release of the Tech Docs Gem](https://github.com/alphagov/tech-docs-gem/releases/tag/v3.0.0) fixes a [Tech Docs Template](https://tdt-documentation.london.cloudapps.digital/#technical-documentation-template) issue with search results.

This means our [Frontend docs site](https://frontend.design-system.service.gov.uk/) is now fully compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/) AA.