### PR TITLE
Moved relevant content from "How it works" into "When not to use"

### DIFF
--- a/src/components/notification-banner/index.md.njk
+++ b/src/components/notification-banner/index.md.njk
@@ -31,6 +31,8 @@ If the information is directly relevant to the thing the user is doing on that p
 
 Do not use a notification banner to tell the user about validation errors (use an [error message](/components/error-message/) and [error summary](/components/error-summary/) instead).
 
+Do not show a notification banner and an [error summary](/components/error-summary/) on the same page. Show the error summary instead of the notification banner.
+
 ## How it works
 
 Position a notification banner immediately before the page `h1`. The notification banner should be the same width as the page's other content, such as components, headings and body text. For example, if the other content takes up two-thirds of the screen on desktop devices, then the notification banner should also take up two-thirds. [Read about how to lay out pages](https://design-system.service.gov.uk/styles/layout/). 
@@ -38,8 +40,6 @@ Position a notification banner immediately before the page `h1`. The notificatio
 Use `role ="region"` and `aria-labelledby="govuk-notification-banner-title"` (with `id="govuk-notification-banner-title"` on `<govuk-notification-banner__title>`) so that screen reader users can navigate to the notification banner.
 
 Avoid showing more than one notification banner on the same page. Instead, combine the messages in a single notification banner. If the messages are too different to combine, only show the highest priority notification banner.
-
-Do not show a notification banner and an [error summary](/components/error-summary/) on the same page. Show the error summary instead of the notification banner.
 
 ### Notification banner headings
 


### PR DESCRIPTION
Moved one line of content from under "How it works" to "When not to use this component" as it is an instruction of when not to use the component.
I had missed this when reviewing the use of the Notification Banner component, and had advised to show both notification banner and error summary on the same page.
Thankfully it was caught in review, and I think this change would help to make the guidance clearer.