### PR TITLE
Fix positioning of code highlighting to exclude 'class'

### DIFF
--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -56,7 +56,7 @@ Within `govuk-width-container` you should add the `govuk-main-wrapper` class to 
 If you’re not using the [breadcrumbs](../../components/breadcrumbs), [back link](../../components/back-link) or [phase banner](../../components/phase-banner) components in your design, add the correct amount of vertical padding above the content by adding one of the following to your `<main>` element:
 
 - the `govuk-main-wrapper--auto-spacing` class
-- the `govuk-main-wrapper--l class` - if `govuk-main-wrapper--auto-spacing` does not work for your service
+- the `govuk-main-wrapper--l` class - if `govuk-main-wrapper--auto-spacing` does not work for your service
 
 ### Exploded view of page wrappers
 


### PR DESCRIPTION
Noticed this while working on https://github.com/alphagov/govuk-frontend/issues/1379 , but this doesn't need to wait for v4.0.0 - just a small tidy-up.

The current guidance for `govuk-main-wrapper--l` is highlighting 'class' as if it is code. This PR moves the code highlighting so it only applies to the class itself.

## Before
<img width="698" alt="Screenshot 2021-10-15 at 13 53 23" src="https://user-images.githubusercontent.com/29889908/137489882-225fb554-a722-4e1f-9fa2-f4ebedf41cfb.png">

## After
<img width="680" alt="Screenshot 2021-10-15 at 13 57 13" src="https://user-images.githubusercontent.com/29889908/137490399-0d73ce16-0af5-4141-a309-c585a1c6092f.png">
