### PR TITLE
Remove mention of triage from community documentation

### DIFF
--- a/src/community/propose-a-content-change-using-github/index.md.njk
+++ b/src/community/propose-a-content-change-using-github/index.md.njk
@@ -80,7 +80,7 @@ Once you’re happy, select ‘create pull request’.
 
 ## 6. Wait for the team to review your pull request
 
-The GOV.UK Design System team will be notified of your suggestion and will review it at their next triage session, which happens every Wednesday.
+The GOV.UK Design System team will be notified of your suggestion and will review it.
 
 The team will either:
 


### PR DESCRIPTION
The GOV.UK Design System team no longer has weekly triage sessions.