### PR TITLE
Delete bullet from equality information pattern

### DIFF
--- a/src/patterns/equality-information/index.md.njk
+++ b/src/patterns/equality-information/index.md.njk
@@ -36,7 +36,6 @@ For a service that people are likely to use on a one-off basis:
 
 - place equality questions between the [‘check your answers’ page](/patterns/check-answers/) and the [confirmation page](/patterns/confirmation-pages/)
 - show the user a screen explaining why you’re asking the questions and what you’ll do with the information they provide, like the one below
-- on the ‘check your answers’ screen, group answers together under an ‘Optional equality questions’ heading
 
 {{ example({group: "patterns", item: "equality-information", example: "explainer-screen", html: true, nunjucks: true, open: false}) }}
 


### PR DESCRIPTION
This PR deletes the following bullet from our [equality information guidance](https://design-system.service.gov.uk/patterns/equality-information/#:~:text=Where%20to%20place%20equality%20questions):

> on the ‘check your answers’ screen, group answers together under an ‘Optional equality questions’ heading

We're deleting it because it clashes with a previous bullet in the same list:

> place equality questions between the ‘check your answers’ page and the confirmation page

For more detail, see the [equality information discussion in the backlog](https://github.com/alphagov/govuk-design-system-backlog/issues/180#issuecomment-945820915).