### PR TITLE
Add CI workflow step to prevent deployment of old code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,26 @@ jobs:
       CF_SPACE: "design-system"
 
     steps:
+      - name: Pre-deploy checks
+        uses: actions/github-script@v5
+        with:
+          script: |
+
+            // Check that the code to be deployed is the latest code on the branch on GitHub
+            // If you want to rollback changes to prod, consider using a revert commit to main
+            //
+            const response = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/heads/main',
+            });
+            const mainBranchCommitSha = response.data.sha
+
+            if (context.sha !== mainBranchCommitSha) {
+              core.info(`Workflow run GITHUB_SHA ${context.sha} does not match main branch commit sha ${mainBranchCommitSha}`)
+              core.error('Code to deploy does not match code in main branch')
+              core.setFailed('Refusing to deploy, please do not re-run this workflow run')
+            }
       - uses: actions/checkout@v2
 
       - name: Download build artifact


### PR DESCRIPTION
We want to prevent against the GitHub Actions CI workflow being run in a circumstance that would result in old/stale/out-of-date code being deployed to production (such as happened with https://github.com/alphagov/design-system-team-internal/issues/527).

This commit adds a new job to the workflow that must complete before a deploy can take place. It contains a single step currently, which uses JavaScript to check the commit sha of the code that would be deployed against the most recent commit sha of the main branch. If this check fails, the user who started the workflow run will be notified of the failure, but we add a warning and a message explaining what has happened and asking them not to try re-running (otherwise they might end up trying to re-run it lots of times).

You can see what this error message looks like by viewing the workflow run https://github.com/alphagov/govuk-design-system/actions/runs/1412473614.

<img width="1388" alt="Screenshot of CI Workflow run #1930" src="https://user-images.githubusercontent.com/503614/138238072-765f9ee4-9e3a-4bfb-9bcc-3c95ed82e0e5.png">

I simulated a bad deploy by lines 50 and 54 from the workflow file.

Closes https://github.com/alphagov/govuk-design-system/issues/1946.