### PR TITLE
Tell users when to change back link default text

### DIFF
--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -39,4 +39,4 @@ There are 2 ways to use the back link component. You can use HTML or, if you are
 
 Using the default link text ('Back') is ideal for services with a simple journey. For example, [applying for a National Insurance number](https://www.gov.uk/apply-national-insurance-number). Users will only ever go back to the previous page in the service.
 
-For more complex user journeys consider using different link text, like 'Return to [page]'. For example, in an admin system with many different areas. In this case, if you used 'Back', it might not be clear to users what they are going back to.
+For more complex user journeys, consider using different link text, like 'Return to [page]'. For example, in an admin system with many different areas. In this case, if you used 'Back', it might not be clear to users what they are going back to.

--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -39,4 +39,4 @@ There are 2 ways to use the back link component. You can use HTML or, if you are
 
 Using the default link text ('Back') is ideal for services with a simple journey. For example, [applying for a National Insurance number](https://www.gov.uk/apply-national-insurance-number). Users will only ever go back to the previous page in the service.
 
-For more complex user journeys, consider using different link text, like 'Return to [page]'. For example, [users who are starting a business need to navigate multiple services](https://insidegovuk.blog.gov.uk/2021/04/28/scoping-the-starting-and-sustaining-a-business-whole-user-journey/). In this case, if you used 'Back', it might not be clear to users what they are going back to.
+For more complex user journeys consider using different link text, like 'Return to [page]'. For example, in an admin system with many different areas. In this case, if you used 'Back', it might not be clear to users what they are going back to.

--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -17,13 +17,17 @@ Although browsers have a back button, some sites break when you use it - so many
 
 ## When to use this component
 
+Back links are ideal for services that users interact with on a one-off basis.
+
 Always include the back link component on GOV.UK [question pages](../../patterns/question-pages).
 
 You can include a back link on other pages within a multi-page transaction, if it makes sense to do so.
 
 ## When not to use this component
 
-Never use the back link component together with [breadcrumbs](../breadcrumbs). If necessary, you should do research with your users to learn which they find more helpful in your service.
+If a service allows users to interact with it multiple times, use [breadcrumbs](../breadcrumbs) instead.
+
+Never use the back link component together with breadcrumbs. If necessary, you should do research with your users to learn which they find more helpful in your service.
 
 ## How it works
 
@@ -32,6 +36,8 @@ Always place back links at the top of a page, before the `<main>` element. Placi
 Make sure the link takes users to the previous page they were on, in the state they last saw it. Where possible, ensure it works even when JavaScript is not available.
 
 If this is not possible, you should hide the back link when JavaScript is not available.
+
+If it helps users get to where they need to be, you can change the default 'back' text. For example, if your service contains a central page that links to other pages, you could use the words 'Return to'.
 
 There are 2 ways to use the back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 

--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -17,17 +17,13 @@ Although browsers have a back button, some sites break when you use it - so many
 
 ## When to use this component
 
-Back links are ideal for services that users interact with on a one-off basis.
-
 Always include the back link component on GOV.UK [question pages](../../patterns/question-pages).
 
 You can include a back link on other pages within a multi-page transaction, if it makes sense to do so.
 
 ## When not to use this component
 
-If a service allows users to interact with it multiple times, use [breadcrumbs](../breadcrumbs) instead.
-
-Never use the back link component together with breadcrumbs. If necessary, you should do research with your users to learn which they find more helpful in your service.
+Never use the back link component together with [breadcrumbs](../breadcrumbs). If necessary, you should do research with your users to learn which they find more helpful in your service.
 
 ## How it works
 
@@ -42,3 +38,7 @@ If it helps users get to where they need to be, you can change the default 'back
 There are 2 ways to use the back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
+
+Using the default link text ('Back') is ideal for services that only contain one 'journey'. For example, [applying for a National Insurance number](https://www.gov.uk/apply-national-insurance-number). This is because users will only ever go back to the previous page in the service.
+
+For more complex user journeys, consider using different link text, like 'Return to [page]'. For example, [users who are starting a business need to navigate multiple services](https://insidegovuk.blog.gov.uk/2021/04/28/scoping-the-starting-and-sustaining-a-business-whole-user-journey/). In this case, if you used 'Back', it might not be clear to users what they are going back to.

--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -33,8 +33,6 @@ Make sure the link takes users to the previous page they were on, in the state t
 
 If this is not possible, you should hide the back link when JavaScript is not available.
 
-If it helps users get to where they need to be, you can change the default 'back' text. For example, if your service contains a central page that links to other pages, you could use the words 'Return to'.
-
 There are 2 ways to use the back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}

--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -37,6 +37,6 @@ There are 2 ways to use the back link component. You can use HTML or, if you are
 
 {{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
-Using the default link text ('Back') is ideal for services that only contain one 'journey'. For example, [applying for a National Insurance number](https://www.gov.uk/apply-national-insurance-number). This is because users will only ever go back to the previous page in the service.
+Using the default link text ('Back') is ideal for services with a simple journey. For example, [applying for a National Insurance number](https://www.gov.uk/apply-national-insurance-number). Users will only ever go back to the previous page in the service.
 
 For more complex user journeys, consider using different link text, like 'Return to [page]'. For example, [users who are starting a business need to navigate multiple services](https://insidegovuk.blog.gov.uk/2021/04/28/scoping-the-starting-and-sustaining-a-business-whole-user-journey/). In this case, if you used 'Back', it might not be clear to users what they are going back to.

--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -39,4 +39,4 @@ There are 2 ways to use the back link component. You can use HTML or, if you are
 
 Using the default link text ('Back') is ideal for services with a simple journey. For example, [applying for a National Insurance number](https://www.gov.uk/apply-national-insurance-number). Users will only ever go back to the previous page in the service.
 
-For more complex user journeys, consider using different link text, like 'Return to [page]'. For example, in an admin system with many different areas. In this case, if you used 'Back', it might not be clear to users what they are going back to.
+For more complex user journeys, consider using different link text, like 'Go back to [page]'. For example, in an admin system with many different areas. In this case, if you used 'Back', it might not be clear to users what they are going back to.


### PR DESCRIPTION
Fixes [#1231](https://github.com/alphagov/govuk-design-system/issues/1231).

This PR updates our [back link guidance](https://design-system.service.gov.uk/components/back-link/) to tell users when they should consider changing the default text ('Back')