### PR TITLE
Tell users who guidance is for and link to GOV.UK

### DIFF
--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 Follow the [validation pattern](/patterns/validation/) and show an error message when there is a validation error. In the error message explain what went wrong and how to fix it.
 

--- a/src/components/error-message/index.md.njk
+++ b/src/components/error-message/index.md.njk
@@ -9,6 +9,8 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
+This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+
 Follow the [validation pattern](/patterns/validation/) and show an error message when there is a validation error. In the error message explain what went wrong and how to fix it.
 
 {{ example({group: "components", item: "error-message", example: "default", html: true, nunjucks: true, open: false, size: "m"}) }}

--- a/src/components/file-upload/index.md.njk
+++ b/src/components/file-upload/index.md.njk
@@ -9,6 +9,8 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
+This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+
 Help users select and upload a file.
 
 {{ example({group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false}) }}

--- a/src/components/file-upload/index.md.njk
+++ b/src/components/file-upload/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 Help users select and upload a file.
 

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -8,6 +8,8 @@ backlog_issue_id: 31
 layout: layout-pane.njk
 ---
 
+This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+
 {% from "_example.njk" import example %}
 
 Help users provide an address using one of the following:

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -8,7 +8,7 @@ backlog_issue_id: 31
 layout: layout-pane.njk
 ---
 
-This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 {% from "_example.njk" import example %}
 

--- a/src/patterns/bank-details/index.md.njk
+++ b/src/patterns/bank-details/index.md.njk
@@ -10,6 +10,8 @@ status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#next-steps">more research</a> is needed to validate it.
 ---
 
+This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+
 {% from "_example.njk" import example %}
 
 {{ example({group: "patterns", item: "bank-details", example: "default", html: true, nunjucks: true, open: false, size: "xl"}) }}

--- a/src/patterns/bank-details/index.md.njk
+++ b/src/patterns/bank-details/index.md.njk
@@ -10,7 +10,7 @@ status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#next-steps">more research</a> is needed to validate it.
 ---
 
-This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 {% from "_example.njk" import example %}
 

--- a/src/patterns/confirm-an-email-address/index.md.njk
+++ b/src/patterns/confirm-an-email-address/index.md.njk
@@ -8,6 +8,8 @@ backlog_issue_id: 39
 layout: layout-pane.njk
 ---
 
+This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+
 Check that a user has access to a specific email account using an email confirmation&nbsp;loop.
 
 ## When to use this pattern

--- a/src/patterns/confirm-an-email-address/index.md.njk
+++ b/src/patterns/confirm-an-email-address/index.md.njk
@@ -8,7 +8,7 @@ backlog_issue_id: 39
 layout: layout-pane.njk
 ---
 
-This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 Check that a user has access to a specific email account using an email confirmation&nbsp;loop.
 

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -8,7 +8,7 @@ backlog_issue_id: 45
 layout: layout-pane.njk
 ---
 
-This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 {% from "_example.njk" import example %}
 

--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -8,6 +8,8 @@ backlog_issue_id: 45
 layout: layout-pane.njk
 ---
 
+This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+
 {% from "_example.njk" import example %}
 
 {{ example({group: "patterns", item: "email-addresses", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -8,7 +8,7 @@ backlog_issue_id: 54
 layout: layout-pane.njk
 ---
 
-This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 {% from "_example.njk" import example %}
 

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -8,6 +8,8 @@ backlog_issue_id: 54
 layout: layout-pane.njk
 ---
 
+This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+
 {% from "_example.njk" import example %}
 
 Ask users to provide their National Insurance number.

--- a/src/patterns/payment-card-details/index.md.njk
+++ b/src/patterns/payment-card-details/index.md.njk
@@ -8,7 +8,7 @@ backlog_issue_id: 80
 layout: layout-pane.njk
 ---
 
-This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 ![A form entitled enter card details which asks for a card number, an expiry date, a name on the card and the card security code.](enter-card-details.jpg)
 

--- a/src/patterns/payment-card-details/index.md.njk
+++ b/src/patterns/payment-card-details/index.md.njk
@@ -8,6 +8,8 @@ backlog_issue_id: 80
 layout: layout-pane.njk
 ---
 
+This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+
 ![A form entitled enter card details which asks for a card number, an expiry date, a name on the card and the card security code.](enter-card-details.jpg)
 
 ## When to use this pattern

--- a/src/patterns/problem-with-the-service-pages/index.md.njk
+++ b/src/patterns/problem-with-the-service-pages/index.md.njk
@@ -9,6 +9,8 @@ layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
 ---
+This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+
 {% from "_example.njk" import example %}
 
 This is a page that tells someone there is something wrong with the service. They are also known as 500 and internal server error pages.

--- a/src/patterns/problem-with-the-service-pages/index.md.njk
+++ b/src/patterns/problem-with-the-service-pages/index.md.njk
@@ -9,11 +9,11 @@ layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
 ---
-This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 {% from "_example.njk" import example %}
 
-This is a page that tells someone there is something wrong with the service. They are also known as 500 and internal server error pages.
+Tell the user there is something wrong with the service. These are also known as 500 and internal server error pages.
 
 {{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, nunjucks: true, open: false, size: "xl"}) }}
 

--- a/src/patterns/service-unavailable-pages/index.md.njk
+++ b/src/patterns/service-unavailable-pages/index.md.njk
@@ -9,11 +9,11 @@ layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
 ---
-This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 {% from "_example.njk" import example %}
 
-This is a page that tells someone a service is unavailable on purpose. These are also known as 503 and shutter pages.
+Tell the user a service is unavailable on purpose. These are also known as 503 and shutter pages.
 
 {{ example({group: "patterns", item: "service-unavailable-pages", example: "default", html: true, nunjucks: true, open: false}) }}
 

--- a/src/patterns/service-unavailable-pages/index.md.njk
+++ b/src/patterns/service-unavailable-pages/index.md.njk
@@ -9,6 +9,8 @@ layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
 ---
+This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+
 {% from "_example.njk" import example %}
 
 This is a page that tells someone a service is unavailable on purpose. These are also known as 503 and shutter pages.

--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -9,14 +9,13 @@ layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
 ---
+This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
 
 {% from "_example.njk" import example %}
 
 {{ example({group: "patterns", item: "telephone-numbers", example: "default", html: true, nunjucks: true, open: false}) }}
 
 ## When to use this pattern
-
-This guidance is for government teams building online services. [To find information on services that citizens use, go to GOV.UK.](https://www.gov.uk/)
 
 Only collect telephone numbers from people if you genuinely need them. Not everyone has or can use a telephone, so make sure you give users a choice about how they can be contacted.
 

--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -16,6 +16,8 @@ statusMessage: This pattern is currently experimental because <a class="govuk-li
 
 ## When to use this pattern
 
+This guidance is for government teams building online services. [To find information on services that citizens use, go to GOV.UK.](https://www.gov.uk/)
+
 Only collect telephone numbers from people if you genuinely need them. Not everyone has or can use a telephone, so make sure you give users a choice about how they can be contacted.
 
 ## How it works

--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
 ---
-This guidance is for government teams building online services. [To find information and services for the public, go to GOV.UK.](https://www.gov.uk/)
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 {% from "_example.njk" import example %}
 


### PR DESCRIPTION
Fixes [#1966](https://github.com/alphagov/govuk-design-system/issues/1966).

### What we're adding

This PR will update several pages across our guidance to tell site-visitors:

- the guidance is for government teams building services
- they need to go to GOV.UK if they're looking for citizen-facing services

#### Components to update

- Error message
- File upload

#### Patterns to update

- Addresses
- Bank details
- Confirm email address
- Email addresses
- National insurance numbers
- Payment card details
- Problem with service
- Service unavailable
- Telephone numbers

### Why we're adding it

[Some users have been ending up in the Design System when they want to find COVID-related services.](https://docs.google.com/presentation/d/1dIx0RQwxFovK6wAFxITZOwyn0PtgWAE_1eakodFWoxw/edit#slide=id.gf61b7945b0_0_183)