### PR TITLE
Refactor GitHub Actions workflows and add concurrency limit to deploys

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: alphagov/govuk-design-system/.github/workflows/test.yaml
+    uses: alphagov/govuk-design-system/.github/workflows/test.yaml@fac33297b13e9e4cfa23d88b46a639dc0cbc25d3
     with:
       upload-artifact: true
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,47 +1,14 @@
-name: CI Workflow
+name: Deploy
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
-# Separate build and deploy jobs so we can build all branches and pull requests
-# but only deploy from main
 jobs:
   build:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    env:
-      ENVIRONMENT: production
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Read node version from .nvmrc
-        id: nvm
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm install --no-optional
-
-      - name: Build
-        run: npm run build
-
-      - name: Lint and test
-        run: npm test -- --runInBand
-
-      # Share data between the build and deploy jobs so we don't need to run `npm run build` again on deploy
-      # Upload the deploy folder as an artifact so it can be downloaded and used in the deploy job
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        if: ${{ github.ref == 'refs/heads/main' }}
-        with:
-            name: build
-            path: deploy/**
-            retention-days: 1
+    uses: alphagov/govuk-design-system/.github/workflows/test.yaml
 
   # Deploy the Design System to production when the main branch is changed
   # Github Actions is not involved in deploying PR or branch previews – these are handled by Netlify
@@ -49,9 +16,9 @@ jobs:
   deploy:
     environment: production
     name: Deploy
-    runs-on: ubuntu-latest
     needs: build
-    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+
     env:
       CF_API: "https://api.cloud.service.gov.uk"
       CF_ORG: "govuk-design-system"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     uses: alphagov/govuk-design-system/.github/workflows/test.yaml
+    with:
+      upload-artifact: true
 
   # Deploy the Design System to production when the main branch is changed
   # Github Actions is not involved in deploying PR or branch previews – these are handled by Netlify

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,8 @@ on:
       - main
   workflow_dispatch:
 
+concurrency: production
+
 jobs:
   build:
     uses: alphagov/govuk-design-system/.github/workflows/test.yaml@fac33297b13e9e4cfa23d88b46a639dc0cbc25d3
@@ -75,11 +77,6 @@ jobs:
       # Parse app name from manifest to ensure it matches up
       - name: Fetch app name from manifest
         run: echo "APP_NAME=$(ruby -e "require 'yaml'; config = YAML.load_file('manifest.yml'); puts config['applications'][0]['name']")" >> $GITHUB_ENV
-
-      - name: Cancel any existing running deploys to avoid conflict
-        run:  |
-          echo "Cancelling any previous deployments in progress"
-          cf cancel-deployment $APP_NAME || true
 
       - name: Deploy to PaaS
         # Deploy app and set up app healthcheck https://docs.cloudfoundry.org/devguide/deploy-apps/healthchecks.html

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,11 @@ on:
     branches-ignore:
       - main  # pushes to main are handled by deploy.yaml
   workflow_call:
+    inputs:
+      upload-artifact:
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   build:
@@ -40,7 +45,7 @@ jobs:
       # Upload the deploy folder as an artifact so it can be downloaded and used in the deploy job
       - name: Upload artifact
         uses: actions/upload-artifact@v2
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ inputs.upload-artifact }}
         with:
             name: build
             path: deploy/**

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,48 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - main  # pushes to main are handled by deploy.yaml
+  workflow_call:
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    env:
+      ENVIRONMENT: production
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Read node version from .nvmrc
+        id: nvm
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install --no-optional
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint and test
+        run: npm test -- --runInBand
+
+      # Share data between the build and deploy jobs so we don't need to run `npm run build` again on deploy
+      # Upload the deploy folder as an artifact so it can be downloaded and used in the deploy job
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+            name: build
+            path: deploy/**
+            retention-days: 1
+


### PR DESCRIPTION
Split the `ci.yaml` workflow into two: `test.yaml` for pull request checks, and `deploy.yaml` for after merge to main. To reduce code duplication the deploy workflow calls the test workflow using the beta reusable workflow feature [[1]].

[1]: https://docs.github.com/en/actions/learn-github-actions/reusing-workflows

The advantage of splitting the workflows like this is that we can then give the entire deploy workflow a concurrency limit [[2]], without affecting test workflows. Having a concurrency limit is an alternative to the step which cancels any in-progress
deploys, which would have resulted in failed deployment messages.

This should make it easier to spot when a deployment fails for real, which should fix #1947.

[2]: https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/

---

I tested the deploy job by removing lines 5, 6, and 19 from `deploy.yaml`, you can see an example workflow run at https://github.com/alphagov/govuk-design-system/actions/runs/1421156778.