### PR TITLE
Tell users how to report inappropriate content

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,11 @@ interface.
 GDS is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, we would like to know so we can fix it.
 
 To learn how to report a security vulnerability, [see our security policy](https://github.com/alphagov/govuk-design-system/security/policy).
+
+## Contributing
+
+The govuk-design-system repository is public and we welcome contributions from anyone.
+
+Contributors to alphagov repositories are expected to follow the [Contributor Covenant Code of Conduct](https://github.com/alphagov/.github/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct). Contributors working within government are also expected to follow the [Civil Service code](https://www.gov.uk/government/publications/civil-service-code/the-civil-service-code).
+
+We're unable to monitor activity on this repository outside of our office hours (10am to 4pm, UK time). To get a faster response at other times, you can [report abuse or spam to GitHub](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam).


### PR DESCRIPTION
Partly addresses [#2396](https://github.com/alphagov/govuk-frontend/issues/2396).

This PR updates the [govuk-design-system README](https://github.com/alphagov/govuk-design-system/blob/main/README.md), so users will know:

- the repo is open, and not monitored outside of office hours
- how to report inappropriate content

We're adding this info because of a [recent security-incident](https://docs.google.com/document/d/1-VZcvII1g9oKFi00JsiuvLE-Y0iAl-qmPeaYLzn6Fmg/edit#).