### PR TITLE
Move cookie banner before skip link

### DIFF
--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -23,14 +23,17 @@
   <script src="/javascripts/vendor/modernizr.js"></script>
 {% endblock %}
 
+{% block bodyStart %}
+  <!--[if gte IE 9]><!-->
+  {% include "_cookie-banner.njk" %}
+  <!--<![endif]-->
+{% endblock %}
+
 {# We provide our own header, so blank the one provided by the template #}
 {% block header %}{% endblock %}
 
 {% block main %}
 <div class="app-pane {% block appPaneClasses %}{% endblock %}" id="top">
-  <!--[if gte IE 9]><!-->
-    {% include "_cookie-banner.njk" %}
-  <!--<![endif]-->
   {% include "_header.njk" %}
   {% include "_mobile-navigation.njk" %}
   {% include "_banner.njk" %}


### PR DESCRIPTION
In the design system guidance for the cookie banner, we tell users to place the cookie banner before the skip to main content link using the `bodyStart` block.

However, we didn't follow our own guidance when adding the cookie banner to the design system website - the cookie banner is placed after the skip link.

We should follow our own guidance, and place the cookie banner before the skip link.

Initial research into positioning of the cookie banner: https://github.com/alphagov/govuk-frontend/issues/2096#issuecomment-767667620