### PR TITLE
Initial Windows support

### DIFF
--- a/__tests__/accessiblity_audit.test.js
+++ b/__tests__/accessiblity_audit.test.js
@@ -3,7 +3,7 @@
 const { AxePuppeteer } = require('axe-puppeteer')
 
 const { setupPage } = require('../lib/jest-utilities.js')
-const configPaths = require('../config/paths.json')
+const configPaths = require('../lib/paths.js')
 const PORT = configPaths.testPort
 
 let page

--- a/__tests__/back-to-top.test.js
+++ b/__tests__/back-to-top.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 const { setupPage } = require('../lib/jest-utilities.js')
-const configPaths = require('../config/paths.json')
+const configPaths = require('../lib/paths.js')
 const PORT = configPaths.testPort
 
 let page

--- a/__tests__/component-options.test.js
+++ b/__tests__/component-options.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 const { setupPage } = require('../lib/jest-utilities.js')
-const configPaths = require('../config/paths.json')
+const configPaths = require('../lib/paths.js')
 const PORT = configPaths.testPort
 
 let page

--- a/__tests__/cookie-banner.test.js
+++ b/__tests__/cookie-banner.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 const { setupPage } = require('../lib/jest-utilities.js')
-const configPaths = require('../config/paths.json')
+const configPaths = require('../lib/paths.js')
 const PORT = configPaths.testPort
 
 let page

--- a/__tests__/cookies-page.test.js
+++ b/__tests__/cookies-page.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 const { setupPage } = require('../lib/jest-utilities.js')
-const configPaths = require('../config/paths.json')
+const configPaths = require('../lib/paths.js')
 const PORT = configPaths.testPort
 
 let page

--- a/__tests__/example.test.js
+++ b/__tests__/example.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 const { setupPage } = require('../lib/jest-utilities.js')
-const configPaths = require('../config/paths.json')
+const configPaths = require('../lib/paths.js')
 const PORT = configPaths.testPort
 
 let page

--- a/__tests__/mobile-navigation.test.js
+++ b/__tests__/mobile-navigation.test.js
@@ -3,7 +3,7 @@ const devices = require('puppeteer/DeviceDescriptors')
 const iPhone = devices['iPhone 6']
 
 const { setupPage } = require('../lib/jest-utilities.js')
-const configPaths = require('../config/paths.json')
+const configPaths = require('../lib/paths.js')
 const PORT = configPaths.testPort
 
 let page

--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 const { setupPage } = require('../lib/jest-utilities.js')
-const configPaths = require('../config/paths.json')
+const configPaths = require('../lib/paths.js')
 const PORT = configPaths.testPort
 
 // Regex that can be used to match on fingerprinted search index files

--- a/__tests__/tabs.test.js
+++ b/__tests__/tabs.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 const { setupPage } = require('../lib/jest-utilities.js')
-const configPaths = require('../config/paths.json')
+const configPaths = require('../lib/paths.js')
 const PORT = configPaths.testPort
 
 let page

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,4 +1,4 @@
-const configPaths = require('./config/paths.json')
+const configPaths = require('./lib/paths.js')
 const PORT = configPaths.testPort
 
 module.exports = {

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const paths = require('../config/paths.json')
+const paths = require('./paths.js')
 
 const fs = require('fs')
 const path = require('path')
@@ -67,7 +67,10 @@ exports.getFingerprint = function (file) {
   // calls to this function with a relative path will fail if made from the
   // source files themselves.
   if (filePath) {
-    const relativeFile = path.join(filePath, file)
+    // Use path.join to correctly join, but metalsmith-fingerprint-ignore
+    // always expects forward slashes, so replace any backslashes (Windows)
+    // with a forward slashes.
+    const relativeFile = path.join(filePath, file).replace(/\\/g, '/')
 
     if (fingerprints.hasOwnProperty(relativeFile)) {
       return '/' + fingerprints[relativeFile]

--- a/lib/generate-sitemap.js
+++ b/lib/generate-sitemap.js
@@ -1,6 +1,6 @@
 const sm = require('sitemap')
 const path = require('path')
-const paths = require('../config/paths.json')
+const paths = require('./paths.js')
 const fs = require('fs-extra')
 const match = require('multimatch')
 

--- a/lib/get-macro-options/__tests__/index.js
+++ b/lib/get-macro-options/__tests__/index.js
@@ -1,5 +1,7 @@
 /* eslint-env jest */
 
+const path = require('path')
+
 jest.mock('fs')
 
 const fs = require('fs')
@@ -94,6 +96,13 @@ const fixtures = {
 describe('getMacroOptions', () => {
   let output
   beforeAll(() => {
+    // need to normalise the path as we're using path.join in getMacroOptionsJson
+    for (const i in fixtures) {
+      const curFixture = fixtures[i]
+      delete fixtures[i]
+      fixtures[path.normalize(i)] = curFixture
+    }
+
     fs.__setMockData(fixtures)
 
     output = getMacroOptions('radios')

--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -3,7 +3,7 @@ const path = require('path')
 
 const markdownRenderer = require('marked')
 
-const paths = require('../../config/paths.json')
+const paths = require('../paths.js')
 
 // Get reference to marked.js
 let renderer = new markdownRenderer.Renderer()

--- a/lib/metalsmith-title-checker.js
+++ b/lib/metalsmith-title-checker.js
@@ -36,6 +36,8 @@ function getDuplicateTitles (groupedFiles) {
       // Default examples always have a duplicated title,
       // this is OK since the iframes are appended with 'example'.
       .filter(file => !file['__filename'].includes('/default/'))
+      // Filter out Windows default paths too:
+      .filter(file => !file['__filename'].includes('\\default\\'))
       // Code examples always have a duplicated title,
       // as it's only used for the code example not the iframe.
       .filter(file => !file['__filename'].endsWith('code.njk'))

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 const metalsmith = require('metalsmith') // static site generator
 const assets = require('metalsmith-assets') // copy static assets
 const brokenLinkChecker = require('metalsmith-broken-link-checker')
@@ -28,7 +30,7 @@ const slugger = require('slugger') // generate slugs from titles
 
 const colours = require('../lib/colours.js') // get colours data
 const fileHelper = require('../lib/file-helper.js') // helper function to operate on files
-const paths = require('../config/paths.json') // specify paths to main working directories
+const paths = require('./paths.js') // specify paths to main working directories
 const highlighter = require('./highlighter.js')
 const getMacroOptions = require('./get-macro-options/index.js')
 
@@ -53,10 +55,10 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
   .use(extractPageHeadings())
 
   // source directory
-  .source('../' + paths.source)
+  .source(path.join('../', paths.source))
 
   // destination directory
-  .destination('../' + paths.public)
+  .destination(path.join('../', paths.public))
 
   // clean destination before build
   .clean(true)
@@ -78,30 +80,30 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
 
   // copy static assets from node_modules/@govukfrontend
   .use(assets({
-    source: '../' + paths.govukfrontend + 'govuk/assets/',
+    source: path.join('../', paths.govukfrontend, 'govuk/assets/'),
     destination: 'assets'
   }))
 
   // copy static assets from node_modules/iframe-resizer
   .use(assets({
-    source: '../' + paths.iframeresizer + 'js/',
-    destination: 'javascripts/vendor'
+    source: path.join('../', paths.iframeresizer, 'js/'),
+    destination: path.normalize('javascripts/vendor')
   }))
 
   // build custom modernizr.js file
   .use(modernizrBuild({
-    config: '../config/modernizr.json',
-    destination: 'javascripts/vendor/',
+    config: path.normalize('../config/modernizr.json'),
+    destination: path.normalize('javascripts/vendor/'),
     filename: 'modernizr.js'
   }))
 
   // build the entrypoint for the IE8 JavaScript that goes in the <head>
   .use(rollup({
-    input: 'src/javascripts/head-ie8.js',
+    input: path.normalize('src/javascripts/head-ie8.js'),
     output: {
       legacy: true,
       format: 'iife',
-      file: 'javascripts/head-ie8.js'
+      file: path.normalize('javascripts/head-ie8.js')
     },
     plugins: [
       // TODO: Since we're not exporting ES6 Modules to NPM we need to import these as commonjs
@@ -112,11 +114,11 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
 
   // build the entrypoint for application specific JavaScript
   .use(rollup({
-    input: 'src/javascripts/application.js',
+    input: path.normalize('src/javascripts/application.js'),
     output: {
       legacy: true,
       format: 'iife',
-      file: 'javascripts/application.js'
+      file: path.normalize('javascripts/application.js')
     },
     plugins: [
       // TODO: Since we're not exporting ES6 Modules to NPM we need to import these as commonjs
@@ -127,11 +129,11 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
 
   // build the entrypoint for application IE8 specific JavaScript
   .use(rollup({
-    input: 'src/javascripts/application-ie8.js',
+    input: path.normalize('src/javascripts/application-ie8.js'),
     output: {
       legacy: true,
       format: 'iife',
-      file: 'javascripts/application-ie8.js'
+      file: path.normalize('javascripts/application-ie8.js')
     },
     plugins: [
       // TODO: Since we're not exporting ES6 Modules to NPM we need to import these as commonjs
@@ -142,11 +144,11 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
 
   // build GOV.UK Frontend JavaScript
   .use(rollup({
-    input: 'src/javascripts/govuk-frontend.js',
+    input: path.normalize('src/javascripts/govuk-frontend.js'),
     output: {
       legacy: true,
       format: 'iife',
-      file: 'javascripts/govuk-frontend.js'
+      file: path.normalize('javascripts/govuk-frontend.js')
     },
     plugins: [
       // TODO: Since we're not exporting ES6 Modules to NPM we need to import these as commonjs
@@ -157,11 +159,11 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
 
   // build the entrypoint for example specific JavaScript
   .use(rollup({
-    input: 'src/javascripts/example.js',
+    input: path.normalize('src/javascripts/example.js'),
     output: {
       legacy: true,
       format: 'iife',
-      file: 'javascripts/example.js'
+      file: path.normalize('javascripts/example.js')
     },
     plugins: [
       // TODO: Since we're not exporting ES6 Modules to NPM we need to import these as commonjs
@@ -177,23 +179,24 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     },
     sameName: true, // overwrite the original files, with the minified ones.
     files: [
-      'javascripts/application-ie8.js',
-      'javascripts/application.js',
-      'javascripts/head-ie8.js',
-      'javascripts/govuk-frontend.js',
-      'javascripts/example.js'
+      path.normalize('javascripts/application-ie8.js'),
+      path.normalize('javascripts/application.js'),
+      path.normalize('javascripts/head-ie8.js'),
+      path.normalize('javascripts/govuk-frontend.js'),
+      path.normalize('javascripts/example.js')
     ]
   }))
 
   // add hash to files
   .use(hashAssets({
     pattern: [
+      '**\\*.css',
       '**/*.css',
-      'javascripts/application-ie8.js',
-      'javascripts/application.js',
-      'javascripts/head-ie8.js',
-      'javascripts/govuk-frontend.js',
-      'javascripts/example.js'
+      path.normalize('javascripts/application-ie8.js'),
+      path.normalize('javascripts/application.js'),
+      path.normalize('javascripts/head-ie8.js'),
+      path.normalize('javascripts/govuk-frontend.js'),
+      path.normalize('javascripts/example.js')
     ]
   }))
 
@@ -266,7 +269,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
   // apply layouts to source files
   .use(layouts({
     default: 'layout.njk',
-    directory: '../' + paths.layouts,
+    directory: path.join('../', paths.layouts),
     pattern: '**/*.html',
     engineOptions: {
       path: views,

--- a/lib/modernizr-build.js
+++ b/lib/modernizr-build.js
@@ -1,7 +1,7 @@
 const modernizr = require('modernizr')
 const fs = require('fs-extra')
 const path = require('path')
-const paths = require('../config/paths.json')
+const paths = require('./paths.js')
 
 /**
  * Metalsmith plugin to create a custom modernizr build

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -5,7 +5,9 @@
 // metalsmith: object containing global information such as meta data
 // done: function which must be called when the plugin has finished working
 
-const paths = require('../config/paths.json')
+const path = require('path')
+
+const paths = require('./paths.js')
 const navigation = require('../config/navigation.json')
 
 const fileHelper = require('../lib/file-helper.js')
@@ -17,7 +19,7 @@ module.exports = function () {
       // if we have a navigation url and it is not homepage then look for subitems
       if (navigation[item].url && navigation[item].url !== '') {
         // define source path
-        let itemPath = paths.source + navigation[item].url
+        let itemPath = path.join(paths.source, navigation[item].url)
         // get directories under main navigation item (e.g. ['breadcrumbs', 'checkboxes', ...])
         let directories = fileHelper.getDirectories(itemPath)
         // if we have directories convert them into menu items
@@ -26,8 +28,8 @@ module.exports = function () {
           navigation[item].items = []
           // convert directory into a navigation item adding url, label and theme
           for (let dir in directories) {
-            let url = navigation[item].url + '/' + directories[dir]
-            let frontmatter = files[url + '/index.html']
+            let url = path.join(navigation[item].url, directories[dir])
+            let frontmatter = files[path.join(url, 'index.html')]
             // if we have frontmatter for that file, create subitem
             if (frontmatter) {
               if (frontmatter.status && frontmatter.status === 'Draft') {

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -1,0 +1,11 @@
+const path = require('path')
+
+const rawPaths = require('../config/paths.json')
+
+for (const i in rawPaths) {
+  if (typeof (rawPaths[i]) === 'string') {
+    module.exports[i] = path.normalize(rawPaths[i])
+  } else {
+    module.exports[i] = rawPaths[i]
+  }
+}

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -1,7 +1,9 @@
+const path = require('path')
+
 const browsersync = require('metalsmith-browser-sync') // setup synchronised browser testing
 const metalsmith = require('../lib/metalsmith') // configured static site generator
 
-const paths = require('../config/paths.json') // specify paths to main working directories
+const paths = require('../lib/paths.js') // specify paths to main working directories
 
 // setup synchronised browser testing
 metalsmith.use(browsersync({
@@ -9,9 +11,9 @@ metalsmith.use(browsersync({
   open: false, // When making changes to the server, we don't want multiple windows opening.
   server: paths.public, // server directory
   files: [
-    paths.source + '**/*',
-    paths.views + '**/*',
-    'node_modules/govuk-frontend/**/*'
+    path.join(paths.source, '**/*'),
+    path.join(paths.views, '**/*'),
+    path.normalize('node_modules/govuk-frontend/**/*')
   ] // files to watch
 }))
 

--- a/tasks/test-serve.js
+++ b/tasks/test-serve.js
@@ -4,7 +4,7 @@ const serveStatic = require('serve-static')
 
 const metalsmith = require('../lib/metalsmith')
 
-const paths = require('../config/paths.json')
+const paths = require('../lib/paths.js')
 
 const runServer = () => {
   // Create a simple server for serving static files


### PR DESCRIPTION
This adds support for building, testing and running on Windows. Tested on Windows 11 (Windows Terminal with [nvm-windows](https://github.com/coreybutler/nvm-windows)) and Ubuntu, macOS test TBD.

The main change is replacing the requires for `config/paths.json` with `lib/paths.js` that returns a _path.normalize_'d version of the paths object. Replaced instances of `blah + '/'` or `blah + blah2` with `path.join(blah, blah2)` as `path` handles the OS support, meaning the correct joins are returned.

Tested:
- `npm install`
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm start`

Related issues:
- https://github.com/alphagov/govuk-design-system/issues/694
- https://github.com/alphagov/govuk-design-system/issues/598

~Keeping in draft until tested on macOS, but making as a PR for others to test!~ Edit: @lfdebrux has tested successfully on macOS.