### PR TITLE
Tell users that change links have hidden text

### DIFF
--- a/src/patterns/check-answers/index.md.njk
+++ b/src/patterns/check-answers/index.md.njk
@@ -49,7 +49,7 @@ On your check answers page you should:
 
 ### Let users go back and change their answers
 
-You should provide a ‘Change’ link next to each section on your check answers page so that users can add or change the information.
+You should provide a ‘Change’ link next to each section on your check answers page so that users can add or change the information. 'Change' links contain hidden text to make them accessible to screen reader users. Update the hidden text to describe what each 'change' link is for.
 
 The answers pages should look the same way they did when the user last used them, with all their answers pre-populated.
 


### PR DESCRIPTION
Fixes [#1574](https://github.com/alphagov/govuk-design-system/issues/1574).

This PR updates our check answers pattern to say that 'change' links contain hidden text. This means the links are accessible to screen reader users.