### PR TITLE
Set phase banner width to 100% on desktop

### DIFF
--- a/src/stylesheets/components/_phase-banner.scss
+++ b/src/stylesheets/components/_phase-banner.scss
@@ -5,6 +5,7 @@
   }
 
   @include govuk-media-query($from: tablet) {
+    width: 100%;
     border-bottom: 0;
   }
 }


### PR DESCRIPTION
On most pages (apart from the homepage), the parent div (`.app-pane`) is a flex container. We used to wrap the phase banner in a `div` but removed this in https://github.com/alphagov/govuk-design-system/pull/1983/commits/a04885bdca2d207d35bdaad2702970e7a4c92f9a as the class being applied to that `div` was only being used for tests.

Unfortunately, removing the `div` had the side effect of changing the positioning of the phase banner when it was inside the flex container - the phase banner appeared centred on the page.

I think this is happening because it's a child item of a flex container and it doesn't have any existing properties to say how much space it should take up, so it's only taking up the space it needs rather than the full width.

This commit sets `width: 100%;` on the phase banner on desktop so that it's centered correctly.

## Before
<img width="1415" alt="Screenshot 2021-11-26 at 11 45 12" src="https://user-images.githubusercontent.com/29889908/143576135-a0d9169b-755c-48c0-9f0f-6fea6ab72b7f.png">

## After
<img width="1418" alt="Screenshot 2021-11-26 at 11 44 42" src="https://user-images.githubusercontent.com/29889908/143576150-fc964acf-13eb-4b51-a713-edd69fee739a.png">
