### PR TITLE
Use 'Address' in summary list examples

### DIFF
--- a/src/components/summary-list/default/index.njk
+++ b/src/components/summary-list/default/index.njk
@@ -43,7 +43,7 @@ layout: layout-example.njk
     },
     {
       key: {
-        text: "Contact information"
+        text: "Address"
       },
       value: {
         html: "72 Guild Street<br>London<br>SE23 6FH"
@@ -53,7 +53,7 @@ layout: layout-example.njk
           {
             href: "#",
             text: "Change",
-            visuallyHiddenText: "contact information"
+            visuallyHiddenText: "address"
           }
         ]
       }

--- a/src/components/summary-list/without-actions/index.njk
+++ b/src/components/summary-list/without-actions/index.njk
@@ -25,7 +25,7 @@ layout: layout-example.njk
     },
     {
       key: {
-        text: "Contact information"
+        text: "Address"
       },
       value: {
         html: "72 Guild Street<br>London<br>SE23 6FH"

--- a/src/components/summary-list/without-borders/index.njk
+++ b/src/components/summary-list/without-borders/index.njk
@@ -26,7 +26,7 @@ layout: layout-example.njk
     },
     {
       key: {
-        text: "Contact information"
+        text: "Address"
       },
       value: {
         html: "72 Guild Street<br>London<br>SE23 6FH"


### PR DESCRIPTION
At the minute we're using two very similar terms ('contact information' and 'contact details') to refer to two different things. This was previously flagged by DAC as confusing and failing WCAG 2.1 2.4.9: Link Purpose (Link Only) (because of the visually hidden text in the links – see #906).

This mirrors the change previously made to similar examples in the 'Help users check their answers' pattern as part of 36b3475 (#912).