### PR TITLE
Update to GOV.UK Frontend v4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4913,9 +4913,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.0.tgz",
+      "integrity": "sha512-liaJildULUNSSvEgDm36SQTivqBHiZLdrm+O7bBxnW4Q1g64asi+mJIMzW8QeOqlG4Yn8s0gSklsIyaFOuCisQ=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clipboard": "^2.0.4",
     "connect": "^3.6.6",
     "eslint": "^5.16.0",
-    "govuk-frontend": "^3.14.0",
+    "govuk-frontend": "^4.0.0",
     "gray-matter": "^4.0.2",
     "highlight.js": "^10.4.1",
     "html5shiv": "^3.7.3",

--- a/src/components/character-count/threshold/index.njk
+++ b/src/components/character-count/threshold/index.njk
@@ -6,8 +6,8 @@ layout: layout-example.njk
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 
 {{ govukCharacterCount({
-  name: "word-count",
-  id: "word-count",
+  name: "threshold",
+  id: "threshold",
   maxlength: 112,
   threshold: 75,
   value: "Type another letter into this field after this message to see the threshold feature",

--- a/src/components/footer/full/index.njk
+++ b/src/components/footer/full/index.njk
@@ -9,6 +9,7 @@ layout: layout-example.njk
   navigation: [
     {
       title: "Services and information",
+      width: "two-thirds",
       columns: 2,
       items: [
         {
@@ -79,6 +80,7 @@ layout: layout-example.njk
     },
     {
       title: "Departments and policy",
+      width: "one-third",
       items: [
         {
           href: "#",

--- a/src/components/footer/with-navigation/index.njk
+++ b/src/components/footer/with-navigation/index.njk
@@ -9,6 +9,7 @@ layout: layout-example.njk
   navigation: [
     {
       title: "Two column list",
+      width: "two-thirds",
       columns: 2,
       items: [
         {
@@ -39,6 +40,7 @@ layout: layout-example.njk
     },
     {
       title: "Single column list",
+      width: "one-third",
       items: [
         {
           href: "#1",

--- a/src/javascripts/govuk-frontend.js
+++ b/src/javascripts/govuk-frontend.js
@@ -9,6 +9,7 @@ import NotificationBanner from 'govuk-frontend/govuk/components/notification-ban
 import Radios from 'govuk-frontend/govuk/components/radios/radios'
 import Header from 'govuk-frontend/govuk/components/header/header'
 import Tabs from 'govuk-frontend/govuk/components/tabs/tabs'
+import SkipLink from 'govuk-frontend/govuk/components/skip-link/skip-link'
 
 var nodeListForEach = common.nodeListForEach
 
@@ -68,3 +69,7 @@ var $tabs = document.querySelectorAll('[data-module="govuk-tabs"]')
 nodeListForEach($tabs, function ($tab) {
   new Tabs($tab).init()
 })
+
+// Find first skip link module to enhance.
+var $skipLink = document.querySelector('[data-module="govuk-skip-link"]')
+new SkipLink($skipLink).init()


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-design-system/issues/1851 

Updates the Design System to use v4.0.0.

**Note:** the current PR updates the Design System to use the v4.0.0 *pre-release*. This PR will need to be updated for the actual release, to point to the version of GOV.UK Frontend published on `npm`.

## Things I've checked

The Design System:

- **does not** use the `govuk-main-wrapper` or `govuk-main-wrapper--l` mixins
- **does not** use the `$govuk-border-width-form-element-error` variable
- **does not** individually import JavaScript files
- **does not** use HTML error messages
- **does not** use HTML hints
- **does not** use HTML skip link
- **does not** use `iff` Sass function
- **does not** use `govuk-tag--inactive` class
- **does not** import individual Sass files from `core` or `overrides`
- **does not** use HTML date input
- **does not** use the HTML cookie banner
- already uses `aria-hidden="true"` for SVGs in the header
- already styles custom HTML being passed to the cookie banner component
- already uses conditional reveals with unique id's per page
- uses the header HTML in non-standard ways (using custom navigation that doesn't sit inside the header like it does for the component) - I'm not sure the changes we've made to the component can be applied directly to the design system implementation
- has a PR raised to update the summary list guidance (https://github.com/alphagov/govuk-design-system/pull/1990)
- has a PR raised to update the accessibility statement for accordions (https://github.com/alphagov/govuk-design-system/pull/1825)
- has a PR raised to update the accordion guidance and examples for the new iteration (https://github.com/alphagov/govuk-design-system/pull/1961)

I've added commits to:

- ensure character counts use unique `id`s
- add the `width` macro option to any footer components that need it