### PR TITLE
Run PR checks on Windows as well as Linux

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,13 @@ on:
 jobs:
   build:
     name: Build & Test
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            upload-artifact: ${{ inputs.upload-artifact }}
+    runs-on: ${{ matrix.os }}
     env:
       ENVIRONMENT: production
 
@@ -45,7 +51,7 @@ jobs:
       # Upload the deploy folder as an artifact so it can be downloaded and used in the deploy job
       - name: Upload artifact
         uses: actions/upload-artifact@v2
-        if: ${{ inputs.upload-artifact }}
+        if: ${{ matrix.upload-artifact }}
         with:
             name: build
             path: deploy/**


### PR DESCRIPTION
We want to be able to support developers using Windows [[1]]. This commit adds a build matrix for PR checks that includes running tests on Windows as well as Linux, so that we can be more confident that any future changes won't break Windows support.

Note that we have to tweak the upload artifact step to only upload if running on Linux, to avoid uploading the artifact twice. We're not sure what would happen if we didn't change this, but we suspect that it wouldn't be good [[2]].

[1]: #598
[2]: https://github.com/actions/upload-artifact#uploading-to-the-same-artifact

---

Outstanding:
- [x] Note that the tests on Windows won't pass until #1981 is merged.
- [x] GitHub branch protection required checks need to be updated just before merging