### PR TITLE
Improve link text from Design System to GitHub

### DIFF
--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -9,7 +9,7 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>
         <a class="govuk-link app-contact-panel__link" href="https://github.com/alphagov/govuk-design-system-backlog/issues/{{ backlog_issue_id }}">
-          share your research or feedback on GitHub
+          take part in the '{{ title }}' discussion on GitHub and share your research
         </a>
       </li>
       <li>


### PR DESCRIPTION
Fixes [#1998](https://github.com/alphagov/govuk-design-system/issues/1998).

This PR rewords some link text that's on our component and pattern pages.

Several users have pointed out that the current link text ("share your research or feedback on GitHub") does not reflect why they visit the discussion pages.