### PR TITLE
Tell users where to put breadcrumbs on page

### DIFF
--- a/src/components/breadcrumbs/index.md.njk
+++ b/src/components/breadcrumbs/index.md.njk
@@ -25,6 +25,8 @@ If you’re using other navigational elements on the page, such as a sidebar, co
 
 ## How it works
 
+Always place breadcrumbs at the top of a page, before the `<main>` element. Placing them here means that the 'Skip to main content' link allows the user to skip all navigation links, including breadcrumbs.
+
 The breadcrumb should start with your 'home' page and end with the parent section of the current page.
 
 There are 2 ways to use the breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.

--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -107,7 +107,7 @@ To change the components that are included in the page template by default, set 
       <td class="govuk-table__cell">
         Add content that needs to appear outside <code>&lt;main&gt;</code> element.
         <br>
-        For example: The <a class="govuk-link" href="/components/back-link/">back link</a> component,
+        For example: The <a class="govuk-link" href="/components/back-link/">back link</a> component, <a class="govuk-link" href="/components/breadcrumbs/">breadcrumbs</a> component,
         <a class="govuk-link" href="/components/phase-banner/">phase banner</a> component.
       </td>
     </tr>


### PR DESCRIPTION
Fixes [#1350](https://github.com/alphagov/govuk-design-system/issues/1350).

This PR updates our breadcrumbs guidance so users will know to place breadcrumbs at the top of a page, before the `<main>` element. This means the 'Skip to main content' link lets users skip all nav links (like breadcrumbs).

We're also adding a breadcrumbs link from the page template guidance.