### PR TITLE
Fix missing favicon for component examples

### DIFF
--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -121,6 +121,11 @@ $app-code-color: #d13118;
   }
 }
 
+.app-example-page__wrapper {
+  overflow: auto;
+  background-color: govuk-colour("white");
+}
+
 .app-example-page {
   padding: govuk-spacing(6);
 }

--- a/views/layouts/layout-example-full-page-govuk.njk
+++ b/views/layouts/layout-example-full-page-govuk.njk
@@ -1,4 +1,7 @@
 {% extends "govuk/template.njk" %}
+
+{% set assetUrl = 'https://design-system.service.gov.uk/assets' %}
+
 {% block pageTitle %}{{ title }} – Example – GOV.UK Design System{% endblock %}
 {% block head %}
   <meta name="robots" content="noindex, nofollow">

--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -1,4 +1,7 @@
 {% extends "govuk/template.njk" %}
+
+{% set assetUrl = 'https://design-system.service.gov.uk/assets' %}
+
 {% block pageTitle %}{{ title }} – Example – GOV.UK Design System{% endblock %}
 {% block head %}
   <meta name="robots" content="noindex, nofollow">

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -1,31 +1,49 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="robots" content="noindex, nofollow">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ title }} – Example – GOV.UK Design System</title>
-    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
-    {#- Include any additional stylesheets specified in the example frontmatter #}
-    {% for stylesheet in stylesheets %}
-    <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all" />
-    {%- endfor %}
+{% extends "govuk/template.njk" %}
 
-    <!--[if lt IE 9]>
-      <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
-    <![endif]-->
-    <script src="/javascripts/vendor/modernizr.js"></script>
-  </head>
-  <body class="govuk-template__body app-example-page">
-    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
-    <!-- Disable browser validation for any examples that include form elements -->
-    <form action="/form-handler" method="post" novalidate>
-      {% block body %}
-        {{ contents | safe }}
-      {% endblock %}
-    </form>
-    <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
-    <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
-    <script src="{{ getFingerprint('javascripts/example.js') }}"></script>
-  </body>
-</html>
+{% set htmlClasses = 'app-example-page__wrapper' %}
+{% set assetUrl = 'https://design-system.service.gov.uk/assets' %}
+
+{% block pageTitle %}{{ title }} – Example - GOV.UK Design System{% endblock %}
+
+{% block head %}
+  <meta name="robots" content="noindex, nofollow">
+  <meta name="og:title" content="{{title}}">
+  <meta name="description" content="{{description}}">
+  <meta name="og:description" content="{{description}}">
+  <link rel="canonical" href="{{ canonical }}" />
+
+  <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
+  {#- Include any additional stylesheets specified in the example frontmatter #}
+  {% for stylesheet in stylesheets %}
+    <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all" />
+  {%- endfor %}
+
+  <!--[if lt IE 9]>
+    <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
+  <![endif]-->
+  <script src="/javascripts/vendor/modernizr.js"></script>
+{% endblock %}
+
+{# Example pages shouldn't have a skip link or header, so blank the one provided by the template #}
+{% block skipLink %}{% endblock %}
+{% block header %}{% endblock %}
+
+{% set bodyClasses = "app-example-page" %}
+
+{% block main %}
+  <!-- Disable browser validation for any examples that include form elements -->
+  <form action="/form-handler" method="post" novalidate>
+    {% block body %}
+      {{ contents | safe }}
+    {% endblock %}
+  </form>
+{% endblock %}
+
+{% block bodyEnd %}
+  <script src="/javascripts/vendor/iframeResizer.contentWindow.js"></script>
+  <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
+  <script src="{{ getFingerprint('javascripts/example.js') }}"></script>
+{% endblock %}
+
+{# Example pages shouldn't have a footer, so blank the one provided by the template #}
+{% block footer %}{% endblock %}


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-design-system/issues/2008

## What
 - Update the `layout-example.njk` template to use the GOV.UK Frontend page template instead of hard coding it. This means we don't have to hardcode a link to the favicon (which is missing at the moment) and we also get other `<head>` tags automatically, e.g: social sharing image.
 - Update other layouts to make sure they have the correct `assetUrl` set.

## Why
Anything using `layout-example` (for example, [tabs](https://design-system.service.gov.uk/components/tabs/default/index.html)) had a missing favicon and no social share image.

Anything using a layout with a missing `assetUrl` had a missing social share image as the asset could not be found (for example, [question pages](https://design-system.service.gov.uk/patterns/question-pages/default/index.html))

## Favicon / layout change
There should be no visual change for examples, other than that a favicon should now appear.

## Social share images
Social share previews tested using https://socialsharepreview.com

### Social share preview, before (component example)
<img width="619" alt="Screenshot 2022-01-04 at 13 18 38" src="https://user-images.githubusercontent.com/29889908/148068417-8082bae8-cc7f-4636-b1c7-914e645e7e92.png">

### Social share preview, after (component example)
<img width="626" alt="Screenshot 2022-01-04 at 13 18 13" src="https://user-images.githubusercontent.com/29889908/148068445-06563bd7-d434-475b-9259-c9bff1aa57f1.png">

### Social share preview, before (full page example)
<img width="644" alt="Screenshot 2022-01-04 at 13 19 18" src="https://user-images.githubusercontent.com/29889908/148068584-83796629-788c-4334-ab55-695304041690.png">

### Social share preview, after (full page example)
<img width="617" alt="Screenshot 2022-01-04 at 13 48 56" src="https://user-images.githubusercontent.com/29889908/148068643-96da30f4-2957-4296-9151-e525800fb338.png">

