### PR TITLE
Tell users about emoji and accent effect on count

### DIFF
--- a/src/components/character-count/index.md.njk
+++ b/src/components/character-count/index.md.njk
@@ -109,6 +109,8 @@ During this research, the component was tested with 17 users, including those wi
 
 There is a known issue with JAWS where the field’s label is repeated every time the count message is played. This is repetitive and likely to be disruptive for users.
 
+Also, this component [counts some characters as multiple characters](https://github.com/alphagov/govuk-frontend/issues/1104). For example, emojis and some non-Latin characters.
+
 ### Services using this component
 
 The component is used in a number of services, including the following.


### PR DESCRIPTION
Fixes [#1969](https://github.com/alphagov/govuk-design-system/issues/1969).

Updates the character count guidance to tell users it counts emojis and accented characters as more than one character. 

This behaviour might confuse users, if they think an emoji or accented character = 1 character, and the count ends up higher than they expected.