### PR TITLE
Remove leavers from the team list

### DIFF
--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -19,7 +19,6 @@ If you want to contact the team you can
 - Charlotte Downs – Interaction Designer
 - Chris Ballantine-Thomas – Senior Interaction Designer
 - Eoin Shaughnessy – Technical Writer
-- Hanna Laakso – Senior Frontend Developer
 - Imran Hussain – Community Manager
 - Izabela Podralska – Delivery Manager
 - Joe Lanman – Lead Interaction Designer
@@ -27,7 +26,6 @@ If you want to contact the team you can
 - Laurence de Bruxelles – Developer
 - Nora Brodian – Content Designer
 - Oliver Byford – Lead Frontend Developer, Government as a Platform
-- Rosie Clayton – User Researcher
 - Sara Cox – Senior Performance Analyst
 - Tim Paul – Head of Interaction Design, GDS
 - Trang Erskine – Senior Product Manager


### PR DESCRIPTION
Hanna and Rosie recently moved to GOV.UK - we should remove them from the team list.