### PR TITLE
Place full stops outside of single quotes

### DIFF
--- a/src/patterns/task-list-pages/index.md.njk
+++ b/src/patterns/task-list-pages/index.md.njk
@@ -95,11 +95,11 @@ This can be helpful when a task involves:
 
 Do this by asking a radio question at the end of the task — either as the last question (if the task is a single page) or on the [‘Check answers’ page](/patterns/check-answers/) (if the task uses multiple [question pages](/patterns/question-pages/)).
 
-Ask ‘Have you completed this section?’ with the radio options ‘Yes, I’ve completed this section’ or ‘No, I’ll come back later.’
+Ask ‘Have you completed this section?’ with the radio options ‘Yes, I’ve completed this section’ or ‘No, I’ll come back later’.
 
-If the user selects ‘No, I’ll come back to it later,’ mark the task as 'Incomplete' or 'In progress.'
+If the user selects ‘No, I’ll come back to it later,’ mark the task as 'Incomplete' or 'In progress'.
 
-If the user selects ‘Yes, I’ve completed this section,’ mark the task as 'Complete.'
+If the user selects ‘Yes, I’ve completed this section,’ mark the task as 'Completed'.
 
 {{ example({group: "patterns", item: "task-list-pages", example: "have-you-completed-this-section", html: true, nunjucks: true, open: false}) }}
 
@@ -107,7 +107,7 @@ Always allow users to go back into a task to change their answer.
 
 #### Error messages
 
-If the user does not select an option, show an [error message](/components/error-message/) to say: ‘Select whether you’ve completed this section.’
+If the user does not select an option, show an [error message](/components/error-message/) to say: 'Select whether you’ve completed this section'.
 
 {{ example({group: "patterns", item: "task-list-pages", example: "have-you-completed-this-section-error", html: true, nunjucks: true, open: false}) }}
 


### PR DESCRIPTION
Minor edit to pace full stops outside of single quotes, as they're not complete sentences (which would put the full stop inside the quotes).

Single quotes (') might need work to turn into 'curly quotes' (‘’), but I think they're changed automatically.