### PR TITLE
Remove error summary override `init` function

### DIFF
--- a/src/components/error-summary/default/code.njk
+++ b/src/components/error-summary/default/code.njk
@@ -7,7 +7,6 @@ layout: layout-example.njk
 
 {{ govukErrorSummary({
   titleText: "There is a problem",
-  disableAutoFocus: true,
   errorList: [
     {
       text: "The date your passport was issued must be in the past",

--- a/src/components/error-summary/full-page-example/code.njk
+++ b/src/components/error-summary/full-page-example/code.njk
@@ -21,11 +21,11 @@ layout: layout-example-full-page.njk
     <div class="govuk-grid-column-two-thirds">
       <form action="/form-handler" method="post" novalidate>
         {{ govukErrorSummary({
-          "titleText": "There is a problem",
-          "errorList": [
+          titleText: "There is a problem",
+          errorList: [
             {
-              "text": "Passport issue date must include a year",
-              "href": "#passport-issued-year"
+              text: "Passport issue date must include a year",
+              href: "#passport-issued-year"
             }
           ]
         }) }}

--- a/src/components/error-summary/full-page-example/code.njk
+++ b/src/components/error-summary/full-page-example/code.njk
@@ -22,7 +22,6 @@ layout: layout-example-full-page.njk
       <form action="/form-handler" method="post" novalidate>
         {{ govukErrorSummary({
           "titleText": "There is a problem",
-          "disableAutoFocus": true,
           "errorList": [
             {
               "text": "Passport issue date must include a year",

--- a/src/components/error-summary/full-page-example/index.njk
+++ b/src/components/error-summary/full-page-example/index.njk
@@ -21,12 +21,12 @@ layout: layout-example-full-page.njk
     <div class="govuk-grid-column-two-thirds">
       <form action="/form-handler" method="post" novalidate>
         {{ govukErrorSummary({
-          "titleText": "There is a problem",
-          "disableAutoFocus": true,
-          "errorList": [
+          titleText: "There is a problem",
+          disableAutoFocus: true,
+          errorList: [
             {
-              "text": "Passport issue date must include a year",
-              "href": "#passport-issued-year"
+              text: "Passport issue date must include a year",
+              href: "#passport-issued-year"
             }
           ]
         }) }}

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -13,7 +13,7 @@ Use this component at the top of a page to summarise any errors a user has made.
 
 When a user makes an error, you must show both an error summary and an [error message](/components/error-message/) next to each answer that contains an error.
 
-{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({group: "components", item: "error-summary", example: "default", customCode: true, html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ## When to use this component
 
@@ -42,20 +42,20 @@ You must link the errors in the error summary to the answer they relate to.
 
 For questions that require a user to answer using a single field, like a file upload, select, textarea, text input or character count, link to the field.
 
-{{ example({group: "components", item: "error-summary", example: "linking", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({group: "components", item: "error-summary", example: "linking", customCode: true, html: true, nunjucks: true, open: false, size: "s"}) }}
 
 When a user has to enter their answer into multiple fields, such as the day, month and year fields in the date input component, link to the first field that contains an error.
 
 If you do not know which field contains an error, link to the first field.
 
-{{ example({group: "components", item: "error-summary", example: "linking-multiple-fields", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({group: "components", item: "error-summary", example: "linking-multiple-fields", customCode: true, html: true, nunjucks: true, open: false, size: "s"}) }}
 
 For questions that require a user to select one or more options from a list using radios or checkboxes, link to the first radio or checkbox.
 
-{{ example({group: "components", item: "error-summary", example: "linking-checkboxes-radios", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({group: "components", item: "error-summary", example: "linking-checkboxes-radios", customCode: true, html: true, nunjucks: true, open: false, size: "s"}) }}
 
 ### Where to put the error summary
 
 Put the error summary at the top of the `main` container. If your page includes breadcrumbs or a back link, place it below these, but above the `<h1>`.
 
-{{ example({group: "components", item: "error-summary", example: "full-page-example", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({group: "components", item: "error-summary", example: "full-page-example", customCode: true, html: true, nunjucks: true, open: false, size: "s"}) }}

--- a/src/components/error-summary/linking-checkboxes-radios/code.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/code.njk
@@ -8,7 +8,6 @@ layout: layout-example.njk
 
 {{ govukErrorSummary({
   "titleText": "There is a problem",
-  "disableAutoFocus": true,
   "errorList": [
     {
       "text": "Select if you are British, Irish or a citizen of a different country",

--- a/src/components/error-summary/linking-checkboxes-radios/code.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/code.njk
@@ -7,11 +7,11 @@ layout: layout-example.njk
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukErrorSummary({
-  "titleText": "There is a problem",
-  "errorList": [
+  titleText: "There is a problem",
+  errorList: [
     {
-      "text": "Select if you are British, Irish or a citizen of a different country",
-      "href": "#nationality"
+      text: "Select if you are British, Irish or a citizen of a different country",
+      href: "#nationality"
     }
   ]
 }) }}

--- a/src/components/error-summary/linking-checkboxes-radios/index.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/index.njk
@@ -7,12 +7,12 @@ layout: layout-example.njk
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukErrorSummary({
-  "titleText": "There is a problem",
-  "disableAutoFocus": true,
-  "errorList": [
+  titleText: "There is a problem",
+  disableAutoFocus: true,
+  errorList: [
     {
-      "text": "Select if you are British, Irish or a citizen of a different country",
-      "href": "#nationality"
+      text: "Select if you are British, Irish or a citizen of a different country",
+      href: "#nationality"
     }
   ]
 }) }}

--- a/src/components/error-summary/linking-multiple-fields/code.njk
+++ b/src/components/error-summary/linking-multiple-fields/code.njk
@@ -8,7 +8,6 @@ layout: layout-example.njk
 
 {{ govukErrorSummary({
   "titleText": "There is a problem",
-  "disableAutoFocus": true,
   "errorList": [
     {
       "text": "Passport issue date must include a year",

--- a/src/components/error-summary/linking-multiple-fields/code.njk
+++ b/src/components/error-summary/linking-multiple-fields/code.njk
@@ -7,11 +7,11 @@ layout: layout-example.njk
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {{ govukErrorSummary({
-  "titleText": "There is a problem",
-  "errorList": [
+  titleText: "There is a problem",
+  errorList: [
     {
-      "text": "Passport issue date must include a year",
-      "href": "#passport-issued-year"
+      text: "Passport issue date must include a year",
+      href: "#passport-issued-year"
     }
   ]
 }) }}

--- a/src/components/error-summary/linking-multiple-fields/index.njk
+++ b/src/components/error-summary/linking-multiple-fields/index.njk
@@ -7,12 +7,12 @@ layout: layout-example.njk
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {{ govukErrorSummary({
-  "titleText": "There is a problem",
-  "disableAutoFocus": true,
-  "errorList": [
+  titleText: "There is a problem",
+  disableAutoFocus: true,
+  errorList: [
     {
-      "text": "Passport issue date must include a year",
-      "href": "#passport-issued-year"
+      text: "Passport issue date must include a year",
+      href: "#passport-issued-year"
     }
   ]
 }) }}

--- a/src/components/error-summary/linking/code.njk
+++ b/src/components/error-summary/linking/code.njk
@@ -7,11 +7,11 @@ layout: layout-example.njk
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {{ govukErrorSummary({
-  "titleText": "There is a problem",
-  "errorList": [
+  titleText: "There is a problem",
+  errorList: [
     {
-      "text": "Enter your full name",
-      "href": "#full-name-input"
+      text: "Enter your full name",
+      href: "#full-name-input"
     }
   ]
 }) }}
@@ -20,13 +20,13 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    "text": 'Full name'
+    text: 'Full name'
   },
   id: "full-name-input",
   name: "name",
   autocomplete: "name",
   errorMessage: {
-    "text": "Enter your full name"
+    text: "Enter your full name"
   }
 }) }}
 

--- a/src/components/error-summary/linking/code.njk
+++ b/src/components/error-summary/linking/code.njk
@@ -8,7 +8,6 @@ layout: layout-example.njk
 
 {{ govukErrorSummary({
   "titleText": "There is a problem",
-  "disableAutoFocus": true,
   "errorList": [
     {
       "text": "Enter your full name",

--- a/src/components/error-summary/linking/index.njk
+++ b/src/components/error-summary/linking/index.njk
@@ -7,12 +7,12 @@ layout: layout-example.njk
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {{ govukErrorSummary({
-  "titleText": "There is a problem",
-  "disableAutoFocus": true,
-  "errorList": [
+  titleText: "There is a problem",
+  disableAutoFocus: true,
+  errorList: [
     {
-      "text": "Enter your full name",
-      "href": "#full-name-input"
+      text: "Enter your full name",
+      href: "#full-name-input"
     }
   ]
 }) }}
@@ -21,13 +21,13 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    "text": 'Full name'
+    text: 'Full name'
   },
   id: "full-name-input",
   name: "name",
   autocomplete: "name",
   errorMessage: {
-    "text": "Enter your full name"
+    text: "Enter your full name"
   }
 }) }}
 

--- a/src/javascripts/govuk-frontend.js
+++ b/src/javascripts/govuk-frontend.js
@@ -31,12 +31,6 @@ nodeListForEach($details, function ($detail) {
 var $errorSummaries = document.querySelectorAll('[data-module="govuk-error-summary"]')
 nodeListForEach($errorSummaries, function ($errorSummary) {
   var errorSummary = new ErrorSummary($errorSummary)
-  // Override the `init` method since it automatically focuses the ErrorSummary.
-  // This is not ideal when showing examples for this component
-  // TODO: Allow option for ErrorSummary to avoid this hack
-  errorSummary.init = function () {
-    this.$module.addEventListener('click', ErrorSummary.prototype.handleClick.bind(this))
-  }
   errorSummary.init()
 })
 


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-design-system/issues/1666

**Note: this PR uses a pre-release of GOV.UK Frontend. The first commit will need to be deleted before merging.**

## What
Replaces the JavaScript override of the error summary `init` function with the new `disableAutoFocus` macro option instead.

Doing this means we have to introduce `code.njk` files for our error summary component examples, so that users viewing the HTML and Nunjucks code examples don't see the `disableAutoFocus` macro option/data attribute being set and accidentally copy that into their own service.

There should be no visual/behavioural changes as a result of this PR.

- The visual examples on the error summary page (or anywhere else they're used on the Design System website - I couldn't find any other uses) shouldn't capture focus
- The HTML/Nunjucks code examples shouldn't show the `disableAutoFocus` macro option or the `data-disable-auto-focus` attribute

## Why
When we release v4.0.1 of GOV.UK Frontend, it'll include a [change to allow `disableAutoFocus` to be passed to the error summary component](https://github.com/alphagov/govuk-frontend/pull/2494). We don't want auto focus on the design system website - if we did have it enabled then if someone visited https://design-system.service.gov.uk/components/error-summary/ they would be autofocused on the examples.

At the moment we have a line of JavaScript code that overrides the error summary `init` function to disable the auto focus behaviour. With v4.0.1, we can replace this and use the `disableAutoFocus` macro option instead.