### PR TITLE
Reference test workflow locally

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,7 +10,7 @@ concurrency: production
 
 jobs:
   build:
-    uses: alphagov/govuk-design-system/.github/workflows/test.yaml@fac33297b13e9e4cfa23d88b46a639dc0cbc25d3
+    uses: ./.github/workflows/test.yaml
     with:
       upload-artifact: true
 


### PR DESCRIPTION
GitHub have now [made it possible to reference other workflows locally][1], rather than needing to specify the repo and version.

Update the deploy workflow, which 'uses' the test workflow, to adopt this new, simpler approach.

[1]: https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/