### PR TITLE
Removed county field

### DIFF
--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -84,7 +84,7 @@ If you use multiple text inputs, you should:
 
 Make sure there are enough text inputs to accommodate longer addresses if you know your users will need them. For example, allow users to include a company name or flat&nbsp;number.
 
-Royal Mail does not need a county as long as the town and postcode are included. You should include an optional county text input so that people who do not know their postcode can give a valid address.
+Avoid including county unless you have good evidence of a need for it. It is not part of a correct address according to Royal Mail and is not used to deliver mail.
 
 #### Use the autocomplete attribute on multiple address fields
 

--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -84,7 +84,7 @@ If you use multiple text inputs, you should:
 
 Make sure there are enough text inputs to accommodate longer addresses if you know your users will need them. For example, allow users to include a company name or flat&nbsp;number.
 
-Avoid including county unless you have good evidence of a need for it. It is not part of a correct address according to Royal Mail and is not used to deliver mail.
+Do not ask for the county (such as Berkshire or Cumbria) unless you have good evidence of a need for it. It's not part of a correct UK address, according to Royal Mail, and it's not used to deliver mail.
 
 #### Use the autocomplete attribute on multiple address fields
 

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -46,15 +46,6 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      text: "County"
-    },
-    classes: "govuk-!-width-two-thirds",
-    id: "address-county",
-    name: "address-county"
-  }) }}
-
-  {{ govukInput({
-    label: {
       text: "Postcode"
     },
     classes: "govuk-input--width-10",


### PR DESCRIPTION
Royal Mail states county is not required for delivering mail. The Royal Mail address finder provides a correct address to customers and this does not contain county https://www.royalmail.com/find-a-postcode

**Royal Mail states:**
- _“There is no need to include a county name, your letters and parcels will reach your intended recipient without one.”_ https://personal.help.royalmail.com/app/answers/detail/a_id/81/~/how-to-address-your-mail-%28clear-addressing%29
- _“The county is not required as part of a correct postal address.”_ https://www.poweredbypaf.com/wp-content/uploads/2015/02/Latest-Programmers_guide_Edition-7-Version-6.pdf
- _“County data was removed from the core PAF files over ten years ago, has not been actively maintained and is not needed for delivery purposes”_ (dated 2017) https://www.poweredbypaf.com/wp-content/uploads/2018/09/BFPO-Data_-Factsheet.pdf

**County has not been required for many years for larger towns, islands, and towns that gave their name to the county.**  https://en.wikipedia.org/wiki/Postal_counties_of_the_United_Kingdom#Special_post_towns

Some UK addresses do not have a county, such as BFPO addresses. If an interface asks the user to give a county, Royal Mail tells the user _"probably the most logical solution is to duplicate the Town entry"_. This is what some people do for London, Birmingham, Bristol, etc.

**County has multiple meanings:**
When Royal Mail used county as part of addresses, each address could have three different entries against it:
* Postal county. https://en.wikipedia.org/wiki/Postal_counties_of_the_United_Kingdom
* Administrative county. https://en.wikipedia.org/wiki/Administrative_counties_of_England
* Traditional or historical county. https://en.wikipedia.org/wiki/Historic_counties_of_England

There is a fourth meaning:
* Ceremonial county. https://en.wikipedia.org/wiki/Ceremonial_counties_of_England

There are welsh equivalents of one or more of the above.

**Databases frequently fail to manage counties correctly**
For example Argos records Manchester as being in Lancashire (it isn’t).

**Royal Mail does not encourage use of county as error mitigation**
Postcode errors.
The postcode enables machine sorting. The rest of the address enables human delivery. If the postcode is absent or incorrect then it may affect the machine but not the human capability to deliver post without the county.

Combined errors.
I've heard people say county can be useful if all the following are true:
1. postcode is absent
2. AND two towns share a name, each of which will have an unambiguous correct postal town name
3. AND the user fails to use the correct postal town name
4. AND the delivery service chooses the wrong one of the two towns
5. AND the delivery service halts delivery rather than using street information to recover from the error

However, neither that scenario nor any other error has been mentioned by Royal Mail or by the PAF advisory board (who made the decision to delete counties from the PAF).

See also:
- _"Royal Mail set to delete counties from addresses"_ https://www.bbc.co.uk/news/uk-10825499
- _"What's the point of counties?"_ https://www.bbc.co.uk/news/magazine-10853705
- _"'Humberside' removed from Royal Mail address lists"_ https://www.bbc.co.uk/news/uk-england-humber-29440246