### PR TITLE
Changed field labels to 'Address line 1' and 'Address line 2'

### DIFF
--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -18,7 +18,7 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
+      html: 'Address line 1'
     },
     id: "address-line-1",
     name: "address-line-1",
@@ -27,7 +27,7 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
+      html: 'Address line 2 (optional)'
     },
     id: "address-line-2",
     name: "address-line-2",


### PR DESCRIPTION
This change did three things:
1. Stopped the second field label being invisible
2. Added 'optional' to second field label
3. Made the labels 'Address line 1' and 'Address line 2'