### PR TITLE
Tell users to support necessary characters

### DIFF
--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -192,11 +192,13 @@ For example, ‘Last name must be between 2 and 35 characters’.
 
 Say ‘[whatever it is] must not include [characters]’.<br>
 For example, ‘Town or city must not include è and £’.
+Support all the characters the user might need to enter, including numbers and symbols.
 
 #### If the input uses characters that are not allowed and you do not know what the characters are
 
 Say ‘[whatever it is] must only include [list of allowed characters]’.<br>
 For example, ‘Full name must only include letters a to z, hyphens, spaces and apostrophes’.
+Support all the characters the user might need to enter, including numbers and symbols.
 
 #### If the input is not a number
 


### PR DESCRIPTION
Fixes [#1857](https://github.com/alphagov/govuk-design-system/issues/1857).

This PR updates our text input guidance.

The current guidance suggests certain characters are not allowed, which conflicts with our guidance elsewhere. Not allowing characters can be discriminatory.