### PR TITLE
Tell users to accept caseless input for usernames

### DIFF
--- a/src/patterns/create-a-username/index.md.njk
+++ b/src/patterns/create-a-username/index.md.njk
@@ -30,13 +30,14 @@ You should do research to understand this group and have a plan for helping them
 
 You should only ask users to create their own custom usernames if your service contains user-generated content that requires attributing, for example, a blog with comments. Allowing custom usernames lets users hide their identity if they want to.
 
-User-generated usernames are harder to create and easier to forget than email&nbsp;addresses.
+User-generated usernames are harder to create and easier to forget than email addresses.
 
 You need to:
 
-- tell people whether their proposed username is unique
-- suggest unique ones for them, in some cases
-- make sure people can retrieve or reset their username
+- tell the user whether their proposed username is unique
+- suggest a unique username for them, in some cases
+- make sure the user can retrieve or reset their username
+- ignore letter case when accepting usernames - for example, if the actual username is ‘Mary<i></i>@example.com’, the user can still sign in with ‘mary<i></i>@example.com’
 
 ### Always let people make changes
 


### PR DESCRIPTION
Fixes [#2055](https://github.com/alphagov/govuk-design-system/issues/2055).

This PR updates our 'Create a username' pattern.