### PR TITLE
Add titleSuffix: "second" to second default button example

### DIFF
--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -42,7 +42,7 @@ Use a default button for the main call to action on a page.
 
 Avoid using multiple default buttons on a single page. Having more than one main call to action reduces their impact, and makes it harder for users to know what to do next.
 
-{{ example({group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 
 ### Start buttons
 


### PR DESCRIPTION
## What
Adds `titleSuffix: "second"` to the second `default` example in the [button component docs](https://design-system.service.gov.uk/components/button/).

## Why
This change sets the ids for the code example containers of the second button example on the page to `button-second-example-{html/nunjucks}`. Without the title suffix, it was just `button-example-{html/nunjucks}` which clashed with the ids of the first example on the page, thus breaking the html spec of not having 2 of the same id on one page.