### PR TITLE
Bump marked to 4.0.10

### DIFF
--- a/lib/extract-page-headings/index.js
+++ b/lib/extract-page-headings/index.js
@@ -1,4 +1,4 @@
-const marked = require('marked')
+const { marked } = require('marked')
 
 const plugin = () => {
   return function (files, metalsmith, done) {

--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -1,12 +1,11 @@
 const fs = require('fs')
 const path = require('path')
-
-const markdownRenderer = require('marked')
+const { marked } = require('marked')
 
 const paths = require('../paths.js')
 
 // Get reference to marked.js
-let renderer = new markdownRenderer.Renderer()
+let renderer = new marked.Renderer()
 // Override marking up paragraphs
 renderer.paragraph = text => text
 
@@ -32,7 +31,7 @@ function addSlugs (option) {
 function renderDescriptionsAsMarkdown (option) {
   if (option.description) {
     try {
-      option.description = markdownRenderer(option.description, { renderer: (renderer) })
+      option.description = marked(option.description, { renderer: (renderer) })
     } catch (e) {
       console.error(e)
       process.exit(1) // Exit with a failure mode

--- a/package-lock.json
+++ b/package-lock.json
@@ -8759,9 +8759,9 @@
       }
     },
     "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
       "dev": true
     },
     "mdurl": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "js-beautify": "^1.9.1",
     "jstransformer-marked": "^1.0.3",
     "jstransformer-nunjucks": "^0.5.0",
-    "marked": "^0.7.0",
+    "marked": "^4.0.10",
     "metalsmith": "^2.3.0",
     "metalsmith-assets": "^0.1.0",
     "metalsmith-broken-link-checker": "^1.0.1",


### PR DESCRIPTION
[This dependabot bump](https://github.com/alphagov/govuk-design-system/pull/2020) is failing because we need to update some `require` statements, since `marked`'s default export was removed in 4.0.0.

https://github.com/markedjs/marked/releases/tag/v4.0.0