### PR TITLE
Fix navigation when zooming 'text only'

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -1,5 +1,4 @@
 .app-navigation {
-  @include govuk-font(19, $weight: bold);
   box-sizing: border-box;
   width: 100%;
   background-color: $app-light-grey;
@@ -20,6 +19,8 @@
 .app-navigation__list-item {
   $navigation-height: 50px;
 
+  @include govuk-font(19, $weight: bold, $line-height: $navigation-height);
+
   box-sizing: border-box;
   display: block;
   position: relative;
@@ -27,7 +28,6 @@
   height: govuk-px-to-rem($navigation-height); // sass-lint:disable-line no-duplicate-properties
   padding: 0 govuk-spacing(3);
   float: left;
-  line-height: $navigation-height;
 }
 
 .app-navigation__list-item--current {

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -1,5 +1,3 @@
-$navigation-height: 50px;
-
 .app-navigation {
   @include govuk-font(19, $weight: bold);
   box-sizing: border-box;
@@ -20,10 +18,13 @@ $navigation-height: 50px;
 }
 
 .app-navigation__list-item {
+  $navigation-height: 50px;
+
   box-sizing: border-box;
   display: block;
   position: relative;
   height: $navigation-height;
+  height: govuk-px-to-rem($navigation-height); // sass-lint:disable-line no-duplicate-properties
   padding: 0 govuk-spacing(3);
   float: left;
   line-height: $navigation-height;

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -1,6 +1,4 @@
 .app-navigation {
-  box-sizing: border-box;
-  width: 100%;
   background-color: $app-light-grey;
 
   @include govuk-media-query($until: tablet) {


### PR DESCRIPTION
Set the height in rem as well as pixels to ensure that the height of the navigation adjusts to fit the text when zooming ‘text only’.

Refactor and tidy up some redundant code – see individual commits for details.

## Before

<img width="1792" alt="Screenshot 2022-02-16 at 17 18 50" src="https://user-images.githubusercontent.com/121939/154320223-0f7e0670-4ac7-4fb7-8af4-5048a4fadcca.png">

## After

<img width="1792" alt="Screenshot 2022-02-16 at 17 18 53" src="https://user-images.githubusercontent.com/121939/154320231-16f90aa8-0e71-4f0f-b4ba-83b8ee47b8e6.png">

Part of #2028 