### PR TITLE
Make navigation links consistent with other links

### DIFF
--- a/src/stylesheets/components/_mobile-navigation.scss
+++ b/src/stylesheets/components/_mobile-navigation.scss
@@ -34,10 +34,6 @@
   @include govuk-typography-weight-bold; // Override .govuk-link weight
   font-size: 19px; // We do not have a font mixin that produces 19px on mobile
   font-size: govuk-px-to-rem(19px); // sass-lint:disable-line no-duplicate-properties
-
-  &:not(:focus):hover {
-    color: $govuk-link-colour;
-  }
 }
 
 .app-mobile-nav-subnav-toggler__link,

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -36,10 +36,6 @@ $navigation-height: 50px;
 .app-navigation__link {
   @include govuk-typography-weight-bold;
 
-  &:not(:focus):hover {
-    color: $govuk-link-colour;
-  }
-
   // Extend the touch area of the link to the list
   &:after {
     content: "";

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -16,10 +16,6 @@
 
   .app-subnav__link {
     padding: 2px 0;
-
-    &:not(:focus):hover {
-      color: $govuk-link-colour;
-    }
   }
 
   .app-subnav__section-item {


### PR DESCRIPTION
Our ‘standard’ links turn darker blue on hover:

![Screenshot 2022-02-16 at 17 38 11](https://user-images.githubusercontent.com/121939/154324705-1d70b4f9-d95b-4bb5-9521-2f7777319156.png)

This CSS is currently overriding that behaviour so that the links _do not_ change colour on hover.

This was [discussed when we first introduced the new link styles to the Design System][1]. It seems like we were mainly looking to preserve the existing behaviour, but it’s not clear that this is desirable and nobody knew of any reason why the links shouldn’t get darker on hover.

Remove the overrides so that the navigation links are consistent with other links across the Design System.

| Navigation element | Before | After |
| -- | -- | -- |
| Top nav | ![Screenshot 2022-02-16 at 17 37 42](https://user-images.githubusercontent.com/121939/154324815-9acb75f7-87b5-4952-acf6-d3373d83409b.png) | ![Screenshot 2022-02-16 at 17 37 35](https://user-images.githubusercontent.com/121939/154324816-ec1d23ad-43de-4ef1-bb9d-7f2946c26298.png) |
| Sub nav | ![Screenshot 2022-02-16 at 17 37 10](https://user-images.githubusercontent.com/121939/154324874-2074bdd0-a2e7-4335-9573-65bc54f491ea.png) | ![Screenshot 2022-02-16 at 17 36 57](https://user-images.githubusercontent.com/121939/154324878-e83d7416-350e-466b-bf07-35847aaea7dd.png) |
| Mobile nav | ![Screenshot 2022-02-16 at 17 45 08](https://user-images.githubusercontent.com/121939/154324919-20cd0100-0143-4874-a963-da2f134f7098.png) | ![Screenshot 2022-02-16 at 17 45 01](https://user-images.githubusercontent.com/121939/154324923-d731e9f7-7b49-4e54-a60a-8b5945f824f2.png) |

[1]: https://github.com/alphagov/govuk-design-system/pull/1648#discussion_r630122484