### PR TITLE
Add guidance on error message for text input

### DIFF
--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -192,12 +192,14 @@ For example, ‘Last name must be between 2 and 35 characters’.
 
 Say ‘[whatever it is] must not include [characters]’.<br>
 For example, ‘Town or city must not include è and £’.
+
 Support all the characters the user might need to enter, including numbers and symbols.
 
 #### If the input uses characters that are not allowed and you do not know what the characters are
 
 Say ‘[whatever it is] must only include [list of allowed characters]’.<br>
-For example, ‘Full name must only include letters a to z, hyphens, spaces and apostrophes’.
+For example, ‘Full name must only include letters a to z, and special characters such as hyphens, spaces and apostrophes’.
+
 Support all the characters the user might need to enter, including numbers and symbols.
 
 #### If the input is not a number


### PR DESCRIPTION
Fixes [#1734](https://github.com/alphagov/govuk-design-system/issues/1734).

Updates our [text input guidance](https://design-system.service.gov.uk/components/text-input/).

### Problem
Current guidance under ['If the input uses characters that are not allowed and you do not know what the characters are'](https://design-system.service.gov.uk/components/text-input/#if-the-input-uses-characters-that-are-not-allowed-and-you-do-not-know-what-the-characters-are):

> Say ‘[whatever it is] must only include [list of allowed characters]’.
> For example, ‘Full name must only include letters a to z, hyphens, spaces and apostrophes’.

Users have reported that if they follow this advice, they will end up listing every character allowed, resulting in overlong UI text.

### Possible solution
Change second sentence so that it reads:

> For example, ‘Full name must only include letters a to z, and special characters such as hyphens, spaces and apostrophes’.

Hopefully, the added "and special characters such as" will convey that the example list can be non-exhaustive. One user is already [following a similar approach](https://github.com/alphagov/govuk-design-system/issues/1734#issuecomment-1044372434).