### PR TITLE
Mark up summary list example with <address>

### DIFF
--- a/src/components/summary-list/default/index.njk
+++ b/src/components/summary-list/default/index.njk
@@ -46,7 +46,7 @@ layout: layout-example.njk
         text: "Address"
       },
       value: {
-        html: "72 Guild Street<br>London<br>SE23 6FH"
+        html: "<address>72 Guild Street<br>London<br>SE23 6FH</address>"
       },
       actions: {
         items: [


### PR DESCRIPTION
The address may use the contact address element ````<address>````, allowed within a ````<dl>```` parent element