### PR TITLE
Tell users we ask for consent before we thank them

### DIFF
--- a/src/community/index.md.njk
+++ b/src/community/index.md.njk
@@ -41,6 +41,8 @@ Share research findings and examples with others. Be open to feedback or changes
 
 Above all, be kind. Encourage others to contribute by being respectful when asking questions or giving feedback.
 
+When our users make a contribution to the Design System, we like to publicly thank them for their work. If you've contributed, we'll ask you for permission before we give you a shout-out.
+
 ### 3. Prioritise openness and honesty
 
 Prioritise sharing components and patterns in the GOV.UK Design System and [community backlog](/community/backlog/). This makes them easier to find and reduces duplication of effort.


### PR DESCRIPTION
Fixes [#1546](https://github.com/alphagov/govuk-design-system/issues/1546).

Updates our [Community homepage](https://design-system.service.gov.uk/community/) to tell users:

- we like to thank them for their contributions
- we'll ask for permission before we thank them publicly