### PR TITLE
Remove unneeded full stop from text input examples

### DIFF
--- a/src/components/text-input/error/index.njk
+++ b/src/components/text-input/error/index.njk
@@ -14,7 +14,7 @@ layout: layout-example.njk
   id: "event-name",
   name: "event-name",
   hint: {
-    text: "The name you’ll use on promotional material."
+    text: "The name you’ll use on promotional material"
   },
   errorMessage: {
     text: "Enter an event name"

--- a/src/components/text-input/input-hint-text/index.njk
+++ b/src/components/text-input/input-hint-text/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
     isPageHeading: true
   },
   hint: {
-    text: "The name you’ll use on promotional material."
+    text: "The name you’ll use on promotional material"
   },
   id: "event-name",
   name: "event-name"


### PR DESCRIPTION
Removes unneeded full stops from these examples within our text input guidance:

- [hint text](https://design-system.service.gov.uk/components/text-input/#hint-text)
- [error messages](https://design-system.service.gov.uk/components/text-input/#:~:text=Error%20messages%20should%20be%20styled%20like%20this%3A)

[A user on Slack pointed out an inconsistency](https://ukgovernmentdigital.slack.com/archives/C6DMEH5R6/p1645710637156809) - the text ("The name you'll use on promotional material") in these examples has a full stop, whereas similar text elsewhere on this page does not.