### PR TITLE
Tell users to left align but not justify body copy

### DIFF
--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -79,6 +79,10 @@ Use:
 - `govuk-!-text-align-right` to align text to the right
 - `govuk-!-text-align-centre` to align text to the centre
 
+You should usually left-align body copy that's read left to right. Right-aligned body copy can be hard for users to find and read when they magnify their screen.
+
+Do not 'justify' blocks of body copy so that they're aligned to both the left and right margins. Doing this creates wider spaces between words, which can make the text hard to read.
+
 ## Font override classes
 
 You might need to set the font size or font weight of an element outside of the predefined heading and paragraph classes. For this you can use the font override classes in your HTML or reference the typography mixins in your own components.


### PR DESCRIPTION
Fixes [#2075](https://github.com/alphagov/govuk-design-system/issues/2075).

Updates our typography guidance to tell users why they should:

- usually left-align body copy
- avoid 'justifying' blocks of text so that it's aligned to both the left and right margins