### PR TITLE
Fix syntax highlighting in telephone numbers pattern

### DIFF
--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -72,7 +72,7 @@ Tell users why you might contact them and when.
 
 It’s possible to mark up telephone numbers as links, like this:
 
-```
+```html
 <a href="tel:+442079476330">020 7947 6330</a>
 ```
 


### PR DESCRIPTION
Explicitly set the language so that the syntax highlighting is applied correctly to the code block.

## Before

![Screenshot 2022-03-03 at 13 54 31](https://user-images.githubusercontent.com/121939/156578823-9e904b20-fe1e-41aa-83bf-ace9c929f51c.png)

## After

![Screenshot 2022-03-03 at 13 54 33](https://user-images.githubusercontent.com/121939/156578828-67f89b42-6ef4-4ba7-b828-43e05b6a59d1.png)
