### PR TITLE
Add missing class to cookie banner in page template

### DIFF
--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -56,8 +56,8 @@ ignore_in_sitemap: true
     messages: [
       {
         headingText: "Cookies on [name of service]",
-        html: "<p>We use some essential cookies to make this service work.</p>
-               <p>We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>",
+        html: "<p class=\"govuk-body\">We use some essential cookies to make this service work.</p>
+               <p class=\"govuk-body\">We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>",
         actions: [
           {
             text: "Accept analytics cookies",

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -51,8 +51,8 @@ ignore_in_sitemap: true
     messages: [
       {
         headingText: "Cookies on [name of service]",
-        html: "<p>We use some essential cookies to make this service work.</p>
-               <p>We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>",
+        html: "<p class=\"govuk-body\">We use some essential cookies to make this service work.</p>
+               <p class=\"govuk-body\">We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>",
         actions: [
           {
             text: "Accept analytics cookies",


### PR DESCRIPTION
Following on from f85db87 (#1891), we also need to add the `govuk-body` class to the paragraphs in the cookie banner in the ‘custom page template’ example.

Previously we were relying on default colour and margins for the text content within the cookie banner, when html was passed to the banner. In the yaml examples in govuk-frontend, we assume a user will add govuk-body classes to any html they pass in.

We then [went on to remove the default font styles from the cookie banner in 4.0.0][1], to make it more obvious when you have not added classes and styles to any custom HTML – but didn’t notice we had an example in the Design System which did just that!

## Before

![Screenshot 2022-03-03 at 14 08 38](https://user-images.githubusercontent.com/121939/156580955-92722b1c-4f0e-4122-bd91-c6024a6bb476.png)

## After

![Screenshot 2022-03-03 at 14 08 55](https://user-images.githubusercontent.com/121939/156580952-f07f274e-3af7-44b3-b50b-99aa8ed65227.png)

[1]: https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md#style-any-custom-html-in-your-cookie-banner