### PR TITLE
Say what to hide when you set cookies client side

### DIFF
--- a/src/components/cookie-banner/index.md.njk
+++ b/src/components/cookie-banner/index.md.njk
@@ -39,7 +39,7 @@ This component page shows several options for using a cookie banner, based on th
 You must not take the information on this page as legal advice. Your organisation is responsible and accountable for what they do to comply with data protection legislation, such as:
 - Privacy and Electronic Communications Regulations (PECR)
 - General Data Protection Regulation (GDPR)
- 
+
 Check with your organisation's privacy expert to see how data protection legislation affects your website and service.
 
 ## How it works
@@ -106,8 +106,8 @@ Here's the same example of a progressively enhanced cookie banner, with the conf
 ### Option 3: If you set non-essential cookies, but only on the client
 
 You can choose to make your banner only work with JavaScript if your service only needs to set non-essential cookies on the client.
- 
-When the page loads, include all the cookie banner messages that the user might see, but hide these with the `hidden` HTML attribute.
+
+When the page loads, the `hidden` html attribute hides the component, as well as all the cookie banner messages it contains, which the user might otherwise see.
 
 #### Show the cookie banner only to users that have enabled JavaScript
 
@@ -129,7 +129,7 @@ Show a confirmation message confirming that the user has either accepted or reje
 
 {{ example({group: "components", item: "cookie-banner", example: "client-side-accepted", html: true, nunjucks: true, open: false}) }}
 
-#### When the user has rejected cookies 
+#### When the user has rejected cookies
 
 {{ example({group: "components", item: "cookie-banner", example: "client-side-rejected", html: true, nunjucks: true, open: false}) }}
 


### PR DESCRIPTION
Fixes [#1849](https://github.com/alphagov/govuk-design-system/issues/1849).

Currently, [option 3 ('If you set non-essential cookies, but only on the client') of our cookie banner guidance](https://design-system.service.gov.uk/components/cookie-banner/#:~:text=When%20the%20page%20loads%2C%20include%20all%20the%20cookie%20banner%20messages%20that%20the%20user%20might%20see%2C%20but%20hide%20these%20with%20the%20hidden%20HTML%20attribute.) reads:

> When the page loads, include all the cookie banner messages that the user might see, but hide these with the hidden HTML attribute.

However, it wasn't clear to a user that both the component and the messages need to be hidden when the page loads. So this PR specifies what containers to hide.