### PR TITLE
Say what fields to highlight when info is missing

### DIFF
--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -85,7 +85,7 @@ Say ‘Enter [whatever it is]’. For example, ‘Enter your date of birth’.
 
 #### If the date is incomplete
 
-Highlight the day, month or year field where the information is missing. If more than one field is missing information, highlight the date input as a whole.<br>
+Highlight the day, month or year field where the information is missing. If more than one field is missing information, highlight the fields the user needs to fill in.<br>
 
 Say ‘[whatever it is] must include a [whatever is missing]’.<br>
 


### PR DESCRIPTION
Fixes [#1637](https://github.com/alphagov/govuk-design-system/issues/1637).

Updates the 'error messages' section of our date input guidance.

Our current guidance says, when information is missing from multiple fields, you should highlight all fields. This means, by implication, also highlighting fields the user has actually filled in.

This PR changes the guidance so that it now says to highlight only the fields the user needs to fill in.