### PR TITLE
Update error guidance to say years need 4 numbers

### DIFF
--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -85,11 +85,11 @@ Say ‘Enter [whatever it is]’. For example, ‘Enter your date of birth’.
 
 #### If the date is incomplete
 
-Highlight the day, month or year field where the information is missing. If more than one field is missing information, highlight the fields the user needs to fill in.<br>
+Highlight the day, month or year field where the information is missing or incomplete. If more than one field is missing information, highlight the fields the user needs to fill in.<br>
 
 Say ‘[whatever it is] must include a [whatever is missing]’.<br>
 
-For example, ‘Date of birth must include a month’ or ‘Date of birth must include a day and month’.
+For example, ‘Date of birth must include a month’, ‘Date of birth must include a day and month’ or ‘Year must include 4 numbers’.
 
 #### If the date entered cannot be correct
 


### PR DESCRIPTION
Fixes [#2029](https://github.com/alphagov/govuk-design-system/issues/2029).

Updates the 'Error messages' section of our date input guidance.

### Why we've made this change
A user asked if we could spell out that the year field requires 4 numbers. Otherwise, some people might enter only 2, and this could be confusing.

The guidance examples all use 4 numbers for the year. Might be good to recommend this in the guidance itself too.