### PR TITLE
Link to scala implementation of govuk-frontend

### DIFF
--- a/src/community/resources-and-tools/index.md.njk
+++ b/src/community/resources-and-tools/index.md.njk
@@ -92,6 +92,11 @@ A Ruby gem that adds the GOV.UK Frontend to Rails applications.
 A complete Rails starter application using GOV.UK Frontend.
 
 
+### Scala
+
+[Play Frontend HMRC](https://github.com/hmrc/play-frontend-hmrc) 
+Scala library providing Twirl implementations of govuk-frontend and hmrc-frontend components.
+
 
 ## Write code
 


### PR DESCRIPTION
Was mentioned in cross gov slack that there wasn't a link to this library in the resources and tools section so I volunteered to propose a change to list it. This library is called play-frontend-hmrc but it also contains an implementation of all govuk components. This library is maintained by the Platform UI team on the HMRC Tax Platform.