### PR TITLE
Link Design System to list of other design systems

### DIFF
--- a/src/community/resources-and-tools/index.md.njk
+++ b/src/community/resources-and-tools/index.md.njk
@@ -11,6 +11,8 @@ You can use these community resources and tools to help you use the GOV.UK Desig
 
 The GOV.UK Design System team is not responsible for these resources and tools and we cannot support you with using them. Please contact the owner if you need help or you want to request a feature.
 
+To find information about other design systems across government, see a community-managed [list of design systems created by different departments](https://github.com/ctdesign/gov-design-systems-list).
+
 
 ## Create flow diagrams
 

--- a/src/index.njk
+++ b/src/index.njk
@@ -57,7 +57,7 @@ masthead: true
         <h2 id="support" class="govuk-heading-l">Support</h2>
         <p class="govuk-body">
           The GOV.UK Design System is <a class="govuk-link" href="/design-system-team/">maintained by a team at the Government Digital Service</a>.
-          If you’ve got a question, idea or suggestion you can <a class="govuk-link" href="/get-in-touch/">contact the team</a>.
+          If you’ve got a question, idea or suggestion, you can <a class="govuk-link" href="/get-in-touch/">contact the team</a>.
         </p>
        <p class="govuk-body">
         See <a class="govuk-link" href="/community/blogs-talks-podcasts/">blog posts, video talks, and podcasts about the GOV.UK Design System and Prototype Kit</a>.


### PR DESCRIPTION
Fixes [#2109](https://github.com/alphagov/govuk-design-system/issues/2109).

### Why we're adding this content
[Support ticket analysis](https://docs.google.com/presentation/d/1TxZ17AJDMKI6djT1lEQj6wuH6U9edjZyRm2MfmGOar8/edit#slide=id.g119a61403dd_0_111) shows that some users have asked us for help with the Home Office Design System. Redirecting them to a [community-managed list of design systems](https://github.com/ctdesign/gov-design-systems-list) might prevent this from happening again.