### PR TITLE
Use text option for address pattern example

### DIFF
--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -18,7 +18,7 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      html: 'Address line 1'
+      text: 'Address line 1'
     },
     id: "address-line-1",
     name: "address-line-1",
@@ -27,7 +27,7 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      html: 'Address line 2 (optional)'
+      text: 'Address line 2 (optional)'
     },
     id: "address-line-2",
     name: "address-line-2",


### PR DESCRIPTION
We previously included some HTML in the label for these two fields in order to add visually hidden suffixes.

We try to ensure we use the `text` option over the `html` option unless passing HTML, as the `text` option escapes any user input that might be passed as part of the string, preventing XSS attacks.

On that basis, now that these labels are ‘just text’, update the example to use the `text` option.