### PR TITLE
Remove ƒ typo in fieldset example

### DIFF
--- a/src/components/fieldset/address-group/index.njk
+++ b/src/components/fieldset/address-group/index.njk
@@ -24,7 +24,7 @@ stylesheets:
     name: "address-line-1",
     autocomplete: "address-line1"
   }) }}
-ƒ
+
   {{ govukInput({
     label: {
       text: 'Address line 2 (optional)'


### PR DESCRIPTION
We accidentally added a rogue ƒ in the last update to the fieldset page – this removes it.