### PR TITLE
Put county field back in address pattern and update guidance

### DIFF
--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -14,9 +14,60 @@ This guidance is for government teams that build online services. [To find infor
 
 Help users provide an address using one of the following:
 
-- Address lookup
 - Multiple text inputs
+- Address lookup
 - Textarea
+
+## Multiple text inputs
+
+{{ example({group: "patterns", item: "addresses", example: "multiple", html: true, nunjucks: true, open: true, size: "xl"}) }}
+
+### When to use multiple text inputs
+
+Only use multiple text inputs when you know which countries the addresses will come from and can find a format that supports them all. This can be difficult to know if you’re asking for addresses outside of the UK.
+
+Using multiple text inputs means:
+
+- you can easily extract and use specific parts of an address
+- you can give help for individual text inputs
+- you can validate each part of the address separately
+- users can complete the form using their browser’s autocomplete function
+
+The disadvantages of using multiple text inputs are that:
+
+- it’s hard to find a single format that works for all addresses
+- there’s no guarantee that users will use the text inputs the way you think they will
+- users cannot easily paste addresses from their clipboards
+
+### How multiple text inputs work
+
+If you use multiple text inputs, you should:
+
+- only make individual text inputs mandatory if you really need the information
+- make the text inputs the appropriate length for the content – it helps people understand the form, for example, make postcode text inputs shorter than street text inputs
+- <a href="#allow-different-postcode-formats">let users enter postcodes in different formats</a>
+
+Make sure there are enough text inputs to accommodate longer addresses if you know your users will need them. For example, allow users to include a company name or flat&nbsp;number.
+
+Make it optional for users to enter their county (such as Berkshire or Cumbria). It’s not part of a correct UK address, according to Royal Mail, and it’s not used to deliver post.
+
+Remove the county field if you’re sure your users will not need it, and your service will not use it.
+
+#### Use the autocomplete attribute on multiple address fields
+
+Use the `autocomplete` attribute on each individual address field to help users enter their address more quickly. This lets you specify each input’s purpose so browsers can autofill the information on a user’s behalf if they’ve entered it previously.
+
+[Check which input purpose to use](https://www.w3.org/TR/WCAG21/#input-purposes) for each field.
+
+In production, you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html). You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
+
+#### Error messages
+
+Error messages should be styled like this:
+
+{{ example({group: "patterns", item: "addresses", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
+
+Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
 ## Address lookup
 
@@ -52,55 +103,6 @@ When using an address lookup, you should:
 It is easier for users if you accept and ignore unwanted characters. This is better than rejecting the input and telling a user they've not provided a valid postcode.
 
 You should allow postcodes that contain upper and lower case letters, no spaces, additional spaces at the beginning, middle or end and punctuation like hyphens, brackets, dashes and full stops.
-
-## Multiple text inputs
-
-{{ example({group: "patterns", item: "addresses", example: "multiple", html: true, nunjucks: true, open: true, size: "xl"}) }}
-
-### When to use multiple text inputs
-
-Only use multiple text inputs when you know which countries the addresses will come from and can find a format that supports them all. This can be difficult to know if you’re asking for addresses outside of the UK.
-
-Using multiple text inputs means:
-
-- you can easily extract and use specific parts of an address
-- you can give help for individual text inputs
-- you can validate each part of the address separately
-- users can complete the form using their browser’s autocomplete function
-
-The disadvantages of using multiple text inputs are that:
-
-- it’s hard to find a single format that works for all addresses
-- there’s no guarantee that users will use the text inputs the way you think they will
-- users cannot easily paste addresses from their clipboards
-
-### How multiple text inputs work
-
-If you use multiple text inputs, you should:
-
-- only make individual text inputs mandatory if you really need the information
-- make the text inputs the appropriate length for the content – it helps people understand the form, for example, make postcode text inputs shorter than street text inputs
-- <a href="#allow-different-postcode-formats">let users enter postcodes in different formats</a>
-
-Make sure there are enough text inputs to accommodate longer addresses if you know your users will need them. For example, allow users to include a company name or flat&nbsp;number.
-
-Do not ask for the county (such as Berkshire or Cumbria) unless you have good evidence of a need for it. It's not part of a correct UK address, according to Royal Mail, and it's not used to deliver mail.
-
-#### Use the autocomplete attribute on multiple address fields
-
-Use the `autocomplete` attribute on each individual address field to help users enter their address more quickly. This lets you specify each input’s purpose so browsers can autofill the information on a user’s behalf if they’ve entered it previously.
-
-[Check which input purpose to use](https://www.w3.org/TR/WCAG21/#input-purposes) for each field.
-
-In production, you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html). You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
-
-#### Error messages
-
-Error messages should be styled like this:
-
-{{ example({group: "patterns", item: "addresses", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
-
-Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
 ## Textarea
 

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -41,7 +41,7 @@ stylesheets:
     classes: "govuk-!-width-two-thirds",
     id: "address-town",
     name: "address-town",
-    autocomplete: "address-level1"
+    autocomplete: "address-level2"
   }) }}
 
   {{ govukInput({

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -18,16 +18,16 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      html: 'Address line 1'
+      text: 'Address line 1'
     },
     id: "address-line-1",
     name: "address-line-1",
-    autocomplete: "address-line1"
+    autocomplete: "address-line-1"
   }) }}
 
   {{ govukInput({
     label: {
-      html: 'Address line 2 (optional)'
+      text: 'Address line 2 (optional)'
     },
     id: "address-line-2",
     name: "address-line-2",
@@ -41,6 +41,16 @@ stylesheets:
     classes: "govuk-!-width-two-thirds",
     id: "address-town",
     name: "address-town",
+    autocomplete: "address-level1"
+  }) }}
+
+  {{ govukInput({
+    label: {
+      text: "County (optional)"
+    },
+    classes: "govuk-!-width-two-thirds",
+    id: "address-county",
+    name: "address-county",
     autocomplete: "address-level2"
   }) }}
 

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -22,7 +22,7 @@ stylesheets:
     },
     id: "address-line-1",
     name: "address-line-1",
-    autocomplete: "address-line-1"
+    autocomplete: "address-line1"
   }) }}
 
   {{ govukInput({
@@ -50,8 +50,7 @@ stylesheets:
     },
     classes: "govuk-!-width-two-thirds",
     id: "address-county",
-    name: "address-county",
-    autocomplete: "address-level2"
+    name: "address-county"
   }) }}
 
   {{ govukInput({


### PR DESCRIPTION
This change updates the address pattern to:
* add the county field back in, after recently removing it (see https://github.com/alphagov/govuk-design-system-backlog/issues/31#issuecomment-1096919621)
* slightly switch the order of the different patterns, so 'multiple text fields' come first

We reordered the content based on a Slack conversation where a few members of the community felt that the 'multiple text fields' use case was more common than the others.