### PR TITLE
Make help text advice clearer in fieldset guidance

### DIFF
--- a/src/components/fieldset/index.md.njk
+++ b/src/components/fieldset/index.md.njk
@@ -2,7 +2,7 @@
 title: Fieldset
 description: Use the fieldset component to group related form inputs
 section: Components
-aliases: 
+aliases:
 backlog_issue_id: 48
 layout: layout-pane.njk
 ---
@@ -31,4 +31,4 @@ Read more about [why and how to set legends as headings](/get-started/labels-leg
 
 On [question pages](/patterns/question-pages/) containing a group of inputs, including the question as the legend helps users of screen readers to understand that the inputs are all related to that&nbsp;question.
 
-Include any general help text which is important for filling in the form and cannot be written as [hint text](/components/text-input/#hint-text) in the legend, but try to keep it as concise as possible.
+Include general help text in the legend if it would help the user fill in the form, and you cannot write it as [hint text](/components/text-input/#hint-text). However, try to keep it as short as possible.


### PR DESCRIPTION
Fixes [#2143](https://github.com/alphagov/govuk-design-system/issues/2143).

Current guidance:

> Include any general help text which is important for filling in the form and cannot be written as [hint text](https://design-system.service.gov.uk/components/text-input/#hint-text) in the legend, but try to keep it as concise as possible.

This sounds like we're saying users can make help text look like a heading. If that's right, then maybe we should add an example.

Also, the current wording is on the long side, so I had a go at rewriting it.