### PR TITLE
Add placeholder text info to text input guidance

### DIFF
--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -21,9 +21,15 @@ Do not use the text input component if you need to let users enter longer answer
 
 ## How it works
 
-All text inputs must have visible labels; placeholder text is not an acceptable replacement for a label as it vanishes when users start typing.
+All text inputs must have labels, and in most cases the label should be visible.
 
-Labels should be aligned above the text input they refer to. They should be short, direct and written in sentence case. Do not use colons at the end of labels.
+You should align labels above the text input they refer to. They should be short, direct and written in sentence case. Do not use colons at the end of labels.
+
+Do not use placeholder text in place of a label, or for hints or examples, as:
+
+- it vanishes when the user starts typing, which can cause problems for users with memory conditions or when reviewing answers
+- not all screen readers read it out
+- its browser default styles often do not meet [minimum contrast requirements](https://www.w3.org/TR/WCAG22/#contrast-minimum)
 
 If you’re asking just [one question per page](/patterns/question-pages/#start-by-asking-one-question-per-page) as recommended, you can set the contents of the `<label>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
 


### PR DESCRIPTION
Fixes [#2149](https://github.com/alphagov/govuk-design-system/issues/2149).

Updates our text input guidance to give more detail on why users should not use placeholder text.