### PR TITLE
Remove node-sass on node v16 troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,6 @@ To enable this we use [nvm (Node Version Manager)](https://github.com/creationix
 npm install
 ```
 
-### Fixing Node 16+ errors
-If you've previously installed `govuk-design-system` locally using Node v14 or earlier, you may see `node-sass`-related errors when updating to Node v16.
-
-To get rid of these errors, delete the `node_modules` folder, then run:
-
-```
-nvm use
-npm uninstall node-sass -g && npm cache clean -force && npm install node-sass
-npm install
-```
-
 ### Start a local server
 This will build sources, serve pages and watch for changes.
 ```


### PR DESCRIPTION
We've previously had [issues with `node-sass`](https://github.com/alphagov/govuk-design-system/issues/2021#issuecomment-1080465176) and updating from Node v14 to Node v16.

We've since updated Metalsmith and moved to Dart Sass, so this issue no longer applies (see https://github.com/alphagov/govuk-design-system/pull/2150)