### PR TITLE
Update link text in examples

### DIFF
--- a/src/styles/typography/link-no-underline/index.njk
+++ b/src/styles/typography/link-no-underline/index.njk
@@ -3,4 +3,4 @@ title: Links without underlines – Typography
 layout: layout-example.njk
 ---
 
-<a href="#" class="govuk-link govuk-link--no-underline">govuk-link govuk-link--no-underline</a>
+<a href="#" class="govuk-link govuk-link--no-underline">link text (with no underline)</a>

--- a/src/styles/typography/link-no-visited-state/index.njk
+++ b/src/styles/typography/link-no-visited-state/index.njk
@@ -3,4 +3,4 @@ title: Links with no visited state – Typography
 layout: layout-example.njk
 ---
 
-<a href="#" class="govuk-link govuk-link--no-visited-state">govuk-link govuk-link--no-visited-state</a>
+<a href="#" class="govuk-link govuk-link--no-visited-state">link text (with no visited state)</a>

--- a/src/styles/typography/link-on-dark-background/index.njk
+++ b/src/styles/typography/link-on-dark-background/index.njk
@@ -5,4 +5,4 @@ stylesheets:
 - ../inverse.css
 ---
 
-<a href="#" class="govuk-link govuk-link--inverse">govuk-link govuk-link--inverse</a>
+<a href="#" class="govuk-link govuk-link--inverse">link text (on dark background)</a>

--- a/src/styles/typography/link-opening-in-new-tab/index.njk
+++ b/src/styles/typography/link-opening-in-new-tab/index.njk
@@ -3,4 +3,4 @@ title: Links that open in a new tab  – Typography
 layout: layout-example.njk
 ---
 
-<a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">govuk-link (opens in new tab)</a>
+<a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">link text (opens in new tab)</a>

--- a/src/styles/typography/link/index.njk
+++ b/src/styles/typography/link/index.njk
@@ -3,4 +3,4 @@ title: Links – Typography
 layout: layout-example.njk
 ---
 
-<a href="#" class="govuk-link">govuk-link</a>
+<a href="#" class="govuk-link">link text</a>


### PR DESCRIPTION
A content designer colleague mentioned that it was confusing where the link text should go, as in the examples the same text is used in 2 places (link text and `class`). This aims to reduce this confusion by making the link text clearer.

"link text" is the phrase used [in the guidance](https://design-system.service.gov.uk/styles/typography/#links) so that seemed like the clearest text to use?

It might also be worth considering making the link in the first example embedded within a sentence, followed by a full stop, so that it is an example of the text before it:

> If your link is at the end of a sentence or paragraph, make sure that the linked text does not include the full stop.

(I've not done that in this pull request though)