### PR TITLE
Add implementation advice to skip link guidance

### DIFF
--- a/src/components/skip-link/index.md.njk
+++ b/src/components/skip-link/index.md.njk
@@ -15,7 +15,9 @@ Use the skip link component to help keyboard-only users skip to the main content
 
 ## When to use this component
 
-All GOV.UK pages must include a skip link in the header.
+All GOV.UK pages must include a skip link. Usually, you should place the skip link immediately after the opening `<body>` tag. However, if you're using a [cookie banner](/components/cookie-banner/), place the skip link immediately after the cookie banner.
+
+Some automated accessibility testing tools may warn that the skip link element is not inside a landmark. This warning does not apply to skip links, so you can ignore it. Do not wrap the skip link in a `<nav>` region, or move it inside the header.
 
 ## How it works
 


### PR DESCRIPTION
Fixes [#2131](https://github.com/alphagov/govuk-design-system/issues/2131).

Updates guidance to say where the skip link should sit.

The current guidance tells users to include a skip link in the header. Doing this makes axe flag it as a failure. As a result, some teams have been using workarounds like wrapping the skip link in `<nav>` tags.