### PR TITLE
Add subheadings to text input guidance

### DIFF
--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -25,11 +25,15 @@ All text inputs must have labels, and in most cases the label should be visible.
 
 You should align labels above the text input they refer to. They should be short, direct and written in sentence case. Do not use colons at the end of labels.
 
+### Avoid placeholder text
+
 Do not use placeholder text in place of a label, or for hints or examples, as:
 
 - it vanishes when the user starts typing, which can cause problems for users with memory conditions or when reviewing answers
 - not all screen readers read it out
 - its browser default styles often do not meet [minimum contrast requirements](https://www.w3.org/TR/WCAG22/#contrast-minimum)
+
+### If you're asking one question on the page
 
 If you’re asking just [one question per page](/patterns/question-pages/#start-by-asking-one-question-per-page) as recommended, you can set the contents of the `<label>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
 


### PR DESCRIPTION
### Update
Adds 2 subheadings to text input guidance:

- Avoid placeholder text
- If you're asking one question on the page

### Reasons for update

- 'Avoid placeholder text': we've had feedback that [some users have struggled to find the guidance on placeholder text](https://github.com/alphagov/govuk-design-system/pull/2152#issuecomment-1112467551)
- 'If you're asking one question on the page:' it feels like this subheading should exist to mirror the later subheading, 'If you’re asking more than one question on the page'