### PR TITLE
Replace double quotes with singles in example

### DIFF
--- a/src/components/checkboxes/with-none-option-in-error/index.njk
+++ b/src/components/checkboxes/with-none-option-in-error/index.njk
@@ -16,7 +16,7 @@ layout: layout-example.njk
     }
   },
   errorMessage: {
-    text: "Select countries you will be travelling to, or select “No, I will not be travelling to any of these countries”"
+    text: "Select countries you will be travelling to, or select ‘No, I will not be travelling to any of these countries’"
   },
   items: [
     {


### PR DESCRIPTION
A checkboxes example has double quotes around a mention of the 'No, I will not be travelling to any of these countries' option.

GOV.UK style guide says to only use double quotes in body text for direct quotations, and singles otherwise.