### PR TITLE
Draft: National Insurance number formatting

### DIFF
--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -49,7 +49,7 @@ Make sure errors follow the guidance in [error message](/components/error-messag
 
 #### If the National Insurance number is not in the correct format and there is no example
 
-Say ‘Enter a National Insurance number that is 2 letters, 6 numbers, then A, B, C or D, like QQ123456C’.
+Say ‘Enter a National Insurance number that is 2 letters, 6 numbers, then A, B, C or D, like QQ 12 34 56 C’.
 
 #### If the National Insurance number is not in the correct format and there is an example
 


### PR DESCRIPTION
I was talking with @abbott567 about formats for screen readers with National Insurance numbers  - we've seen a few instances where it has been replayed with no spaces

I figured some explicit guidance on this might help clear it up.

Assumption was it probably lives in [How it works](https://design-system.service.gov.uk/patterns/national-insurance-numbers/#how-it-works) but happy to take feedback on location/content

```
When replaying the National Insurance number on something like [check your answers](/patterns/check-answers/) keep the format ‘QQ 12 34 56 C’ - the spaces will help break up the number for screen reader users.
```