### PR TITLE
Make layout name consistent throughout guidance

### DIFF
--- a/src/styles/layout/index.md.njk
+++ b/src/styles/layout/index.md.njk
@@ -27,12 +27,12 @@ The default maximum page width is 1020px, but you can make it wider if your cont
 
 {{ example({group: "styles", item: "layout", example: "common-two-thirds", html: true, open: true, size: "m"}) }}
 
-### Two-thirds / one-third
+### Two-thirds and one-third
 
 {{ example({group: "styles", item: "layout", example: "common-two-thirds-one-third", html: true, open: true, size: "m"}) }}
 
 
-### Row 1: Two-thirds <br>Row 2: Two-thirds / one-third
+### Row 1: Two-thirds <br>Row 2: Two-thirds and one-third
 
 {{ example({group: "styles", item: "layout", example: "common-two-thirds-two-thirds-one-third", html: true, open: true, size: "l"}) }}
 
@@ -70,7 +70,7 @@ If you’re not using the [breadcrumbs](/components/breadcrumbs/), [back link](/
 
 Use the grid system to lay out the content on your service’s pages.
 
-Most GOV.UK pages follow a two-thirds to one-third layout but the grid system allows for a number of additional combinations when necessary.
+Most GOV.UK pages follow a 'two-thirds and one-third' layout, but the grid system allows for a number of additional combinations when necessary.
 
 Your main content should always be in a two-thirds column even if you’re not using a corresponding one-third column for secondary content.
 


### PR DESCRIPTION
Fixes [#1900](https://github.com/alphagov/govuk-design-system/issues/1900).

The layout guidance currently uses 3 terms for the same thing:

- 'two-thirds and one-third'
- 'two-thirds / one-third'
- 'two-thirds to one-third'

This PR changes all mentions to 'two-thirds and one-third'.