### PR TITLE
Make validation guidance language more consistent

### DIFF
--- a/src/patterns/addresses/index.md.njk
+++ b/src/patterns/addresses/index.md.njk
@@ -100,9 +100,14 @@ When using an address lookup, you should:
 
 #### Allow different postcode formats
 
-It is easier for users if you accept and ignore unwanted characters. This is better than rejecting the input and telling a user they've not provided a valid postcode.
+It's easier for users if you accept and ignore unwanted characters. This is better than rejecting the input and telling the user they have not provided a valid postcode.
 
-You should allow postcodes that contain upper and lower case letters, no spaces, additional spaces at the beginning, middle or end and punctuation like hyphens, brackets, dashes and full stops.
+You should let users enter postcodes that contain:
+
+- upper and lower case letters
+- no spaces
+- additional spaces at the beginning, middle or end
+- punctuation like hyphens, brackets, dashes and full stops
 
 ## Textarea
 

--- a/src/patterns/national-insurance-numbers/index.md.njk
+++ b/src/patterns/national-insurance-numbers/index.md.njk
@@ -35,7 +35,8 @@ Show a National Insurance number using the format ‘QQ 12 34 56 C’ — the sp
 When asking for a National Insurance number:
 
 - allow for 13 characters as National Insurance numbers are spaced in pairs followed by a single letter
-- allow upper and lower case letters and strip out spaces before validating
+- let users enter upper and lower case letters, additional spaces and punctuation
+- ignore any unwanted characters before validating
 - avoid using ‘AB 12 34 56 C’ as an example because it belongs to a real person and use ‘QQ 12 34 56 C’ instead
 - set the `spellcheck` attribute to `false` so that browsers do not spellcheck the National Insurance number
 

--- a/src/patterns/telephone-numbers/index.md.njk
+++ b/src/patterns/telephone-numbers/index.md.njk
@@ -22,7 +22,7 @@ Only collect telephone numbers from people if you genuinely need them. Not every
 ## How it works
 
 ### Allow different formats
-Users should be allowed to enter telephone numbers in whatever format is familiar to them. You should allow for additional spaces, hyphens, brackets and dashes, and be able to accommodate country and area codes.
+Let users enter telephone numbers in whatever format is familiar to them. Allow for additional spaces, hyphens, dashes and brackets, and be able to accommodate country and area codes.
 
 ### Validate telephone numbers
 You should validate telephone numbers so you can let users know if they have entered one incorrectly. Google’s [libphonenumber](https://github.com/googlei18n/libphonenumber) library can validate telephone numbers from most countries.

--- a/src/patterns/validation/index.md.njk
+++ b/src/patterns/validation/index.md.njk
@@ -39,14 +39,14 @@ Validation should refuse to accept:
 
 For example, if you’re asking for someone’s date of birth you should not accept ‘13’ in the month field.
 
-Validation should help remove (or ignore) any spaces or invisible characters, unless it makes the information too ambiguous for you to use.
+Use validation to ignore unwanted characters, unless it would make the information too unclear for you to use. For example, any spaces, invisible characters or punctuation, like hyphens, brackets, dashes and full stops.
 
-If spaces or invisible characters cause a validation error, it'd be difficult for the user to see and fix — especially if they were added by accident.
+If these characters caused a validation error, it would be difficult for the user to see and fix — especially if added by accident.
 
-Consider removing spaces and invisible characters entered:
+You should ignore unwanted characters entered:
 
 + as part of numbers and codes, such as postcodes or card details
-+ before or after an answer, as these might have been copied and pasted in by accident
++ before or after an answer, as users might have copied and pasted them in by accident
 + by dictation software — this is particularly common when dictating numbers
 
 ### How to tell the user about validation errors


### PR DESCRIPTION
Fixes [#2124](https://github.com/alphagov/govuk-design-system/issues/2124).

We've had user feedback that the various guidance pages touching on validation could be more consistent.

To try and fix this, this PR updates these patterns:

- Addresses
- National insurance numbers
- Recover from validation errors
- Telephone numbers