### PR TITLE
Add accurate content for email field char limit

### DIFF
--- a/src/patterns/email-addresses/index.md.njk
+++ b/src/patterns/email-addresses/index.md.njk
@@ -41,7 +41,7 @@ If the email address field is part of a sign-in box, you do not need to say ‘W
 
 ### Make sure the field works for all of your users
 
-Make sure the field can accommodate up to 256 characters, which is the longest an email address can be.
+Make sure the field can accommodate up to 254 characters, which is the [longest an email address can be](https://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690).
 
 ### Help users to enter a valid email address
 


### PR DESCRIPTION
Fixes [#2189](https://github.com/alphagov/govuk-design-system/issues/2189).

Currently, the 'Ask users for email addresses' pattern says the character limit for the field is 256 characters.

This is untrue - it's actually 320 characters, with 64 chars max for the 'local-part' and 255 chars max for the 'domain' part.