### PR TITLE
Use node-version-file input to specify node version in GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,14 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Read node version from .nvmrc
-        id: nvm
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
           cache: 'npm'


### PR DESCRIPTION
actions/setup-node v2.5.0 and above support reading a .nvmrc file itself [[1]]. This lets us simplify our code.

[1]: https://github.com/actions/setup-node/releases/tag/v2.5.0