### PR TITLE
 Change contact panel headings to reflect the type of page they're on

### DIFF
--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -1,6 +1,6 @@
 {%- set fileEditURL = "https://github.com/alphagov/govuk-design-system/edit/main/src/" + path + "/index.md.njk" -%}
 {% if section === 'Styles' or section === 'Components' or section === 'Patterns'%}
-  <h2 class="govuk-heading-l govuk-!-padding-top-7" id="help-improve-this-page">Help improve this page</h2>
+  <h2 class="govuk-heading-l govuk-!-padding-top-7" id="help-improve-this-page">Help improve this {{ section.slice(0, -1) | lower }}</h2>
 
   {% if backlog_issue_id %}
     <p class="govuk-body">


### PR DESCRIPTION
## What

Update the contact panel on guidance pages, from 'Help improve this page' to 'Help improve this style/component/pattern'

<img width="669" alt="Screenshot 2022-05-24 at 16 02 44" src="https://user-images.githubusercontent.com/19834460/170070415-f488ea44-ee0d-4972-8300-32e3f3754e56.png">
<img width="681" alt="Screenshot 2022-05-24 at 16 02 34" src="https://user-images.githubusercontent.com/19834460/170070438-d8f2e9ba-1e75-4a12-8b81-2762c2d4366e.png">
<img width="674" alt="Screenshot 2022-05-24 at 16 02 25" src="https://user-images.githubusercontent.com/19834460/170070478-161c704e-089c-4ea9-904d-4b4724e1cfc5.png">
 
## Why

I think 'Help improve this page' suggests that the section is about the page itself – things like reporting typos and bugs. I think it's more broadly about improving the component or pattern. That's why we link to the backlog discussion etc.

We discussed changing this on the team Slack a while ago, people were generally positive so thought I'd crack on and raise a PR!

## Who needs to review this

Developer, content designer

## Further detail

The Nunjucks might need a look to see if it could be written more neatly or efficiently. 

A content designer should also probs check it still looks ok. I decided not to change the following paragraph, i.e. 'To help make sure that this page...' because I thought 'page' still made enough sense there. But easy enough to change if we think style/component/pattern reinforces the message better.
