### PR TITLE
Update cookie hide button to be more descriptive

### DIFF
--- a/src/components/cookie-banner/client-side-accepted/index.njk
+++ b/src/components/cookie-banner/client-side-accepted/index.njk
@@ -45,7 +45,7 @@ layout: layout-example.njk
       role: "alert",
       actions: [
         {
-          text: "Hide this message"
+          text: "Hide cookie message"
         }
       ]
     },
@@ -55,7 +55,7 @@ layout: layout-example.njk
       hidden: true,
       actions: [
         {
-          text: "Hide this message"
+          text: "Hide cookie message"
         }
       ]
     }

--- a/src/components/cookie-banner/client-side-rejected/index.njk
+++ b/src/components/cookie-banner/client-side-rejected/index.njk
@@ -46,7 +46,7 @@ layout: layout-example.njk
       hidden: true,
       actions: [
         {
-          text: "Hide this message"
+          text: "Hide cookie message"
         }
       ]
     },
@@ -55,7 +55,7 @@ layout: layout-example.njk
       role: "alert",
       actions: [
         {
-          text: "Hide this message"
+          text: "Hide cookie message"
         }
       ]
     }

--- a/src/components/cookie-banner/client-side/index.njk
+++ b/src/components/cookie-banner/client-side/index.njk
@@ -45,7 +45,7 @@ layout: layout-example.njk
       hidden: true,
       actions: [
         {
-          text: "Hide this message"
+          text: "Hide cookie message"
         }
       ]
     },
@@ -55,7 +55,7 @@ layout: layout-example.njk
       hidden: true,
       actions: [
         {
-          text: "Hide this message"
+          text: "Hide cookie message"
         }
       ]
     }

--- a/src/components/cookie-banner/server-side-confirmation/index.njk
+++ b/src/components/cookie-banner/server-side-confirmation/index.njk
@@ -17,7 +17,7 @@ layout: layout-example.njk
         html: acceptHtml,
         actions: [
         {
-          text: "Hide this message",
+          text: "Hide cookie message",
           href: "#",
           type: "button"
         }

--- a/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
@@ -49,7 +49,7 @@ layout: layout-example.njk
       html: acceptHtml,
       actions: [
         {
-          text: "Hide this message",
+          text: "Hide cookie message",
           href: "#",
           type: "button"
         }
@@ -59,7 +59,7 @@ layout: layout-example.njk
       html: rejectedHtml,
       actions: [
         {
-          text: "Hide this message",
+          text: "Hide cookie message",
           href: "#",
           type: "button"
         }

--- a/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
@@ -48,7 +48,7 @@ layout: layout-example.njk
       html: acceptHtml,
       actions: [
         {
-          text: "Hide this message",
+          text: "Hide cookie message",
           href: "#",
           type: "button"
         }
@@ -59,7 +59,7 @@ layout: layout-example.njk
       html: rejectedHtml,
       actions: [
         {
-          text: "Hide this message",
+          text: "Hide cookie message",
           href: "#",
           type: "button"
         }

--- a/views/partials/_cookie-banner.njk
+++ b/views/partials/_cookie-banner.njk
@@ -47,7 +47,7 @@
       hidden: true,
       actions: [
         {
-          text: "Hide this message",
+          text: "Hide cookie message",
           classes: "js-cookie-banner-hide js-cookie-banner-hide--accept"
         }
       ],
@@ -59,7 +59,7 @@
       hidden: true,
       actions: [
         {
-          text: "Hide this message",
+          text: "Hide cookie message",
           classes: "js-cookie-banner-hide js-cookie-banner-hide--reject"
         }
       ],


### PR DESCRIPTION
Change cookie button text from 'Hide this message' to 'Hide cookie message' to provide context to any users using assistive tech navigating out of context.

This PR changes:

- the cookie banner for the design system website
- all cookie banner visual examples on the cookie banner component page

Note: this text is not hardcoded in the cookie banner component, so there is no corresponding release of `govuk-frontend` and services will need to make this change manually.