### PR TITLE
Remove last line about performance platform

### DIFF
--- a/src/patterns/payment-card-details/index.md.njk
+++ b/src/patterns/payment-card-details/index.md.njk
@@ -103,4 +103,3 @@ Local Land Charges
 **Environment Agency**<br>
 Waste Permitting
 
-See a [full list of services using GOV.UK Pay](https://www.gov.uk/performance/govuk-pay/government-services) on GOV.UK Performance.


### PR DESCRIPTION
Remove last line on the Payment Card details page, which refers to the performance platform. This platform no longer exists.