### PR TITLE
Document `opengraphImageUrl` page template option

### DIFF
--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -104,7 +104,7 @@ To change the components that are included in the page template by default, set 
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">assetUrl</td>
       <td class="govuk-table__cell">Variable</td>
-      <td class="govuk-table__cell">Set the domain for the Open Graph meta tag image asset. If you need to use both your own domain and your own image path and filename, add <code>&lt;meta property="og:image" content="YOUR-ABSOLUTE-URL"&gt;</code> inside the <code>head</code> block instead of using `assetUrl`.</td>
+      <td class="govuk-table__cell">Set the domain for assets where an absolute URL is required, for example the Open Graph image.</td>
     </tr>
 
     <tr class="govuk-table__row">
@@ -239,6 +239,12 @@ To change the components that are included in the page template by default, set 
       <td class="govuk-table__cell">
         Set the language of the <code>&lt;main&gt;</code> element if it's different to <code>htmlLang</code>.
       </td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">opengraphImageUrl</td>
+      <td class="govuk-table__cell">Variable</td>
+      <td class="govuk-table__cell">Set the URL for the Open Graph image meta tag. The URL must be absolute, including the protocol and domain name.</td>
     </tr>
 
     <tr class="govuk-table__row">


### PR DESCRIPTION
Document the new `opengraphImageUrl` page template option, added in https://github.com/alphagov/govuk-frontend/pull/2673.

Update the documentation for the `assetUrl` option to make it slightly more generic and remove the recommendation to override by adding another meta tag to the `head` block as users should use the new `opengraphImageUrl` instead.