### PR TITLE
Add paragraph element to link example

### DIFF
--- a/src/styles/typography/link/index.njk
+++ b/src/styles/typography/link/index.njk
@@ -3,4 +3,4 @@ title: Links – Typography
 layout: layout-example.njk
 ---
 
-Jump to <a href="#" class="govuk-link">HTML example</a>.
+<p class="govuk-body">Jump to <a href="#" class="govuk-link">HTML example</a>.</p>


### PR DESCRIPTION
This link example does not include a wrapping element, meaning that some of the text is appearing as default serif text instead of in Transport in the Design System documentation.

As the text above this example states that it is regarding links at the end of sentences or paragraphs, the example code shouldn't be misleading by the inclusion of a paragraph.