### PR TITLE
Allow start buttons to be forms

### DIFF
--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -47,7 +47,7 @@ Avoid using multiple default buttons on a single page. Having more than one main
 ### Start buttons
 
 Use a start button for the main call to action on your service’s [start page](/patterns/start-using-a-service/).
-Start buttons do not submit form data, so they use a link tag rather than a button tag.
+Start buttons do not usually submit form data, so use a link tag instead of a button tag.
 
 {{ example({group: "components", item: "button", example: "start", html: true, nunjucks: true, open: false}) }}
 


### PR DESCRIPTION
Although unusual, there are a few valid circumstances where you might want to submit a form when pressing the start button. A situation that came up recently was we wanted to record analytics on when a user started a service by recording the time that a user presses the start button, without client-side JavaScript. The implementation for this involved using the Rails `button_to` helper which generates a form which POSTs to a route and includes a single `submit` button.

I think this is a valid use case of the start button, so I suggest changing the wording on this to be slightly more open to the idea of the start button not being a link.

See https://github.com/DFE-Digital/govuk-components/pull/343 and https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/174#discussion_r910155776 for the background on this.