### PR TITLE
Refactor JavaScript for tabs functionality

### DIFF
--- a/__tests__/tabs.test.js
+++ b/__tests__/tabs.test.js
@@ -77,14 +77,14 @@ describe('Patterns page', () => {
     describe('when "hideTab" parameter is set to true', () => {
       it('the tab list is not rendered', async () => {
         await page.goto(baseUrl + '/patterns/question-pages/', { waitUntil: 'load' })
-        const expandedTabContentWithNoTab = await page.evaluate(() => document.body.querySelector('#example-section-headings-open .app-tabs'))
-        expect(expandedTabContentWithNoTab).toBeFalsy()
+        const expandedTabContentWithNoTab = await page.evaluate(() => document.body.querySelector('#section-headings-question-pages-example-open .app-tabs'))
+        expect(expandedTabContentWithNoTab).toBeNull()
       })
 
       it('close button is not shown on the code block', async () => {
         await page.goto(baseUrl + '/patterns/question-pages/', { waitUntil: 'load' })
         const expandedTabContentWithNoTabCloseButton = await page.evaluate(() => document.body.querySelector('.js-tabs__container--no-tabs .js-tabs__close'))
-        expect(expandedTabContentWithNoTabCloseButton).toBeFalsy()
+        expect(expandedTabContentWithNoTabCloseButton).toBeNull()
       })
     })
   })

--- a/src/javascripts/components/options-table.js
+++ b/src/javascripts/components/options-table.js
@@ -28,14 +28,12 @@ var OptionsTable = {
           var detailsText = optionsDetailsElement.querySelector('.govuk-details__text')
 
           if (detailsSummary && detailsText) {
-            tabLink.setAttribute('aria-expanded', true)
+            tabLink.setAttribute('aria-expanded', 'true')
             tabHeading.className += ' app-tabs__item--current'
-            tabsElement.classList.remove('app-tabs__container--hidden')
-            tabsElement.setAttribute('aria-hidden', false)
+            tabsElement.removeAttribute('hidden')
 
             optionsDetailsElement.setAttribute('open', 'open')
-            detailsSummary.setAttribute('aria-expanded', true)
-            detailsText.setAttribute('aria-hidden', false)
+            detailsSummary.setAttribute('aria-expanded', 'true')
             detailsText.style.display = ''
             window.setTimeout(function () {
               tabLink.focus()

--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -3,128 +3,173 @@ import 'govuk-frontend/govuk/vendor/polyfills/Element/prototype/classList'
 import 'govuk-frontend/govuk/vendor/polyfills/Event'
 import { nodeListForEach } from './helpers.js'
 
-var tabsItemClass = 'app-tabs__item'
-var tabsItemCurrentClass = tabsItemClass + '--current'
-var tabsItemJsClass = 'js-tabs__item'
-var headingItemClass = 'app-tabs__heading'
-var headingItemCurrentClass = headingItemClass + '--current'
-var headingItemJsClass = 'js-tabs__heading'
-var headingItemJsLinkSelector = '.js-tabs__heading a'
-var tabContainerHiddenClass = 'app-tabs__container--hidden'
-var tabContainerJsClass = '.js-tabs__container'
-var tabContainerNoTabsJsClass = 'js-tabs__container--no-tabs'
-var allTabTogglers = '.' + tabsItemJsClass + ' a'
-var tabTogglersMarkedOpenClass = '.js-tabs__item--open a'
+/**
+ * The naming of things is a little complicated in here.
+ * For reference:
+ *
+ * - AppTabs - this JS module
+ * - app-tabs, js-tabs - groups of classes used by the tabs component
+ * - mobile tabs - the controls to show or hide panels on mobile; these are functionally closer to being an accordion than tabs
+ * - desktop tabs - the controls to show, hide or switch panels on tablet/desktop
+ * - panels - the content that is shown/hidden/switched; same across all breakpoints
+ */
 
 function AppTabs ($module) {
   this.$module = $module
-  this.$allTabContainers = this.$module.querySelectorAll(tabContainerJsClass)
-  this.$allTabTogglers = this.$module.querySelectorAll(allTabTogglers)
-  this.$allTabTogglersMarkedOpen = this.$module.querySelectorAll(tabTogglersMarkedOpenClass)
-  this.$mobileTabs = this.$module.querySelectorAll(headingItemJsLinkSelector)
+  this.$mobileTabs = this.$module.querySelectorAll('.js-tabs__heading a')
+  this.$desktopTabs = this.$module.querySelectorAll('.js-tabs__item a')
+  this.$panels = this.$module.querySelectorAll('.js-tabs__container')
 }
 
 AppTabs.prototype.init = function () {
+  var self = this
+
+  // Exit if no module has been defined
   if (!this.$module) {
     return
   }
 
-  // Enhance tab links to buttons on mobile if JS enabled
-  this.enhanceMobileButtons(this.$mobileTabs)
+  // Enhance mobile tabs into buttons
+  this.enhanceMobileTabs()
 
-  // reset all tabs
+  // Add bindings to desktop tabs
+  nodeListForEach(this.$desktopTabs, function ($tab) {
+    $tab.bindClick = self.onClick.bind(self)
+    $tab.addEventListener('click', $tab.bindClick)
+  })
+
+  // Reset all tabs and panels to closed state
+  // We also add all our default ARIA goodness here
   this.resetTabs()
-  // add close to each tab
-  this.$module.addEventListener('click', this.handleClick.bind(this))
 
-  nodeListForEach(this.$allTabTogglersMarkedOpen, function ($tabToggler) {
-    $tabToggler.click()
-  })
+  // Show the first panel already open if the `open` attribute is present
+  if (this.$module.hasAttribute('data-open')) {
+    this.openPanel(this.$panels[0].id)
+  }
 }
 
-// expand and collapse functionality
-AppTabs.prototype.activateAndToggle = function (event) {
+/**
+ *
+ */
+AppTabs.prototype.onClick = function (event) {
   event.preventDefault()
-  var $currentToggler = event.target
-  var $currentTogglerSiblings = this.$module.querySelectorAll('[aria-controls="' + $currentToggler.getAttribute('aria-controls') + '"]')
-  var $tabContainer
+  var $currentTab = event.target
+  var panelId = $currentTab.getAttribute('aria-controls')
+  var $panel = this.getPanel(panelId)
+  var isTabAlreadyOpen = $currentTab.getAttribute('aria-expanded') === 'true'
 
-  try {
-    $tabContainer = this.$module.querySelector('#' + $currentToggler.getAttribute('aria-controls'))
-  } catch (exception) {
-    throw new Error('Invalid example ID given: ' + exception)
-  }
-  var isTabAlreadyOpen = $currentToggler.getAttribute('aria-expanded') === 'true'
-
-  if (!$tabContainer) {
-    return
+  if (!$panel) {
+    throw new Error('Invalid example ID given: ' + panelId)
   }
 
+  // If the panel that's been called is already open, close it.
+  // Otherwise, close all panels and open the one requested.
   if (isTabAlreadyOpen) {
-    $tabContainer.classList.add(tabContainerHiddenClass)
-    $tabContainer.setAttribute('aria-hidden', 'true')
-    nodeListForEach($currentTogglerSiblings, function ($tabToggler) {
-      $tabToggler.setAttribute('aria-expanded', 'false')
-      // desktop and mobile
-      $tabToggler.parentNode.classList.remove(tabsItemCurrentClass, headingItemCurrentClass)
-    })
+    this.closePanel(panelId)
   } else {
-    // Reset tabs
     this.resetTabs()
-    // make current active
-    $tabContainer.classList.remove(tabContainerHiddenClass)
-    $tabContainer.setAttribute('aria-hidden', 'false')
-
-    nodeListForEach($currentTogglerSiblings, function ($tabToggler) {
-      $tabToggler.setAttribute('aria-expanded', 'true')
-      if ($tabToggler.parentNode.classList.contains(tabsItemClass)) {
-        $tabToggler.parentNode.classList.add(tabsItemCurrentClass)
-      } else if ($tabToggler.parentNode.classList.contains(headingItemClass)) {
-        $tabToggler.parentNode.classList.add(headingItemCurrentClass)
-      }
-    })
+    this.openPanel(panelId)
   }
 }
 
-// We progressively enhance the mobile tab links to buttons
-// to make sure we're using semantic HTML to describe the behaviour of the tabs
-AppTabs.prototype.enhanceMobileButtons = function (mobileTabs) {
-  nodeListForEach(mobileTabs, function (mobileTab) {
-    var button = document.createElement('button')
-    button.setAttribute('aria-controls', mobileTab.getAttribute('aria-controls'))
-    button.setAttribute('data-track', mobileTab.getAttribute('data-track'))
-    button.classList.add('app-tabs__heading-button')
-    button.innerHTML = mobileTab.innerHTML
-    mobileTab.parentNode.appendChild(button)
-    mobileTab.parentNode.removeChild(mobileTab)
+/**
+ * Enhances mobile tab anchors to buttons elements
+ *
+ * On mobile, tabs act like an accordion and are semantically more similar to
+ * buttons than links, so let's use the appropriate element
+ */
+AppTabs.prototype.enhanceMobileTabs = function () {
+  var self = this
+  // Loop through mobile tabs...
+  nodeListForEach(this.$mobileTabs, function ($tab) {
+    // ...construct a button equivalent of each anchor...
+    var $button = document.createElement('button')
+    $button.setAttribute('aria-controls', $tab.getAttribute('aria-controls'))
+    $button.setAttribute('data-track', $tab.getAttribute('data-track'))
+    $button.classList.add('app-tabs__heading-button')
+    $button.innerHTML = $tab.innerHTML
+    // ...bind controls...
+    $button.bindClick = self.onClick.bind(self)
+    $button.addEventListener('click', $button.bindClick)
+    // ...and replace the anchor with the button
+    $tab.parentNode.appendChild($button)
+    $tab.parentNode.removeChild($tab)
   })
 
-  this.$allTabTogglers = this.$module.querySelectorAll(allTabTogglers)
+  // Replace the value of $mobileTabs with the new buttons
+  this.$mobileTabs = this.$module.querySelectorAll('.js-tabs__heading button')
 }
 
-// reset aria attributes to default and close the tab content container
+/**
+ * Reset tabs and panels to closed state
+ */
 AppTabs.prototype.resetTabs = function () {
-  nodeListForEach(this.$allTabContainers, function ($tabContainer) {
-    // unless the tab content has not tabs and it's been set as open
-    if (!$tabContainer.classList.contains(tabContainerNoTabsJsClass)) {
-      $tabContainer.classList.add(tabContainerHiddenClass)
-      $tabContainer.setAttribute('aria-hidden', 'true')
+  var self = this
+  nodeListForEach(this.$panels, function ($panel) {
+    // We don't want to hide the panel if there are no tabs present to show it
+    if (!$panel.classList.contains('js-tabs__container--no-tabs')) {
+      self.closePanel($panel.id)
     }
   })
-
-  nodeListForEach(this.$allTabTogglers, function ($tabToggler) {
-    $tabToggler.setAttribute('aria-expanded', 'false')
-    // desktop and mobile
-    $tabToggler.parentNode.classList.remove(tabsItemCurrentClass, headingItemCurrentClass)
-  })
 }
 
-AppTabs.prototype.handleClick = function (event) {
-  // toggle and active selected tab and heading (on mobile)
-  if (event.target.parentNode.classList.contains(tabsItemJsClass) ||
-    event.target.parentNode.classList.contains(headingItemJsClass)) {
-    this.activateAndToggle(event)
-  }
+/**
+ * Open a panel and set the associated controls and styles
+ */
+AppTabs.prototype.openPanel = function (panelId) {
+  var $mobileTab = this.getMobileTab(panelId)
+  var $desktopTab = this.getDesktopTab(panelId)
+  $mobileTab.setAttribute('aria-expanded', 'true')
+  $desktopTab.setAttribute('aria-expanded', 'true')
+  $mobileTab.parentNode.classList.add('app-tabs__heading--current')
+  $desktopTab.parentNode.classList.add('app-tabs__item--current')
+  this.getPanel(panelId).removeAttribute('hidden')
+}
+
+/**
+ * Close a panel and set the associated controls and styles
+ */
+AppTabs.prototype.closePanel = function (panelId) {
+  var $mobileTab = this.getMobileTab(panelId)
+  var $desktopTab = this.getDesktopTab(panelId)
+  $mobileTab.setAttribute('aria-expanded', 'false')
+  $desktopTab.setAttribute('aria-expanded', 'false')
+  $mobileTab.parentNode.classList.remove('app-tabs__heading--current')
+  $desktopTab.parentNode.classList.remove('app-tabs__item--current')
+  this.getPanel(panelId).setAttribute('hidden', 'hidden')
+}
+
+/**
+ * Helper function to get a specific mobile tab by the associated panel ID
+ */
+AppTabs.prototype.getMobileTab = function (panelId) {
+  var result = null
+  nodeListForEach(this.$mobileTabs, function ($tab) {
+    if ($tab.getAttribute('aria-controls') === panelId) {
+      result = $tab
+    }
+  })
+  return result
+}
+
+/**
+ * Helper function to get a specific desktop tab by the associated panel ID
+ */
+AppTabs.prototype.getDesktopTab = function (panelId) {
+  var result = null
+  nodeListForEach(this.$desktopTabs, function ($tab) {
+    if ($tab.getAttribute('aria-controls') === panelId) {
+      result = $tab
+    }
+  })
+  return result
+}
+
+/**
+ * Helper function to get a specific panel by ID
+ */
+AppTabs.prototype.getPanel = function (panelId) {
+  return document.getElementById(panelId)
 }
 
 export default AppTabs

--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -157,13 +157,11 @@ AppTabs.prototype.getMobileTab = function (panelId) {
  * Helper function to get a specific desktop tab by the associated panel ID
  */
 AppTabs.prototype.getDesktopTab = function (panelId) {
-  var result = null
-  nodeListForEach(this.$desktopTabs, function ($tab) {
-    if ($tab.getAttribute('aria-controls') === panelId) {
-      result = $tab
-    }
-  })
-  return result
+  var $desktopTabContainer = this.$module.querySelector('.app-tabs')
+  if ($desktopTabContainer) {
+    return $desktopTabContainer.querySelector('[aria-controls="' + panelId + '"]')
+  }
+  return null
 }
 
 /**

--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -22,8 +22,6 @@ function AppTabs ($module) {
 }
 
 AppTabs.prototype.init = function () {
-  var self = this
-
   // Exit if no module has been defined
   if (!this.$module) {
     return
@@ -34,9 +32,8 @@ AppTabs.prototype.init = function () {
 
   // Add bindings to desktop tabs
   nodeListForEach(this.$desktopTabs, function ($tab) {
-    $tab.bindClick = self.onClick.bind(self)
-    $tab.addEventListener('click', $tab.bindClick)
-  })
+    $tab.addEventListener('click', this.onClick.bind(this))
+  }.bind(this))
 
   // Reset all tabs and panels to closed state
   // We also add all our default ARIA goodness here
@@ -79,7 +76,6 @@ AppTabs.prototype.onClick = function (event) {
  * buttons than links, so let's use the appropriate element
  */
 AppTabs.prototype.enhanceMobileTabs = function () {
-  var self = this
   // Loop through mobile tabs...
   nodeListForEach(this.$mobileTabs, function ($tab) {
     // ...construct a button equivalent of each anchor...
@@ -89,12 +85,12 @@ AppTabs.prototype.enhanceMobileTabs = function () {
     $button.classList.add('app-tabs__heading-button')
     $button.innerHTML = $tab.innerHTML
     // ...bind controls...
-    $button.bindClick = self.onClick.bind(self)
+    $button.bindClick = this.onClick.bind(this)
     $button.addEventListener('click', $button.bindClick)
     // ...and replace the anchor with the button
     $tab.parentNode.appendChild($button)
     $tab.parentNode.removeChild($tab)
-  })
+  }.bind(this))
 
   // Replace the value of $mobileTabs with the new buttons
   this.$mobileTabs = this.$module.querySelectorAll('.js-tabs__heading button')
@@ -104,13 +100,12 @@ AppTabs.prototype.enhanceMobileTabs = function () {
  * Reset tabs and panels to closed state
  */
 AppTabs.prototype.resetTabs = function () {
-  var self = this
   nodeListForEach(this.$panels, function ($panel) {
     // We don't want to hide the panel if there are no tabs present to show it
     if (!$panel.classList.contains('js-tabs__container--no-tabs')) {
-      self.closePanel($panel.id)
+      this.closePanel($panel.id)
     }
-  })
+  }.bind(this))
 }
 
 /**

--- a/src/javascripts/components/tabs.js
+++ b/src/javascripts/components/tabs.js
@@ -119,10 +119,16 @@ AppTabs.prototype.resetTabs = function () {
 AppTabs.prototype.openPanel = function (panelId) {
   var $mobileTab = this.getMobileTab(panelId)
   var $desktopTab = this.getDesktopTab(panelId)
-  $mobileTab.setAttribute('aria-expanded', 'true')
-  $desktopTab.setAttribute('aria-expanded', 'true')
-  $mobileTab.parentNode.classList.add('app-tabs__heading--current')
-  $desktopTab.parentNode.classList.add('app-tabs__item--current')
+
+  // Panels can exist without associated tabs—for example if there's a single
+  // panel that's open by default—so make sure they actually exist before use
+  if ($mobileTab && $desktopTab) {
+    $mobileTab.setAttribute('aria-expanded', 'true')
+    $mobileTab.parentNode.classList.add('app-tabs__heading--current')
+    $desktopTab.setAttribute('aria-expanded', 'true')
+    $desktopTab.parentNode.classList.add('app-tabs__item--current')
+  }
+
   this.getPanel(panelId).removeAttribute('hidden')
 }
 

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -153,10 +153,6 @@
   }
 }
 
-.app-tabs__container--hidden {
-  display: none;
-}
-
 .app-tabs__container pre {
   max-width: inherit;
   margin-bottom: 0;

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -19,14 +19,14 @@
 {% endif %}
 
 {% if params.open %}
-  {% set exampleId = exampleId + '-open' %}
+  {% set exampleId = exampleId + "-open" %}
 {% endif %}
 
 {% set display = params.displayExample | default(true) %}
 
 {% set multipleTabs = params.html and params.nunjucks %}
 
-<div class="app-example-wrapper" id="{{ exampleId }}" data-module="app-tabs">
+<div class="app-example-wrapper" id="{{ exampleId }}" data-module="app-tabs" {%- if params.open %} data-open{% endif %}>
   {% if display %}
     <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
       <div class="app-example__toolbar">
@@ -44,7 +44,7 @@
   {%- if (multipleTabs) %}
     <span id="options-{{ exampleId }}"></span>
     <ul class="app-tabs" role="tablist">
-      <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></li>
+      <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></li>
       <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></li>
     </ul>
   {% elif not (params.hideTab) %}
@@ -52,7 +52,7 @@
     {#- if at least one tab is set to true show the list -#}
     {% if tabType %}
       <ul class="app-tabs" role="tablist">
-        <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation">
+        <li class="app-tabs__item js-tabs__item" role="presentation">
           <a href="#{{ exampleId }}-{{ tabType }}" role="tab" aria-controls="{{ exampleId }}-{{ tabType }}" data-track="tab-{{ tabType }}">{{ "HTML" if params.html else ("Nunjucks" if params.nunjucks )}}</a>
         </li>
       </ul>
@@ -61,7 +61,7 @@
 
   {%- if (params.html) %}
     {%- if (multipleTabs) or (not params.hideTab) %}
-      <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
+      <div class="app-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-html" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
     {% endif %}
     <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-html" role="tabpanel">
       <div class="app-example__code">
@@ -76,7 +76,7 @@
     {%- if (multipleTabs) %}
       <div class="app-tabs__heading js-tabs__heading"><a class="app-tabs__heading-link" href="#{{ exampleId }}-nunjucks" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
     {% elif not (params.hideTab) %}
-      <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
+      <div class="app-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
     {% endif %}
     <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-nunjucks" role="tabpanel">
       {%- if (params.group == 'components') %}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -28,130 +28,130 @@
 
 <div class="app-example-wrapper" id="{{ exampleId }}" data-module="app-tabs">
   {% if display %}
-  <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
-    <div class="app-example__toolbar">
-      <a href="{{ exampleURL }}" class="app-example__new-window" target="_blank">
-        Open this
-        {# Don't use full title visually as the context is shown based on location of this link #}
-        <span class="govuk-visually-hidden">{{ exampleTitle | lower }}</span>
-        example in a new tab
-      </a>
+    <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
+      <div class="app-example__toolbar">
+        <a href="{{ exampleURL }}" class="app-example__new-window" target="_blank">
+          Open this
+          {# Don't use full title visually as the context is shown based on location of this link #}
+          <span class="govuk-visually-hidden">{{ exampleTitle | lower }}</span>
+          example in a new tab
+        </a>
+      </div>
+      <iframe title="{{ exampleTitle + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0" loading="lazy"></iframe>
     </div>
-    <iframe title="{{ exampleTitle + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0" loading="lazy"></iframe>
-  </div>
   {% endif %}
 
   {%- if (multipleTabs) %}
-  <span id="options-{{ exampleId }}"></span>
-  <ul class="app-tabs" role="tablist">
-    <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></li>
-    <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></li>
-  </ul>
+    <span id="options-{{ exampleId }}"></span>
+    <ul class="app-tabs" role="tablist">
+      <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></li>
+      <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></li>
+    </ul>
   {% elif not (params.hideTab) %}
-  {% set tabType = "html" if params.html else ("nunjucks" if params.nunjucks ) %}
-  {#- if at least one tab is set to true show the list -#}
-  {% if tabType %}
-  <ul class="app-tabs" role="tablist">
-    <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation">
-      <a href="#{{ exampleId }}-{{ tabType }}" role="tab" aria-controls="{{ exampleId }}-{{ tabType }}" data-track="tab-{{ tabType }}">{{ "HTML" if params.html else ("Nunjucks" if params.nunjucks )}}</a>
-    </li>
-  </ul>
-  {% endif %}
+    {% set tabType = "html" if params.html else ("nunjucks" if params.nunjucks ) %}
+    {#- if at least one tab is set to true show the list -#}
+    {% if tabType %}
+      <ul class="app-tabs" role="tablist">
+        <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation">
+          <a href="#{{ exampleId }}-{{ tabType }}" role="tab" aria-controls="{{ exampleId }}-{{ tabType }}" data-track="tab-{{ tabType }}">{{ "HTML" if params.html else ("Nunjucks" if params.nunjucks )}}</a>
+        </li>
+      </ul>
+    {% endif %}
   {% endif %}
 
   {%- if (params.html) %}
-  {%- if (multipleTabs) or (not params.hideTab) %}
-  <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
-  {% endif %}
-  <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-html" role="tabpanel">
-    <div class="app-example__code">
-      <pre data-module="app-copy" tabindex="0"><code class="hljs html">
-        {{- getHTMLCode(examplePath) | highlight('html') | safe -}}
-      </code></pre>
+    {%- if (multipleTabs) or (not params.hideTab) %}
+      <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
+    {% endif %}
+    <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-html" role="tabpanel">
+      <div class="app-example__code">
+        <pre data-module="app-copy" tabindex="0"><code class="hljs html">
+          {{- getHTMLCode(examplePath) | highlight('html') | safe -}}
+        </code></pre>
+      </div>
     </div>
-  </div>
   {% endif %}
 
   {%- if (params.nunjucks) %}
-  {%- if (multipleTabs) %}
-  <div class="app-tabs__heading js-tabs__heading"><a class="app-tabs__heading-link" href="#{{ exampleId }}-nunjucks" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
-  {% elif not (params.hideTab) %}
-	<div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
-  {% endif %}
-  <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-nunjucks" role="tabpanel">
-    {%- if (params.group == 'components') %}
-      {% set macroOptions = getMacroOptions(params.item) %}
-
-      {% set macroOptionsHTML %}
-
-        <p>
-        Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
-        </p>
-        <p>
-        Some options are required for the macro to work; these are marked as "Required" in the option description.
-        </p>
-        <p>
-        If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must sanitise the HTML to protect against  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting exploits</a>.
-        </p>
-
-        {% for table in macroOptions %}
-          <table class="govuk-table app-options__table" id="options-{{ exampleId }}--{{ table.id }}">
-            <caption class="govuk-table__caption govuk-heading-m {% if table.id == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name }}</caption>
-            <thead class="govuk-table__head">
-              <tr class="govuk-table__row">
-                <th class="govuk-table__header app-options__limit-table-cell" scope="col">Name</th>
-                <th class="govuk-table__header app-options__limit-table-cell" scope="col">Type</th>
-                <th class="govuk-table__header" scope="col">Description</th>
-              </tr>
-            </thead>
-            <tbody class="govuk-table__body">
-
-              {% for option in table.options %}
-                <tr class="govuk-table__row">
-                  <th class="govuk-table__header" scope="row">{{option.name}}</th>
-                  <td class="govuk-table__cell ">{{option.type}}</td>
-                  <td class="govuk-table__cell ">
-                    {% if (option.required === true) %}
-                      <strong>Required.</strong>
-                    {% endif %}
-                    {{ option.description | safe }}
-                    {% if (option.isComponent) %}
-                      {# Create separate table data for components that are hidden in the Design System #}
-                      {% if (option.name === "hint" or option.name === "label") %}
-                        See <a href="#options-{{ exampleId }}--{{ option.name }}">{{ option.name }}</a>.
-                      {% else %}
-                        See <a href="/components/{{ option.slug }}/#options-{{ option.name | kebabCase }}-example">{{ option.name }}</a>.
-                      {% endif %}
-                    {% endif %}
-                    {% if (option.params) %}
-                      See <a href="#options-{{ exampleId }}--{{ option.name }}">{{ option.name }}</a>.
-                    {% endif %}
-                  </td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        {% endfor %}
-
-      {% endset %}
-
-      {% from "govuk/components/details/macro.njk" import govukDetails %}
-
-      {{ govukDetails({
-        summaryHtml: "<span data-components='github-component-arguments'>Nunjucks macro options</span>",
-        html: macroOptionsHTML,
-        classes: "app-options",
-        attributes:{
-          id: "options-" + exampleId + "-details"
-        }
-      })}}
+    {%- if (multipleTabs) %}
+      <div class="app-tabs__heading js-tabs__heading"><a class="app-tabs__heading-link" href="#{{ exampleId }}-nunjucks" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
+    {% elif not (params.hideTab) %}
+      <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
     {% endif %}
-    <div class="app-example__code">
-      <pre data-module="app-copy" tabindex="0"><code class="hljs js">
-        {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
-      </code></pre>
+    <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-nunjucks" role="tabpanel">
+      {%- if (params.group == 'components') %}
+        {% set macroOptions = getMacroOptions(params.item) %}
+  
+        {% set macroOptionsHTML %}
+  
+          <p>
+          Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
+          </p>
+          <p>
+          Some options are required for the macro to work; these are marked as "Required" in the option description.
+          </p>
+          <p>
+          If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must sanitise the HTML to protect against  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting exploits</a>.
+          </p>
+  
+          {% for table in macroOptions %}
+            <table class="govuk-table app-options__table" id="options-{{ exampleId }}--{{ table.id }}">
+              <caption class="govuk-table__caption govuk-heading-m {% if table.id == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name }}</caption>
+              <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th class="govuk-table__header app-options__limit-table-cell" scope="col">Name</th>
+                  <th class="govuk-table__header app-options__limit-table-cell" scope="col">Type</th>
+                  <th class="govuk-table__header" scope="col">Description</th>
+                </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+  
+                {% for option in table.options %}
+                  <tr class="govuk-table__row">
+                    <th class="govuk-table__header" scope="row">{{option.name}}</th>
+                    <td class="govuk-table__cell ">{{option.type}}</td>
+                    <td class="govuk-table__cell ">
+                      {% if (option.required === true) %}
+                        <strong>Required.</strong>
+                      {% endif %}
+                      {{ option.description | safe }}
+                      {% if (option.isComponent) %}
+                        {# Create separate table data for components that are hidden in the Design System #}
+                        {% if (option.name === "hint" or option.name === "label") %}
+                          See <a href="#options-{{ exampleId }}--{{ option.name }}">{{ option.name }}</a>.
+                        {% else %}
+                          See <a href="/components/{{ option.slug }}/#options-{{ option.name | kebabCase }}-example">{{ option.name }}</a>.
+                        {% endif %}
+                      {% endif %}
+                      {% if (option.params) %}
+                        See <a href="#options-{{ exampleId }}--{{ option.name }}">{{ option.name }}</a>.
+                      {% endif %}
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          {% endfor %}
+  
+        {% endset %}
+  
+        {% from "govuk/components/details/macro.njk" import govukDetails %}
+  
+        {{ govukDetails({
+          summaryHtml: "<span data-components='github-component-arguments'>Nunjucks macro options</span>",
+          html: macroOptionsHTML,
+          classes: "app-options",
+          attributes:{
+            id: "options-" + exampleId + "-details"
+          }
+        })}}
+      {% endif %}
+      <div class="app-example__code">
+        <pre data-module="app-copy" tabindex="0"><code class="hljs js">
+          {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
+        </code></pre>
+      </div>
     </div>
-  </div>
   {% endif %}
 </div>
 


### PR DESCRIPTION
Refactors the JavaScript associated with the tabbed interface used for code examples. 

## Why

It was felt that the existing code had become more difficult to understand and maintain over time; and did not align with how the Design System team now prefers to author JavaScript.

Also fixes #2042.

## Changes

### Refactored JavaScript

The JavaScript has been heavily refactored. It's a little more verbose and there is definitely some repetition that could be reduced (`getMobileTab` and `getDesktopTab` are almost identical functions), but it's hopefully a lot easier to understand now! (And it actually minifies to *less* code than the previous version. 3351 bytes for old vs. 2835 bytes for new, when piped through Uglify!)

Classes are no longer defined as variables at the top of the file. Many of these classes were only used once, and it quickly became tedious having to keep looking up what elements/classes a piece of code was actually referring to. Personally, I think the code is easier to understand with the classes written in-line. 

### Terminology changes

I've tried to make the terminology more clearly reflect the actual role those elements play. I've only made these naming changes in the JS, though it would probably be sensible to port them—or something similar—over to HTML/CSS too.

|Old name|New name|
|:-|:-|
|`tabsItem`|`desktopTabs`|
|`headingItem`|`mobileTabs`|
|`tabContainer`|`panel`|

### HTML and CSS tweaks

There are a few minor differences to the HTML and CSS, outside of the refactoring efforts.

- There are various whitespace-only changes to the `example` macro so that Nunjucks code is indented in the same way as HTML, to try and make it easier to read.
- Panels were previously hidden using a CSS class. This now uses the `hidden` HTML attribute instead.
- The setting of `aria-hidden` has been removed (redundant as `hidden` removes it from the accessibility tree anyway).
- Setting the `open` Nunjucks parameter would previously apply additional classes to several elements. This has been reduced to a single data-* attribute (`data-open`) set on the module container. This doesn't strike me as a breaking change as the original classes were only used for detection by JavaScript, and served no other stylistic or functional purpose.

### Test changes

- One of the Jest tests associated with these tabs was attempting to reference an element with the ID `example-section-headings-open` on the Question Pages pattern page. No such element exists. It's been replaced with `section-headings-question-pages-example-open`, which seems to be the equivalent in the current version of the page.
- The two tests that check for the non-existence of elements have been changed from `expect.toBeFalsy()` to `expect.toBeNull()`, as this better describes the expected outcome. 

## Not changed

### Using the design system's tabs component

This refactor does not make use of [the equivalent design system component](https://design-system.service.gov.uk/components/tabs/) as discussed in #385, due to large differences in mobile functionality and the ability to entirely collapse tab panels. This is refactoring, not revolution!

### `open` and `id`

Setting the `open` Nunjucks parameter currently modifies the `id` used throughout the macro. 

I couldn't see any obvious reason for this to be happening, barring some legacy reason, but have not changed it as it's (mostly) harmless and may break tests and some direct links to specific examples. 