### PR TITLE
Remove govuk-react-jsx which is no longer supported

### DIFF
--- a/src/community/resources-and-tools/index.md.njk
+++ b/src/community/resources-and-tools/index.md.njk
@@ -73,12 +73,6 @@ GOV.UK Frontend WTForms Widgets.
 A GOV.UK Design System theme for R Markdown.
 
 
-### React
-
-[govuk-react-jsx](https://github.com/surevine/govuk-react-jsx) -
-GOV.UK Frontend compatible React components.
-
-
 ### Ruby on Rails
 
 [GOV.UK Design System Formbuilder](https://github.com/DFE-Digital/govuk_design_system_formbuilder) -


### PR DESCRIPTION
I am no longer able to maintain govuk-react-jsx and therefore I think it should be removed from this list.
Thanks
Andy