### PR TITLE
Remove ‘mainstream’ from images guidance

### DIFF
--- a/src/styles/images/index.md.njk
+++ b/src/styles/images/index.md.njk
@@ -28,7 +28,7 @@ If your image represents something physical, such as a letter, document or credi
 
 ## Alternative text
 
-This guidance is for government teams that build online services. [To learn about publishing alternative text in GOV.UK mainstream content, go to GOV.UK's 'Images' guidance.](https://www.gov.uk/guidance/content-design/images)
+This guidance is for government teams that build online services. [To learn about writing alternative text for website pages on www.gov.uk, using the main GOV.UK publishing platform, go to GOV.UK’s ‘Images’ guidance.](https://www.gov.uk/guidance/content-design/images)
 
 Alternative text, or alt text, is read out by screen readers or displayed if an image does not load or if images have been switched off.
 


### PR DESCRIPTION
As flagged in https://github.com/alphagov/govuk-design-system-backlog/issues/70#issuecomment-1187335536:

> Mainstream is 2500 pages managed by GDS, but this guidance also applies to all content on www.gov.uk produced by depts, the half a million 'whitehall' pages.

Closes #2250 