### PR TITLE
Use the official metalsmith postcss plugin

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -13,7 +13,7 @@ const permalinks = require('metalsmith-permalinks') // apply a permalink pattern
 const canonical = require('metalsmith-canonical') // add a canonical url property to pages
 
 const sass = require('@metalsmith/sass') // convert Sass files to CSS using Dart Sass
-const postcss = require('metalsmith-postcss')
+const postcss = require('@metalsmith/postcss')
 
 const rollup = require('metalsmith-rollup') // used to build GOV.UK Frontend JavaScript
 const resolve = require('rollup-plugin-node-resolve') // rollup plugin to resolve node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@metalsmith/postcss": "^5.0.0",
         "acorn": "^6.4.1",
         "autoprefixer": "^9.5.1",
         "clipboard": "^2.0.4",
@@ -18,9 +19,8 @@
         "highlight.js": "^10.4.1",
         "html5shiv": "^3.7.3",
         "lunr": "^2.3.6",
-        "metalsmith-postcss": "^4.2.0",
         "modernizr": "^3.7.1",
-        "postcss": "^6.0.23",
+        "postcss": "^8.4.14",
         "sass-export": "^2.1.0",
         "serve-static": "^1.13.2",
         "slugger": "^1.0.1"
@@ -1915,6 +1915,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@metalsmith/postcss": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@metalsmith/postcss/-/postcss-5.0.0.tgz",
+      "integrity": "sha512-sMjGcerJMi76m9tFac/3I+20dvLHkmYfMnYFDnLrWyWNSerqNjS/vdI81sSQRvAhNRjr0QK+F+YBOKguBIcdUA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "metalsmith": "^2.4.1",
+        "postcss": "^5.0.4 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/@metalsmith/sass": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@metalsmith/sass/-/sass-1.0.0.tgz",
@@ -2885,14 +2897,6 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
-    "node_modules/browserslist/node_modules/caniuse-lite": {
-      "version": "1.0.30001228",
-      "license": "CC-BY-4.0",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
-    },
     "node_modules/browserslist/node_modules/electron-to-chromium": {
       "version": "1.3.736",
       "license": "ISC"
@@ -2987,8 +2991,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30000962",
-      "license": "CC-BY-4.0"
+      "version": "1.0.30001367",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz",
+      "integrity": "sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -3216,7 +3231,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-      "dev": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -3247,7 +3261,6 @@
     },
     "node_modules/co-from-stream": {
       "version": "0.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "co-read": "0.0.1"
@@ -3255,7 +3268,6 @@
     },
     "node_modules/co-fs-extra": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "co-from-stream": "~0.0.0",
@@ -3265,7 +3277,6 @@
     },
     "node_modules/co-fs-extra/node_modules/fs-extra": {
       "version": "0.26.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -3277,7 +3288,6 @@
     },
     "node_modules/co-fs-extra/node_modules/jsonfile": {
       "version": "2.4.0",
-      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -3285,7 +3295,6 @@
     },
     "node_modules/co-read": {
       "version": "0.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/code-point-at": {
@@ -3428,7 +3437,6 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3441,7 +3449,6 @@
     },
     "node_modules/cross-spawn/node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3449,7 +3456,6 @@
     },
     "node_modules/cross-spawn/node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3460,7 +3466,6 @@
     },
     "node_modules/cross-spawn/node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3468,7 +3473,6 @@
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3841,7 +3845,6 @@
     },
     "node_modules/enable": {
       "version": "1.3.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10.0"
@@ -5581,7 +5584,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.1.11",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=0.4.0"
@@ -6346,7 +6348,6 @@
     },
     "node_modules/is-utf8": {
       "version": "0.2.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-wsl": {
@@ -9178,7 +9179,6 @@
     },
     "node_modules/klaw": {
       "version": "1.3.1",
-      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
@@ -9583,7 +9583,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/metalsmith/-/metalsmith-2.4.2.tgz",
       "integrity": "sha512-HS/MRADloJS3+O5V/+4f/khBkwtdYUQFWEGqeviLT/7wNgHWknMiIflV99JeYzj0hbw+L0aTb2spPlnWW4/Adg==",
-      "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
         "clone": "^2.1.2",
@@ -9852,16 +9851,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/metalsmith-postcss": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "^3.0.4"
-      },
-      "peerDependencies": {
-        "postcss": "^5.0.4 || ^6.0.0"
-      }
-    },
     "node_modules/metalsmith-rollup": {
       "version": "2.0.0",
       "dev": true,
@@ -9913,7 +9902,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -9928,7 +9916,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -9944,7 +9931,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -9956,7 +9942,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -9965,7 +9950,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -9985,7 +9969,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9994,7 +9977,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -10009,7 +9991,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
       "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -10018,7 +9999,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -10028,7 +10008,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.1",
@@ -10040,7 +10019,6 @@
     },
     "node_modules/micromatch/node_modules/picomatch": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -10345,6 +10323,17 @@
     "node_modules/mute-stream": {
       "version": "0.0.7",
       "license": "ISC"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -10842,6 +10831,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
     "node_modules/picomatch": {
       "version": "2.2.2",
       "license": "MIT",
@@ -11093,59 +11087,31 @@
       }
     },
     "node_modules/postcss": {
-      "version": "6.0.23",
-      "license": "MIT",
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
       "dependencies": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postcss-value-parser": {
       "version": "3.3.1",
       "license": "MIT"
-    },
-    "node_modules/postcss/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss/node_modules/chalk": {
-      "version": "2.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postcss/node_modules/supports-color": {
-      "version": "5.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/preact": {
       "version": "8.5.3",
@@ -11586,7 +11552,6 @@
     },
     "node_modules/rimraf": {
       "version": "2.6.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.0.5"
@@ -12503,8 +12468,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.1",
-      "license": "BSD-3-Clause",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13269,12 +13235,10 @@
     },
     "node_modules/thunkify": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/thunkify-wrap": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "enable": "1"
@@ -13512,14 +13476,12 @@
     },
     "node_modules/unyield": {
       "version": "0.0.1",
-      "dev": true,
       "dependencies": {
         "co": "~3.1.0"
       }
     },
     "node_modules/unyield/node_modules/co": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -13832,7 +13794,6 @@
     },
     "node_modules/ware": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "wrap-fn": "^0.1.0"
@@ -13900,7 +13861,6 @@
     },
     "node_modules/wrap-fn": {
       "version": "0.1.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "co": "3.1.0"
@@ -13908,7 +13868,6 @@
     },
     "node_modules/wrap-fn/node_modules/co": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrappy": {
@@ -15443,6 +15402,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@metalsmith/postcss": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@metalsmith/postcss/-/postcss-5.0.0.tgz",
+      "integrity": "sha512-sMjGcerJMi76m9tFac/3I+20dvLHkmYfMnYFDnLrWyWNSerqNjS/vdI81sSQRvAhNRjr0QK+F+YBOKguBIcdUA==",
+      "requires": {}
+    },
     "@metalsmith/sass": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@metalsmith/sass/-/sass-1.0.0.tgz",
@@ -16118,9 +16083,6 @@
         "node-releases": "^1.1.71"
       },
       "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001228"
-        },
         "electron-to-chromium": {
           "version": "1.3.736"
         },
@@ -16185,7 +16147,9 @@
       "version": "3.1.0"
     },
     "caniuse-lite": {
-      "version": "1.0.30000962"
+      "version": "1.0.30001367",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz",
+      "integrity": "sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -16347,8 +16311,7 @@
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-      "dev": true
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "clone-deep": {
       "version": "0.2.4",
@@ -16367,14 +16330,12 @@
     },
     "co-from-stream": {
       "version": "0.0.0",
-      "dev": true,
       "requires": {
         "co-read": "0.0.1"
       }
     },
     "co-fs-extra": {
       "version": "1.2.1",
-      "dev": true,
       "requires": {
         "co-from-stream": "~0.0.0",
         "fs-extra": "~0.26.5",
@@ -16383,7 +16344,6 @@
       "dependencies": {
         "fs-extra": {
           "version": "0.26.7",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^2.1.0",
@@ -16394,7 +16354,6 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
@@ -16402,8 +16361,7 @@
       }
     },
     "co-read": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.0.1"
     },
     "code-point-at": {
       "version": "1.1.0"
@@ -16508,7 +16466,6 @@
     },
     "cross-spawn": {
       "version": "7.0.3",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -16516,23 +16473,19 @@
       },
       "dependencies": {
         "path-key": {
-          "version": "3.1.1",
-          "dev": true
+          "version": "3.1.1"
         },
         "shebang-command": {
           "version": "2.0.0",
-          "dev": true,
           "requires": {
             "shebang-regex": "^3.0.0"
           }
         },
         "shebang-regex": {
-          "version": "3.0.0",
-          "dev": true
+          "version": "3.0.0"
         },
         "which": {
           "version": "2.0.2",
-          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -16798,8 +16751,7 @@
       "version": "7.0.3"
     },
     "enable": {
-      "version": "1.3.2",
-      "dev": true
+      "version": "1.3.2"
     },
     "encodeurl": {
       "version": "1.0.2"
@@ -17979,8 +17931,7 @@
       "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ=="
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "dev": true
+      "version": "4.1.11"
     },
     "gray-matter": {
       "version": "4.0.3",
@@ -18503,8 +18454,7 @@
       "dev": true
     },
     "is-utf8": {
-      "version": "0.2.1",
-      "dev": true
+      "version": "0.2.1"
     },
     "is-wsl": {
       "version": "1.1.0",
@@ -20327,7 +20277,6 @@
     },
     "klaw": {
       "version": "1.3.1",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
       }
@@ -20606,7 +20555,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/metalsmith/-/metalsmith-2.4.2.tgz",
       "integrity": "sha512-HS/MRADloJS3+O5V/+4f/khBkwtdYUQFWEGqeviLT/7wNgHWknMiIflV99JeYzj0hbw+L0aTb2spPlnWW4/Adg==",
-      "dev": true,
       "requires": {
         "chalk": "^4.1.2",
         "clone": "^2.1.2",
@@ -20627,7 +20575,6 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -20636,7 +20583,6 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -20646,7 +20592,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -20654,14 +20599,12 @@
         "commander": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-          "dev": true
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
         },
         "glob": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
           "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -20674,14 +20617,12 @@
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -20689,14 +20630,12 @@
         "stat-mode": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
-          "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
-          "dev": true
+          "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg=="
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -20898,12 +20837,6 @@
         }
       }
     },
-    "metalsmith-postcss": {
-      "version": "4.2.0",
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
-    },
     "metalsmith-rollup": {
       "version": "2.0.0",
       "dev": true,
@@ -20939,15 +20872,13 @@
     },
     "micromatch": {
       "version": "4.0.4",
-      "dev": true,
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
       },
       "dependencies": {
         "picomatch": {
-          "version": "2.3.0",
-          "dev": true
+          "version": "2.3.0"
         }
       }
     },
@@ -21146,6 +21077,11 @@
     },
     "mute-stream": {
       "version": "0.0.7"
+    },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "natural-compare": {
       "version": "1.4.0"
@@ -21451,6 +21387,11 @@
       "version": "2.1.0",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
     "picomatch": {
       "version": "2.2.2"
     },
@@ -21606,36 +21547,13 @@
       }
     },
     "postcss": {
-      "version": "6.0.23",
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
       "requires": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1"
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       }
     },
     "postcss-value-parser": {
@@ -21955,7 +21873,6 @@
     },
     "rimraf": {
       "version": "2.6.2",
-      "dev": true,
       "requires": {
         "glob": "^7.0.5"
       }
@@ -22635,7 +22552,9 @@
       }
     },
     "source-map-js": {
-      "version": "1.0.1"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "source-map-support": {
       "version": "0.5.20",
@@ -23167,12 +23086,10 @@
       "version": "2.3.8"
     },
     "thunkify": {
-      "version": "2.1.2",
-      "dev": true
+      "version": "2.1.2"
     },
     "thunkify-wrap": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "enable": "1"
       }
@@ -23322,14 +23239,12 @@
     },
     "unyield": {
       "version": "0.0.1",
-      "dev": true,
       "requires": {
         "co": "~3.1.0"
       },
       "dependencies": {
         "co": {
-          "version": "3.1.0",
-          "dev": true
+          "version": "3.1.0"
         }
       }
     },
@@ -23558,7 +23473,6 @@
     },
     "ware": {
       "version": "1.3.0",
-      "dev": true,
       "requires": {
         "wrap-fn": "^0.1.0"
       }
@@ -23606,14 +23520,12 @@
     },
     "wrap-fn": {
       "version": "0.1.5",
-      "dev": true,
       "requires": {
         "co": "3.1.0"
       },
       "dependencies": {
         "co": {
-          "version": "3.1.0",
-          "dev": true
+          "version": "3.1.0"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     ]
   },
   "dependencies": {
+    "@metalsmith/postcss": "^5.0.0",
     "acorn": "^6.4.1",
     "autoprefixer": "^9.5.1",
     "clipboard": "^2.0.4",
@@ -38,9 +39,8 @@
     "highlight.js": "^10.4.1",
     "html5shiv": "^3.7.3",
     "lunr": "^2.3.6",
-    "metalsmith-postcss": "^4.2.0",
     "modernizr": "^3.7.1",
-    "postcss": "^6.0.23",
+    "postcss": "^8.4.14",
     "sass-export": "^2.1.0",
     "serve-static": "^1.13.2",
     "slugger": "^1.0.1"


### PR DESCRIPTION
Metalsmith is being updated fairly regularly now, and have an [official PostCSS plugin](https://github.com/metalsmith/postcss).

We've been blocked on bumping some dependencies prior to this (#2016), but are now able to fully bump `postcss`.

I've run `npm build` and there is one small prefixing change in the resulting CSS, but otherwise it's exactly the same.

In the generated IE8 CSS we go from:
`.govuk-template{background-color:#f3f2f1;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;text-size-adjust:100%;overflow-y:scroll}`

to:
.govuk-template{background-color:#f3f2f1;-webkit-text-size-adjust:100%;-moz-text-size-adjust:100%;-ms-text-size-adjust:100%;text-size-adjust:100%;overflow-y:scroll}

and in the standard generated CSS we go from:
`.govuk-template{background-color:#f3f2f1;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;text-size-adjust:100%`

to:
`.govuk-template{background-color:#f3f2f1;-webkit-text-size-adjust:100%;-moz-text-size-adjust:100%;-ms-text-size-adjust:100%;text-size-adjust:100%`