### PR TITLE
Bump metalsmith to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "jstransformer-marked": "^1.0.3",
         "jstransformer-nunjucks": "^0.5.0",
         "marked": "^4.0.10",
-        "metalsmith": "^2.4.2",
+        "metalsmith": "^2.5.0",
         "metalsmith-assets": "^0.1.0",
         "metalsmith-broken-link-checker": "^1.0.1",
         "metalsmith-browser-sync": "^1.1.1",
@@ -1364,29 +1364,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@jest/core/node_modules/micromatch": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/@jest/core/node_modules/picomatch": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@jest/core/node_modules/rimraf": {
       "version": "3.0.2",
       "dev": true,
@@ -1731,29 +1708,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/micromatch": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/picomatch": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@jest/transform/node_modules/slash": {
@@ -3212,15 +3166,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/clone-deep": {
       "version": "0.2.4",
       "dev": true,
@@ -3244,49 +3189,6 @@
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
       }
-    },
-    "node_modules/co-from-stream": {
-      "version": "0.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "co-read": "0.0.1"
-      }
-    },
-    "node_modules/co-fs-extra": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "co-from-stream": "~0.0.0",
-        "fs-extra": "~0.26.5",
-        "thunkify-wrap": "~1.0.4"
-      }
-    },
-    "node_modules/co-fs-extra/node_modules/fs-extra": {
-      "version": "0.26.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
-      }
-    },
-    "node_modules/co-fs-extra/node_modules/jsonfile": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/co-read": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/code-point-at": {
       "version": "1.1.0",
@@ -3838,14 +3740,6 @@
     "node_modules/emoji-regex": {
       "version": "7.0.3",
       "license": "MIT"
-    },
-    "node_modules/enable": {
-      "version": "1.3.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10.0"
-      }
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -6867,29 +6761,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-config/node_modules/micromatch": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/jest-config/node_modules/picomatch": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-config/node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -7228,29 +7099,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/jest-haste-map/node_modules/micromatch": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/picomatch": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-jasmine2": {
       "version": "27.2.3",
       "dev": true,
@@ -7558,29 +7406,6 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jest-message-util/node_modules/micromatch": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/picomatch": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/jest-message-util/node_modules/slash": {
       "version": "3.0.0",
@@ -8410,17 +8235,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-util/node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -9176,14 +8990,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/klaw": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.9"
-      }
-    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "dev": true,
@@ -9580,23 +9386,20 @@
       "license": "MIT"
     },
     "node_modules/metalsmith": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/metalsmith/-/metalsmith-2.4.2.tgz",
-      "integrity": "sha512-HS/MRADloJS3+O5V/+4f/khBkwtdYUQFWEGqeviLT/7wNgHWknMiIflV99JeYzj0hbw+L0aTb2spPlnWW4/Adg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/metalsmith/-/metalsmith-2.5.0.tgz",
+      "integrity": "sha512-tBFpCMq8t/ZeD8qbvyWSLjyW7aO8RJYeFSk8LyclgHYaeMWiSPrMxXc3NORVCJ3iG17aRxuL/+nla58Qq3DBcQ==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
-        "chalk": "^4.1.2",
-        "clone": "^2.1.2",
-        "co-fs-extra": "^1.2.1",
         "commander": "^6.2.1",
         "cross-spawn": "^7.0.3",
+        "debug": "^4.3.3",
         "gray-matter": "^4.0.3",
         "is-utf8": "~0.2.0",
-        "micromatch": "^4.0.4",
+        "micromatch": "^4.0.5",
         "rimraf": "^3.0.2",
         "stat-mode": "^1.0.0",
-        "thunkify": "^2.1.2",
-        "unyield": "0.0.1",
         "ware": "^1.3.0"
       },
       "bin": {
@@ -9604,7 +9407,7 @@
         "metalsmith": "bin/metalsmith"
       },
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       }
     },
     "node_modules/metalsmith-assets": {
@@ -9909,49 +9712,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/metalsmith/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/metalsmith/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/metalsmith/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
     "node_modules/metalsmith/node_modules/commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -9959,6 +9719,23 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/metalsmith/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/metalsmith/node_modules/glob": {
@@ -9981,14 +9758,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/metalsmith/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/metalsmith/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/metalsmith/node_modules/rimraf": {
       "version": "3.0.2",
@@ -10014,39 +9788,17 @@
         "node": ">= 6"
       }
     },
-    "node_modules/metalsmith/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/micromatch": {
-      "version": "4.0.4",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime": {
@@ -10843,8 +10595,9 @@
       "license": "MIT"
     },
     "node_modules/picomatch": {
-      "version": "2.2.2",
-      "license": "MIT",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -13267,19 +13020,6 @@
       "version": "2.3.8",
       "license": "MIT"
     },
-    "node_modules/thunkify": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/thunkify-wrap": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "enable": "1"
-      }
-    },
     "node_modules/tiny-emitter": {
       "version": "2.1.0",
       "license": "MIT"
@@ -13509,18 +13249,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/unyield": {
-      "version": "0.0.1",
-      "dev": true,
-      "dependencies": {
-        "co": "~3.1.0"
-      }
-    },
-    "node_modules/unyield/node_modules/co": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.2.2",
@@ -15076,18 +14804,6 @@
           "version": "4.0.0",
           "dev": true
         },
-        "micromatch": {
-          "version": "4.0.4",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.2.3"
-          }
-        },
-        "picomatch": {
-          "version": "2.3.0",
-          "dev": true
-        },
         "rimraf": {
           "version": "3.0.2",
           "dev": true,
@@ -15317,18 +15033,6 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.4",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.2.3"
-          }
-        },
-        "picomatch": {
-          "version": "2.3.0",
           "dev": true
         },
         "slash": {
@@ -16344,12 +16048,6 @@
         }
       }
     },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-      "dev": true
-    },
     "clone-deep": {
       "version": "0.2.4",
       "dev": true,
@@ -16363,46 +16061,6 @@
     },
     "co": {
       "version": "4.6.0",
-      "dev": true
-    },
-    "co-from-stream": {
-      "version": "0.0.0",
-      "dev": true,
-      "requires": {
-        "co-read": "0.0.1"
-      }
-    },
-    "co-fs-extra": {
-      "version": "1.2.1",
-      "dev": true,
-      "requires": {
-        "co-from-stream": "~0.0.0",
-        "fs-extra": "~0.26.5",
-        "thunkify-wrap": "~1.0.4"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "0.26.7",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        }
-      }
-    },
-    "co-read": {
-      "version": "0.0.1",
       "dev": true
     },
     "code-point-at": {
@@ -16796,10 +16454,6 @@
     },
     "emoji-regex": {
       "version": "7.0.3"
-    },
-    "enable": {
-      "version": "1.3.2",
-      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2"
@@ -18929,18 +18583,6 @@
           "version": "4.0.0",
           "dev": true
         },
-        "micromatch": {
-          "version": "4.0.4",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.2.3"
-          }
-        },
-        "picomatch": {
-          "version": "2.3.0",
-          "dev": true
-        },
         "supports-color": {
           "version": "7.2.0",
           "dev": true,
@@ -19172,18 +18814,6 @@
         "graceful-fs": {
           "version": "4.2.8",
           "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.4",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.2.3"
-          }
-        },
-        "picomatch": {
-          "version": "2.3.0",
-          "dev": true
         }
       }
     },
@@ -19389,18 +19019,6 @@
         },
         "js-tokens": {
           "version": "4.0.0",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.4",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.2.3"
-          }
-        },
-        "picomatch": {
-          "version": "2.3.0",
           "dev": true
         },
         "slash": {
@@ -19936,10 +19554,6 @@
           "version": "4.0.0",
           "dev": true
         },
-        "picomatch": {
-          "version": "2.3.0",
-          "dev": true
-        },
         "supports-color": {
           "version": "7.2.0",
           "dev": true,
@@ -20325,13 +19939,6 @@
         "is-buffer": "^1.1.5"
       }
     },
-    "klaw": {
-      "version": "1.3.1",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.9"
-      }
-    },
     "kleur": {
       "version": "3.0.3",
       "dev": true
@@ -20603,59 +20210,36 @@
       "dev": true
     },
     "metalsmith": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/metalsmith/-/metalsmith-2.4.2.tgz",
-      "integrity": "sha512-HS/MRADloJS3+O5V/+4f/khBkwtdYUQFWEGqeviLT/7wNgHWknMiIflV99JeYzj0hbw+L0aTb2spPlnWW4/Adg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/metalsmith/-/metalsmith-2.5.0.tgz",
+      "integrity": "sha512-tBFpCMq8t/ZeD8qbvyWSLjyW7aO8RJYeFSk8LyclgHYaeMWiSPrMxXc3NORVCJ3iG17aRxuL/+nla58Qq3DBcQ==",
       "dev": true,
       "requires": {
-        "chalk": "^4.1.2",
-        "clone": "^2.1.2",
-        "co-fs-extra": "^1.2.1",
         "commander": "^6.2.1",
         "cross-spawn": "^7.0.3",
+        "debug": "^4.3.3",
         "gray-matter": "^4.0.3",
         "is-utf8": "~0.2.0",
-        "micromatch": "^4.0.4",
+        "micromatch": "^4.0.5",
         "rimraf": "^3.0.2",
         "stat-mode": "^1.0.0",
-        "thunkify": "^2.1.2",
-        "unyield": "0.0.1",
         "ware": "^1.3.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
         "commander": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
           "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
           "dev": true
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
         },
         "glob": {
           "version": "7.2.0",
@@ -20671,10 +20255,10 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "rimraf": {
@@ -20691,15 +20275,6 @@
           "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
           "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
           "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },
@@ -20938,17 +20513,13 @@
       }
     },
     "micromatch": {
-      "version": "4.0.4",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
-      },
-      "dependencies": {
-        "picomatch": {
-          "version": "2.3.0",
-          "dev": true
-        }
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "mime": {
@@ -21452,7 +21023,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.2"
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pify": {
       "version": "2.3.0",
@@ -23166,17 +22739,6 @@
     "through": {
       "version": "2.3.8"
     },
-    "thunkify": {
-      "version": "2.1.2",
-      "dev": true
-    },
-    "thunkify-wrap": {
-      "version": "1.0.4",
-      "dev": true,
-      "requires": {
-        "enable": "1"
-      }
-    },
     "tiny-emitter": {
       "version": "2.1.0"
     },
@@ -23319,19 +22881,6 @@
     },
     "unpipe": {
       "version": "1.0.0"
-    },
-    "unyield": {
-      "version": "0.0.1",
-      "dev": true,
-      "requires": {
-        "co": "~3.1.0"
-      },
-      "dependencies": {
-        "co": {
-          "version": "3.1.0",
-          "dev": true
-        }
-      }
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jstransformer-marked": "^1.0.3",
     "jstransformer-nunjucks": "^0.5.0",
     "marked": "^4.0.10",
-    "metalsmith": "^2.4.2",
+    "metalsmith": "^2.5.0",
     "metalsmith-assets": "^0.1.0",
     "metalsmith-broken-link-checker": "^1.0.1",
     "metalsmith-browser-sync": "^1.1.1",


### PR DESCRIPTION
## [2.5.0] - 2022-06-10

Important note to [metalsmith-watch](https://github.com/FWeinb/metalsmith-watch#readme) users:
Although 2.5.0 is a semver-minor release, it breaks compatibility with metalsmith-watch, which relies on the Metalsmith < 2.4.x private method signature using the outdated unyield package. See [issue #374](https://github.com/metalsmith/metalsmith/issues/374) for more details.

### Added

- [#354] Added `Metalsmith#env` method. Supports passing `DEBUG` and `DEBUG_LOG` amongst others. Sets `CLI: true` when run from the metalsmith CLI. [`b42df8c`](https://github.com/metalsmith/metalsmith/commit/b42df8c), [`446c676`](https://github.com/metalsmith/metalsmith/commit/446c676), [`33d936b`](https://github.com/metalsmith/metalsmith/commit/33d936b), [`4c483a3`](https://github.com/metalsmith/metalsmith/commit/4c483a3)
- [#356] Added `Metalsmith#debug` method for creating plugin debuggers
- [#362] Upgraded all generator-based methods (`Metalsmith#read`,`Metalsmith#readFile`,`Metalsmith#write`,`Metalsmith#writeFile`, `Metalsmith#run` and `Metalsmith#process`) to dual callback-/ promise-based methods [`16a91c5`](https://github.com/metalsmith/metalsmith/commit/16a91c5), [`faf6ab6`](https://github.com/metalsmith/metalsmith/commit/faf6ab6), [`6cb6229`](https://github.com/metalsmith/metalsmith/commit/6cb6229)
- Added org migration notification to postinstall script to encourage users to upgrade [`3a11a24`](https://github.com/metalsmith/metalsmith/commit/3a11a24)

### Removed

- [#231] Dropped support for Node < 12 [`0a53007`](https://github.com/metalsmith/metalsmith/commit/0a53007)
- **Dependencies:**
  - `thunkify`: replaced with promise-based implementation [`faf6ab6`](https://github.com/metalsmith/metalsmith/commit/faf6ab6)
  - `unyield` replaced with promise-based implementation [`faf6ab6`](https://github.com/metalsmith/metalsmith/commit/faf6ab6)
  - `co-fs-extra`: replaced with native Node.js methods [`faf6ab6`](https://github.com/metalsmith/metalsmith/commit/faf6ab6)
  - `chalk`: not necessary for the few colors used by Metalsmith CLI [`1dae1cb`](https://github.com/metalsmith/metalsmith/commit/a1dae1cb)
  - `clone`: see [#247] [`a871af6`](https://github.com/metalsmith/metalsmith/commit/a871af6)

### Updated

- Restructured and updated `README.md` [`0da0c4d`](https://github.com/metalsmith/metalsmith/commit/0da0c4d)
- [#247] Calling `Metalsmith#metadata` no longer clones the object passed to it, overwriting the previous metadata, but merges it into existing metadata.

[#362]: https://github.com/metalsmith/metalsmith/issues/362
[#354]: https://github.com/metalsmith/metalsmith/issues/354
[#355]: https://github.com/metalsmith/metalsmith/issues/355
[#356]: https://github.com/metalsmith/metalsmith/issues/356
[#247]: https://github.com/metalsmith/metalsmith/issues/247

### Fixed

- [#355] Proper path resolution for edge-cases using CLI, running metalsmith from outside or subfolder of `metalsmith.directory()`[`5d75539`](https://github.com/metalsmith/metalsmith/commit/5d75539)
