### PR TITLE
Only toggle details ARIA attributes if already set

### DIFF
--- a/src/javascripts/components/options-table.js
+++ b/src/javascripts/components/options-table.js
@@ -33,8 +33,19 @@ var OptionsTable = {
             tabsElement.removeAttribute('hidden')
 
             optionsDetailsElement.setAttribute('open', 'open')
-            detailsSummary.setAttribute('aria-expanded', 'true')
+
+            // If the browser does not natively support the <details> element
+            // the polyfill included with the Details component adds ARIA
+            // attributes and explicit display styles that we need to keep in
+            // sync with the open attribute.
+            if (detailsSummary.hasAttribute('aria-expanded')) {
+              detailsSummary.setAttribute('aria-expanded', 'true')
+            }
+            if (detailsText.hasAttribute('aria-hidden')) {
+              detailsText.setAttribute('aria-hidden', false)
+            }
             detailsText.style.display = ''
+
             window.setTimeout(function () {
               tabLink.focus()
               if (isLinkToTable) document.querySelector(hash).scrollIntoView()


### PR DESCRIPTION
I believe this dates from when the polyfill for the `<details>` element used to be applied in all browsers, and added extra ARIA attributes which always needed to be kept in sync when this script toggled the open state.

However, [since GOV.UK Frontend v3.1.0 the polyfill now does nothing in browsers that natively support the `<details>` elements][1].

This means that once these attributes are set on page load, unless the polyfill is running there is nothing to keep them in sync if the user toggles the details element:

- `aria-expanded` will always be `true`, potentially causing AT to announce the expanded state incorrectly
- `aria-hidden` will always be `false` – although this is likely not an issue as aria-hidden can't make things hidden using display:none 're-appear' in the accessibility tree

Instead, only toggle `aria-expanded` if it is already set on the element (which should only happen if the polyfill has run, in which case the browser does not natively support the `<details>` element).

We also need to re-introduce the `aria-hidden` attribute removed in 8b53583 as when the polyfill runs it currently adds an `aria-hidden` attribute which means the content inside the `<details>` element will be inaccessible even when opened unless we remove it.

Add a comment to try and explain why this code needs to exist.

Fixes #2257 

[1]: https://github.com/alphagov/govuk-frontend/pull/1523