### PR TITLE
Update link to task list Sass file

### DIFF
--- a/src/patterns/task-list-pages/index.md.njk
+++ b/src/patterns/task-list-pages/index.md.njk
@@ -23,7 +23,7 @@ Task list pages help users understand:
 There’s a [coded example of a task list page](https://govuk-prototype-kit.herokuapp.com/docs/templates/task-list) in the GOV.UK Prototype Kit. To use the example, get the following code from the Prototype Kit repository on GitHub:
 
 - [HTML from the task list page's HTML file](https://github.com/alphagov/govuk-prototype-kit/blob/main/docs/views/templates/task-list.html#L18)
-- [custom styles from the task list page's SCSS file](https://github.com/alphagov/govuk-prototype-kit/blob/main/app/assets/sass/patterns/_task-list.scss)
+- [custom styles from the task list page's SCSS file](https://github.com/alphagov/govuk-prototype-kit/blob/main/lib/assets/sass/patterns/_task-list.scss)
 
 ## When to use this pattern
 


### PR DESCRIPTION
This file has changed location in recent changes to the Prototype Kit, this updates the URL to no longer 404.