### PR TITLE
Remove broken link in page template guidance

### DIFF
--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -104,7 +104,7 @@ To change the components that are included in the page template by default, set 
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">assetUrl</td>
       <td class="govuk-table__cell">Variable</td>
-      <td class="govuk-table__cell">Set the domain for the Open Graph meta tag image asset. If you need to use both your own domain and your own image path and filename, add <code>&lt;meta property="og:image" content="YOUR-ABSOLUTE-URL"&gt;</code> inside the <code>head</code> <a href="#blocks">block</a> instead of using `assetUrl`.</td>
+      <td class="govuk-table__cell">Set the domain for the Open Graph meta tag image asset. If you need to use both your own domain and your own image path and filename, add <code>&lt;meta property="og:image" content="YOUR-ABSOLUTE-URL"&gt;</code> inside the <code>head</code> block instead of using `assetUrl`.</td>
     </tr>
 
     <tr class="govuk-table__row">


### PR DESCRIPTION
The ‘variables’ and ‘blocks’ tables were merged in #1311 but this link was missed.