### PR TITLE
Tweaks to spacing scale table in spacing guidance

### DIFF
--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -64,7 +64,6 @@ The Design System uses a responsive spacing scale which adapts based on screen s
       <td class="govuk-table__cell govuk-table__cell--numeric">10px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">10px</td>
     </tr>
-    </tr>
     <tr>
       <th class="govuk-table__header" scope="row">1</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">5px</td>

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -16,61 +16,61 @@ The Design System uses a responsive spacing scale which adapts based on screen s
 
 <table class="govuk-table app-table--constrained">
   <caption class="govuk-table__caption small govuk-visually-hidden">GOV.UK Frontend spacing scale</caption>
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
+  <thead>
+    <tr>
       <th class="govuk-table__header" scope="col">Spacing unit</th>
       <th class="govuk-table__header govuk-table__header--numeric" scope="col">Large screens</th>
       <th class="govuk-table__header govuk-table__header--numeric" scope="col">Small screens</th>
     </tr>
   </thead>
-  <tbody class="govuk-table__body">
-    <tr class="govuk-table__row">
+  <tbody>
+    <tr>
       <th class="govuk-table__header" scope="row">9</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">60px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">40px</td>
     </tr>
-    <tr class="govuk-table__row">
+    <tr>
       <th class="govuk-table__header" scope="row">8</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">50px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">30px</td>
     </tr>
-    <tr class="govuk-table__row">
+    <tr>
       <th class="govuk-table__header" scope="row">7</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">40px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">25px</td>
     </tr>
-    <tr class="govuk-table__row">
+    <tr>
       <th class="govuk-table__header" scope="row">6</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">30px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">20px</td>
     </tr>
-    <tr class="govuk-table__row">
+    <tr>
       <th class="govuk-table__header" scope="row">5</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">25px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
     </tr>
-    <tr class="govuk-table__row">
+    <tr>
       <th class="govuk-table__header" scope="row">4</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">20px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
     </tr>
-    <tr class="govuk-table__row">
+    <tr>
       <th class="govuk-table__header" scope="row">3</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
     </tr>
-    <tr class="govuk-table__row">
+    <tr>
       <th class="govuk-table__header" scope="row">2</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">10px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">10px</td>
     </tr>
     </tr>
-    <tr class="govuk-table__row">
+    <tr>
       <th class="govuk-table__header" scope="row">1</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">5px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">5px</td>
     </tr>
-    <tr class="govuk-table__row">
+    <tr>
       <th class="govuk-table__header" scope="row">0</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">0</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">0</td>

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -19,40 +19,40 @@ The Design System uses a responsive spacing scale which adapts based on screen s
   <thead>
     <tr>
       <th class="govuk-table__header" scope="col">Spacing unit</th>
-      <th class="govuk-table__header govuk-table__header--numeric" scope="col">Large screens</th>
       <th class="govuk-table__header govuk-table__header--numeric" scope="col">Small screens</th>
+      <th class="govuk-table__header govuk-table__header--numeric" scope="col">Large screens</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <th class="govuk-table__header" scope="row">9</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">60px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">40px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">60px</td>
     </tr>
     <tr>
       <th class="govuk-table__header" scope="row">8</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">50px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">30px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">50px</td>
     </tr>
     <tr>
       <th class="govuk-table__header" scope="row">7</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">40px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">25px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">40px</td>
     </tr>
     <tr>
       <th class="govuk-table__header" scope="row">6</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">30px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">20px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">30px</td>
     </tr>
     <tr>
       <th class="govuk-table__header" scope="row">5</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">25px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">25px</td>
     </tr>
     <tr>
       <th class="govuk-table__header" scope="row">4</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">20px</td>
       <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">20px</td>
     </tr>
     <tr>
       <th class="govuk-table__header" scope="row">3</th>

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -25,44 +25,9 @@ The Design System uses a responsive spacing scale which adapts based on screen s
   </thead>
   <tbody>
     <tr>
-      <th class="govuk-table__header" scope="row">9</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">40px</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">60px</td>
-    </tr>
-    <tr>
-      <th class="govuk-table__header" scope="row">8</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">30px</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">50px</td>
-    </tr>
-    <tr>
-      <th class="govuk-table__header" scope="row">7</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">25px</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">40px</td>
-    </tr>
-    <tr>
-      <th class="govuk-table__header" scope="row">6</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">20px</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">30px</td>
-    </tr>
-    <tr>
-      <th class="govuk-table__header" scope="row">5</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">25px</td>
-    </tr>
-    <tr>
-      <th class="govuk-table__header" scope="row">4</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">20px</td>
-    </tr>
-    <tr>
-      <th class="govuk-table__header" scope="row">3</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
-    </tr>
-    <tr>
-      <th class="govuk-table__header" scope="row">2</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">10px</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">10px</td>
+      <th class="govuk-table__header" scope="row">0</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">0</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">0</td>
     </tr>
     <tr>
       <th class="govuk-table__header" scope="row">1</th>
@@ -70,9 +35,44 @@ The Design System uses a responsive spacing scale which adapts based on screen s
       <td class="govuk-table__cell govuk-table__cell--numeric">5px</td>
     </tr>
     <tr>
-      <th class="govuk-table__header" scope="row">0</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">0</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">0</td>
+      <th class="govuk-table__header" scope="row">2</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">10px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">10px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">3</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">4</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">20px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">5</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">25px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">6</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">20px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">30px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">7</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">25px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">40px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">8</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">30px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">50px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">9</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">40px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">60px</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
- Swap the small and large screen sizes
- Reverse the order of the table so that we go from smallest to largest size
- Remove redundant `govuk-table__head`, `govuk-table__body` and `govuk-table__row` classes that don't do anything – see https://github.com/alphagov/govuk-frontend/issues/2733
- Remove an extra `</tr>` that had snuck in, the sneaky little thing making our HTML all invalid

👉🏻 [Preview the change](https://deploy-preview-2274--govuk-design-system-preview.netlify.app/styles/spacing/)

## Before
![Screenshot 2022-07-26 at 18 06 00](https://user-images.githubusercontent.com/121939/181068010-012a4bd4-d710-4eb0-9221-ed144b88fd8c.png)

## After
![Screenshot 2022-07-26 at 18 06 10](https://user-images.githubusercontent.com/121939/181068004-54a29aee-a96f-4f79-b6c3-4c24ec45eec6.png)

It just makes more sense this way doesn't it?