### PR TITLE
Document the static spacing scale and generally improve the spacing guidance

### DIFF
--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -137,7 +137,7 @@ The static spacing scale is the same as the spacing for 'large screens' in the r
   </tbody>
 </table>
 
-### Spacing override classes
+## Overriding spacing
 
 Occasionally, you might need to make minor adjustments like adding or removing spacing to elements of your design. You can use the responsive spacing override classes for this.
 
@@ -161,7 +161,7 @@ The last part of the class represents the value you want to apply. For example, 
 
 {{ example({group: "styles", item: "spacing", example: "spacing-scale-margin", html: true, open: false, size: "xl"}) }}
 
-## Spacing on custom components
+## Using the spacing scale in your own CSS
 
 If you’re building your own components and want to reference the spacing scale directly in your SCSS file you can use the spacing scale through a mixin or a function.
 

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -10,12 +10,16 @@ show_page_nav: true
 
 {% from "_example.njk" import example %}
 
-## The responsive spacing scale
+The Design System uses two different spacing scales – responsive and static.
 
-The Design System uses a responsive spacing scale which adapts based on screen size. For example, if you apply spacing unit 9 to a margin, it will be 60px on large screens and 40px on small screens.
+## Responsive spacing
+
+The responsive spacing scale adapts based on screen width.
+
+Spacing increases when the screen is wider than the tablet breakpoint (640px), except for the lower end of the scale (0-3) where the spacing is the same at all screen sizes.
 
 <table class="govuk-table app-table--constrained">
-  <caption class="govuk-table__caption small govuk-visually-hidden">GOV.UK Frontend spacing scale</caption>
+  <caption class="govuk-table__caption small govuk-visually-hidden">The responsive spacing scale</caption>
   <thead>
     <tr>
       <th class="govuk-table__header" scope="col">Spacing unit</th>
@@ -72,6 +76,62 @@ The Design System uses a responsive spacing scale which adapts based on screen s
     <tr>
       <th class="govuk-table__header" scope="row">9</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">40px</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">60px</td>
+    </tr>
+  </tbody>
+</table>
+
+## Static spacing
+
+The static spacing scale is the same as the spacing for 'large screens' in the responsive spacing scale, but always uses the same spacing regardless of the screen width.
+
+<table class="govuk-table app-table--constrained">
+  <caption class="govuk-table__caption small govuk-visually-hidden">The static spacing scale</caption>
+  <thead>
+    <tr>
+      <th class="govuk-table__header" scope="col">Spacing unit</th>
+      <th class="govuk-table__header govuk-table__header--numeric" scope="col">All screens</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class="govuk-table__header" scope="row">0</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">0</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">1</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">5px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">2</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">10px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">3</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">15px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">4</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">20px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">5</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">25px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">6</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">30px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">7</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">40px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">8</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">50px</td>
+    </tr>
+    <tr>
+      <th class="govuk-table__header" scope="row">9</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">60px</td>
     </tr>
   </tbody>

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -181,19 +181,17 @@ margin-top: govuk-spacing(-3);
 
 Occasionally, you might need to make minor adjustments like adding or removing spacing to elements of your design. You can use the responsive spacing override classes for this.
 
-
 ### Using the override classes
 
-The spacing override classes are structured to allow you to apply any size of the scale, using margin or padding in any direction.
+The spacing override classes start with `govuk-!-` followed by either `margin-` or `padding-`, and then the spacing unit you want to apply.
 
-For example, `govuk-!-margin-9` will set a margin of 60px on large screens and 40px on small screens.
+To apply spacing in a single direction, include `left-`, `right-`, `top-`, or `bottom-` between `margin-` or `padding-` and the spacing unit.
 
-To add padding use `-padding` instead of `-margin`.
+For example:
 
-If you want to add the margin or padding in a particular direction, add `left` for left, `right` for right, `top` for top, or `bottom` for bottom. For example, `-margin-top` will set margin-top, `-padding-right` will set padding-right.
-If you do not specify a direction, the margin or padding will be applied to all sides of the element.
-
-The last part of the class represents the value you want to apply. For example, in `govuk-!-margin-9`, the `-9` represents 9 on the spacing scale.
+- `govuk-!-margin-9` will apply a 40px margin to all sides of the element on small screens, increasing to 60px on large screens
+- `govuk-!-padding-right-5` will apply 15px of padding to the right side of the element on small screens, increasing to 25px on large screens
+- `govuk-!-margin-0` will remove all margins at all screen sizes
 
 ### Examples
 

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -14,9 +14,9 @@ The Design System uses two different spacing scales – responsive and static.
 
 ## Responsive spacing
 
-The responsive spacing scale adapts based on screen width.
+The responsive spacing scale adapts based on screen size.
 
-Spacing increases when the screen is wider than the tablet breakpoint (640px), except for the lower end of the scale (0-3) where the spacing is the same at all screen sizes.
+The spacing for 'large screens' is used when the screen is wider than the tablet breakpoint (640px). Spacing for the smallest units (0-3) stays the same for all screen sizes.
 
 <table class="govuk-table app-table--constrained">
   <caption class="govuk-table__caption small govuk-visually-hidden">The responsive spacing scale</caption>
@@ -83,7 +83,7 @@ Spacing increases when the screen is wider than the tablet breakpoint (640px), e
 
 ## Static spacing
 
-The static spacing scale is the same as the spacing for 'large screens' in the responsive spacing scale, but always uses the same spacing regardless of the screen width.
+The static spacing scale stays the same for all screen sizes, and uses the same spacing as 'large screens' in the responsive spacing scale.
 
 <table class="govuk-table app-table--constrained">
   <caption class="govuk-table__caption small govuk-visually-hidden">The static spacing scale</caption>
@@ -183,9 +183,9 @@ Occasionally, you might need to make minor adjustments like adding or removing s
 
 ### Using the override classes
 
-The spacing override classes start with `govuk-!-` followed by either `margin-` or `padding-`, and then the spacing unit you want to apply.
+The spacing override classes start with: `govuk-!-`, followed by either `margin-` or `padding-`, and then a spacing unit number.
 
-To apply spacing in a single direction, include `left-`, `right-`, `top-`, or `bottom-` between `margin-` or `padding-` and the spacing unit.
+To apply spacing in a single direction, include `left-`, `right-`, `top-`, or `bottom-` just before the spacing unit.
 
 For example:
 

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -137,30 +137,6 @@ The static spacing scale is the same as the spacing for 'large screens' in the r
   </tbody>
 </table>
 
-## Overriding spacing
-
-Occasionally, you might need to make minor adjustments like adding or removing spacing to elements of your design. You can use the responsive spacing override classes for this.
-
-
-### Using the override classes
-
-The spacing override classes are structured to allow you to apply any size of the scale, using margin or padding in any direction.
-
-For example, `govuk-!-margin-9` will set a margin of 60px on large screens and 40px on small screens.
-
-To add padding use `-padding` instead of `-margin`.
-
-If you want to add the margin or padding in a particular direction, add `left` for left, `right` for right, `top` for top, or `bottom` for bottom. For example, `-margin-top` will set margin-top, `-padding-right` will set padding-right.
-If you do not specify a direction, the margin or padding will be applied to all sides of the element.
-
-The last part of the class represents the value you want to apply. For example, in `govuk-!-margin-9`, the `-9` represents 9 on the spacing scale.
-
-### Examples
-
-{{ example({group: "styles", item: "spacing", example: "spacing-scale-padding", html: true, open: false, size: "l"}) }}
-
-{{ example({group: "styles", item: "spacing", example: "spacing-scale-margin", html: true, open: false, size: "xl"}) }}
-
 ## Using the spacing scale in your own CSS
 
 If you’re building your own components and want to reference the spacing scale directly in your SCSS file you can use the spacing scale through a mixin or a function.
@@ -200,3 +176,27 @@ For example, to apply spacing unit -3 for a negative 15px top margin on both lar
 ```scss
 margin-top: govuk-spacing(-3);
 ```
+
+## Overriding spacing
+
+Occasionally, you might need to make minor adjustments like adding or removing spacing to elements of your design. You can use the responsive spacing override classes for this.
+
+
+### Using the override classes
+
+The spacing override classes are structured to allow you to apply any size of the scale, using margin or padding in any direction.
+
+For example, `govuk-!-margin-9` will set a margin of 60px on large screens and 40px on small screens.
+
+To add padding use `-padding` instead of `-margin`.
+
+If you want to add the margin or padding in a particular direction, add `left` for left, `right` for right, `top` for top, or `bottom` for bottom. For example, `-margin-top` will set margin-top, `-padding-right` will set padding-right.
+If you do not specify a direction, the margin or padding will be applied to all sides of the element.
+
+The last part of the class represents the value you want to apply. For example, in `govuk-!-margin-9`, the `-9` represents 9 on the spacing scale.
+
+### Examples
+
+{{ example({group: "styles", item: "spacing", example: "spacing-scale-padding", html: true, open: false, size: "l"}) }}
+
+{{ example({group: "styles", item: "spacing", example: "spacing-scale-margin", html: true, open: false, size: "xl"}) }}

--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -137,11 +137,11 @@ The static spacing scale is the same as the spacing for 'large screens' in the r
   </tbody>
 </table>
 
-## Using the spacing scale in your own CSS
+## Applying spacing in your own CSS
 
-If you’re building your own components and want to reference the spacing scale directly in your SCSS file you can use the spacing scale through a mixin or a function.
+If you want to reference the spacing scale in your CSS, use the spacing helpers.
 
-### Using the responsive spacing mixin
+### Using the responsive spacing helper
 
 To use the responsive spacing scale, include the [`govuk-responsive-margin`](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-responsive-margin) or [`govuk-responsive-padding`](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-responsive-padding) mixins.
 
@@ -159,11 +159,11 @@ For example, to apply spacing unit 6 for a 30px bottom margin on large screens a
 @include govuk-responsive-margin(6, "bottom");
 ```
 
-### Using the static spacing function
+### Using the static spacing helper
 
-If you want to apply large screen spacing at all breakpoints, use the [`govuk-spacing` function](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-spacing) instead.
+For the static spacing scale, use the [`govuk-spacing` function](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-spacing).
 
-For example, to apply spacing unit 6 for 30px top padding on both large and small screens, use:
+For example, to apply spacing unit 6 for 30px top padding on all screens, use:
 
 ```scss
 padding-top: govuk-spacing(6);
@@ -171,7 +171,7 @@ padding-top: govuk-spacing(6);
 
 For negative spacing, use a negative spacing unit number.
 
-For example, to apply spacing unit -3 for a negative 15px top margin on both large and small screens, use:
+For example, to apply spacing unit -3 for a negative 15px top margin all screens, use:
 
 ```scss
 margin-top: govuk-spacing(-3);


### PR DESCRIPTION
Document the static spacing scale as part of the spacing guidance, as well as:

- improving the header structure of the page
- moving the section on overrides last, to try and encourage users who are writing their own CSS to use the helpers instead
- tweaking the guidance on helpers and overrides

Suggest reviewing commit-by-commit as some of the content has moved around – this will make it easier to see what's changed.

This does **not** include documenting the new static spacing override classes (#2244) – that will be done in a follow up PR. This means that these changes can go out before v4.3.0 is released.

Fixes #1210.