### PR TITLE
Change to more up to date link for Ethnicity harmonised standard

### DIFF
--- a/src/patterns/equality-information/index.md.njk
+++ b/src/patterns/equality-information/index.md.njk
@@ -16,7 +16,7 @@ Public sector bodies often collect equality information about service users to h
 
 ## When to use this pattern
 
-These patterns are based on the [harmonised standards developed by the Government Statistical Service](https://analysisfunction.civilservice.gov.uk/policy-store/ethnicity-harmonised-standard/).
+These patterns are based on the [harmonised standards developed by the Government Statistical Service](https://analysisfunction.civilservice.gov.uk/government-statistical-service-and-statistician-group/gss-support/gss-harmonisation-support/harmonised-standards-and-guidance/).
 
 Collecting equality information in a consistent way across the public sector makes the data more useful. For example, an organisation can benchmark its own services against other public sector services or the population in general. And it can adjust its approach if it finds a particular group is under-represented.
 

--- a/src/patterns/equality-information/index.md.njk
+++ b/src/patterns/equality-information/index.md.njk
@@ -16,7 +16,7 @@ Public sector bodies often collect equality information about service users to h
 
 ## When to use this pattern
 
-These patterns are based on the [harmonised standards developed by the Government Statistical Service](https://gss.civilservice.gov.uk/guidances/harmonised-standards-guidance/).
+These patterns are based on the [harmonised standards developed by the Government Statistical Service](https://analysisfunction.civilservice.gov.uk/policy-store/ethnicity-harmonised-standard/).
 
 Collecting equality information in a consistent way across the public sector makes the data more useful. For example, an organisation can benchmark its own services against other public sector services or the population in general. And it can adjust its approach if it finds a particular group is under-represented.
 


### PR DESCRIPTION
GSS appear to have moved to a new site - the link was pointing at the old (and out of date) archived standard.

See #2284 for more relevant conversation.

