### PR TITLE
Fix markdown lists on pagination component page

### DIFF
--- a/src/components/pagination/index.md.njk
+++ b/src/components/pagination/index.md.njk
@@ -60,16 +60,19 @@ Show the page number in the page `<title>` so that screen reader users know they
 Show an appropriate number of pages to fit the horizontal space available.
 
 For smaller screens, show page numbers for:
+
 - the current page
 - previous and next pages
 - first and last pages
 
 For larger screens, show page numbers for:
+
 - the current page
 - at least one page immediately before and after the current page 
 - first and last pages
 
 Use ellipses (…) to replace any skipped pages. For example:
+
 - **[1]** 2 … 100
 - 1 **[2]** 3 … 100
 - 1 2 **[3]** 4 … 100


### PR DESCRIPTION
When there's no empty line before the list the Markdown renderer is treating it like it's part of the preceding paragraph.

| Before | After |
| ------- | ------- |
| ![Screenshot from 2022-08-01 16-30-06](https://user-images.githubusercontent.com/128088/182185777-f37d3c40-bdfe-4caf-9b8f-a0173005c4be.png) | ![Screenshot from 2022-08-01 16-30-16](https://user-images.githubusercontent.com/128088/182185794-b3cd937d-b000-42c8-a688-80fa3f147fbb.png) |