### PR TITLE
Fix matchMedia event listener in IE / Safari < 14

### DIFF
--- a/src/javascripts/components/navigation.js
+++ b/src/javascripts/components/navigation.js
@@ -136,7 +136,13 @@ Navigation.prototype.init = function () {
 
   if (typeof window.matchMedia === 'function') {
     this.mql = window.matchMedia('(min-width: 40.0625em)')
-    this.mql.addEventListener('change', this.setHiddenStates.bind(this))
+
+    // IE and Safari < 14 do not support MediaQueryList.addEventListener
+    if ('addEventListener' in this.mql) {
+      this.mql.addEventListener('change', this.setHiddenStates.bind(this))
+    } else {
+      this.mql.addListener(this.setHiddenStates.bind(this))
+    }
   }
 
   this.setHiddenStates()


### PR DESCRIPTION
IE 10/11 and Safari >= 5.1 < 14 support `window.matchMedia` but do not support `MediaQueryList.addEventListener`.

Instead we have to use the non-standard (and deprecated) [`MediaQueryList.addListener`][1], which only takes one argument which is the callback function to run when the media query status changes.

Test for the presence of the `MediaQueryList.addEventListener` method and then use whichever method is appropriate for the browser.

## Safari (iOS 13)

### Before

<img width="466" alt="Screenshot 2022-08-04 at 09 50 28" src="https://user-images.githubusercontent.com/121939/182813762-dad6f485-2ed0-46be-b3da-a4912ee993e9.png">

### After

<img width="466" alt="Screenshot 2022-08-04 at 09 50 21" src="https://user-images.githubusercontent.com/121939/182813664-e2f29712-82fa-48cc-a3db-d92e5fc98d06.png">

## IE 11

### Before

<img width="514" alt="Screenshot 2022-08-04 at 09 52 22" src="https://user-images.githubusercontent.com/121939/182813853-1e25dd34-b4b8-4878-b157-5be40082d26d.png">

### After

<img width="514" alt="Screenshot 2022-08-04 at 09 51 49" src="https://user-images.githubusercontent.com/121939/182813870-72c56ab6-0ba7-4932-b60d-e4ba2fd6dce7.png">

[1]: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener