### PR TITLE
Add alias for section break

### DIFF
--- a/lib/extract-page-headings/fixtures/src/example-with-aliases.md.njk
+++ b/lib/extract-page-headings/fixtures/src/example-with-aliases.md.njk
@@ -1,0 +1,19 @@
+---
+title: Example with aliases
+headingAliases:
+    Heading level 1: one
+    Heading level 2: two
+    Heading level 3: three
+---
+
+Contents
+
+# Heading level 1
+
+Paragraph
+
+## Heading level 2
+
+[Link](/)
+
+### Heading level 3

--- a/lib/extract-page-headings/index.js
+++ b/lib/extract-page-headings/index.js
@@ -21,8 +21,8 @@ const plugin = () => {
           aliases =
             Object.entries(data.headingAliases)
               .filter(([text]) => { return text === token.text })
-              .map(([text, alias]) => { return alias; })
-              .join();
+              .map(([text, alias]) => { return alias })
+              .join()
         }
 
         let heading = {

--- a/lib/extract-page-headings/index.js
+++ b/lib/extract-page-headings/index.js
@@ -12,14 +12,26 @@ const plugin = () => {
       let tokens = lexer.lex(contents)
       let headingsArray = []
       tokens.forEach(token => {
-        if (token.type === 'heading') {
-          let heading = {
-            depth: token.depth,
-            text: token.text,
-            url: token.text.toLowerCase().replace(/[^\w]+/g, '-')
-          }
-          headingsArray.push(heading)
+        if (token.type !== 'heading') {
+          return
         }
+
+        let aliases = null
+        if (data.headingAliases) {
+          aliases =
+            Object.entries(data.headingAliases)
+              .filter(([text]) => { return text === token.text })
+              .map(([text, alias]) => { return alias; })
+              .join();
+        }
+
+        let heading = {
+          depth: token.depth,
+          text: token.text,
+          url: token.text.toLowerCase().replace(/[^\w]+/g, '-'),
+          aliases
+        }
+        headingsArray.push(heading)
       })
       data.headings = headingsArray
     })

--- a/lib/extract-page-headings/index.test.js
+++ b/lib/extract-page-headings/index.test.js
@@ -4,7 +4,7 @@ const metalsmith = require('metalsmith')
 const plugin = require('./index.js')
 
 describe('extract-page-headings plugin', () => {
-  let pages;
+  let pages
   beforeAll((done) => {
     metalsmith('lib/extract-page-headings/fixtures')
       .use(plugin())
@@ -12,7 +12,7 @@ describe('extract-page-headings plugin', () => {
         if (err) {
           return done(err)
         }
-        pages = files;
+        pages = files
 
         done()
       })
@@ -27,12 +27,11 @@ describe('extract-page-headings plugin', () => {
     expect(metadataHeadings).toEqual(expectedHeadings)
   })
   it('generates headings with aliases', () => {
-
     const metadataHeadings = pages['example-with-aliases.md.njk'].headings
     const expectedHeadings = [
-      { aliases: "one", depth: 1, text: 'Heading level 1', url: 'heading-level-1' },
-      { aliases: "two", depth: 2, text: 'Heading level 2', url: 'heading-level-2' },
-      { aliases: "three", depth: 3, text: 'Heading level 3', url: 'heading-level-3' }
+      { aliases: 'one', depth: 1, text: 'Heading level 1', url: 'heading-level-1' },
+      { aliases: 'two', depth: 2, text: 'Heading level 2', url: 'heading-level-2' },
+      { aliases: 'three', depth: 3, text: 'Heading level 3', url: 'heading-level-3' }
     ]
     expect(metadataHeadings).toEqual(expectedHeadings)
   })

--- a/lib/extract-page-headings/index.test.js
+++ b/lib/extract-page-headings/index.test.js
@@ -4,23 +4,36 @@ const metalsmith = require('metalsmith')
 const plugin = require('./index.js')
 
 describe('extract-page-headings plugin', () => {
-  it('generated heading metadata matches expected', (done) => {
+  let pages;
+  beforeAll((done) => {
     metalsmith('lib/extract-page-headings/fixtures')
       .use(plugin())
       .build((err, files) => {
         if (err) {
           return done(err)
         }
-        Object.keys(files).forEach((file) => {
-          const metadataHeadings = files[file].headings
-          const expectedHeadings = [
-            { depth: 1, text: 'Heading level 1', url: 'heading-level-1' },
-            { depth: 2, text: 'Heading level 2', url: 'heading-level-2' },
-            { depth: 3, text: 'Heading level 3', url: 'heading-level-3' }
-          ]
-          expect(metadataHeadings).toEqual(expectedHeadings)
-        })
+        pages = files;
+
         done()
       })
+  })
+  it('generated heading metadata matches expected', () => {
+    const metadataHeadings = pages['example.md.njk'].headings
+    const expectedHeadings = [
+      { aliases: null, depth: 1, text: 'Heading level 1', url: 'heading-level-1' },
+      { aliases: null, depth: 2, text: 'Heading level 2', url: 'heading-level-2' },
+      { aliases: null, depth: 3, text: 'Heading level 3', url: 'heading-level-3' }
+    ]
+    expect(metadataHeadings).toEqual(expectedHeadings)
+  })
+  it('generates headings with aliases', () => {
+
+    const metadataHeadings = pages['example-with-aliases.md.njk'].headings
+    const expectedHeadings = [
+      { aliases: "one", depth: 1, text: 'Heading level 1', url: 'heading-level-1' },
+      { aliases: "two", depth: 2, text: 'Heading level 2', url: 'heading-level-2' },
+      { aliases: "three", depth: 3, text: 'Heading level 3', url: 'heading-level-3' }
+    ]
+    expect(metadataHeadings).toEqual(expectedHeadings)
   })
 })

--- a/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md.njk
+++ b/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md.njk
@@ -1,6 +1,8 @@
 ---
 title: Page with headings
 show_page_nav: true
+headingAliases:
+    Heading level 2: two
 ---
 
 # Heading level 1

--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -50,7 +50,8 @@ module.exports = function lunrPlugin () {
                 path: `${documentPath}/#${heading.url}`,
                 title: heading.text,
                 page: file.title,
-                section: file.section
+                section: file.section,
+                aliases: heading.aliases === null ? undefined : heading.aliases
               }
             })
           return headings
@@ -98,7 +99,8 @@ module.exports = function lunrPlugin () {
         store[doc.path] = {
           title: doc.title,
           path: doc.path,
-          section: `${doc.section}${separator}${doc.page}`
+          section: `${doc.section}${separator}${doc.page}`,
+          aliases: doc.aliases
         }
         this.add(doc)
       })

--- a/lib/metalsmith-lunr-index/index.test.js
+++ b/lib/metalsmith-lunr-index/index.test.js
@@ -111,5 +111,12 @@ describe('metalsmith-lunr-index plugin', () => {
 
       expect(documentStore[resultRef].title).toEqual('Heading level 2')
     })
+
+    it('stores the aliases for the page heading of the page in the metadata', () => {
+      const searchResults = searchIndex.search('two')
+      const resultRef = searchResults[0].ref
+
+      expect(documentStore[resultRef].title).toEqual('Heading level 2')
+    })
   })
 })

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -5,6 +5,8 @@ section: Styles
 backlog_issue_id: 64
 layout: layout-pane.njk
 show_page_nav: true
+headingAliases:
+  Section break: horizontal rule, hr
 ---
 
 {% from "_example.njk" import example %}


### PR DESCRIPTION
I was building a page and wanted to have a styled `<hr>` so typed "Horizontal rule" and nothing came up in the search, I knew it was on the typography page from memory but I think other people may assume it doesnt exist.

This pull request enables aliases for headings, which aligns with top level aliases.

<img width="339" alt="Search entry of rule that shows section breaks" src="https://user-images.githubusercontent.com/2445413/182855909-8928d288-58c7-48c9-97f9-584f06196d84.png">

