### PR TITLE
Update govuk-frontend to 4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "clipboard": "^2.0.4",
         "connect": "^3.6.6",
         "eslint": "^5.16.0",
-        "govuk-frontend": "^4.2.0",
+        "govuk-frontend": "^4.3.0",
         "gray-matter": "^4.0.2",
         "highlight.js": "^10.4.1",
         "html5shiv": "^3.7.3",
@@ -5680,9 +5680,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
-      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.0.tgz",
+      "integrity": "sha512-U8IyhayW5tpEktTU1Ea2wYyUsmS6UQWkuec/ebB51keSCUfZtrLsj5u9oa6GtwzTatk+3NYMOEEclGNTz4/FKQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -18368,9 +18368,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
-      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.0.tgz",
+      "integrity": "sha512-U8IyhayW5tpEktTU1Ea2wYyUsmS6UQWkuec/ebB51keSCUfZtrLsj5u9oa6GtwzTatk+3NYMOEEclGNTz4/FKQ=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clipboard": "^2.0.4",
     "connect": "^3.6.6",
     "eslint": "^5.16.0",
-    "govuk-frontend": "^4.2.0",
+    "govuk-frontend": "^4.3.0",
     "gray-matter": "^4.0.2",
     "highlight.js": "^10.4.1",
     "html5shiv": "^3.7.3",


### PR DESCRIPTION
Update the design system website to use the latest version govuk-frontend.