### PR TITLE
Retry failed tests

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,4 @@
 /* eslint-env jest */
 
 jest.setTimeout(10000)
+jest.retryTimes(3, { logErrorsBeforeRetry: true })


### PR DESCRIPTION
The "see no evil, hear no evil" approach. This does not address the flaky tests themselves, but sets `jest.retryTimes` to 3, rerunning failed tests and greatly increasing the likelihood of a CI test task passing.

This is speedier (and more automatic) than rerunning a full CI task again, so might be enough if the flakiness isn't easily addressable.

Before this change, my local `npm test` runs were consistently failing each time. After this I couldn't get 'em to fail after 20 attempts (very scientific, I know).

I think it might be worth merging this and seeing if it helps with the effect, then keeping #1957 open to deal with the cause.