### PR TITLE
Reference cookie banner in updating guidance

### DIFF
--- a/src/get-started/updating-your-code/index.md.njk
+++ b/src/get-started/updating-your-code/index.md.njk
@@ -81,7 +81,9 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
 
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:cookie_message</td>
-      <td class="govuk-table__cell">No replacement, we are looking to improve this component based on GDPR requirements.</td>
+      <td class="govuk-table__cell">
+        See the <a class="govuk-link" href="/components/cookie-banner/">cookie banner component</a> for more details.
+      </td>
     </tr>
 
     <tr class="govuk-table__row">


### PR DESCRIPTION
We now have a cookie banner component, so we should link to it from this guide.