### PR TITLE
Static spacing override classes don't start with `govuk-!-static` (as documented)

### DIFF
--- a/src/styles/spacing/index.md.njk
+++ b/src/styles/spacing/index.md.njk
@@ -199,9 +199,9 @@ The static spacing override classes start with `govuk-!-static`. Use them the sa
 
 For example, use:
 
-- `govuk-!-static-margin-9` to apply a 60px margin to all sides of the element at all screen sizes
-- `govuk-!-static-padding-right-5` to apply 25px of padding to the right side of the element at all screen sizes
-- `govuk-!-static-margin-0` to remove all margins at all screen sizes, same as `govuk-!-margin-0`
+- `govuk-!-margin-static-9` to apply a 60px margin to all sides of the element at all screen sizes
+- `govuk-!-padding-right-static-5` to apply 25px of padding to the right side of the element at all screen sizes
+- `govuk-!-margin-static-0` to remove all margins at all screen sizes, same as `govuk-!-margin-0`
 
 ### Examples
 


### PR DESCRIPTION
New static classes in 4.3.0 css assets have the phrase 'static' towards the end of the class name rather than the beginning. eg.

.govuk-\!-margin-static-1 {
  margin: 5px !important
}

The sentence above the examples 'The static spacing override classes start with `govuk-!-static`. Use them the same way as the responsive spacing override classes.' would also need to be changed as it states the class starts with static. That is unless the guidance is actually correct and it's the generated assets that are back to front?