### PR TITLE
Stop recommending using `pattern="[0-9]*"` on number inputs

### DIFF
--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -93,7 +93,9 @@ Do not include links within hint text. While screen readers will read out the li
 
 #### Asking for whole numbers
 
-If you're asking the user to enter a whole number and you want to bring up the numeric keypad on a mobile device, set the `inputmode` attribute to `numeric` and the `pattern` attribute to `[0-9]*`. See how to do this in the HTML and Nunjucks tabs in the following example.
+If you're asking the user to enter a whole number, set the `inputmode` attribute to `numeric` to use the numeric keypad on devices with on-screen keyboards. 
+
+See how to do this by opening the HTML and Nunjucks tabs in this example:
 
 {{ example({group: "components", item: "text-input", example: "number-input", html: true, nunjucks: true, open: false, size: "m"}) }}
 

--- a/src/components/text-input/number-input/index.njk
+++ b/src/components/text-input/number-input/index.njk
@@ -18,6 +18,5 @@ layout: layout-example.njk
   id: "account-number",
   name: "account-number",
   inputmode: "numeric",
-  pattern: "[0-9]*",
   spellcheck: false
 }) }}

--- a/src/patterns/bank-details/default/index.njk
+++ b/src/patterns/bank-details/default/index.njk
@@ -29,7 +29,6 @@ layout: layout-example.njk
   id: "sort-code",
   name: "sort-code",
   inputmode: "numeric",
-  pattern: "[0-9]*",
   spellcheck: false
 }) }}
 
@@ -44,7 +43,6 @@ layout: layout-example.njk
   id: "account-number",
   name: "account-number",
   inputmode: "numeric",
-  pattern: "[0-9]*",
   spellcheck: false
 }) }}
 

--- a/src/patterns/bank-details/error/index.njk
+++ b/src/patterns/bank-details/error/index.njk
@@ -17,7 +17,6 @@ layout: layout-example.njk
   id: "sort-code",
   name: "sort-code",
   inputmode: "numeric",
-  pattern: "[0-9]*",
   spellcheck: false,
   errorMessage: {
     text: "Enter a valid sort code like 309430"

--- a/src/patterns/confirm-a-phone-number/default/index.njk
+++ b/src/patterns/confirm-a-phone-number/default/index.njk
@@ -19,7 +19,6 @@ title: Default – Confirm a phone number
   type: "text",
   autocomplete: "one-time-code",
   classes: "govuk-input--width-4",
-  pattern: "[0-9]*",
   inputmode: "numeric"
 }) }}
 

--- a/src/patterns/confirm-a-phone-number/error-expired/index.njk
+++ b/src/patterns/confirm-a-phone-number/error-expired/index.njk
@@ -22,7 +22,6 @@ title: Error, security code expired – Confirm a phone number
   type: "text",
   autocomplete: "one-time-code",
   classes: "govuk-input--width-4",
-  pattern: "[0-9]*",
   inputmode: "numeric"
 }) }}
 

--- a/src/patterns/confirm-a-phone-number/error-incorrect/index.njk
+++ b/src/patterns/confirm-a-phone-number/error-incorrect/index.njk
@@ -22,7 +22,6 @@ title: Error, incorrect security code – Confirm a phone number
   type: "text",
   autocomplete: "one-time-code",
   classes: "govuk-input--width-4",
-  pattern: "[0-9]*",
   inputmode: "numeric"
 }) }}
 


### PR DESCRIPTION
We previously recommended using `pattern="[0-9]*"` on number inputs to prompt iOS to display the numeric keypad.

This has been unnecessary since Safari 12.2, when support for the standardised `inputmode` attribute was added to Safari.

We [stopped using the `pattern` attribute on the date input component][1] in v4.1.0 (released in May 2022) as the proportion of GOV.UK visitors using versions of iOS 12.x and below had fallen to 0.08% of total traffic.

[1]: https://github.com/alphagov/govuk-frontend/pull/2599