### PR TITLE
Add border to 'preview' / 'archive' banner

### DIFF
--- a/src/stylesheets/components/_phase-banner.scss
+++ b/src/stylesheets/components/_phase-banner.scss
@@ -6,7 +6,6 @@
 
   @include govuk-media-query($from: tablet) {
     width: 100%;
-    border-bottom: 0;
   }
 }
 


### PR DESCRIPTION
We moved the banner when refactoring the nav in 2b6a27b.

Now that the banner is not between the header and the navigation, it makes sense to add the bottom border back to separate the banner from the page content.

Keep the `--no-border` modifier which we use on the homepage when the banner is followed immediately by the masthead.

## Before

<img width="1116" alt="Screenshot 2022-08-19 at 14 50 12" src="https://user-images.githubusercontent.com/121939/185637856-8891587b-6026-49f7-b905-45b24ee3695e.png">

## After

<img width="1116" alt="Screenshot 2022-08-19 at 14 50 10" src="https://user-images.githubusercontent.com/121939/185637859-ab3bb024-d712-4d45-a0fb-8df67674b460.png">

