### PR TITLE
Remove use of `govuk-exports` in Design System Sass

### DIFF
--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -3,25 +3,23 @@
 //
 // GOV.UK Frontend footer adapted for full width
 
-@include govuk-exports("app-footer") {
-  .app-width-container--full {
-    min-width: calc(100% - #{$govuk-gutter * 2});
-    max-width: 100%;
-    padding: 0;
-    @include govuk-media-query($from: desktop) {
-      margin: 0 auto;
-      padding: 0 govuk-spacing(6);
-    }
+.app-width-container--full {
+  min-width: calc(100% - #{$govuk-gutter * 2});
+  max-width: 100%;
+  padding: 0;
+  @include govuk-media-query($from: desktop) {
+    margin: 0 auto;
+    padding: 0 govuk-spacing(6);
   }
+}
 
-  .app-footer .govuk-footer__section-break {
-    margin-bottom: 0;
-    border-bottom: 0;
-  }
+.app-footer .govuk-footer__section-break {
+  margin-bottom: 0;
+  border-bottom: 0;
+}
 
-  // Fix the visually hidden 'Support links' heading causing Safari to pad out
-  // the bottom of the page or... something.
-  .app-footer .govuk-visually-hidden {
-    position: relative;
-  }
+// Fix the visually hidden 'Support links' heading causing Safari to pad out
+// the bottom of the page or... something.
+.app-footer .govuk-visually-hidden {
+  position: relative;
 }

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -1,20 +1,17 @@
-@include govuk-exports("app-header") {
+// Move the blue border from the container to the header so that it spans
+// the full width of the page
+.app-header {
+  border-bottom: 10px solid $govuk-brand-colour;
+}
 
-  // Move the blue border from the container to the header so that it spans
-  // the full width of the page
-  .app-header {
-    border-bottom: 10px solid $govuk-brand-colour;
-  }
+.app-header__container {
+  margin-bottom: 0;
+  border-bottom: 0;
+}
 
-  .app-header__container {
-    margin-bottom: 0;
-    border-bottom: 0;
-  }
-
-  // Override the default 33% width on the logo in GOV.UK Frontend (prevents
-  // unnecessary wrapping of "GOV.UK Design System" on smaller tablet / desktop
-  // viewports)
-  .app-header__logo {
-    width: auto;
-  }
+// Override the default 33% width on the logo in GOV.UK Frontend (prevents
+// unnecessary wrapping of "GOV.UK Design System" on smaller tablet / desktop
+// viewports)
+.app-header__logo {
+  width: auto;
 }

--- a/src/stylesheets/components/_split-pane.scss
+++ b/src/stylesheets/components/_split-pane.scss
@@ -1,57 +1,55 @@
-@include govuk-exports("app-split-pane") {
-  $toc-width: 260px;
-  $toc-width-tablet: 210px;
+$toc-width: 260px;
+$toc-width-tablet: 210px;
 
+.app-split-pane {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    position: relative;
+    min-height: 0;
+    overflow: inherit;
+  }
+
+  @include govuk-media-query(1160px) {
+    width: 100%;
+  }
+}
+
+.app-split-pane__nav {
+  @include govuk-media-query($until: tablet) {
+    display: none;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    width: $toc-width-tablet;
+    flex: 0 0 auto;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    width: $toc-width;
+  }
+}
+
+.app-split-pane__content {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    min-width: 0;
+    flex: 1 1 100%;
+    flex-direction: column;
+  }
+}
+
+.no-flexbox.no-flexboxtweener {
   .app-split-pane {
-    @include govuk-media-query($from: tablet) {
-      display: flex;
-      position: relative;
-      min-height: 0;
-      overflow: inherit;
-    }
-
-    @include govuk-media-query(1160px) {
-      width: 100%;
-    }
+    @include govuk-clearfix;
   }
 
   .app-split-pane__nav {
-    @include govuk-media-query($until: tablet) {
-      display: none;
-    }
-
-    @include govuk-media-query($from: tablet) {
-      width: $toc-width-tablet;
-      flex: 0 0 auto;
-    }
-
-    @include govuk-media-query($from: desktop) {
-      width: $toc-width;
-    }
+    width: $toc-width;
+    float: left;
+    border-right: 0;
   }
 
   .app-split-pane__content {
-    @include govuk-media-query($from: tablet) {
-      display: flex;
-      min-width: 0;
-      flex: 1 1 100%;
-      flex-direction: column;
-    }
-  }
-
-  .no-flexbox.no-flexboxtweener {
-    .app-split-pane {
-      @include govuk-clearfix;
-    }
-
-    .app-split-pane__nav {
-      width: $toc-width;
-      float: left;
-      border-right: 0;
-    }
-
-    .app-split-pane__content {
-      margin-left: $toc-width;
-    }
+    margin-left: $toc-width;
   }
 }

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -1,61 +1,59 @@
-@include govuk-exports("app-subnav") {
-  .app-subnav {
-    // Since the back to top link is outside the flow of the document we need to create a space for it.
-    // This number is magic and was determined by manually judging the visual spacing.
-    margin-bottom: 100px;
-    padding: govuk-spacing(6) govuk-spacing(3) 0 0;
-    @include govuk-font(16);
-  }
+.app-subnav {
+  // Since the back to top link is outside the flow of the document we need to create a space for it.
+  // This number is magic and was determined by manually judging the visual spacing.
+  margin-bottom: 100px;
+  padding: govuk-spacing(6) govuk-spacing(3) 0 0;
+  @include govuk-font(16);
+}
 
-  .app-subnav__section {
-    margin: 0 0 govuk-spacing(4);
-    padding: 0;
-    list-style-type: none;
-  }
+.app-subnav__section {
+  margin: 0 0 govuk-spacing(4);
+  padding: 0;
+  list-style-type: none;
+}
 
-  .app-subnav__link {
-    padding: 2px 0;
-  }
+.app-subnav__link {
+  padding: 2px 0;
+}
 
-  .app-subnav__section-item {
-    margin-bottom: govuk-spacing(1);
-    padding-top: govuk-spacing(1);
-    padding-bottom: govuk-spacing(1);
-  }
+.app-subnav__section-item {
+  margin-bottom: govuk-spacing(1);
+  padding-top: govuk-spacing(1);
+  padding-bottom: govuk-spacing(1);
+}
 
-  .app-subnav__section-item--current {
-    $_current-indicator-width: 4px;
-    margin-left: -(govuk-spacing(2) + $_current-indicator-width);
-    padding-left: govuk-spacing(2);
-    border-left: $_current-indicator-width solid govuk-colour("blue");
-    background-color: govuk-colour("white");
-  }
+.app-subnav__section-item--current {
+  $_current-indicator-width: 4px;
+  margin-left: -(govuk-spacing(2) + $_current-indicator-width);
+  padding-left: govuk-spacing(2);
+  border-left: $_current-indicator-width solid govuk-colour("blue");
+  background-color: govuk-colour("white");
+}
 
-  .app-subnav__section-item--current .app-subnav__link {
-    font-weight: bold;
-  }
+.app-subnav__section-item--current .app-subnav__link {
+  font-weight: bold;
+}
 
-  .app-subnav__section--nested {
-    margin-top: govuk-spacing(2);
-    margin-bottom: 0;
-    padding-left: govuk-spacing(4);
-  }
+.app-subnav__section--nested {
+  margin-top: govuk-spacing(2);
+  margin-bottom: 0;
+  padding-left: govuk-spacing(4);
+}
 
-  .app-subnav__section--nested .app-subnav__section-item:before {
-    content: "—";
-    margin-left: -(govuk-spacing(4));
-    color: govuk-colour("dark-grey");
-  }
+.app-subnav__section--nested .app-subnav__section-item:before {
+  content: "—";
+  margin-left: -(govuk-spacing(4));
+  color: govuk-colour("dark-grey");
+}
 
-  .app-subnav__section--nested .app-subnav__link {
-    padding-left: 0;
-    font-weight: normal;
-  }
+.app-subnav__section--nested .app-subnav__link {
+  padding-left: 0;
+  font-weight: normal;
+}
 
-  .app-subnav__theme {
-    margin: 0;
-    padding: govuk-spacing(2) govuk-spacing(3) govuk-spacing(2) 0;
-    color: govuk-colour("dark-grey");
-    @include govuk-font(19);
-  }
+.app-subnav__theme {
+  margin: 0;
+  padding: govuk-spacing(2) govuk-spacing(3) govuk-spacing(2) 0;
+  color: govuk-colour("dark-grey");
+  @include govuk-font(19);
 }


### PR DESCRIPTION
We need to use govuk-exports in GOV.UK Frontend as files can be imported multiple times but we only ever want the CSS to be outputted once.

As we're in control of how and where Sass in the Design System is imported, we don't need to worry about this and don't need to use the exports function.

Suggest [reviewing without whitespace](https://github.com/alphagov/govuk-design-system/pull/2328/files?diff=unified&w=1) to see the changes more clearly.

This branch is built on top of #2327 which needs to be merged first.