### PR TITLE
Remove idPrefix from examples

### DIFF
--- a/src/components/radios/default/index.njk
+++ b/src/components/radios/default/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {{ govukRadios({
-  idPrefix: "where-do-you-live",
   name: "where-do-you-live",
   fieldset: {
     legend: {


### PR DESCRIPTION
Proposal is, reduce the GOV.UK Design System examples to only show what’s required and allow the good defaults to be the ones people copy and paste.

In this case, a lot of people dont need to set `idPrefix` and I’ve seen that having to manage that and name has led to an accessibility issue where the error summary list no longer linked up to the first radio option.

So we could consider having the examples simpler and allowing `idPrefix` to automatically be assigned to the name.

If you’re into this I could flesh the contribution out properly, let me know.