### PR TITLE
Fix copy button glitch on Safari

### DIFF
--- a/src/javascripts/components/copy.js
+++ b/src/javascripts/components/copy.js
@@ -15,7 +15,7 @@ Copy.prototype.init = function () {
   $button.setAttribute('aria-live', 'assertive')
   $button.textContent = 'Copy code'
 
-  $module.insertBefore($button, $module.firstChild)
+  $module.insertAdjacentElement('beforebegin', $button)
   this.copyAction()
 }
 Copy.prototype.copyAction = function () {


### PR DESCRIPTION
Fixes #1529 by moving the Copy button outside of the `<pre>` element containing the code. This seemed to be the source of Safari keeping the text white after the click. I'm not 100% sure why this would be causing the glitch as [in isolation, Safari looks perfectly fine with a `<button>` inside a `<pre>`](https://codepen.io/rhumaric/pen/GRdgzao). That change doesn't affect tabbing order as the element was already the first one inside the `<pre>`.

Given the Copy action is only used for the examples, I didn't feel too bad about updating the method used for inserting the button directly. If we need more flexibility, we can look into adding a data attribute for more control.

While looking in this button, I also noticed that its `aria-live="assertive"` would cause "Copy code" to be announced again when its content shifts back from "Code copied" to the original label. It's probably best tackled separately, but thought I'd note it so we can decide whether we want to change things there.
