### PR TITLE
Fix reference to `%govuk-body` placeholder

### DIFF
--- a/src/get-started/updating-your-code/index.md.njk
+++ b/src/get-started/updating-your-code/index.md.njk
@@ -676,7 +676,7 @@ GOV.UK Frontend uses ["Block, Element, Modifier" (BEM)](http://getbem.com/) and 
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell ">@include copy-19</td>
-      <td class="govuk-table__cell ">@extend %govuk-body</td>
+      <td class="govuk-table__cell ">@extend %govuk-body-m</td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell ">@include copy-14</td>


### PR DESCRIPTION
I don't think there is a `%govuk-body` placeholder
to extend, or at least if I try to, I get an error
saying `The target selector was not found` and I
can't find any in the govuk-frontend repo'.

This copies the approach from the next pairing,
for `@include copy-14`, but with the `m` size, to
set the font-size to '19' rather than '14'.