### PR TITLE
Edit What's new to remove Design System Day (for now)

### DIFF
--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -8,8 +8,6 @@
         <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
 <p class="govuk-body">18 August 2022: We’ve released GOV.UK Frontend v4.3.1. This fix release includes a change to the naming of our static spacing override classes.</p>
         <p class="govuk-body"><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v4.3.1" class="govuk-link">Read the release notes to see what changes you should make</a>.</p>
-<p class="govuk-body">17 August 2022: We're running our flagship online event, Design System Day 2022, on 20 and 21 September.</p>
-<p class="govuk-body"><a href="https://designnotes.blog.gov.uk/2022/08/16/join-us-for-design-system-day-2022/" class="govuk-link">See what we have planned and how to join us</a>.</p>
 
         <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design  System</a>.</p>
       </div>


### PR DESCRIPTION
Remove Design System Day message from What's New panel to reflect the postponement. Removing quietly instead of announcing the change in line with national mourning period.