### PR TITLE
Remove references to the `pattern` attribute in guidance

### DIFF
--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -99,8 +99,6 @@ See how to do this by opening the HTML and Nunjucks tabs in this example:
 
 {{ example({group: "components", item: "text-input", example: "number-input", html: true, nunjucks: true, open: false, size: "m"}) }}
 
-You should also [turn off HTML5 validation](/patterns/validation/#turn-off-html5-validation) to prevent browsers from validating the `pattern` attribute.
-
 There is specific guidance on how to ask for:
 
 - [dates](/patterns/dates/)
@@ -108,7 +106,7 @@ There is specific guidance on how to ask for:
 
 #### Asking for decimal numbers
 
-If you're asking the user to enter a number that might include decimal places, use `input type="text"` without `inputmode` or `pattern` attributes.
+If you're asking the user to enter a number that might include decimal places, use `input type="text"`.
 
 Do not set the `inputmode` attribute to `decimal` as it causes some devices to bring up a keypad without a key for the decimal separator.
 

--- a/src/patterns/bank-details/index.md.njk
+++ b/src/patterns/bank-details/index.md.njk
@@ -56,10 +56,6 @@ Let users choose to get paid by an alternative method.
 
 Adapt this question depending on what payment options your users need and what your service can support.
 
-### Turn off HTML5 validation
-
-You should [turn off HTML5 validation](/patterns/validation/#turn-off-html5-validation) to prevent browsers from validating the `pattern` attribute used by the bank details pattern.
-
 {{ example({group: "patterns", item: "bank-details", example: "branch", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 ### International bank account details


### PR DESCRIPTION
We stopped recommending using the `pattern` attribute on number inputs in #2323 but I missed this reference in the guidance for the text input component and the bank details pattern.

We still tell users to turn off HTML validation in [the broader 'validation' pattern](https://design-system.service.gov.uk/patterns/validation/#turn-off-html5-validation) – that hasn't changed – but now that we're not using the pattern attribute there's no need to call it out in these specific places.