### PR TITLE
Remove `idPrefix` from examples

### DIFF
--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -47,7 +47,6 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukCheckboxes({
-  idPrefix: "contact",
   name: "contact",
   fieldset: {
     legend: {

--- a/src/components/checkboxes/default/index.njk
+++ b/src/components/checkboxes/default/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
-  idPrefix: "waste",
   name: "waste",
   fieldset: {
     legend: {

--- a/src/components/checkboxes/error/index.njk
+++ b/src/components/checkboxes/error/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
-  idPrefix: "nationality",
   name: "nationality",
   fieldset: {
     legend: {

--- a/src/components/checkboxes/hint/index.njk
+++ b/src/components/checkboxes/hint/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
-  idPrefix: "nationality",
   name: "nationality",
   fieldset: {
     legend: {

--- a/src/components/checkboxes/small/index.njk
+++ b/src/components/checkboxes/small/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
-  idPrefix: "organisation",
   name: "organisation",
   classes: "govuk-checkboxes--small",
   fieldset: {

--- a/src/components/checkboxes/with-none-option-in-error/index.njk
+++ b/src/components/checkboxes/with-none-option-in-error/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
-  idPrefix: "countries",
   name: "countries",
   fieldset: {
     legend: {

--- a/src/components/checkboxes/with-none-option/index.njk
+++ b/src/components/checkboxes/with-none-option/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
-  idPrefix: "countries",
   name: "countries",
   fieldset: {
     legend: {

--- a/src/components/checkboxes/without-heading/index.njk
+++ b/src/components/checkboxes/without-heading/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
-  idPrefix: "waste",
   name: "waste",
   fieldset: {
     legend: {

--- a/src/components/error-message/legend/index.njk
+++ b/src/components/error-message/legend/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
-  idPrefix: "nationality",
   name: "nationality",
   fieldset: {
     legend: {

--- a/src/components/error-summary/linking-checkboxes-radios/code.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/code.njk
@@ -17,7 +17,6 @@ layout: layout-example.njk
 }) }}
 
 {{ govukCheckboxes({
-  idPrefix: "nationality",
   name: "nationality",
   fieldset: {
     legend: {

--- a/src/components/error-summary/linking-checkboxes-radios/index.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/index.njk
@@ -18,7 +18,6 @@ layout: layout-example.njk
 }) }}
 
 {{ govukCheckboxes({
-  idPrefix: "nationality",
   name: "nationality",
   fieldset: {
     legend: {

--- a/src/components/radios/conditional-reveal-error/index.njk
+++ b/src/components/radios/conditional-reveal-error/index.njk
@@ -50,7 +50,6 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukRadios({
-  idPrefix: "contact",
   name: "contact",
   fieldset: {
     legend: {

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -47,7 +47,6 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukRadios({
-  idPrefix: "contact",
   name: "contact",
   fieldset: {
     legend: {

--- a/src/components/radios/default/index.njk
+++ b/src/components/radios/default/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {{ govukRadios({
-  idPrefix: "where-do-you-live",
   name: "where-do-you-live",
   fieldset: {
     legend: {

--- a/src/components/radios/divider/index.njk
+++ b/src/components/radios/divider/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {{ govukRadios({
-  idPrefix: "where-do-you-live",
   name: "where-do-you-live",
   fieldset: {
     legend: {

--- a/src/components/radios/error/index.njk
+++ b/src/components/radios/error/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {{ govukRadios({
-  idPrefix: "where-do-you-live",
   name: "where-do-you-live",
   fieldset: {
     legend: {

--- a/src/components/radios/hint/index.njk
+++ b/src/components/radios/hint/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {{ govukRadios({
-  idPrefix: "sign-in",
   name: "sign-in",
   fieldset: {
     legend: {

--- a/src/components/radios/inline/index.njk
+++ b/src/components/radios/inline/index.njk
@@ -7,7 +7,6 @@ layout: layout-example.njk
 
 {{ govukRadios({
   classes: "govuk-radios--inline",
-  idPrefix: "changed-name",
   name: "changed-name",
   fieldset: {
     legend: {

--- a/src/components/radios/small/index.njk
+++ b/src/components/radios/small/index.njk
@@ -7,7 +7,6 @@ layout: layout-example.njk
 
 {{ govukRadios({
   classes: "govuk-radios--small",
-  idPrefix: "changed-name",
   name: "changed-name",
   fieldset: {
     legend: {

--- a/src/components/radios/without-heading/index.njk
+++ b/src/components/radios/without-heading/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {{ govukRadios({
-  idPrefix: "where-do-you-live",
   name: "where-do-you-live",
   fieldset: {
     legend: {

--- a/src/get-started/labels-legends-headings/legend-h1/index.njk
+++ b/src/get-started/labels-legends-headings/legend-h1/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
-  idPrefix: "checkbox",
   name: "checkbox",
   fieldset: {
     legend: {

--- a/src/get-started/labels-legends-headings/legend-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/legend-m-s/index.njk
@@ -6,7 +6,6 @@ layout: layout-example.njk
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
-  idPrefix: "checkbox",
   name: "checkbox",
   fieldset: {
     legend: {
@@ -34,7 +33,6 @@ layout: layout-example.njk
 }) }}
 
 {{ govukCheckboxes({
-  idPrefix: "checkbox-2",
   name: "checkbox-2",
   fieldset: {
     legend: {

--- a/src/patterns/bank-details/branch/index.njk
+++ b/src/patterns/bank-details/branch/index.njk
@@ -7,7 +7,6 @@ layout: layout-example.njk
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {{ govukRadios({
-  idPrefix: "method-of-payment",
   name: "method-of-payment",
   fieldset: {
     legend: {

--- a/src/patterns/cookies-page/cookies-form/index.njk
+++ b/src/patterns/cookies-page/cookies-form/index.njk
@@ -11,7 +11,6 @@ layout: layout-example.njk
     <h2 class="govuk-heading-l">Change your cookie settings</h2>
     <form action="/form-handler" method="post" novalidate>
       {{ govukRadios({
-          idPrefix: "functional-cookies",
           name: "functional-cookies",
           fieldset: {
             legend: {
@@ -33,7 +32,6 @@ layout: layout-example.njk
         }) }}
 
         {{ govukRadios({
-          idPrefix: "analytics-cookies",
           name: "analytics-cookies",
           fieldset: {
             legend: {

--- a/src/patterns/equality-information/asian/index.njk
+++ b/src/patterns/equality-information/asian/index.njk
@@ -20,7 +20,6 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukRadios({
-  idPrefix: "ethnicity-detail",
   name: "ethnicity-detail",
   fieldset: {
     legend: {

--- a/src/patterns/equality-information/black/index.njk
+++ b/src/patterns/equality-information/black/index.njk
@@ -20,7 +20,6 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukRadios({
-  idPrefix: "ethnicity-detail",
   name: "ethnicity-detail",
   fieldset: {
     legend: {

--- a/src/patterns/equality-information/disability-impact/index.njk
+++ b/src/patterns/equality-information/disability-impact/index.njk
@@ -7,7 +7,6 @@ layout: layout-example.njk
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {{ govukRadios({
-  idPrefix: "disability",
   name: "disability",
   fieldset: {
     legend: {

--- a/src/patterns/equality-information/disability/index.njk
+++ b/src/patterns/equality-information/disability/index.njk
@@ -7,7 +7,6 @@ layout: layout-example.njk
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {{ govukRadios({
-  idPrefix: "disability",
   name: "disability",
   fieldset: {
     legend: {

--- a/src/patterns/equality-information/error-ethnicity/index.njk
+++ b/src/patterns/equality-information/error-ethnicity/index.njk
@@ -7,7 +7,6 @@ layout: layout-example.njk
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {{ govukRadios({
-  idPrefix: "ethnicity",
   name: "ethnicity",
   fieldset: {
     legend: {

--- a/src/patterns/equality-information/ethnic-group/index.njk
+++ b/src/patterns/equality-information/ethnic-group/index.njk
@@ -7,7 +7,6 @@ layout: layout-example.njk
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {{ govukRadios({
-  idPrefix: "ethnicity",
   name: "ethnicity",
   fieldset: {
     legend: {

--- a/src/patterns/equality-information/explainer-screen/index.njk
+++ b/src/patterns/equality-information/explainer-screen/index.njk
@@ -17,7 +17,6 @@ layout: layout-example.njk
 <p class="govuk-body">Before you finish using the service, we’d like to ask some equality questions.</p>
 
 {{ govukRadios({
-  idPrefix: "equalities-info",
   name: "equalities-info",
   fieldset: {
     legend: {

--- a/src/patterns/equality-information/marriage-status/index.njk
+++ b/src/patterns/equality-information/marriage-status/index.njk
@@ -7,7 +7,6 @@ layout: layout-example.njk
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {{ govukRadios({
-  idPrefix: "marriage-civil-partnership",
   name: "marriage-civil-partnership",
   fieldset: {
     legend: {

--- a/src/patterns/equality-information/multiple/index.njk
+++ b/src/patterns/equality-information/multiple/index.njk
@@ -20,7 +20,6 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukRadios({
-  idPrefix: "ethnicity-detail",
   name: "ethnicity-detail",
   fieldset: {
     legend: {

--- a/src/patterns/equality-information/other/index.njk
+++ b/src/patterns/equality-information/other/index.njk
@@ -20,7 +20,6 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukRadios({
-  idPrefix: "ethnicity-detail",
   name: "ethnicity-detail",
   fieldset: {
     legend: {

--- a/src/patterns/equality-information/religion/index.njk
+++ b/src/patterns/equality-information/religion/index.njk
@@ -20,7 +20,6 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukRadios({
-  idPrefix: "religion",
   name: "religion",
   fieldset: {
     legend: {

--- a/src/patterns/equality-information/sex-gender/index.njk
+++ b/src/patterns/equality-information/sex-gender/index.njk
@@ -22,7 +22,6 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukRadios({
-  idPrefix: "sex",
   name: "sex",
   fieldset: {
     legend: {
@@ -47,7 +46,6 @@ layout: layout-example.njk
 }) }}
 
 {{ govukRadios({
-  idPrefix: "gender-identity",
   name: "gender-identity",
   fieldset: {
     legend: {

--- a/src/patterns/equality-information/sexual-orientation/index.njk
+++ b/src/patterns/equality-information/sexual-orientation/index.njk
@@ -20,7 +20,6 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukRadios({
-  idPrefix: "sexual-orientation",
   name: "sexual-orientation",
   fieldset: {
     legend: {

--- a/src/patterns/equality-information/white/index.njk
+++ b/src/patterns/equality-information/white/index.njk
@@ -20,7 +20,6 @@ layout: layout-example.njk
 {% endset -%}
 
 {{ govukRadios({
-  idPrefix: "ethnicity-detail",
   name: "ethnicity-detail",
   fieldset: {
     legend: {

--- a/src/patterns/question-pages/default/index.njk
+++ b/src/patterns/question-pages/default/index.njk
@@ -21,7 +21,6 @@ layout: layout-example-full-page.njk
       <form action="/form-handler" method="post" novalidate>
 
         {{ govukRadios({
-          idPrefix: "where-do-you-live",
           name: "where-do-you-live",
           fieldset: {
             legend: {

--- a/src/patterns/question-pages/explanatory-text/index.njk
+++ b/src/patterns/question-pages/explanatory-text/index.njk
@@ -42,7 +42,6 @@ layout: layout-example-full-page.njk
       <form action="/form-handler" method="post" novalidate>
 
         {{ govukRadios({
-          idPrefix: "interview-needs",
           name: "interview-needs",
           fieldset: {
             legend: {

--- a/src/patterns/task-list-pages/have-you-completed-this-section-error/index.njk
+++ b/src/patterns/task-list-pages/have-you-completed-this-section-error/index.njk
@@ -9,7 +9,6 @@ title: Have you completed this section error – Task list pages
 <form action="/form-handler" method="post" novalidate>
 
   {{ govukRadios({
-    idPrefix: "have-you-completed-this-section-error",
     name: "have-you-completed-this-section-error",
     fieldset: {
       legend: {

--- a/src/patterns/task-list-pages/have-you-completed-this-section/index.njk
+++ b/src/patterns/task-list-pages/have-you-completed-this-section/index.njk
@@ -9,7 +9,6 @@ title: Have you completed this section – Task list pages
 <form action="/form-handler" method="post" novalidate>
 
   {{ govukRadios({
-    idPrefix: "have-you-completed-this-section",
     name: "have-you-completed-this-section",
     fieldset: {
       legend: {


### PR DESCRIPTION
`idPrefix` is not required as `name` option will be used by default.

> String to prefix id for each checkbox item if no id is specified on each item.
> If not passed, fall back to using the name option instead.

This change is based on findings that when users change their `idPrefix` they can often forget to change their error handling to account for this when outputing links in their Error Summary component.

By keeping these in sync by default it lowers the risk of breaking that relationship.

A real world example of this happening which we then found was an issue across the entire project:

https://github.com/alphagov/di-authentication-frontend/pull/756