### PR TITLE
Don't capitalise 'Multiple ethnic background'

### DIFF
--- a/src/patterns/equality-information/multiple/index.njk
+++ b/src/patterns/equality-information/multiple/index.njk
@@ -23,7 +23,7 @@ layout: layout-example.njk
   name: "ethnicity-detail",
   fieldset: {
     legend: {
-      text: "Which of the following best describes your Mixed or Multiple ethnic groups background?",
+      text: "Which of the following best describes your Mixed or multiple ethnic groups background?",
       isPageHeading: true,
       classes: "govuk-fieldset__legend--l"
     }
@@ -43,7 +43,7 @@ layout: layout-example.njk
     },
     {
       value: "other",
-      text: "Any other Mixed or Multiple ethnic background",
+      text: "Any other Mixed or multiple ethnic background",
       conditional: {
         html: ethnicityHtml
       }


### PR DESCRIPTION
Multiple is currently capitalised within the question "Which of the following best describes your Mixed or Multiple ethnic groups background?" but not within the answer to the initial question "What is your ethnic group?" where it is just "Mixed or multiple ethnic groups", which is inconsistent.

The GDS style guide on [ethnic minorities](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#ethnic-minorities) now uses lowercase for mixed, as well as black and white (but not Asian), and links to a page which says:

> Capitalisation
> 
> The government’s preferred style is not to capitalise ethnic groups, (such as ‘black’ or ‘white’) unless that group’s name includes a geographic place (for example, ’Asian’, ‘Indian’ or ‘black Caribbean’).