### PR TITLE
Organise 'community' pages into subsections (themes)

### DIFF
--- a/src/community/blogs-talks-podcasts/index.md.njk
+++ b/src/community/blogs-talks-podcasts/index.md.njk
@@ -2,7 +2,7 @@
 title: Blog posts, videos and podcasts
 description: See blog posts, video talks, and podcasts about the GOV.UK Design System and Prototype Kit
 section: Community
-theme: Resources
+theme: How we work
 layout: layout-pane.njk
 order: 8
 ---

--- a/src/community/blogs-talks-podcasts/index.md.njk
+++ b/src/community/blogs-talks-podcasts/index.md.njk
@@ -2,6 +2,7 @@
 title: Blog posts, videos and podcasts
 description: See blog posts, video talks, and podcasts about the GOV.UK Design System and Prototype Kit
 section: Community
+theme: Resources
 layout: layout-pane.njk
 order: 8
 ---

--- a/src/community/blogs-talks-podcasts/index.md.njk
+++ b/src/community/blogs-talks-podcasts/index.md.njk
@@ -4,7 +4,7 @@ description: See blog posts, video talks, and podcasts about the GOV.UK Design S
 section: Community
 theme: How we work
 layout: layout-pane.njk
-order: 8
+order: 6
 ---
 
 To learn more about the GOV.UK Design System and Prototype Kit, check out these blog posts, video talks and podcasts that our team and community have shared.

--- a/src/community/contribution-criteria/index.md.njk
+++ b/src/community/contribution-criteria/index.md.njk
@@ -4,7 +4,7 @@ description: To help ensure that the contents of the GOV.UK Design System are of
 section: Community
 theme: How we work
 layout: layout-pane.njk
-order: 6
+order: 7
 ---
 
 {% from "govuk/components/table/macro.njk" import govukTable %}

--- a/src/community/contribution-criteria/index.md.njk
+++ b/src/community/contribution-criteria/index.md.njk
@@ -2,6 +2,7 @@
 title: Contribution criteria
 description: To help ensure that the contents of the GOV.UK Design System are of a high quality and meet user needs, all components and patterns must meet the following criteria
 section: Community
+theme: How we work
 layout: layout-pane.njk
 order: 6
 ---

--- a/src/community/design-system-working-group/index.md.njk
+++ b/src/community/design-system-working-group/index.md.njk
@@ -2,6 +2,7 @@
 title: Design System working group
 description: The GOV.UK Design System working group is a multidisciplinary, cross-government group whose purpose is to ensure that components and patterns published in the GOV.UK Design System are of a high quality and meet user needs
 section: Community
+theme: How we work
 layout: layout-pane.njk
 order: 7
 ---
@@ -27,7 +28,7 @@ The working group does not review minor design or content changes, such as updat
 
 By including representatives from a mixture of disciplines and departments, the working group helps to ensure that the Design System represents its users.
 
-It means that decisions made are fair and unbiased, and that the Design System reflects the experiences of the whole of government not just one department. 
+It means that decisions made are fair and unbiased, and that the Design System reflects the experiences of the whole of government not just one department.
 
 ## Join the working group
 

--- a/src/community/design-system-working-group/index.md.njk
+++ b/src/community/design-system-working-group/index.md.njk
@@ -4,7 +4,7 @@ description: The GOV.UK Design System working group is a multidisciplinary, cros
 section: Community
 theme: How we work
 layout: layout-pane.njk
-order: 7
+order: 8
 ---
 
 The Design System working group is a multidisciplinary panel of representatives from across government. It makes sure that all components and patterns published in the Design System are of a high quality and meet user needs.

--- a/src/community/develop-a-component-or-pattern/index.md.njk
+++ b/src/community/develop-a-component-or-pattern/index.md.njk
@@ -2,6 +2,7 @@
 title: Develop a component or pattern
 description: Find out how to develop a component or pattern for the GOV.UK Design System
 section: Community
+theme: Ways to get involved
 layout: layout-pane.njk
 order: 5
 ---

--- a/src/community/develop-a-component-or-pattern/index.md.njk
+++ b/src/community/develop-a-component-or-pattern/index.md.njk
@@ -4,7 +4,7 @@ description: Find out how to develop a component or pattern for the GOV.UK Desig
 section: Community
 theme: Ways to get involved
 layout: layout-pane.njk
-order: 5
+order: 3
 ---
 
 Anyone can choose to work on contributions marked as 'Needs more detail' in the [Community Backlog project board on GitHub](https://github.com/alphagov/govuk-design-system-backlog/projects/1).

--- a/src/community/propose-a-component-or-pattern/index.md.njk
+++ b/src/community/propose-a-component-or-pattern/index.md.njk
@@ -2,6 +2,7 @@
 title: Propose a component or pattern
 description: Find out how to propose a new component or pattern for the GOV.UK Design System
 section: Community
+theme: Ways to get involved
 layout: layout-pane.njk
 order: 4
 ---
@@ -14,7 +15,7 @@ Follow the 3 steps to propose a component or pattern for the Design System.
 
 ## 1. Check the Community Backlog
 
-Check if someone else has already suggested your idea or something similar on the [Community Backlog project board on GitHub](https://github.com/alphagov/govuk-design-system-backlog/projects/1). 
+Check if someone else has already suggested your idea or something similar on the [Community Backlog project board on GitHub](https://github.com/alphagov/govuk-design-system-backlog/projects/1).
 
 If your idea is on the backlog and marked as 'Needs more evidence', go into the issue page and comment on the issue. Say you need the component or pattern, and share any examples or evidence you have to support the proposal.
 

--- a/src/community/propose-a-content-change-using-github/index.md.njk
+++ b/src/community/propose-a-content-change-using-github/index.md.njk
@@ -4,7 +4,7 @@ description: Find out how to suggest a change to content in the GOV.UK Design Sy
 section: Community
 theme: Ways to get involved
 layout: layout-pane.njk
-order: 3
+order: 5
 ---
 
 The GOV.UK Design System team uses a service called GitHub to manage content in the GOV.UK Design System.

--- a/src/community/propose-a-content-change-using-github/index.md.njk
+++ b/src/community/propose-a-content-change-using-github/index.md.njk
@@ -2,6 +2,7 @@
 title: Propose a content change using GitHub
 description: Find out how to suggest a change to content in the GOV.UK Design System using GitHub
 section: Community
+theme: Ways to get involved
 layout: layout-pane.njk
 order: 3
 ---
@@ -24,23 +25,23 @@ If you get stuck whilst following these steps and you need help, you can:
 
 ## 1. Go to the page you want to edit
 
-At the bottom of every page in the Design System you will find a section called 'Help improve this page'. 
+At the bottom of every page in the Design System you will find a section called 'Help improve this page'.
 
-Follow the link to propose a change to the page. This will take you to the page's Markdown file. 
+Follow the link to propose a change to the page. This will take you to the page's Markdown file.
 
-You might be told you need to fork the Design System repository to make changes. This is nothing to worry about. It just means you're making a copy of the Design System that you can edit. Select "fork this repository and propose changes" to continue. 
+You might be told you need to fork the Design System repository to make changes. This is nothing to worry about. It just means you're making a copy of the Design System that you can edit. Select "fork this repository and propose changes" to continue.
 
 ![](fork-this-repo.png)
 
 ## 2. Edit the page file
 
-Edit the Markdown to make your change. 
+Edit the Markdown to make your change.
 
 Here is an example showing how to update the description of the checkboxes component.
 
 ![The checkboxes description in the file in GitHub with an uppercase C in the word checkboxes](checkboxes-uppercase.png)
 
-In this example, the uppercase ‘C’ on the word ‘Checkbox’ has been changed to lowercase. 
+In this example, the uppercase ‘C’ on the word ‘Checkbox’ has been changed to lowercase.
 
 ![The checkboxes description in the file in GitHub after the C in the word checkboxes has been changed to lowercase](checkboxes-lowercase.png)
 
@@ -48,7 +49,7 @@ In this example, the uppercase ‘C’ on the word ‘Checkbox’ has been chang
 
 Once you’re happy, find the section called 'Propose file change' at the bottom of the page.
 
-Add a short description explaining the reason for your change in the first field. This information will be added to the file’s changelog. Try to be as clear as possible, to help future users understand the update. 
+Add a short description explaining the reason for your change in the first field. This information will be added to the file’s changelog. Try to be as clear as possible, to help future users understand the update.
 
 If you need to provide more information about your change, you can add more detail in the larger field below.
 
@@ -58,9 +59,9 @@ When you are happy with your description, select ‘propose file change’. You'
 
 ## 4. Confirm your changes
 
-You'll be shown a confirmation page where you can review the changes you’ve made. 
+You'll be shown a confirmation page where you can review the changes you’ve made.
 
-If you spot a mistake, you can go back to the previous page and correct it. 
+If you spot a mistake, you can go back to the previous page and correct it.
 
 If you are happy with your changes, select ‘Create pull request’. You'll have one more chance to review your change on the next page before you submit it to the GOV.UK Design System team to review.
 

--- a/src/community/resources-and-tools/index.md.njk
+++ b/src/community/resources-and-tools/index.md.njk
@@ -2,6 +2,7 @@
 title: Resources and tools
 description: Useful community resources and tools
 section: Community
+theme: Resources
 layout: layout-pane.njk
 order: 1
 status: Experimental
@@ -23,7 +24,7 @@ A Sketch file for creating flow diagrams of GOV.UK services.
 A Miro file for creating flow diagrams of GOV.UK services.
 
 [GOV.UK Design System Flow Diagrams for Mural](https://github.com/clare-brown/govuk-designsystem-flow-diagram-mural) -
-A Mural file for creating flow diagrams of GOV.UK services. 
+A Mural file for creating flow diagrams of GOV.UK services.
 
 [GOV Flow](https://github.com/charlesrt/gov-flow) -
 A Sketch file for creating flow diagrams of GOV.UK services.

--- a/src/community/resources-and-tools/index.md.njk
+++ b/src/community/resources-and-tools/index.md.njk
@@ -4,7 +4,7 @@ description: Useful community resources and tools
 section: Community
 theme: Resources
 layout: layout-pane.njk
-order: 1
+order: 9
 status: Experimental
 ---
 

--- a/src/community/roadmap/index.md.njk
+++ b/src/community/roadmap/index.md.njk
@@ -2,6 +2,7 @@
 title: Roadmap
 description: This roadmap shows what we’re working on and planning to do.
 section: Community
+theme: What we’re working on
 layout: layout-pane.njk
 order: 9
 ---
@@ -26,7 +27,7 @@ We recently:
 - released [GOV.UK Frontend v4.1.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.1.0) with improvements to the screen reader experience for the character count component
 - published the [Confirm a phone number](https://design-system.service.gov.uk/patterns/confirm-a-phone-number/) pattern
 - released [GOV.UK Frontend v4.2.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.2.0) with the new pagination component, and improvements to the checkboxes, radios and select components
-- published the [Pagination](https://design-system.service.gov.uk/components/pagination) component 
+- published the [Pagination](https://design-system.service.gov.uk/components/pagination) component
 - completed our investigation into potential changes to [browser support](https://github.com/alphagov/govuk-frontend/discussions/2607)
 
 ## Working on now

--- a/src/community/upcoming-components-patterns/index.md.njk
+++ b/src/community/upcoming-components-patterns/index.md.njk
@@ -2,8 +2,9 @@
 title: Upcoming components and patterns
 description: Anyone can propose, develop or contribute to new patterns and components, or improvements to existing ones.
 section: Community
+theme: What we’re working on
 layout: layout-pane.njk
-order: 2
+order: 1
 ---
 
 These are the components and patterns we’re working on right now, and the ones we plan to work on next.
@@ -149,7 +150,7 @@ We particularly welcome input on the following themes. To contribute, you can ad
           }
         ]
       }
-    }  
+    }
   ]
 }) }}
 


### PR DESCRIPTION
This PR splits the pages in the 'Community' section into subsections, or 'themes', in a similar way to the [Patterns](https://design-system.service.gov.uk/patterns/) and [Get Started ](https://design-system.service.gov.uk/get-started/)sections of the website.

This change would make the pages easier to navigate when displayed on the left sidebar.

You can see what the new left sidebar looks like in preview:
**https://deploy-preview-2372--govuk-design-system-preview.netlify.app/community/**

## Proposed structure and subsection names

### What we’re working on
Backlog (to be renamed in https://github.com/alphagov/govuk-design-system/issues/2310)
Roadmap

### Ways to get involved
Discussions, events, co-design (could eventually we add an "alias link" that'd go back to community landing page in https://github.com/alphagov/govuk-design-system/pull/2356?)
Propose a content change using GitHub
Propose a component or pattern
Develop a component or pattern

### How we work
Contribution criteria
Design System working group
Blog posts, videos and podcasts

### Resources
Resources and tools