### PR TITLE
Organise team page into teams and squads

### DIFF
--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -1,12 +1,12 @@
 ---
-title: GOV.UK Design System and Prototype Kit team
-description: about the GOV.UK Design System and Prototype Kit team and who works on them
+title: GOV.UK Design System and Prototype team
+description: about the GOV.UK Design System and Prototype team and who works on them
 layout: layout-single-page-prose.njk
 ---
 
-# GOV.UK Design System and Prototype Kit team
+# GOV.UK Design System and Prototype team
 
-The GOV.UK Design System and Prototype Kit team at the
+The GOV.UK Design System and Prototype team at the
 [Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service) (GDS) maintains this design system. We also maintain the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs).
 
 If you want to contact the team you can
@@ -36,7 +36,7 @@ If you want to contact the team you can
 - Oliver Byford – Lead Frontend Developer, Digital Service Platforms (Tech Lead for Frontend squad)
 - Romaric Pascal – Senior Frontend Developer
 
-## GOV.UK Prototype Kit team
+## GOV.UK Prototype team
 
 - Amelia Phillips – User Researcher
 - Ben Surgison – Senior Node JS Developer

--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -23,9 +23,9 @@ If you want to contact the team you can
 - Chris Ballantine-Thomas – Senior Interaction Designer
 - Ciandelle Scollan – Interaction Designer
 - David Cox – Senior Accessibility Specialist
-- Imran Hussain – Community Manager
+- Imran Hussain – Community Designer
 - Katrina Birch – User Researcher
-- Kim Grey – Frontend Developer
+- Kim 'beeps' Grey – Frontend Developer
 - Owen Jones – Senior Frontend Developer (Tech Lead for Design System squad)
 
 ### Frontend squad

--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -16,7 +16,7 @@ If you want to contact the team you can
 - Kelly Lee – Delivery Manager
 - Trang Erskine – Senior Product Manager
 
-### 'Design System' squad
+### Design System squad
 
 - Calvin Lau – Senior Content Designer
 - Charlotte Downs – Interaction Designer
@@ -28,7 +28,7 @@ If you want to contact the team you can
 - Kim Grey – Frontend Developer
 - Owen Jones – Senior Frontend Developer
 
-### 'Frontend' squad
+### Frontend squad
 
 - Brett Kyle – Frontend Developer
 - Claire Ashworth – Technical Writer

--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -39,7 +39,7 @@ If you want to contact the team you can
 ## GOV.UK Prototype team
 
 - Amelia Phillips – User Researcher
-- Ben Surgison – Senior Node JS Developer
+- Ben Surgison – Senior Node.js Developer
 - Izabela Podralska – Delivery Manager
 - Joe Lanman – Lead Interaction Designer
 - Laurence de Bruxelles – Developer

--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -26,14 +26,14 @@ If you want to contact the team you can
 - Imran Hussain – Community Manager
 - Katrina Birch – User Researcher
 - Kim Grey – Frontend Developer
-- Owen Jones – Senior Frontend Developer
+- Owen Jones – Senior Frontend Developer (Tech Lead for Design System squad)
 
 ### Frontend squad
 
 - Brett Kyle – Frontend Developer
 - Claire Ashworth – Technical Writer
 - Colin Rotherham – Senior Frontend Developer
-- Oliver Byford – Lead Frontend Developer, Digital Service Platforms
+- Oliver Byford – Lead Frontend Developer, Digital Service Platforms (Tech Lead for Frontend squad)
 - Romaric Pascal – Senior Frontend Developer
 
 ## GOV.UK Prototype Kit team

--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -1,41 +1,48 @@
 ---
-title: GOV.UK Design System team
-description: about the GOV.UK Design System team and who works on it
+title: GOV.UK Design System and Prototype Kit team
+description: about the GOV.UK Design System and Prototype Kit team and who works on them
 layout: layout-single-page-prose.njk
 ---
 
-# GOV.UK Design System team
+# GOV.UK Design System and Prototype Kit team
 
-The GOV.UK Design System team at the
-[Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service) (GDS) maintains this design system.
+The GOV.UK Design System and Prototype Kit team at the
+[Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service) (GDS) maintains this design system. We also maintain the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs).
 
 If you want to contact the team you can
 [get in touch via email or Slack](/get-in-touch/).
 
-## Members
+## GOV.UK Design System team
+- Kelly Lee – Delivery Manager
+- Trang Erskine – Senior Product Manager
 
-- Amelia Phillips – User Researcher
-- Ben Surgison – Senior Node JS Developer
-- Brett Kyle – Frontend Developer
+### 'Design System' squad
+
 - Calvin Lau – Senior Content Designer
 - Charlotte Downs – Interaction Designer
 - Chris Ballantine-Thomas – Senior Interaction Designer
 - Ciandelle Scollan – Interaction Designer
-- Claire Ashworth – Technical Writer
-- Colin Rotherham – Senior Frontend Developer
 - David Cox – Senior Accessibility Specialist
 - Imran Hussain – Community Manager
+- Katrina Birch – User Researcher
+- Kim Grey – Frontend Developer
+- Owen Jones – Senior Frontend Developer
+
+### 'Frontend' squad
+
+- Brett Kyle – Frontend Developer
+- Claire Ashworth – Technical Writer
+- Colin Rotherham – Senior Frontend Developer
+- Oliver Byford – Lead Frontend Developer, Digital Service Platforms
+- Romaric Pascal – Senior Frontend Developer
+
+## GOV.UK Prototype Kit team
+
+- Amelia Phillips – User Researcher
+- Ben Surgison – Senior Node JS Developer
 - Izabela Podralska – Delivery Manager
 - Joe Lanman – Lead Interaction Designer
-- Katrina Birch – User Researcher
-- Kelly Lee – Delivery Manager
-- Kim Grey – Frontend Developer
 - Laurence de Bruxelles – Developer
 - Natalie Carey – Senior Developer (Tech Lead)
 - Nora Brodian – Content Designer
-- Oliver Byford – Lead Frontend Developer, Government as a Platform
-- Owen Jones – Senior Frontend Developer
-- Romaric Pascal – Senior Frontend Developer
 - Ruth Hammond – Product Manager
-- Tim Paul – Head of Interaction Design, GDS
-- Trang Erskine – Senior Product Manager


### PR DESCRIPTION
The [list of team members](https://design-system.service.gov.uk/design-system-team/) is getting long, hard to read and does not help users understand what we do as a team.

This change to organise us into teams and squads works to help give a better idea of who we are.