### PR TITLE
Add prioritisation blog post

### DIFF
--- a/src/community/blogs-talks-podcasts/index.md.njk
+++ b/src/community/blogs-talks-podcasts/index.md.njk
@@ -12,6 +12,8 @@ To learn more about the GOV.UK Design System and Prototype Kit, check out these 
 
 Find out how the Design System and Prototype Kit work and what they do to make services more accessible and inclusive.
 
+[How we prioritise additions to the GOV.UK Design System](https://designnotes.blog.gov.uk/2022/09/07/how-we-prioritise-additions-to-the-gov-uk-design-system/) (blog) — 7 September 2022
+
 [The GOV.UK Design System is now live](https://gds.blog.gov.uk/2022/03/31/the-gov-uk-design-system-is-now-live/) (blog) - 31 March 2022
 
 [Help us shape the GOV.UK Design System](https://designnotes.blog.gov.uk/2022/02/23/help-us-shape-the-gov-uk-design-system/) (blog) - 23 February 2022


### PR DESCRIPTION
Add 'How we prioritise additions to the GOV.UK Design System' blog post to the 'Blog posts, videos and podcasts' page