### PR TITLE
Update What's new and blogs pages with 'prioritisation' work

### DIFF
--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -6,9 +6,8 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
-<p class="govuk-body">18 August 2022: We’ve released GOV.UK Frontend v4.3.1. This fix release includes a change to the naming of our static spacing override classes.</p>
-        <p class="govuk-body"><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v4.3.1" class="govuk-link">Read the release notes to see what changes you should make</a>.</p>
-
+<p class="govuk-body">17 October 2022: We’ve changed our ‘Backlog’ page into the new '<a href="/community/upcoming-components-patterns/">Upcoming components and patterns</a>' page and chosen 3 priorities that we plan to work on next.
+</p>
         <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design  System</a>.</p>
       </div>
     </div>


### PR DESCRIPTION
Adds the new 'Upcoming components and patterns' page as the latest 'what's new' item and adds the blogpost about prioritisation into the Blogs page.

I think I've rebased this branch now so it should not conflict with #2372 