### PR TITLE
Tidy up references to the community backlog

### DIFF
--- a/src/community/backlog.md.njk
+++ b/src/community/backlog.md.njk
@@ -1,0 +1,8 @@
+---
+title: This page has been archived
+layout: layout-archived.njk
+ignore_in_sitemap: true
+---
+
+To find out what we’re working on right now, and what we plan to work on next, see the [Upcoming components and patterns](/community/upcoming-components-patterns/) page.
+

--- a/src/community/contribution-criteria/index.md.njk
+++ b/src/community/contribution-criteria/index.md.njk
@@ -53,7 +53,7 @@ To be successful, proposals need to show that the component or pattern being sug
 }) }}
 
 
-The [Design System working group](/community/design-system-working-group/) reviews proposals in the [community backlog](/community/upcoming-components-patterns/) to check they meet these criteria. Proposals that meet the criteria then move to the next step, 'Needs more detail', to show they're ready for working on.
+The [Design System working group](/community/design-system-working-group/) reviews proposals to check they meet these criteria. Proposals that meet the criteria then move to the next step to show they're ready to publish.
 
 ## Developing a component or pattern
 

--- a/src/community/develop-a-component-or-pattern/index.md.njk
+++ b/src/community/develop-a-component-or-pattern/index.md.njk
@@ -4,15 +4,14 @@ description: Find out how to develop a component or pattern for the GOV.UK Desig
 section: Community
 theme: Ways to get involved
 layout: layout-pane.njk
-order: 3
+order: 4
 ---
 
-Anyone can choose to work on contributions marked as 'Needs more detail' in the [Community Backlog project board on GitHub](https://github.com/alphagov/govuk-design-system-backlog/projects/1).
+The Design System team focuses on developing [prioritised components and patterns](/community/upcoming-components-patterns/) with the community. However, anyone can choose to work on something from the [list of discussions on GitHub](https://github.com/orgs/alphagov/projects/43/views/2). 
 
 If you see something you'd like to work on, join the discussion in the contribution's issue page or email the Design System team at govuk-design-system-support@digital.cabinet-office.gov.uk.
 
-If you have an idea for a new component or pattern that’s not already on the backlog, [propose it](/community/propose-a-component-or-pattern/).
-
+If you have an idea for a new component or pattern that’s not already on the list, [propose it](/community/propose-a-component-or-pattern/).
 
 ## Plan your work with the Design System team
 

--- a/src/community/index.md.njk
+++ b/src/community/index.md.njk
@@ -10,7 +10,7 @@ The GOV.UK Design System is for everyone. It has a strong cross-government commu
 Find out:
 
 - about [community resources and tools](/community/resources-and-tools/)
-- what people are currently working on in the [community backlog](/community/upcoming-components-patterns/)
+- about the [upcoming components and patterns](/community/upcoming-components-patterns/) we've prioritised and chosen to work on
 - how to [propose a component or pattern](/community/propose-a-component-or-pattern/)
 - how to [develop a component or pattern](/community/develop-a-component-or-pattern/)
 - about [blog posts, videos and podcasts](/community/blogs-talks-podcasts/)
@@ -27,7 +27,7 @@ Reuse as much as possible and iterate based on user needs.
 
 Start by checking what exists in the [GOV.UK Design System](/).
 
-If something is not in the Design System, check the [community backlog](/community/upcoming-components-patterns/) and [community resources and tools](/community/resources-and-tools/) to see what colleagues in other departments have done before.
+If something is not in the Design System, check the [list of discussions on GitHub](https://github.com/orgs/alphagov/projects/43/views/2) and [community resources and tools](/community/resources-and-tools/) to see what colleagues in other departments have done before.
 
 Reach out to the community to ask questions, gather examples and learn from others’ mistakes.
 
@@ -45,7 +45,7 @@ When our users make a contribution to the Design System, we like to publicly tha
 
 ### 3. Prioritise openness and honesty
 
-Prioritise sharing components and patterns in the GOV.UK Design System and [community backlog](/community/upcoming-components-patterns/). This makes them easier to find and reduces duplication of effort.
+Prioritise sharing components and patterns in the GOV.UK Design System and [list of discussions on GitHub](https://github.com/orgs/alphagov/projects/43/views/2). This makes them easier to find and reduces duplication of effort.
 
 Share work in progress as early as possible. Be honest about the amount and nature of your research and findings. Share what works and what does not.
 

--- a/src/community/propose-a-component-or-pattern/index.md.njk
+++ b/src/community/propose-a-component-or-pattern/index.md.njk
@@ -4,42 +4,27 @@ description: Find out how to propose a new component or pattern for the GOV.UK D
 section: Community
 theme: Ways to get involved
 layout: layout-pane.njk
-order: 4
+order: 3
 ---
 
 Anyone can propose a new component or pattern for the GOV.UK Design System.
 
-To be successful, proposals need to show that the component or pattern being suggested would be [useful and unique](/community/contribution-criteria/).
+Proposals need to show that the component or pattern being suggested would be [useful and unique](/community/contribution-criteria/).
 
-Follow the 3 steps to propose a component or pattern for the Design System.
+Follow the steps to propose a component or pattern for the Design System.
 
-## 1. Check the Community Backlog
+## 1. Check the list of discussions on GitHub
 
-Check if someone else has already suggested your idea or something similar on the [Community Backlog project board on GitHub](https://github.com/alphagov/govuk-design-system-backlog/projects/1).
+Check if someone else has already suggested your idea or something similar on the [list of discussions on GitHub](https://github.com/orgs/alphagov/projects/43/views/2).
 
-If your idea is on the backlog and marked as 'Needs more evidence', go into the issue page and comment on the issue. Say you need the component or pattern, and share any examples or evidence you have to support the proposal.
+If your idea is on the list, go into the issue page and comment on the issue. Say you need the component or pattern, and share any examples or evidence you have to support the proposal.
 
-If it’s marked as 'Needs more detail' and you'd like to work on it, read how to [develop a component or pattern](/community/develop-a-component-or-pattern/).
+If you'd like to work on it, read how to [develop a component or pattern](/community/develop-a-component-or-pattern/).
 
 ## 2. Raise an issue
 
-If your idea is not on the backlog, [raise an issue](https://github.com/alphagov/govuk-design-system-backlog/issues/new). A member of the Design System team will get in touch to discuss your proposal.
+If your idea is not on the list, [raise an issue](https://github.com/alphagov/govuk-design-system-backlog/issues/new). A member of the Design System team will review your proposal.
 
 At this stage, you just need to present your idea and evidence of the user needs. You can include screenshots or links to versions of the component or pattern in use, but avoid spending time working on a specific design or writing code.
 
-## 3. Send your proposal for review
-
-The Design System team will help you prepare your proposal and share it with the [Design System working group](/community/design-system-working-group/) to review.
-
-When your proposal is ready, the Design System team will send it to the working group 2 weeks before their next monthly meeting.
-
-At the meeting, the working group will review your proposal and decide if it is useful and unique. This review helps people avoid spending time and effort on something that’s not needed.
-
-After the meeting, the Design System team will let you know the decision and recommendations, if there are any.
-
-If the working group agrees your proposal is useful and unique, the Design System team will:
-
-- move the proposal to the next step
-- mark it as 'Needs more detail' on the [Community Backlog project board on GitHub](https://github.com/alphagov/govuk-design-system-backlog/projects/1)
-
-At this point, you can either start to [develop the component or pattern](/community/develop-a-component-or-pattern/) or leave it for someone else to work on.
+Every year the Design System community [prioritises components and patterns to work on](/community/upcoming-components-patterns/). If your proposal is not prioritised, you can either start to [develop the component or pattern](/community/develop-a-component-or-pattern/) or leave it for someone else to work on.

--- a/src/get-started/extending-and-modifying-components/index.md.njk
+++ b/src/get-started/extending-and-modifying-components/index.md.njk
@@ -144,6 +144,6 @@ For example, a large modification of an existing component is the [step by step 
 
 If you’ve extended something and you think it’s useful for the wider government community you can propose an improvement.
 
-You can do this by proposing your change to a component on the [community backlog](/community/upcoming-components-patterns/).
+You can do this by proposing your change to a component on the [list of discussions on GitHub](https://github.com/orgs/alphagov/projects/43/views/2).
 
 [prefix]: #use-a-unique-prefix-for-component-names

--- a/src/get-started/focus-states/index.md.njk
+++ b/src/get-started/focus-states/index.md.njk
@@ -74,4 +74,4 @@ To make a component's focus state accessible without using Sass, you can:
 
 If you’ve extended or modified a component and you think this is useful for the wider government community you can propose an improvement.
 
-You can propose your change to a component on the [community backlog](https://github.com/alphagov/govuk-design-system-backlog/projects/1).
+You can propose your change to a component on the [list of discussions on GitHub](https://github.com/orgs/alphagov/projects/43/views/2).

--- a/src/index.njk
+++ b/src/index.njk
@@ -44,7 +44,7 @@ masthead: true
         </ul>
 
         <p class="govuk-body">
-          You can also see what people are currently working on in the <a href="/community/upcoming-components-patterns/" class="govuk-link" data-hcontribute="guidelinegh">community backlog</a>.
+          You can also see <a href="/community/upcoming-components-patterns/" class="govuk-link" data-hcontribute="guidelinegh">upcoming components and patterns</a> to contribute to.
         </p>
 
       </div>


### PR DESCRIPTION
After updating the backlog page in https://github.com/alphagov/govuk-design-system/pull/2354, there are still a few references to the community backlog that need updating. Hopefully this PR covers everything on the Design System website.

I've tried not to rewrite any descriptions of the contribution process, except where it's completely out of date or misleading. This should be done as part of a more comprehensive piece of work. The biggest change is where I removed step 3 from the 'Propose a component or pattern' page, because we don't review every new suggestion with the working group.