### PR TITLE
Fix link style and smart quotes

### DIFF
--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -6,7 +6,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
-<p class="govuk-body">17 October 2022: We’ve changed our ‘Backlog’ page into the new '<a href="/community/upcoming-components-patterns/">Upcoming components and patterns</a>' page and chosen 3 priorities that we plan to work on next.
+<p class="govuk-body">17 October 2022: We’ve changed our ‘Backlog’ page into the new ‘<a href="/community/upcoming-components-patterns/" class="govuk-link">Upcoming components and patterns</a>’ page and chosen 3 priorities that we plan to work on next.
 </p>
         <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design  System</a>.</p>
       </div>


### PR DESCRIPTION
Fixes the design system homepage.

Screenshot showing incorrect quotes and wrong link style:

<img width="963" alt="Screenshot 2022-10-22 at 12 46 28" src="https://user-images.githubusercontent.com/319055/197337421-4c1cde29-88e4-4f4b-abaf-1c67157028a4.png">
