### PR TITLE
Remove extra full stop

### DIFF
--- a/src/community/upcoming-components-patterns/index.md.njk
+++ b/src/community/upcoming-components-patterns/index.md.njk
@@ -139,7 +139,7 @@ We particularly welcome input on the following themes. To contribute, you can ad
         text: "Navigation"
       },
       value: {
-        text: "Exploration into different kinds of navigation, for example sub-navigation and side navigation.."
+        text: "Exploration into different kinds of navigation, for example sub-navigation and side navigation."
       },
       actions: {
         classes: "govuk-!-text-align-left",


### PR DESCRIPTION
The description for the "Navigation" item has two full stops at the end. This removes one of them. 