### PR TITLE
Update Marked and switch to Github Flavoured Markdown

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -37,10 +37,16 @@ exports.getNunjucksCode = path => {
   // Omit any `{% extends "foo.njk" %}` nunjucks code, because we extend
   // templates that only exist within the Design System – it's not useful to
   // include this in the code we expect others to copy.
-  let content = parsedFile.content.replace(
-    /{%\s*extends\s*\S*\s*%}\s+/,
-    ''
-  )
+  let content = parsedFile.content
+    .replace(
+      /{%\s*extends\s*\S*\s*%}\s+/,
+      ''
+    )
+    // Remove empty lines to avoid broken markdown rendering
+    .replace(
+      /^\s*[\r\n]/gm,
+      ''
+    )
 
   return content
 }
@@ -107,12 +113,15 @@ exports.getHTMLCode = path => {
 
   return beautify(html.trim(), {
     indent_size: 2,
-    end_with_newline: true,
-    // If there are multiple blank lines, reduce down to one blank new line.
-    max_preserve_newlines: 1,
+    end_with_newline: false,
+    // Remove blank lines
+    max_preserve_newlines: 0,
     // set unformatted to a small group of elements, not all inline (the default)
     // otherwise tags like label arent indented properly
-    unformatted: ['code', 'pre', 'em', 'strong']
+    unformatted: ['code', 'pre', 'em', 'strong'],
+    // Ensure no empty lines after <head> and <body> tags - this breaks markdown
+    // rendering
+    extra_liners: []
   })
 }
 

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -232,7 +232,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
       },
 
       // Markdown engine options
-      mangle: false,
+      mangle: false, // Don't mangle emails
       smartypants: true, // use "smart" typographic punctuation
       highlight: highlighter
     }

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -232,6 +232,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
       },
 
       // Markdown engine options
+      mangle: false,
       smartypants: true, // use "smart" typographic punctuation
       pedantic: true,
       highlight: highlighter

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -234,7 +234,6 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
       // Markdown engine options
       mangle: false,
       smartypants: true, // use "smart" typographic punctuation
-      pedantic: true,
       highlight: highlighter
     }
   }))

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "jest-environment-jsdom": "^29.3.1",
         "jest-puppeteer": "^6.1.1",
         "js-beautify": "^1.14.7",
-        "jstransformer-marked": "~1.0.3",
+        "jstransformer-marked": "1.2.0",
         "jstransformer-nunjucks": "^1.1.0",
         "marked": "^4.2.2",
         "metalsmith": "^2.5.1",
@@ -10725,25 +10725,15 @@
       }
     },
     "node_modules/jstransformer-marked": {
-      "version": "1.0.3",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jstransformer-marked/-/jstransformer-marked-1.2.0.tgz",
+      "integrity": "sha512-GWWtG0JSv0BfB6m9ZjlEO2fzctRop0YixdpQSm4mjGHzEqGjmsKABwinypgLWf+7x6RL6OV95xTlke0SzPswTg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "marked": "^0.3.9"
+        "marked": "^4.0.17"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/jstransformer-marked/node_modules/marked": {
-      "version": "0.3.19",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8.17.0"
       }
     },
     "node_modules/jstransformer-nunjucks": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jest-environment-jsdom": "^29.3.1",
     "jest-puppeteer": "^6.1.1",
     "js-beautify": "^1.14.7",
-    "jstransformer-marked": "~1.0.3",
+    "jstransformer-marked": "1.2.0",
     "jstransformer-nunjucks": "^1.1.0",
     "marked": "^4.2.2",
     "metalsmith": "^2.5.1",

--- a/src/accessibility.md.njk
+++ b/src/accessibility.md.njk
@@ -14,7 +14,7 @@ This page explains how the team works to ensure the Design System and Frontend a
 
 ## Accessibility statement for the GOV.UK Design System website
 
-This accessibility statement applies to the GOV.UK Design System at https://design-system.service.gov.uk/, and the components and patterns from the GOV.UK Frontend codebase which appear in the examples throughout the Design System.
+This accessibility statement applies to the GOV.UK Design System at <https://design-system.service.gov.uk/>, and the components and patterns from the GOV.UK Frontend codebase which appear in the examples throughout the Design System.
 
 The GOV.UK Design System team wants as many people as possible to be able to use this website. For example, that means you should be able to:
 
@@ -30,7 +30,7 @@ The team has also made the website text as simple as possible to understand.
 
 ### Feedback and contact information
 
-The GOV.UK Design System team is always looking to improve the accessibility of this website. If you find any problems that are not listed on this page or think this website is not meeting accessibility requirements, email the GOV.UK Design System team at govuk-design-system-support@digital.cabinet-office.gov.uk
+The GOV.UK Design System team is always looking to improve the accessibility of this website. If you find any problems that are not listed on this page or think this website is not meeting accessibility requirements, email the GOV.UK Design System team at <govuk-design-system-support@digital.cabinet-office.gov.uk>
 
 The GOV.UK Design System team will review your request and get back to you in 2 working days.
 
@@ -103,4 +103,4 @@ If you're using these products, you should start [updating your service to use t
 If you have any questions or need help, contact the GOV.UK Design System team:
 
 - using the [#govuk-design-system channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)
-- by email at govuk-design-system-support@digital.cabinet-office.gov.uk
+- by email at <govuk-design-system-support@digital.cabinet-office.gov.uk>

--- a/src/community/contribution-criteria/index.md.njk
+++ b/src/community/contribution-criteria/index.md.njk
@@ -79,7 +79,6 @@ Before a new component or pattern is published the working group reviews the imp
       },
       {
         html: "<p>It has been tested  in user research and shown to work with a representative sample of users, including those with disabilities.</p>
-
         <p class='govuk-!-margin-bottom-0'>Components and patterns which are not proven usable can be published as experimental. But they must be clearly based on relevant user research from other organisations and best practice, and meet the other criteria.</p>"
       }
     ],
@@ -89,9 +88,7 @@ Before a new component or pattern is published the working group reviews the imp
       },
       {
         html: "<p>It reuses existing styles and components in the Design System where relevant.</p>
-
         <p>Both the guidance and any content included in examples must follow the <a href='https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style'>GOV.UK content style guide</a>.</p>
-
         <p class='govuk-!-margin-bottom-0'>If there is code, it follows the <a href='https://github.com/alphagov/govuk-frontend/blob/main/CONTRIBUTING.md#conventions-to-follow'>GOV.UK Frontend coding standards</a> and is ready to merge in GOV.UK Frontend.</p>"
       }
     ],
@@ -101,9 +98,7 @@ Before a new component or pattern is published the working group reviews the imp
       },
       {
         html: "<p>The implementation is versatile enough that the component or pattern can be used in a range of different services that may need it.</p>
-
         <p>For example, a versatile date input component could be set up to ask for a year only, a month and year only, a precise date, or any other combination you may need.</p>
-
         <p class='govuk-!-margin-bottom-0'>The component or pattern must also have been tested and shown to work with a range of <a href='https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices'>browsers, assistive technologies and devices</a>.</p>"
       }
     ]

--- a/src/community/develop-a-component-or-pattern/index.md.njk
+++ b/src/community/develop-a-component-or-pattern/index.md.njk
@@ -9,7 +9,7 @@ order: 4
 
 The Design System team focuses on developing [prioritised components and patterns](/community/upcoming-components-patterns/) with the community. However, anyone can choose to work on something from the [list of discussions on GitHub](https://github.com/orgs/alphagov/projects/43/views/2). 
 
-If you see something you'd like to work on, join the discussion in the contribution's issue page or email the Design System team at govuk-design-system-support@digital.cabinet-office.gov.uk.
+If you see something you'd like to work on, join the discussion in the contribution's issue page or email the Design System team at <govuk-design-system-support@digital.cabinet-office.gov.uk>.
 
 If you have an idea for a new component or pattern that’s not already on the list, [propose it](/community/propose-a-component-or-pattern/).
 

--- a/src/community/propose-a-content-change-using-github/index.md.njk
+++ b/src/community/propose-a-content-change-using-github/index.md.njk
@@ -21,7 +21,7 @@ If you do not have one already, you can [create a GitHub account for free](https
 If you get stuck whilst following these steps and you need help, you can:
 
 - get in touch on [#govuk-design-system channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)
-- email the GOV.UK Design System team on <br>govuk-design-system-support@digital.cabinet-office.gov.uk
+- email the GOV.UK Design System team on <br><govuk-design-system-support@digital.cabinet-office.gov.uk>
 
 ## 1. Go to the page you want to edit
 

--- a/src/community/roadmap/index.md.njk
+++ b/src/community/roadmap/index.md.njk
@@ -29,6 +29,7 @@ We recently:
 ## Working on now
 
 We're working to:
+
 - host community co-design work to [turn task-list into a component](/patterns/task-list-pages/)
 - host community co-design work to make maps better
 - release the [Hide this page](https://github.com/alphagov/govuk-design-system-backlog/issues/213) component
@@ -38,6 +39,7 @@ We're working to:
 ## Coming up next
 
 We're getting ready to:
+
 - implement our [proposal](https://github.com/alphagov/govuk-frontend/discussions/2607) for reducing browser support
 - release the [Summary Card](https://github.com/alphagov/govuk-design-system-backlog/issues/210) variant
 - make it easier to find information about contributing and the community
@@ -47,6 +49,7 @@ We're getting ready to:
 ## Future plans
 
 We plan to:
+
 - investigate Sass module system
 - make sure the Design System meets WCAG 2.2
 - investigate removing compatibility mode

--- a/src/components/accordion/index.md.njk
+++ b/src/components/accordion/index.md.njk
@@ -55,6 +55,7 @@ Do not use the accordion component if the amount of content inside will make the
 Accordions, [tabs](/components/tabs/) and [details](/components/details/) all work by hiding sections of content which a user can choose to reveal. Avoid using any of these components within one another.
 
 If you decide to use one of these components, consider if:
+
 - the user needs to look at more than one section at a time — an accordion can show multiple sections at a time, unlike tabs
 - the user needs to switch quickly between sections — tabs can show content without pushing other sections down the page, unlike accordions
 - there are many sections of content — accordions can fit more sections as they’re arranged vertically, unlike tabs which are arranged horizontally
@@ -71,6 +72,7 @@ The accordion component uses JavaScript. When JavaScript is not available, users
 An accordion will usually start with all sections hidden. To show a section, the user can interact anywhere in the heading button.
 
 The heading button includes all of these areas:
+
 - heading text
 - summary line (if you decide to add one)
 - call-to-action text to 'show' or 'hide'

--- a/src/components/cookie-banner/index.md.njk
+++ b/src/components/cookie-banner/index.md.njk
@@ -20,10 +20,12 @@ Allow users to accept or reject cookies which are not essential to making your s
 Use this component if your service sets any cookies on a user’s device.
 
 Remember, you must:
+
 - tell users about the cookies your service sets on their device
 - let users accept or reject any cookies that are not essential to providing your service
 
 The term ‘non-essential cookies’ includes:
+
 - HTML5 local storage
 - service workers
 - any other technologies that store files on the user’s device
@@ -37,6 +39,7 @@ This component page shows several options for using a cookie banner, based on th
 [Audit and categorise your cookies](/patterns/cookies-page/#auditing-and-categorising-your-cookies) as shown in the cookies page pattern to help you choose the best option for your service.
 
 You must not take the information on this page as legal advice. Your organisation is responsible and accountable for what they do to comply with data protection legislation, such as:
+
 - Privacy and Electronic Communications Regulations (PECR)
 - General Data Protection Regulation (GDPR)
 
@@ -45,15 +48,18 @@ Check with your organisation's privacy expert to see how data protection legisla
 ## How it works
 
 Show the cookie banner every time the user accesses your service until they either:
+
 - accept or reject cookies using the buttons in the cookie banner
 - save their cookie preferences on the service’s [cookies page](/patterns/cookies-page/)
 
 Once the user has accepted or rejected cookies, the cookie banner should:
+
 - hide the cookie banner message
 - show a confirmation message — and a 'hide' button to let the user close the banner
 - set a cookie to save the user’s preferences for 1 year
 
 Make sure the cookie banner does not:
+
 - show when the user visits again, once their preferences have been saved
 - set any non-essential cookies unless the user accepted them on a previous visit
 
@@ -114,6 +120,7 @@ When the page loads, the `hidden` html attribute hides the component, as well as
 Use JavaScript to show cookie banner messages to users that have not accepted or rejected cookies by removing the `hidden` attribute as needed.
 
 Write your own JavaScript code so that when the user accepts or rejects cookies, the cookie banner will:
+
 - hide the cookie message by adding the hidden attribute
 - show a confirmation message by removing its hidden attribute
 - give the confirmation message the `tabindex="-1"` and `role="alert"` attributes — this will allow the element to be focused so assistive technology can read the message
@@ -155,6 +162,7 @@ You can use this example text for a service which sets essential and analytics c
 ### If you’re using more than one type of non-essential cookie
 
 You can use this example text for a service that set:
+
 - essential cookies
 - analytics cookies
 - functional cookies to remember the user’s settings but are not essential
@@ -173,6 +181,7 @@ When the user accepts or rejects cookies, a confirmation message will display. F
 However, a visible focus indicator does not display around the confirmation message. This is different from the notification banner, which does display a visible focus indicator.
 
 We decided to remove the visible focus indicator from the confirmation message for a few reasons, as:
+
 - a user cannot interact with it
 - it's the first element, at the very top of the page
 - it displays in place of the cookie message, which is the last thing the user interacted with

--- a/src/components/footer/index.md.njk
+++ b/src/components/footer/index.md.njk
@@ -36,8 +36,8 @@ Make it clear whether content is available for re-use - and if it is, under what
 ## Adding links
 
 You can add links to:
-- [privacy notice](https://www.gov.uk/service-manual/design/collecting-personal-information-from-users
-)
+
+- [privacy notice](https://www.gov.uk/service-manual/design/collecting-personal-information-from-users)
 - [accessibility statement](https://www.gov.uk/service-manual/helping-people-to-use-your-service/publishing-information-about-your-services-accessibility)
 - [cookies page](/patterns/cookies-page/)
 - terms and conditions

--- a/src/components/notification-banner/index.md.njk
+++ b/src/components/notification-banner/index.md.njk
@@ -93,5 +93,6 @@ To make the green version of the notification banner accessible:
 ## Research on this component
 
 We need more research to understand:
+
 - how common it is for users to miss important information in notification banners (including users of assistive technology, who might skip straight to the `h1`)
 - whether it’s sometimes helpful to allow users to dismiss notifications, and how to do this

--- a/src/components/pagination/index.md.njk
+++ b/src/components/pagination/index.md.njk
@@ -16,6 +16,7 @@ Help users navigate forwards and backwards through a series of pages. For exampl
 ## When to use this component
 
 Consider using pagination when:
+
 - showing all the content on a single page makes the page take too long to load
 - most users will only need the content on the first page or first few pages
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -63,6 +63,7 @@ If you're asking more than one question on the page, do not set the contents of 
 In some cases, you can choose to display radios 'inline' beside one another (horizontally).
 
 Only use inline radios when:
+
 - the question only has two options
 - both options are short
 

--- a/src/components/tabs/index.md.njk
+++ b/src/components/tabs/index.md.njk
@@ -48,6 +48,7 @@ Test your content without tabs first. Consider if it’s better to:
 Tabs, [accordions](/components/accordion/), and [details](/components/details/) all hide sections of content which a user can choose to reveal.
 
 If you decide to use one of these components, consider if:
+
 - the user does not need to view more than one section at a time — consider using tabs
 - the user needs to switch quickly between sections — tabs can show content without pushing other sections down the page, unlike accordions
 - there are many pieces of content — tabs can fit fewer sections as they’re arranged horizontally, unlike accordions which are arranged vertically

--- a/src/get-started/extending-and-modifying-components/index.md.njk
+++ b/src/get-started/extending-and-modifying-components/index.md.njk
@@ -13,6 +13,7 @@ You might need to extend or modify components in the GOV.UK Design System from t
 - meet a specific user need in your service
 
 Consider whether your changes:
+
 - help the long term maintenance of your service
 - allow you to safely install updates from the GOV.UK Design System
 - reduce the risk of technical debt

--- a/src/get-started/updating-your-code/index.md.njk
+++ b/src/get-started/updating-your-code/index.md.njk
@@ -26,42 +26,34 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:top_of_page</td>
       <td class="govuk-table__cell">Deprecated: putting content above the <code>&lt;!DOCTYPE html&gt;</code> will result in broken pages for users of older Internet Explorer versions.</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:html_lang</td>
       <td class="govuk-table__cell">htmlLang</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:page_title</td>
       <td class="govuk-table__cell">pageTitle</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:asset_path</td>
       <td class="govuk-table__cell">assetPath</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:head</td>
       <td class="govuk-table__cell">head</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:body_classes</td>
       <td class="govuk-table__cell">bodyClasses</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:body_start</td>
       <td class="govuk-table__cell">bodyStart</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:skip_link_message</td>
       <td class="govuk-table__cell">
@@ -78,14 +70,12 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
         </p>
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:cookie_message</td>
       <td class="govuk-table__cell">
         See the <a class="govuk-link" href="/components/cookie-banner/">cookie banner component</a> for more details.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">header_class</td>
       <td class="govuk-table__cell">
@@ -102,7 +92,6 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
         </p>
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">homepage_url</td>
       <td class="govuk-table__cell">
@@ -119,14 +108,12 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
         </p>
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">global_header_text</td>
       <td class="govuk-table__cell">
         No equivalent. <a href="https://github.com/alphagov/govuk-frontend/issues/new/choose">Raise an issue</a> if you need this.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">inside_header</td>
       <td class="govuk-table__cell">
@@ -143,7 +130,6 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
         </p>
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">proposition_header</td>
       <td class="govuk-table__cell">
@@ -160,12 +146,10 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
         </p>
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:after_header</td>
       <td class="govuk-table__cell">beforeContent</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:content</td>
       <td class="govuk-table__cell">
@@ -183,7 +167,6 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
         </p>
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:footer_top</td>
       <td class="govuk-table__cell">
@@ -200,7 +183,6 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
         </p>
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:footer_support_links</td>
       <td class="govuk-table__cell">
@@ -217,14 +199,12 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
         </p>
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:licence_message</td>
       <td class="govuk-table__cell">
         No equivalent. <a href="https://github.com/alphagov/govuk-frontend/issues/new/choose">Raise an issue</a> if you need this.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">:body_end</td>
       <td class="govuk-table__cell">bodyEnd</td>
@@ -475,7 +455,6 @@ GOV.UK Frontend uses ["Block, Element, Modifier" (BEM)](http://getbem.com/) and 
       <td class="govuk-table__cell ">form-control<br>form-control-3-4<br>form-control-2-3<br>form-control-1-2<br>form-control-1-3<br>form-control-1-4<br>form-control-1-8</td>
       <td class="govuk-table__cell "><a class="govuk-link" href="/styles/layout/#width-override-classes">Width override classes</a></td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell ">form-section</td>
       <td class="govuk-table__cell ">Deprecated: not required with new spacing implementation</td>

--- a/src/patterns/confirm-a-phone-number/index.md.njk
+++ b/src/patterns/confirm-a-phone-number/index.md.njk
@@ -25,8 +25,9 @@ You can ask for a security code every time a user signs in or only once per devi
 ## How it works
 
 Send and ask the user for the security code when they:
-* create an account
-* sign in later
+
+- create an account
+- sign in later
 
 ### When the user creates an account
 
@@ -48,6 +49,7 @@ Let the user enter the code in whatever format is familiar to them. Allow additi
 Give a time limit of 15 minutes for the user to enter the code — the code should expire after this time limit.
 
 If the user enters an expired code that was sent more than:
+
 - 15 minutes ago, show a ‘code has expired’ error message and send the user a new code
 - 2 hours ago, show an ‘incorrect security code’ message, even if the code was correct
 

--- a/src/patterns/cookies-page/index.md.njk
+++ b/src/patterns/cookies-page/index.md.njk
@@ -48,6 +48,7 @@ You should also identify if each cookie is set on the server or client.
 The result of your audit will guide your cookie policy and how the service should use a cookies page and cookie banner. 
 
 The [cookie banner component](/components/cookie-banner/) shows several options for using a cookie banner for services that:
+
 - only set essential cookies
 - sets non-essential cookies on the server - including services that also set non-essential cookies on the client
 - sets non-essential cookies - but only on the client

--- a/src/patterns/dates/index.md.njk
+++ b/src/patterns/dates/index.md.njk
@@ -21,6 +21,7 @@ Follow this pattern whenever you need users to provide or select a date as part 
 The way you should ask users for dates depends on the types of date you’re asking for.
 
 Dates you may need users to provide include:
+
 - memorable dates, like a date of birth or marriage
 - dates from documents or cards, like a passport or credit card
 - approximate dates, like ‘December 2017’

--- a/src/patterns/question-pages/index.md.njk
+++ b/src/patterns/question-pages/index.md.njk
@@ -95,9 +95,10 @@ Do not use hint text if you need to give a lengthy explanation with lists and pa
 Do not use links in hint text. While screen readers will read out the link text when describing the field, they will not tell users the text is a link.
 
 If you're asking a question that needs a detailed explanation, use:
-* a `h1` heading that's a statement (for example, 'Interview needs') rather than a question
-* whatever mix of text, paragraphs, lists and examples best explains your question to users
-* a label, above the form input, that asks users a specific question – for example, 'Do you have any interview needs?'
+
+- a `h1` heading that's a statement (for example, 'Interview needs') rather than a question
+- whatever mix of text, paragraphs, lists and examples best explains your question to users
+- a label, above the form input, that asks users a specific question – for example, 'Do you have any interview needs?'
 
 {{ example({group: "patterns", item: "question-pages", example: "explanatory-text", html: true, nunjucks: true, open: false}) }}
 

--- a/src/patterns/start-using-a-service/index.md.njk
+++ b/src/patterns/start-using-a-service/index.md.njk
@@ -19,6 +19,7 @@ The public-facing version of your service will need to start on a GOV.UK content
 ## How it works
 
 A service's start point should:
+
 - give the user just enough information to help them understand what the service does and whether it will meet their need — including [giving the service a name that reflects the problem it solves for users](https://www.gov.uk/service-manual/design/naming-your-service)
 - include a ‘button’ linking into the service, with text that’s consistent with the action you’re asking users to take — for example, ‘Start now’, ‘Sign in’ or ‘Register or update your details’ (if you need a secondary call to action, use a standard link)
 - let users sign in, resume an application they’ve already started or update their details (if relevant)
@@ -47,6 +48,7 @@ The content team at GDS is responsible for creating mainstream start points on G
 ### Mainstream start points
 
 For a mainstream start point, the options are:
+
 - a simple start page
 - a start point within a multipart guide
 

--- a/src/privacy-policy.md.njk
+++ b/src/privacy-policy.md.njk
@@ -20,6 +20,7 @@ The GOV.UK Design System is provided by the [Government Digital Service (GDS)](h
 For a number of the activities that we undertake to complete our function, we need to process personal data. The purposes are to manage and coordinate the [GOV.UK Design System](/) and contributions from the community.
 
 This includes:
+
 - contribution process, including working with you on contributions, where you’ve proposed to add or improve part of the Design System
 - support, including both the provision of support and responses to user enquiries
 - feedback, including gathering it to improve our services, and responding to it, if you have asked us to
@@ -30,11 +31,13 @@ This includes:
 We collect certain information and data about you when you use the [GOV.UK Design System](/).
 
 We collect your:
+
 - name
 - business contact details
 - user profile on collaboration tools and platforms
 
 If you sign up to our mailing list, we'll collect your:
+
 - name
 - email address and business contact details
 
@@ -47,6 +50,7 @@ The legal basis for processing this data is that processing is necessary for the
 We also carry out performance analysis to see how you use the GOV.UK Design System and how well the site performs on your device during your visit — we do this to make sure it is meeting the needs of its users and improve it.
 
 Where you provide consent, we collect the following information:
+
 - your IP address
 - the pages you visit on the GOV.UK Design System
 - how long you spend on each GOV.UK Design System page
@@ -58,6 +62,7 @@ The legal basis for performing web analytics is your consent. You will be asked 
 ## How long we keep your data
 
 We will only keep your personal data for as long as:
+
 - the law requires us to
 - we need for the purposes listed above
 
@@ -74,12 +79,14 @@ Your personal data may be transferred outside the United Kingdom while being pro
 ## Providers we use
 
 As part of [GOV.UK Design System](/) we share your personal data with data processors who provide us with:
+
 - software collaboration platforms when you share research, feedback or make a contribution
 - mailing list providers when you sign up to receive emails from us
 - [support providers](https://www.gov.uk/government/publications/government-digital-service-user-support-privacy-notice/user-support-privacy-notice) when you contact us for assistance
 - web analytics services
 
 We will not:
+
 - sell or rent your data to third parties
 - share your data with third parties for marketing purposes
 
@@ -91,16 +98,19 @@ We are committed to doing all that we can to keep your data secure. We set up sy
 ## Your rights
 
 You have the right to request:
+
 - information about how your personal data is processed
 - a copy of that personal data
 - that anything inaccurate in your personal data is corrected without undue delay
 
 You can also:
+
 - raise an objection about how your personal data is processed
 - request that your personal data is erased if there is no longer a justification for it
 - ask that the processing of your personal data is restricted in certain circumstances
 
 If your personal data is processed on the basis of consent, you have the right to:
+
 - withdraw consent to the processing of your personal data at any time
 - request a copy of your personal data - this copy will be provided in a structured, commonly used and machine-readable format
 
@@ -109,6 +119,7 @@ If your personal data is processed on the basis of consent, you have the right t
 ## Questions and complaints
 
 Contact the GDS Privacy Office if you:
+
 - have any questions about anything in this document
 - think that your personal data has been misused or mishandled
 - want to make a [subject access request (SAR)](https://ico.org.uk/your-data-matters/your-right-of-access/)

--- a/src/styles/colour/index.md.njk
+++ b/src/styles/colour/index.md.njk
@@ -30,8 +30,8 @@ use `govuk-colour("red")` rather than `$govuk-error-colour`.
 
 <table class="govuk-body app-colour-list" summary="Table of main colours">
   <tbody>
-  {# colours is an object built by ./lib/colours.js based on data defined in ./data/colours.json #}
-  {% for groupName, group in colours.applied %}
+  {#- colours is an object built by ./lib/colours.js based on data defined in ./data/colours.json #}
+  {% for groupName, group in colours.applied -%}
     <tr>
       <td colspan="3">
         <h3 class="govuk-heading-m {% if not loop.first %}govuk-!-padding-top-6{% endif %}">
@@ -39,7 +39,7 @@ use `govuk-colour("red")` rather than `$govuk-error-colour`.
         </h3>
       </td>
     </tr>
-    {% for colour in group %}
+    {% for colour in group -%}
       <tr class="app-colour-list-row">
         <th class="app-colour-list-column app-colour-list-column--name" scope="row">
           <span class="app-swatch {% if colour.colour == "#ffffff" %}app-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>
@@ -48,9 +48,14 @@ use `govuk-colour("red")` rather than `$govuk-error-colour`.
         <td class="app-colour-list-column app-colour-list-column--colour">
           <code>{{colour.colour}}</code>
         </td>
+        {% if colour.notes %}
         <td class="app-colour-list-column app-colour-list-column--notes">
           {{colour.notes}}
         </td>
+        {% else %}
+        <td class="app-colour-list-column app-colour-list-column--notes">
+        </td>
+        {% endif %}
       </tr>
     {% endfor %}
   {% endfor %}

--- a/src/styles/page-template/index.md.njk
+++ b/src/styles/page-template/index.md.njk
@@ -92,7 +92,6 @@ To change the components that are included in the page template by default, set 
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">assetPath</td>
       <td class="govuk-table__cell">Variable</td>
@@ -100,13 +99,11 @@ To change the components that are included in the page template by default, set 
         Specify a path to the <a href="https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#font-and-image-assets">GOV.UK Frontend assets</a> (icons, images, font files).
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">assetUrl</td>
       <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">Set the domain for assets where an absolute URL is required, for example the Open Graph image.</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">beforeContent</td>
       <td class="govuk-table__cell">Block</td>
@@ -117,20 +114,16 @@ To change the components that are included in the page template by default, set 
         <a class="govuk-link" href="/components/phase-banner/">phase banner</a> component.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">bodyAttributes</td>
       <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">Add attributes to the <code>&lt;body&gt;</code> element. Add each attribute and its value in the <code>bodyAttributes</code> object.</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">bodyClasses</td>
       <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">Add a class to the <code>&lt;body&gt;</code> element.</td>
     </tr>
-
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">bodyEnd</td>
       <td class="govuk-table__cell">Block</td>
@@ -138,7 +131,6 @@ To change the components that are included in the page template by default, set 
         Add content just before the closing <code>&lt;/body&gt;</code> element.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">bodyStart</td>
       <td class="govuk-table__cell">Block</td>
@@ -148,13 +140,11 @@ To change the components that are included in the page template by default, set 
         For example: The <a class="govuk-link" href="/components/cookie-banner/">cookie banner</a> component.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">containerClasses</td>
       <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">Add a class to the container. This is useful if you want to make the page wrapper a fixed width.</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">content</td>
       <td class="govuk-table__cell">Block</td>
@@ -162,7 +152,6 @@ To change the components that are included in the page template by default, set 
         Add content that needs to appear centered in the <code>&lt;main&gt;</code> element.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">cspNonce</td>
       <td class="govuk-table__cell">Variable</td>
@@ -170,7 +159,6 @@ To change the components that are included in the page template by default, set 
         Add a <code>nonce</code> attribute to the script for your Content Security Policy (CSP). Provide a nonce that hostile actors cannot guess, as otherwise they can easily find a way around your CSP. However, you should use this attribute only if you’re not able to <a class="govuk-link" href="https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-is-not-working-properly">include the hash for the inline scripts in your service’s CSP</a>.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">footer</td>
       <td class="govuk-table__cell">Block</td>
@@ -178,7 +166,6 @@ To change the components that are included in the page template by default, set 
         Override the default <a class="govuk-link" href="/components/footer/">footer</a> component.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">head</td>
       <td class="govuk-table__cell">Block</td>
@@ -188,7 +175,6 @@ To change the components that are included in the page template by default, set 
         For example: <code>&lt;meta name="description" content="My page description"&gt;</code>
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">header</td>
       <td class="govuk-table__cell">Block</td>
@@ -196,7 +182,6 @@ To change the components that are included in the page template by default, set 
         Override the default <a class="govuk-link" href="/components/header/">header</a> component.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">headIcons</td>
       <td class="govuk-table__cell">Block</td>
@@ -206,19 +191,16 @@ To change the components that are included in the page template by default, set 
         For example: <code>&lt;link rel="shortcut icon" href="favicon.ico" type="image/x-icon" /&gt;</code>
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">htmlClasses</td>
       <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">Add a class to the <code>&lt;html&gt;</code> element.</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">htmlLang</td>
       <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">Set the language of the whole document. If your <code>&lt;title&gt;</code> and <code>&lt;main&gt;</code> element are in a different language to the rest of the page, use <code>htmlLang</code> to set the language of the rest of the page.</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">main</td>
       <td class="govuk-table__cell">Block</td>
@@ -226,13 +208,11 @@ To change the components that are included in the page template by default, set 
         Override the main section of the page, which by default wraps the <code>&lt;main&gt;</code> element, <code>beforeContent</code> block and <code>content</code> block.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">mainClasses</td>
       <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">Add a class to the <code>&lt;main&gt;</code> element. </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">mainLang</td>
       <td class="govuk-table__cell">Variable</td>
@@ -240,13 +220,11 @@ To change the components that are included in the page template by default, set 
         Set the language of the <code>&lt;main&gt;</code> element if it's different to <code>htmlLang</code>.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">opengraphImageUrl</td>
       <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">Set the URL for the Open Graph image meta tag. The URL must be absolute, including the protocol and domain name.</td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">pageTitle</td>
       <td class="govuk-table__cell">Block</td>
@@ -254,7 +232,6 @@ To change the components that are included in the page template by default, set 
         Override the default page title (<code>&lt;title&gt;</code> element).
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">pageTitleLang</td>
       <td class="govuk-table__cell">Variable</td>
@@ -262,7 +239,6 @@ To change the components that are included in the page template by default, set 
         Set the language of the <code>&lt;title&gt;</code> element if it's different to <code>htmlLang</code>.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">skipLink</td>
       <td class="govuk-table__cell">Block</td>
@@ -270,7 +246,6 @@ To change the components that are included in the page template by default, set 
         Override the default <a class="govuk-link" href="/components/skip-link/">skip link</a> component.
       </td>
     </tr>
-
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">themeColor</td>
       <td class="govuk-table__cell">Variable</td>
@@ -278,7 +253,6 @@ To change the components that are included in the page template by default, set 
         Set the <a href="https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android">toolbar colour on some devices</a>.
       </td>
     </tr>
-
   </tbody>
 </table>
 

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -21,8 +21,8 @@ If your service is publicly available on a subdomain other than service.gov.uk, 
 
 If you’re not sure whether you should use GDS Transport, do one of the following:
 
-  - [read the 'If your service is not on GOV.UK' section on 'Making your service look like GOV.UK'](https://www.gov.uk/service-manual/design/making-your-service-look-like-govuk#if-your-service-isnt-on-govuk)
-  - [contact the Design System team](/get-in-touch/)
+- [read the 'If your service is not on GOV.UK' section on 'Making your service look like GOV.UK'](https://www.gov.uk/service-manual/design/making-your-service-look-like-govuk#if-your-service-isnt-on-govuk)
+- [contact the Design System team](/get-in-touch/)
 
 ## Headings
 
@@ -77,6 +77,7 @@ The majority of your body copy should use the standard 19px paragraph size.
 If you need to align text differently to how it usually displays on the page, you can use text alignment override classes.
 
 Use:
+
 - `govuk-!-text-align-left` to align text to the left
 - `govuk-!-text-align-right` to align text to the right
 - `govuk-!-text-align-centre` to align text to the centre
@@ -135,8 +136,8 @@ Include `rel="noreferrer noopener"` along with `target="_blank"` to reduce the r
 
 If you're displaying lots of links together and want to save space and avoid repetition, consider doing both of the following:
 
-  - adding a line of text before the links saying 'The following links open in a new tab'
-  - including `<span class="govuk-visually-hidden">(opens in new tab)</span>` as part of the link text, so that part of the link text is visually hidden but still accessible to screen readers
+- adding a line of text before the links saying 'The following links open in a new tab'
+- including `<span class="govuk-visually-hidden">(opens in new tab)</span>` as part of the link text, so that part of the link text is visually hidden but still accessible to screen readers
 
 ### Links on dark backgrounds
 

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -32,7 +32,7 @@
       <div class="app-example__toolbar">
         <a href="{{ exampleURL }}" class="app-example__new-window" target="_blank">
           Open this
-          {# Don't use full title visually as the context is shown based on location of this link #}
+          {#- Don't use full title visually as the context is shown based on location of this link #}
           <span class="govuk-visually-hidden">{{ exampleTitle | lower }}</span>
           example in a new tab
         </a>
@@ -77,13 +77,12 @@
       <div class="app-tabs__heading js-tabs__heading"><a class="app-tabs__heading-link" href="#{{ exampleId }}-nunjucks" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
     {% elif not (params.hideTab) %}
       <div class="app-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
-    {% endif %}
+    {% endif -%}
     <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-nunjucks" role="tabpanel">
       {%- if (params.group == 'components') %}
         {% set macroOptions = getMacroOptions(params.item) %}
-  
+
         {% set macroOptionsHTML %}
-  
           <p>
           Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
           </p>
@@ -93,7 +92,6 @@
           <p>
           If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must sanitise the HTML to protect against  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting exploits</a>.
           </p>
-  
           {% for table in macroOptions %}
             <table class="govuk-table app-options__table" id="options-{{ exampleId }}--{{ table.id }}">
               <caption class="govuk-table__caption govuk-heading-m {% if table.id == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name }}</caption>
@@ -105,8 +103,7 @@
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
-  
-                {% for option in table.options %}
+                {% for option in table.options -%}
                   <tr class="govuk-table__row">
                     <th class="govuk-table__header" scope="row">{{option.name}}</th>
                     <td class="govuk-table__cell ">{{option.type}}</td>
@@ -115,8 +112,8 @@
                         <strong>Required.</strong>
                       {% endif %}
                       {{ option.description | safe }}
-                      {% if (option.isComponent) %}
-                        {# Create separate table data for components that are hidden in the Design System #}
+                      {% if (option.isComponent) -%}
+                        {# Create separate table data for components that are hidden in the Design System -#}
                         {% if (option.name === "hint" or option.name === "label") %}
                           See <a href="#options-{{ exampleId }}--{{ option.name }}">{{ option.name }}</a>.
                         {% else %}
@@ -125,19 +122,19 @@
                       {% endif %}
                       {% if (option.params) %}
                         See <a href="#options-{{ exampleId }}--{{ option.name }}">{{ option.name }}</a>.
-                      {% endif %}
+                      {% endif -%}
                     </td>
                   </tr>
                 {% endfor %}
               </tbody>
             </table>
           {% endfor %}
-  
-        {% endset %}
-  
-        {% from "govuk/components/details/macro.njk" import govukDetails %}
-  
-        {{ govukDetails({
+
+        {%- endset %}
+
+        {%- from "govuk/components/details/macro.njk" import govukDetails %}
+
+        {{- govukDetails({
           summaryHtml: "<span data-components='github-component-arguments'>Nunjucks macro options</span>",
           html: macroOptionsHTML,
           classes: "app-options",
@@ -145,7 +142,7 @@
             id: "options-" + exampleId + "-details"
           }
         })}}
-      {% endif %}
+      {% endif -%}
       <div class="app-example__code">
         <pre data-module="app-copy" tabindex="0"><code class="hljs js">
           {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}


### PR DESCRIPTION
## What
We use `@metalsmith/in-place` to transform our source markdown and nunjucks files.

Under the hood, `@metalsmith/in-place` uses `jstransformer`, which in turn relies on `jstransformer-nunjucks` and `jstransformer-marked` to handle our Nunjucks and markdown code respectively.

Previously, we've been using `jstransformer-marked` v1.0.3, not realising that it was using an outdated version of `marked` (0.3.9), and not the direct dependency that we've specified. This means that if we try to update, we generate a lot of rendering errors (at one point I had a 100,000+ line diff) because of various bugs being ironed out in more recent versions of `marked`.

### Stick with pedantic rules?
Previously, we've used [`pedantic` rules](https://marked.js.org/using_advanced#options), but some of our usage is incorrect, flying under the radar because of `marked` bugs/changes. If we stick with pedantic rules and update `marked`, we generate some errors, including:

- [Lists with no blank line after the preceding paragraph break](https://github.com/alphagov/govuk-design-system/pull/2288)
- Raw URLs no longer autolink - you have to wrap them in angle brackets
- Fenced code blocks no longer work

This last point is not easily fixable with pedantic rules in place: we could mess around with indentation, but it'd be tricky to specify code languages for highlighting, and difficult to enforce.

### Switch to Github Flavoured Markdown!
Switching to GFM solves the 3 problems listed above, and is arguably more recognisable to our team as we're using the Github ecosystem.

However, it introduces a new problem:

- Our `.md.njk` share Nunjucks and markdown code
- `@metalsmith/in-place` renders the Nunjucks, then does another pass to render the markdown
- The Nunjucks is often rendered with empty blank lines. In some cases, I think this enhances readability a bit. In other cases, it's just due to not controlling white space within our code.
- These empty lines (despite being in a `<pre>` block!) run afoul of [GFM's HTML Block rules](https://github.github.com/gfm/#html-blocks), specifically rule 6 and 7. I've done a lot of messing about with the `<pre>` blocks in the `_example.njk` template to no avail.
- As a result, code in `<pre>` blocks can be wrapped in `<p>` tags, and code outside of `<pre>` blocks can be treated as raw preformatted code.

## How
The bulk of this PR is [fixing these spacing errors](https://github.com/alphagov/govuk-design-system/pull/2427/commits/b13c99c8ee1dc6259ffd9592c234815e281ead73) so that the new output differs from the old output only in the following ways:

- The single email we were mangling is no longer mangled (we don't mangle any others)
- Autogenerated heading ids concatenate contractions
  - GOV.UK becomes `govuk` rather than `gov-uk`
  - You're become `youre` rather than `you-re`
- Headings ending in quotes don't generate an extra dash at the end of the id (eg: `<h4 id="users-that-navigate-using-elements-lists-">Users that navigate using ‘elements lists’</h4>`)
- Repeated headings get numbers appended after the duplication (there's only one example of this, so we should decide whether to fix it!)
- Non-breaking spaces in text content remain in place rather than being replaced by a normal space
- highlight.js now uses `language-[language]` in class names instead of `lang-[language]`
- blank line removal
- whitespace differences to prevent blank lines

### Method
To test these changes, I ran an `npm run build` command using the latest `main` branch, copied the resulting `deploy/public` folder, then diffed subsequent builds against that folder, ignoring whitespace and blank line changes (i.e: by running `diff -r -w -B deploy/mainpublic deploy/public`)

I'll attach this diff in a comment on this PR, as one of the issues with this work is there was no built-in way to do this diffing.

## Concerns/questions

### Am I missing something?

I've spent a lot of time playing around with the `<pre>` tags around the sample code in `views/partials/_example.njk` in order to get the sample code rendering fine without having to mess around with spacing (there's a possible issue where a `<pre>` tag needs a blank line before it to register as a new block of HTML), but I haven't been able to jig it into shape.

### Are we concerned about the loss of blank lines in code examples?

- This largely feels like a positive change with HTML code, which is now nicely beautified all the time rather than occasionally having random whitespace/blank lines
- But less clear cut with Nunjucks

#### Character Count HTML Before
![Before: Character count HTML code](https://user-images.githubusercontent.com/22524634/202823743-f22532e2-a76b-4e03-b873-407aaf0ee310.png)

#### Character Count HTML After
![After: Character count HTML code](https://user-images.githubusercontent.com/22524634/202823812-bf87dea0-203a-465d-ad96-09736e4bccac.png)

#### Character Count Nunjucks Before
![Before: Character count Nunjucks code](https://user-images.githubusercontent.com/22524634/202823768-74593322-ea5b-4c4d-aed9-973d9f5fb5b1.png)

#### Character Count Nunjucks After
![After: Character count Nunjucks code](https://user-images.githubusercontent.com/22524634/202823838-af1f4f9b-2340-4384-88c7-e82425878925.png)

### Fragility
We only noticed this issue because a [user spotted an error when we tried bumping this before](https://github.com/alphagov/govuk-design-system/pull/2288). We have multiple content editors - it's inevitable small issues will crop up again the future unless we guard against it.

## Possible future work
### Beautify and validate all compiled HTML
I've got a rough idea of what this might look like here: https://github.com/alphagov/govuk-design-system/pull/2408/files, though we could make the validation part of testing only.

Validating the compiled HTML would give us one layer of assurance that we're not deploying anything weird.

### Diff the public folder on PRs?
It'd be great if we could see what changes our work would create in compiled code. Don't think we're going to add `deploy/public` to version control, so it makes sense to diff it to make sure we haven't done anything weird.

### Split out sample code rendering
A lot of the issues stemmed from rendering problems in our `example` component's sample code blocks. It'd be great if we could somehow render page nunjucks source code, then markdown, then `example`s. This would give us full control over what code samples looked like without having to worry about markdown issues.

### Rename all `.md.njk` files to `.md` files
It's far easier to edit `.md` files in Github (which non-devs are largely encouraged to do), and we can generate previews for them.

To make this work with the current set up, we could use `metalsmith-renamer` to rename the relevant files to `.md.njk` before passing them to `@metalsmith/in-place`. This would happen under the hood, so users would only have to deal with the `.md` files.

I've tested this locally and it works fine and doesn't seem to add much build time at all.

### Switch to another site generator
Investigating this is on our radar, and at a glance, I think 11ty is set up to handle our "nunjucks in markdown" set up with minimal fuss or config, so it'd definitely make sense to spike that.

To those of you who've made it this far, thank you for reading! Hope that all made sense - feel free to shoot me any questions.