### PR TITLE
Update links to GOV.UK Prototype Kit website

### DIFF
--- a/src/components/back-link/index.md.njk
+++ b/src/components/back-link/index.md.njk
@@ -33,7 +33,7 @@ Make sure the link takes users to the previous page they were on, in the state t
 
 If this is not possible, you should hide the back link when JavaScript is not available.
 
-There are 2 ways to use the back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 

--- a/src/components/breadcrumbs/index.md.njk
+++ b/src/components/breadcrumbs/index.md.njk
@@ -29,7 +29,7 @@ Always place breadcrumbs at the top of a page, before the `<main>` element. Plac
 
 The breadcrumb should start with your 'home' page and end with the parent section of the current page.
 
-There are 2 ways to use the breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 

--- a/src/components/button/index.md.njk
+++ b/src/components/button/index.md.njk
@@ -34,7 +34,7 @@ You may need to include more or different words to better describe the action. F
 
 Align the primary action button to the left edge of your form.
 
-There are 2 ways to use the button component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the button component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 ### Default buttons
 

--- a/src/components/checkboxes/index.md.njk
+++ b/src/components/checkboxes/index.md.njk
@@ -49,7 +49,7 @@ If you're asking just [one question per page](/patterns/question-pages/#start-by
 
 Read more about [why and how to set legends as headings](/get-started/labels-legends-headings/).
 
-There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs), you can use the Nunjucks macro.
+There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
 

--- a/src/components/date-input/index.md.njk
+++ b/src/components/date-input/index.md.njk
@@ -35,7 +35,7 @@ Read more about [why and how to set legends as headings](/get-started/labels-leg
 
 Make sure that any example dates you use in hint text are valid for the question being asked.
 
-There are 2 ways to use the date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 

--- a/src/components/details/index.md.njk
+++ b/src/components/details/index.md.njk
@@ -33,7 +33,7 @@ The details component is less visually prominent than tabs and accordions, so te
 
 The details component is a short link that shows more detailed help text when a user clicks on it.
 
-There are 2 ways to use the details component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the details component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 

--- a/src/components/error-summary/index.md.njk
+++ b/src/components/error-summary/index.md.njk
@@ -32,7 +32,7 @@ As well as showing an error summary, follow the [validation pattern](/patterns/v
 
 And make your [error messages](/components/error-message/#be-clear-and-concise) clear and concise.
 
-There are 2 ways to use the error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 

--- a/src/components/file-upload/index.md.njk
+++ b/src/components/file-upload/index.md.njk
@@ -21,7 +21,7 @@ You should only ask users to upload something if it’s critical to the delivery
 
 ## How it works
 
-There are 2 ways to use the file upload component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the file upload component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 

--- a/src/components/index.md.njk
+++ b/src/components/index.md.njk
@@ -8,6 +8,6 @@ Components are reusable parts of the user interface that have been made to suppo
 
 You can use individual components in many different [patterns](/patterns/) and contexts. For example, you can use the [text input](/components/text-input/) component to ask for an email address, a National Insurance number or someone’s name.
 
-Each component in the GOV.UK Design System has coded examples. If you're using the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), or have included [GOV.UK Frontend](https://frontend.design-system.service.gov.uk/) in your build, coded examples will render the same as in the Design System.
+Each component in the GOV.UK Design System has coded examples. If you're using the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), or have included [GOV.UK Frontend](https://frontend.design-system.service.gov.uk/) in your build, coded examples will render the same as in the Design System.
 
 The GOV.UK Design System's code is public and freely available under a [Massachusetts Institute of Technology (MIT) license](https://github.com/alphagov/govuk-frontend/blob/main/LICENSE.txt). You can [find our code repositories on GitHub](https://github.com/topics/govuk-design-system-team), where we [code in the open](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/).

--- a/src/components/pagination/index.md.njk
+++ b/src/components/pagination/index.md.njk
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-Help users navigate forwards and backwards through a series of pages. For example, search results or guidance that's divided into multiple website pages — like [the GOV.UK mainstream guide format](https://govuk-prototype-kit.herokuapp.com/docs/templates/mainstream-guide).
+Help users navigate forwards and backwards through a series of pages. For example, search results or guidance that's divided into multiple website pages — like [the GOV.UK mainstream guide format](https://prototype-kit.service.gov.uk/docs/templates/mainstream-guide).
 
 {{ example({group: "components", item: "pagination", example: "default", html: true, nunjucks: true }) }}
 

--- a/src/components/panel/index.md.njk
+++ b/src/components/panel/index.md.njk
@@ -25,7 +25,7 @@ Never use the panel component to highlight important information within body con
 
 ## How it works
 
-There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
 

--- a/src/components/phase-banner/index.md.njk
+++ b/src/components/phase-banner/index.md.njk
@@ -23,7 +23,7 @@ Use an alpha banner when your service is in alpha, and a beta banner if your ser
 
 Your banner must be directly under the black GOV.UK header and colour bar.
 
-There are 2 ways to use the phase banner component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the phase banner component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 

--- a/src/components/radios/index.md.njk
+++ b/src/components/radios/index.md.njk
@@ -48,7 +48,7 @@ If you are asking just [one question per page](/patterns/question-pages/#start-b
 
 Read more about [why and how to set legends as headings](/get-started/labels-legends-headings/).
 
-There are 2 ways to use the radios component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the radios component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 

--- a/src/components/select/index.md.njk
+++ b/src/components/select/index.md.njk
@@ -27,7 +27,7 @@ If you use the component for settings, you can make an option pre-selected by de
 
 If you use the component for questions, you should not pre-select any of the options in case it influences users' answers.
 
-There are 2 ways to use the select component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com),  you can use the Nunjucks macro.
+There are 2 ways to use the select component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk),  you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 

--- a/src/components/skip-link/index.md.njk
+++ b/src/components/skip-link/index.md.njk
@@ -29,6 +29,6 @@ Including the skip link component gives users the option to bypass the top-level
 
 The skip link component is visually hidden until a keyboard press activates it.
 
-There are 2 ways to use the skip link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the skip link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}

--- a/src/components/summary-list/index.md.njk
+++ b/src/components/summary-list/index.md.njk
@@ -28,7 +28,7 @@ Do not use it for tabular data or a simple list of information or tasks, like a 
 
 ## How it works
 
-There are 2 ways to use the summary list component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the summary list component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "summary-list", example: "without-actions", html: true, nunjucks: true, open: false}) }}
 

--- a/src/components/table/index.md.njk
+++ b/src/components/table/index.md.njk
@@ -35,7 +35,7 @@ There are other styling options for table captions. You can use `govuk-table__ca
 
 Use table headers to tell users what the rows and columns represent. Use the `scope` attribute to help users of assistive technology distinguish between row and column headers.
 
-There are 2 ways to use the table component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the table component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
 

--- a/src/components/tabs/index.md.njk
+++ b/src/components/tabs/index.md.njk
@@ -55,7 +55,7 @@ If you decide to use one of these components, consider if:
 
 ## How it works
 
-There are 2 ways to use the tabs component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
+There are 2 ways to use the tabs component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false, size: "xl", titleSuffix: "second"}) }}
 

--- a/src/components/tag/index.md.njk
+++ b/src/components/tag/index.md.njk
@@ -19,7 +19,7 @@ Use the tag component when it’s possible for something to have more than one s
 
 ## How it works
 
-There are two ways to use the tag component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are two ways to use the tag component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 Tags are just used to indicate a status, so do not add links. Use adjectives rather than verbs for the names of your tags. Using a verb might make a user think that clicking on them will do something.
 

--- a/src/components/text-input/index.md.njk
+++ b/src/components/text-input/index.md.njk
@@ -39,7 +39,7 @@ If you’re asking just [one question per page](/patterns/question-pages/#start-
 
 Read more about [why and how to set legends as headings](/get-started/labels-legends-headings/).
 
-There are 2 ways to use the text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 

--- a/src/components/textarea/index.md.njk
+++ b/src/components/textarea/index.md.njk
@@ -29,7 +29,7 @@ You must label textareas. Placeholder text is not a suitable substitute for a la
 
 Labels must be aligned above the textarea they refer to. They should be short, direct and written in sentence case. Do not use colons at the end of labels.
 
-There are 2 ways to use the textarea component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the textarea component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
 

--- a/src/components/warning-text/index.md.njk
+++ b/src/components/warning-text/index.md.njk
@@ -17,7 +17,7 @@ Use the warning text component when you need to warn users about something impor
 
 ## How it works
 
-There are 2 ways to use the warning text component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
+There are 2 ways to use the warning text component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
 

--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -7,7 +7,7 @@ layout: layout-single-page-prose.njk
 # GOV.UK Design System and Prototype team
 
 The GOV.UK Design System and Prototype team at the
-[Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service) (GDS) maintains this design system. We also maintain the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs).
+[Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service) (GDS) maintains this design system. We also maintain the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk).
 
 If you want to contact the team you can
 [get in touch via email or Slack](/get-in-touch/).

--- a/src/get-started/prototyping/index.md.njk
+++ b/src/get-started/prototyping/index.md.njk
@@ -14,7 +14,7 @@ This guide explains how to create prototypes using the GOV.UK Design System and 
 
 ## Before you start
 
-To make prototypes you will need to install version 7 or later of the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs/install) which has been built to work with the Design System.
+To make prototypes you will need to install version 7 or later of the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk/docs/install) which has been built to work with the Design System.
 
 Version 7 of the Prototype Kit works in the same way as previous versions except that it uses a new frontend framework called GOV.UK Frontend.
 

--- a/src/get-started/prototyping/index.md.njk
+++ b/src/get-started/prototyping/index.md.njk
@@ -14,7 +14,7 @@ This guide explains how to create prototypes using the GOV.UK Design System and 
 
 ## Before you start
 
-To make prototypes you will need to install version 7 or later of the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk/docs/install) which has been built to work with the Design System.
+To make prototypes you will need to install version 7 or later of the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk/docs/create-new-prototype) which has been built to work with the Design System.
 
 Version 7 of the Prototype Kit works in the same way as previous versions except that it uses a new frontend framework called GOV.UK Frontend.
 

--- a/src/patterns/step-by-step-navigation/index.md.njk
+++ b/src/patterns/step-by-step-navigation/index.md.njk
@@ -58,8 +58,8 @@ Step by step navigation is displayed in 2 ways.
 
 You can use the following examples in the GOV.UK Prototype Kit to prototype a step by step:
 
-- [Step by step page](https://govuk-prototype-kit.herokuapp.com/docs/templates/step-by-step-navigation)
-- [Start page with step by step navigation as a sidebar](https://govuk-prototype-kit.herokuapp.com/docs/templates/start-with-step-by-step)
+- [Step by step page](https://prototype-kit.service.gov.uk/docs/templates/step-by-step-navigation)
+- [Start page with step by step navigation as a sidebar](https://prototype-kit.service.gov.uk/docs/templates/start-with-step-by-step)
 
 Remember that step by step navigation is not for use within transactional services. We have included it in the Prototype Kit only so you can prototype your end to end journeys. Unlike most other components and patterns in the Design System, we do not provide the code for step by step navigation in `govuk-frontend`.
 

--- a/src/patterns/task-list-pages/index.md.njk
+++ b/src/patterns/task-list-pages/index.md.njk
@@ -20,7 +20,7 @@ Task list pages help users understand:
 
 ![A screenshot showing an example of the task list page, includes a heading, and three grouped sections that each contain tasks, some of these tasks are marked as completed.](task-list-whole.png)
 
-There’s a [coded example of a task list page](https://govuk-prototype-kit.herokuapp.com/docs/templates/task-list) in the GOV.UK Prototype Kit. To use the example, get the following code from the Prototype Kit repository on GitHub:
+There’s a [coded example of a task list page](https://prototype-kit.service.gov.uk/docs/templates/task-list) in the GOV.UK Prototype Kit. To use the example, get the following code from the Prototype Kit repository on GitHub:
 
 - [HTML from the task list page's HTML file](https://github.com/alphagov/govuk-prototype-kit/blob/main/docs/views/templates/task-list.html#L18)
 - [custom styles from the task list page's SCSS file](https://github.com/alphagov/govuk-prototype-kit/blob/main/app/assets/sass/patterns/_task-list.scss)

--- a/src/styles/index.md.njk
+++ b/src/styles/index.md.njk
@@ -7,6 +7,6 @@ show_subnav: true
 
 Make your service look and feel like GOV.UK.
 
-If you are using the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com) or have [GOV.UK Frontend](https://frontend.design-system.service.gov.uk/) included in your build, the coded examples in the Design System will not need any additional styling.
+If you are using the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk) or have [GOV.UK Frontend](https://frontend.design-system.service.gov.uk/) included in your build, the coded examples in the Design System will not need any additional styling.
 
 If you need to apply styles manually, you should still follow existing GOV.UK conventions. For example, do not assign new meanings to colours, do not change the style of buttons or adjust the thickness of borders on form inputs.


### PR DESCRIPTION
The GOV.UK Protoype Kit website has moved to a service domain :tada:

This PR updates links to match. We also update the link to the install page, as the GOV.UK Prototype Kit version 13 is installed in a different way to previous versions, and the documentation has been changed to reflect that.