### PR TITLE
Update Node to LTS ‘Hydrogen’ (v18) release version

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/hydrogen

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,8 +58,8 @@
         "stylelint-order": "^5.0.0"
       },
       "engines": {
-        "node": "^16.13.0",
-        "npm": "^8.1.0"
+        "node": "^18.12.0",
+        "npm": "^8.1.0 || ^9.1.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     "stylelint-order": "^5.0.0"
   },
   "engines": {
-    "node": "^16.13.0",
-    "npm": "^8.1.0"
+    "node": "^18.12.0",
+    "npm": "^8.1.0 || ^9.1.0"
   },
   "jest": {
     "preset": "jest-puppeteer",


### PR DESCRIPTION
Run and build the Design System site using Node.js LTS ‘Hydrogen’ (v18) release version.

This updates Node in `.nvmrc` and the `package.json` `engines` range.

Also widens the `npm` engines range, since this will be [backported to Node 18 later this year](https://github.com/npm/statusboard/issues/587).