### PR TITLE
Update roadmap page

### DIFF
--- a/src/community/roadmap/index.md.njk
+++ b/src/community/roadmap/index.md.njk
@@ -13,18 +13,16 @@ Some things on the roadmap might change — the purpose is to tell you what’s 
 
 See our [Github team board](https://github.com/orgs/alphagov/projects/4) for more details on our plans and day-to-day activities.
 
-Last updated 27 June 2022.
+Last updated 2 December 2022.
 
 ## Recently shipped
 
 We recently:
 
-- released [GOV.UK Frontend v4.1.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.1.0) with improvements to the screen reader experience for the character count component
-- published the [Confirm a phone number](https://design-system.service.gov.uk/patterns/confirm-a-phone-number/) pattern
-- released [GOV.UK Frontend v4.2.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.2.0) with the new pagination component, and improvements to the checkboxes, radios and select components
 - published the [Pagination](https://design-system.service.gov.uk/components/pagination) component
 - completed our investigation into potential changes to [browser support](https://github.com/alphagov/govuk-frontend/discussions/2607)
 - released [GOV.UK Frontend v4.4.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.4.0) which allow users to localise hardcoded strings in component JavaScript
+- hosted Design System Day 2022
 
 ## Working on now
 
@@ -35,6 +33,7 @@ We're working to:
 - release the [Hide this page](https://github.com/alphagov/govuk-design-system-backlog/issues/213) component
 - improve how [JavaScript works in GOV.UK Frontend](https://github.com/alphagov/govuk-frontend/issues/1389)
 - iterate on alt text guidance for the images style page
+- publish an accessibility strategy for the GOV.UK Design System
 
 ## Coming up next
 


### PR DESCRIPTION
- amended the 'last updated' date
- removed releases 4.1.0 and 4.2.0 from 'Recently shipped' as over 6 months ago
- removed Confirm a phone number from 'Recently shipped' as over 6 months ago
- added "hosted Design System Day 2022" to 'Recently shipped'
- added "publish an accessibility strategy for the GOV.UK Design System" to 'Working on now'