### PR TITLE
Update homepage links to recent updates

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -33,7 +33,7 @@ masthead: true
       <div class="govuk-grid-column-two-thirds govuk-!-mb-r4">
         <h2 class="govuk-heading-l">Principles we follow</h2>
         <p class="govuk-body">
-The GOV.UK Design System helps service teams follow the <a class="govuk-link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a> and <a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a>. This website also follows the Government Digital Service (GDS) <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide">style guide</a> and <a class="govuk-link" href="https://www.gov.uk/guidance/content-design">content design guidance</a>.
+The GOV.UK Design System helps service teams follow the <a class="govuk-link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a> and <a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a>. This website also follows the <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide">style guide</a> and <a class="govuk-link" href="https://www.gov.uk/guidance/content-design">content design guidance</a> used by GOV.UK.
         </p>
 
       <p class="govuk-body">

--- a/src/index.njk
+++ b/src/index.njk
@@ -27,7 +27,7 @@ masthead: true
       </div>
 
       <div class="govuk-grid-column-full">
-        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl govuk-!-margin-top-0">
       </div>
 
       <div class="govuk-grid-column-two-thirds govuk-!-mb-r4">
@@ -41,7 +41,7 @@ The GOV.UK Design System helps service teams follow the <a class="govuk-link" hr
       </div>
 
       <div class="govuk-grid-column-full">
-        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl govuk-!-margin-top-0">
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
       </div>
 
       <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/src/index.njk
+++ b/src/index.njk
@@ -27,6 +27,20 @@ masthead: true
       </div>
 
       <div class="govuk-grid-column-full">
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+      </div>
+
+      <div class="govuk-grid-column-two-thirds govuk-!-mb-r4">
+        <h2 class="govuk-heading-l">Principles we follow</h2>
+        <p class="govuk-body">
+The GOV.UK Design System helps service teams follow the <a class="govuk-link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a> and <a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a>. This website also follows the Government Digital Service (GDS) <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide">style guide</a> and <a class="govuk-link" href="https://www.gov.uk/guidance/content-design">content design guidance</a>.
+        </p>
+
+      <p class="govuk-body">
+<a class="govuk-link" href="/community/accessibility-strategy/">Our accessiblity strategy</a> outlines our principles and work to improve accessibility within the GOV.UK Design System.</p>
+      </div>
+
+      <div class="govuk-grid-column-full">
         <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl govuk-!-margin-top-0">
       </div>
 
@@ -36,13 +50,12 @@ masthead: true
           The GOV.UK Design System is for everyone, with a strong community sitting behind it. It brings together the latest research, design and development from across government to make sure it’s representative and relevant for its users.</p>
 
         <p class="govuk-body">
-          <a class="govuk-link" href="/community/">Find out how you can help improve the Design System</a> and read our <a class="govuk-link" href="/community/community-principles/">community principles</a>.          
+          You can help improve the Design System by <a class="govuk-link" href="/community/">joining our discussions, events and co-design collaborations</a>.
         </p>
 
         <p class="govuk-body">
-          You can also see <a href="/community/upcoming-components-patterns/" class="govuk-link" data-hcontribute="guidelinegh">upcoming components and patterns</a> to contribute to.
+Also see <a href="/community/upcoming-components-patterns/" class="govuk-link" data-hcontribute="guidelinegh">upcoming components and patterns</a> we're working on and how you can help.
         </p>
-
       </div>
 
       <div class="govuk-grid-column-full">
@@ -58,20 +71,6 @@ masthead: true
        <p class="govuk-body">
         See <a class="govuk-link" href="/community/blogs-talks-podcasts/">blog posts, video talks, and podcasts about the GOV.UK Design System and Prototype Kit</a>.
 </p>
-      </div>
-
-      <div class="govuk-grid-column-full">
-        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
-      </div>
-
-      <div class="govuk-grid-column-two-thirds govuk-!-mb-r4">
-        <h2 class="govuk-heading-l">How we work</h2>
-        <p class="govuk-body">
-        The GOV.UK Design System helps teams follow the <a class="govuk-link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a> and <a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a>. This website also follows the <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide">Government Digital Service (GDS) style guide</a> and <a class="govuk-link" href="https://www.gov.uk/guidance/content-design">content design guidance.</a>
-        </p>
-
-        <p class="govuk-body">
-<a class="govuk-link" href="/community/accessibility-strategy/">Our accessiblity strategy</a> outlines our principles and work to improve the accessibility within the Design System.</p>
       </div>
 
       <div class="govuk-grid-column-full">

--- a/src/index.njk
+++ b/src/index.njk
@@ -36,12 +36,8 @@ masthead: true
           The GOV.UK Design System is for everyone, with a strong community sitting behind it. It brings together the latest research, design and development from across government to make sure it’s representative and relevant for its users.</p>
 
         <p class="govuk-body">
-          You can contribute to the Design System by:
+          <a class="govuk-link" href="/community/">Find out how you can help improve the Design System</a> and read our <a class="govuk-link" href="/community/community-principles/">community principles</a>.          
         </p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li><a href="/community/propose-a-component-or-pattern/" class="govuk-link" data-hcontribute="guidelinegh">proposing a new component or pattern</a></li>
-          <li><a href="/community/develop-a-component-or-pattern/" class="govuk-link" data-hcontribute="guidelinegh">developing a component or pattern</a></li>
-        </ul>
 
         <p class="govuk-body">
           You can also see <a href="/community/upcoming-components-patterns/" class="govuk-link" data-hcontribute="guidelinegh">upcoming components and patterns</a> to contribute to.
@@ -62,6 +58,20 @@ masthead: true
        <p class="govuk-body">
         See <a class="govuk-link" href="/community/blogs-talks-podcasts/">blog posts, video talks, and podcasts about the GOV.UK Design System and Prototype Kit</a>.
 </p>
+      </div>
+
+      <div class="govuk-grid-column-full">
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+      </div>
+
+      <div class="govuk-grid-column-two-thirds govuk-!-mb-r4">
+        <h2 class="govuk-heading-l">How we work</h2>
+        <p class="govuk-body">
+        The GOV.UK Design System helps teams follow the <a class="govuk-link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a> and <a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a>. This website also follows the <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide">Government Digital Service (GDS) style guide</a> and <a class="govuk-link" href="https://www.gov.uk/guidance/content-design">content design guidance.</a>
+        </p>
+
+        <p class="govuk-body">
+<a class="govuk-link" href="/community/accessibility-strategy/">Our accessiblity strategy</a> outlines our principles and work to improve the accessibility within the Design System.</p>
       </div>
 
       <div class="govuk-grid-column-full">

--- a/views/partials/_footer.njk
+++ b/views/partials/_footer.njk
@@ -3,22 +3,6 @@
 {{ govukFooter({
   "classes": "app-footer",
   "containerClasses" : "app-width-container",
-  "navigation": [
-    {
-      "title": "Related resources",
-      "columns": 1,
-      "items": [
-        {
-          "href": "https://www.gov.uk/guidance/government-design-principles",
-          "text": "Government Design Principles"
-        },
-        {
-          "href": "https://www.gov.uk/service-manual",
-          "text": "GOV.UK Service Manual"
-        }
-      ]
-    }
-  ],
   "meta": {
     "items": [
       {


### PR DESCRIPTION
Update homepage to link to recently published and updated pages.
- Adds link to accessibility strategy
- Updates link to new community landing page (and call-to-action)
- Moves related resources out of the footer and into the homepage (also add style guide and content design guidance)