### PR TITLE
Add comment on team page reminding editors to use em dashes

### DIFF
--- a/src/design-system-team.md.njk
+++ b/src/design-system-team.md.njk
@@ -3,6 +3,7 @@ title: GOV.UK Design System and Prototype team
 description: about the GOV.UK Design System and Prototype team and who works on them
 layout: layout-single-page-prose.njk
 ---
+{# The dashes between team member name and role are em dashes (–) not standard hyphens (-) #}
 
 # GOV.UK Design System and Prototype team
 


### PR DESCRIPTION
## What/Why
When updating the [team page](https://design-system.service.gov.uk/design-system-team/), the most common review comment is that editors don't use the longer em dash between the team member name and that same team member's role. This is an attempt to mitigate the likelihood of that mistake.