### PR TITLE
Remove unused Nunjucks global property

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -277,7 +277,6 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
     engineOptions: {
       path: views,
       globals: {
-        joinPaths: fileHelper.joinPaths,
         getFingerprint: fileHelper.getFingerprint
       }
     }


### PR DESCRIPTION
This line was added in #503, but it looks like the function `joinPaths` never actually made it into the merge, so this isn't referencing anything.