### PR TITLE
Use npm ci to install GitHub Actions dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install --no-optional
+        run: npm ci
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
In automated environments, it’s preferable to use `npm ci` over `npm install`.

It is ‘more strict than a regular install, which can help catch errors or inconsistencies’. Specifically, ‘[i]f dependencies in the package lock do not match those in `package.json`, `npm ci` will exit with an error, instead of updating the package lock.’ [1]

As far as I can tell, we do not have any optional dependencies, so I have also removed the `--no-optional` flag.

[1]: https://docs.npmjs.com/cli/v6/commands/npm-ci