### PR TITLE
Compress SVG and ICO files with gzip

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -43,7 +43,19 @@ http {
   gzip_proxied any;
   gunzip on;
   gzip_static always;
-  gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
+  gzip_types
+    application/javascript
+    application/json
+    application/x-javascript
+    application/xml
+    application/xml+rss
+    image/svg+xml
+    image/x-icon
+    text/css
+    text/javascript
+    text/js
+    text/plain
+    text/xml;
   gzip_vary on;
 
   # Yeah, like, networking stuff ¯\_(ツ)_/¯


### PR DESCRIPTION
[Running the Design System homepage through WebPageTest][1] flagged that we’re not currently compressing SVG or ICO files:

> FAILED - (17.7 KB, compressed = 2.3 KB - savings of 15.4 KB) - https://design-system.service.gov.uk/images/homepage-illustration.svg
> FAILED - (6.2 KB, compressed = 2.5 KB - savings of 3.7 KB) - https://design-system.service.gov.uk/assets/images/favicon.ico

We also have a number of SVGs on other pages – including the community page – where we’d see a benefit from enabling compression:

```
/patterns/check-a-service-is-suitable/check-a-service-is-suitable-new.svg
/images/homepage-illustration.svg
/community/images/dsday22-logo.svg
/community/images/discuss-and-give-feedback.svg
/community/images/propose-a-change-to-pages.svg
/community/images/share-your-examples-and-research.svg
/community/images/chat-with-us-on-slack.svg
/assets/images/govuk-mask-icon.svg
```

Other best practise guides for configuring gzip for nginx include both `image/svg+xml` and `image/x-icon` in the list of mime types to gzip.

Add them to our list of mime types so users can benefit from the extra compression. Sort the list and multi-line it so that it’s easier to read.

## Homepage
### Before

![Screenshot 2023-01-09 at 09 51 43](https://user-images.githubusercontent.com/121939/211282462-6f9cb704-4da6-43fc-bc69-f57928880d21.png)

### After

![Screenshot 2023-01-09 at 09 52 11](https://user-images.githubusercontent.com/121939/211282469-ef50bb33-932c-46aa-a89d-a5720cf86b53.png)

## Community page

### Before

![Screenshot 2023-01-09 at 09 55 02](https://user-images.githubusercontent.com/121939/211282473-1ae55a40-0bdc-40ca-a712-6f98998e7f75.png)

### After

![Screenshot 2023-01-09 at 09 55 39](https://user-images.githubusercontent.com/121939/211282456-30d9bf4c-5af1-4ae2-8b31-c1ac5763a7f3.png)

[1]: https://www.webpagetest.org/result/230106_BiDc3X_9B5/3/performance_optimization/