### PR TITLE
Include 'Get started' and 'Community' pages in search

### DIFF
--- a/config/navigation.js
+++ b/config/navigation.js
@@ -1,7 +1,8 @@
 module.exports = [
   {
     label: 'Get started',
-    url: 'get-started'
+    url: 'get-started',
+    includeInSearch: true
   },
   {
     label: 'Styles',
@@ -20,6 +21,7 @@ module.exports = [
   },
   {
     label: 'Community',
-    url: 'community'
+    url: 'community',
+    includeInSearch: true
   }
 ]

--- a/src/community/upcoming-components-patterns/index.md
+++ b/src/community/upcoming-components-patterns/index.md
@@ -2,6 +2,7 @@
 title: Upcoming components and patterns
 description: Anyone can propose, develop or contribute to new patterns and components, or improvements to existing ones.
 section: Community
+aliases: exit this page, maps, task list, autocomplete, choosing a date, navigation
 theme: What we’re working on
 layout: layout-pane.njk
 order: 1


### PR DESCRIPTION
## What
1. Include all sections of the website in site search
2. Add aliases for upcoming work to the [Upcoming components and patterns](http://localhost:3000/community/upcoming-components-patterns/) page so searches for things on our roadmap will lead to that page

## Why
So that users looking for information on upcoming work have an easier experience finding out about this work.