### PR TITLE
Fix links to renamed files 

### DIFF
--- a/docs/contributing/archiving-deleted-urls.md
+++ b/docs/contributing/archiving-deleted-urls.md
@@ -3,7 +3,7 @@ When removing or renaming a page or folder previously associated with a URL rout
 
 For example:
 
-Renaming `community/juggling.md.njk` to `community/circus-performance.md.njk` means that the URL **design-system.service.gov.uk/community/juggling/** no longer exists. You need to provide a redirect to the correct URL.
+Renaming `community/juggling.md` to `community/circus-performance.md` means that the URL **design-system.service.gov.uk/community/juggling/** no longer exists. You need to provide a redirect to the correct URL.
 
 The archive page is a content page that is not indexed by search engines and typically doesn't appear in our sitemap. It will give a brief explanation to users that:
 
@@ -27,7 +27,7 @@ The team has chosen to do this instead of explicitly redirecting pages using 301
 ## How to create an archived page
 Along with the pull request to delete or rename the URL you want to change, you will need to do the following:
 
-1. If the URL being archived is from a folder with an `index.md.njk` file, you will need to replace the folder with a `.md.njk file` of the same name - for example `/juggling/index.md.njk` becomes `juggling.md.njk`.
+1. If the URL being archived is from a folder with an `index.md` file, you will need to replace the folder with a `.md file` of the same name - for example `/juggling/index.md` becomes `juggling.md`.
 2. In the file you want to archive, keep it in the same location, but replace the contents with the following code:
 
 

--- a/src/community/blogs-talks-podcasts/index.md
+++ b/src/community/blogs-talks-podcasts/index.md
@@ -87,7 +87,7 @@ Find out how our community works and how to be a part of it.
 
 ## Add a link to this page
 
-To help us make this page better, you can [propose to add a link](https://github.com/alphagov/govuk-design-system/edit/main/src/community/blogs-talks-podcasts/index.md.njk) that you’ve created or think would be useful to the community. Links need to meet the [GOV.UK external link policy](https://www.gov.uk/guidance/content-design/links) and the Design System [community principles](/community/#community-principles).
+To help us make this page better, you can [propose to add a link](https://github.com/alphagov/govuk-design-system/edit/main/src/community/blogs-talks-podcasts/index.md) that you’ve created or think would be useful to the community. Links need to meet the [GOV.UK external link policy](https://www.gov.uk/guidance/content-design/links) and the Design System [community principles](/community/#community-principles).
 
 Before we publish a new link, we’ll make sure that:
 

--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -107,6 +107,6 @@ You can download GOV.UK Frontend Nunjucks macro snippets for:
 
 ## Help improve this page
 
-To help make sure that this page is useful, relevant and up to date, you can [propose a change](https://github.com/alphagov/govuk-design-system/edit/main/src/community/resources-and-tools/index.md.njk) – read more about [how to propose changes in GitHub](/community/propose-a-content-change-using-github/).
+To help make sure that this page is useful, relevant and up to date, you can [propose a change](https://github.com/alphagov/govuk-design-system/edit/main/src/community/resources-and-tools/index.md) – read more about [how to propose changes in GitHub](/community/propose-a-content-change-using-github/).
 
 If you want to submit a resource or tool, check that it meets the [contribution criteria for resources](/community/contribution-criteria/#developing-a-community-resource-or-tool) first.

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -1,4 +1,4 @@
-{%- set fileEditURL = "https://github.com/alphagov/govuk-design-system/edit/main/src/" + path + "/index.md.njk" -%}
+{%- set fileEditURL = "https://github.com/alphagov/govuk-design-system/edit/main/src/" + path + "/index.md" -%}
 {% if section === 'Styles' or section === 'Components' or section === 'Patterns'%}
   <h2 class="govuk-heading-l govuk-!-padding-top-7" id="help-improve-this-page">Help improve this {{ section.slice(0, -1) | lower }}</h2>
 


### PR DESCRIPTION
In #2519 we changed the file extensions for documentation pages from `.md.njk` to `.md`—however links to where these files were hosted on GitHub were not updated, leading to 404s. 

This PR fixes those broken links by removing the `.njk` part of the URL.

Additionally it updates our contributor documentation on archiving pages to use the new file extension format.