### PR TITLE
Add GOV.UK Frontend Flask community resource

### DIFF
--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -74,8 +74,7 @@ GOV.UK Frontend Jinja Macros.
 [GOV.UK Frontend WTForms](https://github.com/LandRegistry/govuk-frontend-wtf) -
 GOV.UK Frontend WTForms Widgets.
 
-[GOV.UK Frontend Flask](https://github.com/LandRegistry/govuk-frontend-flask) -
-Template Flask application using GOV.UK Frontend that implements the Jinja and WTForms packages above.
+[GOV.UK Frontend Flask](https://github.com/LandRegistry/govuk-frontend-flask) - Complete Flask app template that implements the Jinja and WTForms packages to integrate with GOV.UK Frontend.
 
 ### R
 

--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -74,6 +74,9 @@ GOV.UK Frontend Jinja Macros.
 [GOV.UK Frontend WTForms](https://github.com/LandRegistry/govuk-frontend-wtf) -
 GOV.UK Frontend WTForms Widgets.
 
+[GOV.UK Frontend Flask](https://github.com/LandRegistry/govuk-frontend-flask) -
+Template Flask application using GOV.UK Frontend that implements the Jinja and WTForms packages above.
+
 ### R
 
 [Govdown](https://github.com/ukgovdatascience/govdown) -


### PR DESCRIPTION
Add the template repository for GOV.UK Frontend Flask to the design system community resources. GOV.UK Frontend Flask is a complete Flask app template that implements the two Python port packages to integrate with GOV.UK Frontend.

This template app will replace the two current "demo" apps for the Jinja and WTForms packages respectively, serving as both the reference implementation of those packages and a best practice Flask app with sensible defaults to build upon.