### PR TITLE
Fix broken links to task list code on the Prototype Kit repo

### DIFF
--- a/src/patterns/task-list-pages/index.md
+++ b/src/patterns/task-list-pages/index.md
@@ -22,8 +22,8 @@ Task list pages help users understand:
 
 There’s a [coded example of a task list page](https://prototype-kit.service.gov.uk/docs/templates/task-list) in the GOV.UK Prototype Kit. To use the example, get the following code from the Prototype Kit repository on GitHub:
 
-- [HTML from the task list page's HTML file](https://github.com/alphagov/govuk-prototype-kit/blob/main/docs/views/templates/task-list.html#L18)
-- [custom styles from the task list page's SCSS file](https://github.com/alphagov/govuk-prototype-kit/blob/main/app/assets/sass/patterns/_task-list.scss)
+- [HTML from the task list page's HTML file](https://github.com/alphagov/govuk-prototype-kit/blob/main/lib/nunjucks/templates/task-list.html)
+- [custom styles from the task list page's SCSS file](https://github.com/alphagov/govuk-prototype-kit/blob/main/lib/assets/sass/patterns/_task-list.scss)
 
 ## When to use this pattern
 


### PR DESCRIPTION
These got flagged on support - looks like a result of the changes for v13 of the Kit.