### PR TITLE
Write to `sitemap.xml` + `modernizr.js` using metalsmith

### DIFF
--- a/lib/generate-sitemap.js
+++ b/lib/generate-sitemap.js
@@ -1,7 +1,4 @@
 const sm = require('sitemap')
-const path = require('path')
-const paths = require('./paths.js')
-const { writeFile } = require('fs')
 const match = require('multimatch')
 
 // Only include keys that have values
@@ -16,19 +13,17 @@ const removeEmptyKeys = (obj) => {
 }
 
 /**
- * Plugin to generate a sitemap with sitemap.js
+ * Plugin to generate a sitemap
  *
- * @param {Object} options
- *  @property {String} hostname
- *  @property {String} changefreq (optional)
- *  @property {Date}   lastmod (optional)
- *  @property {String} priority (optional)
- *  @property {String} destination (optional)
- *  @property {String} filename (optional)
- *  @property {String} pattern (optional)
- * @return {Function}
+ * @param {object} opts - Sitemap options
+ * @param {string} opts.hostname
+ * @param {string} [opts.changefreq]
+ * @param {string} [opts.lastmod]
+ * @param {string} [opts.priority]
+ * @param {string} [opts.filename]
+ * @param {string} [opts.pattern]
+ * @returns {import('metalsmith').Plugin} Metalsmith plugin
  */
-
 const plugin = (opts) => {
   opts = opts || {}
 
@@ -43,7 +38,6 @@ const plugin = (opts) => {
   const priority = opts.priority
 
   // additional options
-  const destination = opts.destination || paths.public
   const filename = opts.filename || 'sitemap.xml'
   const pattern = opts.pattern || '**/*.html'
 
@@ -95,8 +89,12 @@ const plugin = (opts) => {
       sitemap.add(removeEmptyKeys(sitemapEntry))
     })
 
-    // create a sitemap
-    writeFile(path.join(destination, filename), sitemap.toString(), done)
+    // Add Metalsmith file
+    files[filename] = {
+      contents: Buffer.from(sitemap.toString())
+    }
+
+    done()
   }
 }
 module.exports = plugin

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -214,7 +214,8 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
       path.normalize('javascripts/application.js'),
       path.normalize('javascripts/head-ie8.js'),
       path.normalize('javascripts/govuk-frontend.js'),
-      path.normalize('javascripts/example.js')
+      path.normalize('javascripts/example.js'),
+      path.normalize('javascripts/vendor/modernizr.js')
     ]
   }))
 

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -44,7 +44,16 @@ const views = [
 ]
 
 // static site generator
-module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of current working
+module.exports = metalsmith(path.resolve(__dirname, '../'))
+
+  // source directory
+  .source(paths.source)
+
+  // destination directory
+  .destination(paths.public)
+
+  // clean destination before build
+  .clean(true)
 
   // global variables used in layout files
   .metadata({
@@ -65,17 +74,8 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
 // extract page headings
   .use(extractPageHeadings())
 
-  // source directory
-  .source(path.join('../', paths.source))
-
   // Ignore internal config
   .ignore('.eslintrc.js')
-
-  // destination directory
-  .destination(path.join('../', paths.public))
-
-  // clean destination before build
-  .clean(true)
 
   // include environment variables as metalsmith metadata
   // used to e.g. detect when we're building in a preview environment
@@ -284,7 +284,7 @@ module.exports = metalsmith(__dirname) // __dirname defined by node.js: name of 
   // apply layouts to source files
   .use(layouts({
     default: 'layout.njk',
-    directory: path.join('../', paths.layouts),
+    directory: paths.layouts,
     pattern: '**/*.html',
     engineOptions: {
       path: views,

--- a/lib/modernizr-build.js
+++ b/lib/modernizr-build.js
@@ -1,28 +1,28 @@
 const modernizr = require('modernizr')
-const { mkdir, writeFile } = require('fs')
-const { dirname, join } = require('path')
-const paths = require('./paths.js')
+const { join } = require('path')
 
 /**
  * Metalsmith plugin to create a custom modernizr build
  *
- * @return {Function}
+ * @param {object} opts - Sitemap options
+ * @param {string} opts.config - Path to modernizr config
+ * @param {string} opts.destination - Destination directory
+ * @param {string} opts.filename - Destination filename
+ * @returns {import('metalsmith').Plugin} Metalsmith plugin
  */
-
 const plugin = (opts) => {
   opts = opts || {}
   const buildConfig = require(opts.config)
   return function (files, metalsmith, done) {
     modernizr.build(buildConfig, (content) => {
-      const filePath = join(paths.public, opts.destination, opts.filename)
+      const filePath = join(opts.destination, opts.filename)
 
-      // Ensures that the directory exists. If the directory structure does not exist, it is created. Like mkdir -p.
-      mkdir(dirname(filePath), { recursive: true }, err => {
-        if (err) {
-          return console.log('Failed to create directories for modernizr build', err)
-        }
-        writeFile(filePath, content, done)
-      })
+      // Add Metalsmith file
+      files[filePath] = {
+        contents: Buffer.from(content)
+      }
+
+      done()
     })
   }
 }

--- a/src/styles/page-template/block-areas/index.njk
+++ b/src/styles/page-template/block-areas/index.njk
@@ -19,7 +19,7 @@ stylesheets:
     <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all">
     <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
-  <script src="/javascripts/vendor/modernizr.js"></script>
+  <script src="{{ getFingerprint('javascripts/vendor/modernizr.js') }}"></script>
   {% for stylesheet in stylesheets %}
     <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all">
   {%- endfor %}

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -42,7 +42,7 @@ ignore_in_sitemap: true
     <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all">
     <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
-  <script src="/javascripts/vendor/modernizr.js"></script>
+  <script src="{{ getFingerprint('javascripts/vendor/modernizr.js') }}"></script>
 {% endblock %}
 
 {% block bodyStart %}

--- a/src/styles/page-template/default/index.njk
+++ b/src/styles/page-template/default/index.njk
@@ -13,7 +13,7 @@ layout: false
     <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all">
     <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
-  <script src="/javascripts/vendor/modernizr.js"></script>
+  <script src="{{ getFingerprint('javascripts/vendor/modernizr.js') }}"></script>
 {% endblock %}
 
 {% block content %}

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -20,7 +20,7 @@
   <!--[if !IE 8]><!-->
     <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
   <!--<![endif]-->
-  <script src="/javascripts/vendor/modernizr.js"></script>
+  <script src="{{ getFingerprint('javascripts/vendor/modernizr.js') }}"></script>
 {% endblock %}
 
 {% block bodyStart %}

--- a/views/layouts/layout-example-full-page-govuk.njk
+++ b/views/layouts/layout-example-full-page-govuk.njk
@@ -13,7 +13,7 @@
   <!--[if lt IE 9]>
     <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
-  <script src="/javascripts/vendor/modernizr.js"></script>
+  <script src="{{ getFingerprint('javascripts/vendor/modernizr.js') }}"></script>
 {% endblock %}
 
 {% block header %}

--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -13,7 +13,7 @@
   <!--[if lt IE 9]>
     <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
-  <script src="/javascripts/vendor/modernizr.js"></script>
+  <script src="{{ getFingerprint('javascripts/vendor/modernizr.js') }}"></script>
 {% endblock %}
 
 {% block header %}

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -21,7 +21,7 @@
   <!--[if lt IE 9]>
     <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
-  <script src="/javascripts/vendor/modernizr.js"></script>
+  <script src="{{ getFingerprint('javascripts/vendor/modernizr.js') }}"></script>
 {% endblock %}
 
 {# Example pages shouldn't have a skip link or header, so blank the one provided by the template #}


### PR DESCRIPTION
This PR fixes a few issues split out from:

* https://github.com/alphagov/govuk-design-system/pull/2497

Including:

1. Write to `sitemap.xml` using metalsmith
2. Write to `modernizr.js` using metalsmith
3. Add `modernizr.js` fingerprint hashing

These changes replace `mkdir()` + `writeFile()` combos and enables asset fingerprinting as needed