### PR TITLE
Prevent duplicate checks on GitHub Actions "Test" workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,8 @@ on:
         required: false
         type: boolean
 
+  workflow_dispatch:
+
 jobs:
   build:
     name: Build & Test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,12 @@ name: Test
 
 on:
   pull_request:
+
   push:
-    branches-ignore:
-      - main  # pushes to main are handled by deploy.yaml
+    branches:
+      - 'feature/**'
+      - 'v[0-9]'
+
   workflow_call:
     inputs:
       upload-artifact:


### PR DESCRIPTION
Checks on PRs are currently running twice on every push:

* 1x on `pull_request` event
* 1x on `push` event

This PR ensures we only run checks once on PRs (keeping pushes to branches with protection rules)

But also adds `workflow_dispatch` for manual runs as we do on [`govuk-frontend`](https://github.com/alphagov/govuk-frontend)