### PR TITLE
Fix issue with Rollup `config.input` in watch mode

### DIFF
--- a/lib/rollup/index.js
+++ b/lib/rollup/index.js
@@ -13,13 +13,11 @@ const plugin = (config) => async (files, metalsmith, done) => {
   const file = normalize(config.input)
   const map = `${file}.map`
 
-  // Resolve paths from Metalsmith source
-  config.input = resolve(metalsmith.source(), file)
-  config.output.file = resolve(metalsmith.destination(), file)
-
   try {
     // Create Rollup bundle
-    const bundle = await rollup(config)
+    const bundle = await rollup({
+      ...config, input: resolve(metalsmith.source(), file)
+    })
 
     // Configure source maps
     if (config.output.sourcemap) {


### PR DESCRIPTION
This resolves `npm start` (BrowserSync watch + rebuild) overwriting source files during development

## The issue
Our Rollup plugin replaces [`config.input`](https://rollupjs.org/configuration-options/#input) (relative) with an absolute path:

```mjs
config.input = resolve(metalsmith.source(), file)
```

This means Rollup can correctly find our source input but it has some side effects:

**On initial build:** Metalsmith resolves config `file` path (relative) to `metalsmith.destination()`
**On watch + rebuild:** Metalsmith uses overwritten `file` path (absolute) to `metalsmith.source()`

## The fix
Don't overwrite `config.input` and always use child paths for [Metalsmith `Files`](https://metalsmith.io/api/#Files)