### PR TITLE
Fix various code highlighting issues

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -106,7 +106,9 @@ exports.getHTMLCode = path => {
     // Ensure nested labels in headings are indented properly
     inline: options.inline.filter((tag) => !['label'].includes(tag)),
     // Remove blank lines
-    max_preserve_newlines: 0
+    max_preserve_newlines: 0,
+    // Ensure attribute wrapping in header SVG is preserved
+    wrap_attributes: 'preserve'
   })
 }
 

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -8,7 +8,7 @@ const nunjucks = require('nunjucks')
 const matter = require('gray-matter')
 const slash = require('slash')
 
-const beautify = require('js-beautify').html
+const beautify = require('js-beautify')
 
 nunjucks.configure(paths.layouts)
 
@@ -90,22 +90,23 @@ exports.getHTMLCode = path => {
   const parsedFile = matter(fileContents)
   const content = parsedFile.content
 
-  let html
+  let html = ''
   try {
-    html = nunjucks.renderString(content)
+    html = nunjucks.renderString(content).trim()
   } catch (err) {
     if (err) {
       console.log('Could not get HTML code from ' + path)
     }
   }
 
-  return beautify(html.trim(), {
+  const options = beautify.html.defaultOptions()
+
+  return beautify.html(html, {
     indent_size: 2,
+    // Ensure nested labels in headings are indented properly
+    inline: options.inline.filter((tag) => !['label'].includes(tag)),
     // Remove blank lines
-    max_preserve_newlines: 0,
-    // set unformatted to a small group of elements, not all inline (the default)
-    // otherwise tags like label arent indented properly
-    unformatted: ['code', 'pre', 'em', 'strong']
+    max_preserve_newlines: 0
   })
 }
 

--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -8,8 +8,7 @@ const hljs = require('highlight.js')
  * @returns {string} Code with syntax highlighting
  */
 function highlight (code, language) {
-  const languages = language ? [language] : ['plaintext']
-  return hljs.highlightAuto(code.trim(), languages).value
+  return hljs.highlight(code.trim(), { language: language || 'plaintext' }).value
 }
 
 module.exports = highlight

--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -1,6 +1,15 @@
-const highlightjs = require('highlight.js')
+const hljs = require('highlight.js')
 
-module.exports = (code, language) => {
-  const languages = language ? [language] : false
-  return highlightjs.highlightAuto(code.trim(), languages).value
+/**
+ * Format code with syntax highlighting
+ *
+ * @param {string} code - Code in plain text
+ * @param {string} [language] - Code programming language
+ * @returns {string} Code with syntax highlighting
+ */
+function highlight (code, language) {
+  const languages = language ? [language] : ['plaintext']
+  return hljs.highlightAuto(code.trim(), languages).value
 }
+
+module.exports = highlight


### PR DESCRIPTION
This PR fixes various bugs and issues spotted with our code blocks

## Fix `highlight.js` crash without code language

In commit https://github.com/alphagov/govuk-design-system/pull/2427/commits/1a615e755cda063d4fbf5598d3140fed81cee230 (via PR https://github.com/alphagov/govuk-design-system/pull/2427) we had to remove new lines to fix Markdown parsing. Turns out part of the issue was a default language not being set for code blocks.

## Fix `highlight.js` code detection for HTML in Nunjucks

The Accordion example “with summary section” was failing JavaScript detection and lacked code syntax highlighting. We no longer use `highlightAuto()` but instead tell `highlight.js` exactly what language to use

<img width="793" alt="Highlighting off" src="https://user-images.githubusercontent.com/415517/215444977-a5836bda-212b-4580-8fee-4151cf19d1aa.png">

## Fix HTML code `<label>` indentation nested in headings

Removes `<label>` from the “inline” HTML list as the [previous “unformatted” fix](https://github.com/alphagov/govuk-design-system/commit/819a94e0783a24368f4b94f73c665e72140043f3) appears to have stopped working

<img width="737" alt="Label not wrapping" src="https://user-images.githubusercontent.com/415517/215445423-f09efc65-9294-48ee-a986-1a951bcfc506.png">

## Fix HTML code attribute wrapping

In the Header component we intentionally wrap SVG attributes for readability, we should preserve these if already expanded. This is an option available with `beautify-js`

<img width="792" alt="Attribute wrapping preserved" src="https://user-images.githubusercontent.com/415517/215445850-49278c74-3e35-4ef8-9e6d-0d323a9fe6bd.png">

## Add Nunjucks code highlighting on “Updating your code” page

We hadn't set a code language for the Nunjucks examples
https://design-system.service.gov.uk/get-started/updating-your-code/

## Add Sass code highlighting on “Focus states” page

We hadn't set a code language for the Sass focus `@include` example
https://design-system.service.gov.uk/get-started/focus-states/