### PR TITLE
Enable text wrapping in markdown/plaintext code

### DIFF
--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -294,6 +294,12 @@ pre code {
   }
 }
 
+// Allow text to wrap
+pre .language-markdown,
+pre .language-plaintext {
+  white-space: pre-wrap;
+}
+
 .app-prose-scope {
   h1 {
     @extend %govuk-heading-xl;


### PR DESCRIPTION
This PR adds "text wrapping by default" for code languages:

1. Plain text
2. Markdown

Otherwise we have lots of horizontal scrolling

## Markdown example

<img width="738" alt="Markdown example with text wrapping" src="https://user-images.githubusercontent.com/415517/215461122-8532fe90-b889-4c0a-be5f-03d2c0d94e72.png">