### PR TITLE
Lint compiled HTML

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,10 +42,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
-
-      - name: Lint and test
+      - name: Build, lint and test
         run: npm test -- --color --maxWorkers=2
 
       # Share data between the build and deploy jobs so we don't need to run `npm run build` again on deploy

--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -82,6 +82,12 @@ module.exports = {
           type: { required: false }
         }
       },
+      // Allow h1 to have children. This is because we have status tags within
+      // the <h1>. There's an issue to fix this:
+      // https://github.com/alphagov/govuk-design-system/issues/2606
+      h1: {
+        permittedContent: ['div', 'label', 'span']
+      },
       // "frameborder" is required for IE8 support
       // https://github.com/alphagov/govuk-design-system/pull/116
       iframe: {

--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -45,7 +45,12 @@ module.exports = {
     //
     // Relax the rule to allow anything that is valid according to the
     // spec.
-    'valid-id': ['error', { relaxed: true }]
+    'valid-id': ['error', { relaxed: true }],
+
+    // Flags our back to top anchor (/views/layouts/_generic.njk#L27) for not
+    // having descriptive text. Automated accessibility testing doesn't flag,
+    // so turning this off until we review our navigation.
+    'wcag/h30': 'off'
   },
   elements: [
     'html5',

--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -11,7 +11,10 @@ module.exports = {
 
     // Allow for multiple buttons in the same form to have the same name
     // (as in the cookie banner examples)
-    'form-dup-name': ['error', { shared: ['radio', 'checkbox', 'submit'] }],
+    'form-dup-name': [
+      'error',
+      { shared: ['radio', 'checkbox', 'submit', 'button'] }
+    ],
 
     // Allow pattern attribute on input type="number"
     'input-attributes': 'off',

--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -1,0 +1,68 @@
+module.exports = {
+  extends: ['html-validate:recommended'],
+  rules: {
+    // We don't use boolean attributes consistently – buttons currently
+    // use disabled="disabled"
+    'attribute-boolean-style': 'off',
+
+    // Allow for multiple buttons in the same form to have the same name
+    // (as in the cookie banner examples)
+    'form-dup-name': ['error', { shared: ['radio', 'checkbox', 'submit'] }],
+
+    // Allow pattern attribute on input type="number"
+    'input-attributes': 'off',
+
+    // Allow for conditional comments (used in header for fallback png)
+    'no-conditional-comment': 'off',
+
+    // Allow inline styles for testing purposes
+    'no-inline-style': 'off',
+
+    // Allow for explicit roles on regions that have implict roles
+    // We do this to better support AT with older versions of IE that
+    // have partial support for HTML5 semantic elements
+    'no-redundant-role': 'off',
+
+    // More hassle than it's worth 👾
+    'no-trailing-whitespace': 'off',
+
+    // We still support creating `input type=button` with the button
+    // component, but you have to explicitly choose to use them over
+    // buttons
+    'prefer-button': 'off',
+
+    // Allow use of roles where there are native elements that would give
+    // us that role automatically, e.g. <section> instead of
+    // <div role="region">
+    //
+    // This is mainly needed for links styled as buttons, but we do this
+    // in the cookie banner and notification banner too
+    'prefer-native-element': 'off',
+
+    // HTML Validate is opinionated about IDs beginning with a letter and
+    // only containing letters, numbers, underscores and dashes – which is
+    // more restrictive than the spec allows.
+    //
+    // Relax the rule to allow anything that is valid according to the
+    // spec.
+    'valid-id': ['error', { relaxed: true }]
+  },
+  elements: [
+    'html5',
+    {
+    // Allow textarea autocomplete attribute to be street-address
+    // (html-validate only allows on/off in default rules)
+      textarea: {
+        attributes: {
+          autocomplete: { enum: ['on', 'off', 'street-address'] }
+        }
+      },
+      // Allow buttons to omit the type attribute (defaults to 'submit')
+      button: {
+        attributes: {
+          type: { required: false }
+        }
+      }
+    }
+  ]
+}

--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -85,6 +85,11 @@ module.exports = {
           type: { required: false }
         }
       },
+      // Horrible hack to allow nested form elements for 3 current instances:
+      // https://github.com/alphagov/govuk-design-system/issues/2609
+      form: {
+        permittedDescendants: [{}]
+      },
       // Allow h1 to have children. This is because we have status tags within
       // the <h1>. There's an issue to fix this:
       // https://github.com/alphagov/govuk-design-system/issues/2606

--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -51,10 +51,16 @@ module.exports = {
     // spec.
     'valid-id': ['error', { relaxed: true }],
 
-    // Flags our back to top anchor (/views/layouts/_generic.njk#L27) for not
+    // Flags our back to top anchor (views/layouts/_generic.njk#L27) for not
     // having descriptive text. Automated accessibility testing doesn't flag,
     // so turning this off until we review our navigation.
-    'wcag/h30': 'off'
+    'wcag/h30': 'off',
+
+    // Flags the form in views/layouts/layout-example.njk#L35 when the example
+    // code does not have a submit button. This is because we wrap our
+    // examples in <form> elements to disable browser validation:
+    // https://github.com/alphagov/govuk-design-system/pull/522
+    'wcag/h32': 'off'
   },
   elements: [
     'html5',

--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -96,6 +96,16 @@ module.exports = {
             deprecated: false
           }
         }
+      },
+      // We added a summary to fix an accessibility issue, though we could
+      // probably revisit.
+      // https://github.com/alphagov/govuk-design-system/pull/301
+      table: {
+        attributes: {
+          summary: {
+            deprecated: false
+          }
+        }
       }
     }
   ]

--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -16,6 +16,10 @@ module.exports = {
     // Allow pattern attribute on input type="number"
     'input-attributes': 'off',
 
+    // Flags most of our page titles because we append "- GOV.UK Design System"
+    // to all of them.
+    'long-title': 'off',
+
     // Allow for conditional comments (used in header for fallback png)
     'no-conditional-comment': 'off',
 

--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -50,8 +50,8 @@ module.exports = {
   elements: [
     'html5',
     {
-    // Allow textarea autocomplete attribute to be street-address
-    // (html-validate only allows on/off in default rules)
+      // Allow textarea autocomplete attribute to be street-address
+      // (html-validate only allows on/off in default rules)
       textarea: {
         attributes: {
           autocomplete: { enum: ['on', 'off', 'street-address'] }
@@ -61,6 +61,15 @@ module.exports = {
       button: {
         attributes: {
           type: { required: false }
+        }
+      },
+      // "frameborder" is required for IE8 support
+      // https://github.com/alphagov/govuk-design-system/pull/116
+      iframe: {
+        attributes: {
+          frameborder: {
+            deprecated: false
+          }
         }
       }
     }

--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -1,6 +1,10 @@
 module.exports = {
   extends: ['html-validate:recommended'],
   rules: {
+    // In some Nunjucks macro calls, we use single quotes for attributes since
+    // we wrap macro string properties in double quotes.
+    'attr-quotes': ['error', { style: 'any' }],
+
     // We don't use boolean attributes consistently – buttons currently
     // use disabled="disabled"
     'attribute-boolean-style': 'off',

--- a/.htmlvalidateignore
+++ b/.htmlvalidateignore
@@ -1,0 +1,1 @@
+deploy/public/components/*/*/index.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint-plugin-n": "^15.6.1",
         "eslint-plugin-promise": "^6.1.1",
         "glob": "^8.1.0",
+        "html-validate": "^7.13.2",
         "iframe-resizer": "3.5.15",
         "jest": "^29.4.3",
         "jest-axe": "^7.0.0",
@@ -811,6 +812,27 @@
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@html-validate/stylish": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-3.0.1.tgz",
+      "integrity": "sha512-jQNDrSnWvJEPSlqC1tFqcbmVuJy2x61UwqFsXHxYT2sgCXFW4AVhsoIcHkECCmUHtQ8hpHU6yOBGA+rMLZhS7A==",
+      "dev": true,
+      "dependencies": {
+        "kleur": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14.0"
+      }
+    },
+    "node_modules/@html-validate/stylish/node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2444,6 +2466,86 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "dev": true
+    },
+    "node_modules/@sidvind/better-ajv-errors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-2.1.0.tgz",
+      "integrity": "sha512-JuIb009FhHuL9priFBho2kv7QmZOydj0LgYvj+h1t0mMCmhM/YmQNRlJR5wVtBZya6wrVFK5Hi5TIbv5BKEx7w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "4.11.8 - 8"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.21",
@@ -6634,6 +6736,95 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/html-validate": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-7.13.2.tgz",
+      "integrity": "sha512-ZUinzQ/a9zC0vP3uoCAKhHWogkCCK8KXcl5gMd+d8esuCl+p5d8P4zL/qSuvhc+zJ3qiIFyDaZ/wyUE1A78vNA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.0",
+        "@html-validate/stylish": "^3.0.0",
+        "@sidvind/better-ajv-errors": "^2.0.0",
+        "acorn-walk": "^8.0.0",
+        "ajv": "^8.0.0",
+        "deepmerge": "^4.2.0",
+        "espree": "^9.0.0",
+        "glob": "^8.0.0",
+        "ignore": "^5.0.0",
+        "kleur": "^4.1.0",
+        "minimist": "^1.2.0",
+        "prompts": "^2.0.0",
+        "semver": "^7.0.0"
+      },
+      "bin": {
+        "html-validate": "bin/html-validate.js"
+      },
+      "engines": {
+        "node": ">= 14.0"
+      },
+      "peerDependencies": {
+        "jest": "^25.1 || ^26 || ^27.1 || ^28.1.3 || ^29.0.3",
+        "jest-diff": "^25.1 || ^26 || ^27.1 || ^28.1.3 || ^29.0.3",
+        "jest-snapshot": "^25.1 || ^26 || ^27.1 || ^28.1.3 || ^29.0.3"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        },
+        "jest-diff": {
+          "optional": true
+        },
+        "jest-snapshot": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/html-validate/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/html-validate/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/html-validate/node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/html-validate/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/html5shiv": {
@@ -16285,6 +16476,23 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "@html-validate/stylish": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-3.0.1.tgz",
+      "integrity": "sha512-jQNDrSnWvJEPSlqC1tFqcbmVuJy2x61UwqFsXHxYT2sgCXFW4AVhsoIcHkECCmUHtQ8hpHU6yOBGA+rMLZhS7A==",
+      "dev": true,
+      "requires": {
+        "kleur": "^4.0.0"
+      },
+      "dependencies": {
+        "kleur": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+          "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+          "dev": true
+        }
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -17542,6 +17750,61 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "dev": true
+    },
+    "@sidvind/better-ajv-errors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-2.1.0.tgz",
+      "integrity": "sha512-JuIb009FhHuL9priFBho2kv7QmZOydj0LgYvj+h1t0mMCmhM/YmQNRlJR5wVtBZya6wrVFK5Hi5TIbv5BKEx7w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.0",
+        "chalk": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "@sinclair/typebox": {
       "version": "0.25.21",
@@ -20596,6 +20859,62 @@
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
       "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
       "dev": true
+    },
+    "html-validate": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-7.13.2.tgz",
+      "integrity": "sha512-ZUinzQ/a9zC0vP3uoCAKhHWogkCCK8KXcl5gMd+d8esuCl+p5d8P4zL/qSuvhc+zJ3qiIFyDaZ/wyUE1A78vNA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.0",
+        "@html-validate/stylish": "^3.0.0",
+        "@sidvind/better-ajv-errors": "^2.0.0",
+        "acorn-walk": "^8.0.0",
+        "ajv": "^8.0.0",
+        "deepmerge": "^4.2.0",
+        "espree": "^9.0.0",
+        "glob": "^8.0.0",
+        "ignore": "^5.0.0",
+        "kleur": "^4.1.0",
+        "minimist": "^1.2.0",
+        "prompts": "^2.0.0",
+        "semver": "^7.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        },
+        "kleur": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+          "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "html5shiv": {
       "version": "3.7.3"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "build": "node tasks/build.js",
     "start": "node tasks/serve.js",
     "test": "npm run lint && jest",
-    "lint": "npm run lint:js && npm run lint:scss",
+    "lint": "npm run lint:js && npm run lint:scss && npm run lint:html",
+    "prelint:html": "npm run build",
+    "lint:html": "html-validate \"deploy/public/**/index.html\"",
     "lint:js": "eslint --cache --cache-location .cache/eslint --cache-strategy content --color --ignore-path .gitignore \"**/*.{cjs,js,mjs}\"",
     "lint:scss": "stylelint \"**/*.scss\""
   },
@@ -52,6 +54,7 @@
     "eslint-plugin-n": "^15.6.1",
     "eslint-plugin-promise": "^6.1.1",
     "glob": "^8.1.0",
+    "html-validate": "^7.13.2",
     "iframe-resizer": "3.5.15",
     "jest": "^29.4.3",
     "jest-axe": "^7.0.0",

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -115,12 +115,12 @@ We’ve also formed cross-government groups to co-design new additions to the De
 <div class="govuk-grid-row govuk-!-margin-bottom-8">
   <div class="govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
     <h3>Maps in services</h3>
-    <p>Help us explore best practices for the use of maps across the public sector so we can make them more accessible and consistent.<p>
+    <p>Help us explore best practices for the use of maps across the public sector so we can make them more accessible and consistent.</p>
     <p><a href="https://join.slack.com/t/mapsinservices/shared_invite/zt-163npa168-e5EREuQZU3NqwfdojWw2ew">Join the Maps Slack group</a>.</p>
   </div>
   <div class="govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
     <h3>Task list component</h3>
-    <p>Share your experience, research and skills to help us reiterate the Task list pages pattern into a component.<p>
+    <p>Share your experience, research and skills to help us reiterate the Task list pages pattern into a component.</p>
     <p><a href="https://join.slack.com/t/task-list-collab/shared_invite/zt-1gfbxa78k-Ql8885Iuan17w5v26F6yVQ">Join the Task list Slack group</a>.</p>
   </div>
 </div>

--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -7,6 +7,8 @@ backlog_issue_id: 96
 layout: layout-pane.njk
 ---
 
+<!-- [html-validate-disable no-dup-id -- See https://github.com/alphagov/govuk-design-system/issues/2260] -->
+
 {% from "_example.njk" import example %}
 
 The footer provides copyright, licensing and other information about your service.
@@ -56,3 +58,5 @@ Only add secondary GOV.UK navigation if you’re creating a GOV.UK service, and 
 ### Footer with links and secondary navigation
 
 {{ example({group: "components", item: "footer", example: "full", html: true, nunjucks: true, open: false, size: "xl"}) }}
+
+<!-- [html-validate-enable no-dup-id] -->

--- a/src/cookies.njk
+++ b/src/cookies.njk
@@ -22,7 +22,7 @@ layout: layout-single-page.njk
         html: successNotificationBannerHtml,
         classes: "js-cookies-page-success",
         attributes: {
-          hidden: true
+          hidden: ""
         }
       }) }}
 
@@ -118,7 +118,7 @@ layout: layout-single-page.njk
             classes: "js-cookies-page-form-fieldset",
             attributes: {
               id: "analytics",
-              hidden: true
+              hidden: ""
             }
           },
           items: [
@@ -137,7 +137,7 @@ layout: layout-single-page.njk
           text: 'Save cookie settings',
           classes: "js-cookies-form-button",
           attributes: {
-            hidden: true
+            hidden: ""
           }
         }) }}
       </form>

--- a/src/get-started/labels-legends-headings/legend-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/legend-m-s/index.njk
@@ -6,7 +6,7 @@ layout: layout-example.njk
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukCheckboxes({
-  name: "checkbox",
+  name: "checkbox-1",
   fieldset: {
     legend: {
       text: "govuk-fieldset__legend--m",

--- a/src/patterns/confirm-a-phone-number/index.md
+++ b/src/patterns/confirm-a-phone-number/index.md
@@ -42,7 +42,7 @@ After saving the user’s password and mobile phone number, verify their mobile 
 
 Then ask the user to enter this code:
 
-{{ example({group: "patterns", item: "confirm-a-phone-number", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({group: "patterns", item: "confirm-a-phone-number", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false}) }}
 
 Let the user enter the code in whatever format is familiar to them. Allow additional spaces, hyphens and dashes.
 

--- a/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
+++ b/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
@@ -17,7 +17,7 @@ layout: layout-example-full-page.njk
       We have not saved your answers. When the service is available, you will have to start again.
     </p>
     <p class="govuk-body">
-      <a class ="govuk-link" href="#">Contact the Tax Credits Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
+      <a class="govuk-link" href="#">Contact the Tax Credits Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
     </p>
   </div>
 </div>

--- a/src/patterns/service-unavailable-pages/default/index.njk
+++ b/src/patterns/service-unavailable-pages/default/index.njk
@@ -14,7 +14,7 @@ layout: layout-example-full-page.njk
         You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.
       </p>
       <p class="govuk-body">
-        <a class ="govuk-link" href="#">Contact the Tax Credits Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
+        <a class="govuk-link" href="#">Contact the Tax Credits Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
       </p>
     </div>
   </div>

--- a/src/styles/colour/index.md
+++ b/src/styles/colour/index.md
@@ -82,7 +82,7 @@ You can find departmental colours in the GOV.UK Frontend [_colours-organisations
   <tbody>
   {% for name, colour in colours.palette %}
     <tr class="app-colour-list-row">
-      <th class="app-colour-list-column app-colour-list-column--name">
+      <th class="app-colour-list-column app-colour-list-column--name" scope="row">
         <span class="app-swatch {% if colour == "#ffffff" %}app-swatch-border{% endif %}" style="background-color:{{colour}}"></span>
         <code>govuk-colour("{{name}}")</code>
       </th>

--- a/src/styles/page-template/index.md
+++ b/src/styles/page-template/index.md
@@ -56,7 +56,7 @@ To set a 'variable' option, use `set` to pass in a single value or string. For e
 
 By default, the template contains a [skip link](/components/skip-link/), [header](/components/header/) and [footer](/components/footer/), all of which require 'blocks' to change.
 
-To set a 'block' option, use `block` to pass in a multiline value or HTML markup. For example, to add a block of HTML before the closing </body> element in the page template using the `bodyEnd` option:
+To set a 'block' option, use `block` to pass in a multiline value or HTML markup. For example, to add a block of HTML before the closing `</body>` element in the page template using the `bodyEnd` option:
 
 ```javascript
 {% raw %}

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -12,13 +12,13 @@
   <meta name="og:title" content="{{title}}">
   <meta name="description" content="{{description}}">
   <meta name="og:description" content="{{description}}">
-  <link rel="canonical" href="{{ canonical }}" />
+  <link rel="canonical" href="{{ canonical }}">
   <!--[if lt IE 9]>
-    <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint('stylesheets/main-ie8.css') }}" rel="stylesheet" media="all">
     <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>
   <![endif]-->
   <!--[if !IE 8]><!-->
-    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all">
   <!--<![endif]-->
   <script src="{{ getFingerprint('javascripts/vendor/modernizr.js') }}"></script>
 {% endblock %}

--- a/views/layouts/layout-example-full-page-govuk.njk
+++ b/views/layouts/layout-example-full-page-govuk.njk
@@ -5,10 +5,10 @@
 {% block pageTitle %}{{ title }} – Example – GOV.UK Design System{% endblock %}
 {% block head %}
   <meta name="robots" content="noindex, nofollow">
-  <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
+  <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all">
   {#- Include any additional stylesheets specified in the example frontmatter #}
   {% for stylesheet in stylesheets %}
-  <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all" />
+  <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all">
   {%- endfor %}
   <!--[if lt IE 9]>
     <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>

--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -5,10 +5,10 @@
 {% block pageTitle %}{{ title }} – Example – GOV.UK Design System{% endblock %}
 {% block head %}
   <meta name="robots" content="noindex, nofollow">
-  <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
+  <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all">
   {#- Include any additional stylesheets specified in the example frontmatter #}
   {% for stylesheet in stylesheets %}
-  <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all" />
+  <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all">
   {%- endfor %}
   <!--[if lt IE 9]>
     <script src="{{ getFingerprint('javascripts/head-ie8.js') }}"></script>

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -10,12 +10,12 @@
   <meta name="og:title" content="{{title}}">
   <meta name="description" content="{{description}}">
   <meta name="og:description" content="{{description}}">
-  <link rel="canonical" href="{{ canonical }}" />
+  <link rel="canonical" href="{{ canonical }}">
 
-  <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all" />
+  <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all">
   {#- Include any additional stylesheets specified in the example frontmatter #}
   {% for stylesheet in stylesheets %}
-    <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all" />
+    <link href="{{ getFingerprint(stylesheet) }}" rel="stylesheet" media="all">
   {%- endfor %}
 
   <!--[if lt IE 9]>

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -37,7 +37,7 @@
           example in a new tab
         </a>
       </div>
-      <iframe title="{{ exampleTitle + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0" loading="lazy"></iframe>
+      <iframe title="{{ exampleTitle + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameborder="0" loading="lazy"></iframe>
     </div>
   {% endif %}
 

--- a/views/partials/_image-card.njk
+++ b/views/partials/_image-card.njk
@@ -1,7 +1,7 @@
 {% macro imageCard(params) %}
   <div class="app-image-card {{- ' app-image-card--large' if params.large }}">
     <figure class="app-image-card__image-wrapper">
-      <img src="{{ params.src }}" alt="{{ params.alt }}" class="app-image--no-border" loading="lazy" />
+      <img src="{{ params.src }}" alt="{{ params.alt }}" class="app-image--no-border" loading="lazy">
     </figure>
     <div class="app-image-card__text">
       <h3>{{ params.title }}</h3>

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -11,7 +11,7 @@
           <button hidden class="app-navigation__button js-app-navigation__button">
             {{ item.label }}
           </button>
-
+          <!-- [html-validate-disable-next aria-label-misuse --- inline fix for html-validate rule, rather than disable it entirely] -->
           <ul class="app-navigation__subnav js-app-navigation__subnav {% if permalink.startsWith(item.url) %}app-navigation__subnav--active{% endif %}"
             aria-label="{{ item.label }}"
             hidden


### PR DESCRIPTION
We currently have no built-in way of ensuring our compiled HTML changes in the way we expect, and doesn't break.

This PR adds HTML linting using `html-validate`. There are quite a few commits, but they're all really small, promise!

There are some issues to consider:

- I've ignored a coupla "WCAG techniques" type rules which we might want to review as part of our accessibility work ([495be15](https://github.com/alphagov/govuk-design-system/pull/2569/commits/4bc4910b110dfe170bbce3d66f02037d47a451c1) and [d1dea99](https://github.com/alphagov/govuk-design-system/pull/2569/commits/d1dea99330909005c43473a4521434f8e70ef0b6))
- I've tried to avoid inline validation as far as possible, but sometimes this was the most targetted way
- We currently have status labels contained within `<h1>` tags, which introduces invalid child elements. See #2606 
- I've popped in a temporary inline fix for #2260 until that's fixed
- I've allowed nested forms for the few cases where that's an issue: #2609. Chrome, at least, simply rips out the inner `<form>` elements, but it's still messy
