### PR TITLE
Update What's new for v4.5.0

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -37,7 +37,7 @@ The GOV.UK Design System helps service teams follow the <a class="govuk-link" hr
         </p>
 
       <p class="govuk-body">
-<a class="govuk-link" href="/community/accessibility-strategy/">Our accessiblity strategy</a> outlines our principles and work to improve accessibility within the GOV.UK Design System.</p>
+<a class="govuk-link" href="/community/accessibility-strategy/">Our accessibility strategy</a> outlines our principles and work to improve accessibility within the GOV.UK Design System.</p>
       </div>
 
       <div class="govuk-grid-column-full">

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -7,7 +7,7 @@
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
         <p class="govuk-body">
-          31 January 2023: We’ve released GOV.UK Frontend v4.5.0. With this feature release you can now use summary cards to organise multiple summary lists, search content within an accordion (on supporting browsers) and use source maps for precompiled files.
+          31 January 2023: We’ve released GOV.UK Frontend v4.5.0. With this feature release you can now use summary cards to organise multiple summary lists, search content within an accordion (on supported browsers) and use source maps for precompiled files.
         </p>
         <p class="govuk-body"><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v4.5.0" class="govuk-link">Read the full release notes for more details</a>.</p>
         <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design System</a>.</p>

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -7,9 +7,9 @@
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
         <p class="govuk-body">
-          16 December 2022: We’ve released GOV.UK Frontend v4.4.1. This release fixes a WCAG-failing accessibility issue. It fixes focus styles for links not displaying correctly when split over multiple lines in Chromium 108+ (Chrome 108+, Edge 108+, Opera 94+)
+          31 January 2023: We’ve released GOV.UK Frontend v4.5.0. With this feature release you can now use summary cards to organise multiple summary lists, search content within an accordion (on supporting browsers) and use source maps for precompiled files.
         </p>
-        <p class="govuk-body"><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v4.4.1" class="govuk-link">Read the full release notes</a>.</p>
+        <p class="govuk-body"><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v4.5.0" class="govuk-link">Read the full release notes for more details</a>.</p>
         <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design System</a>.</p>
       </div>
     </div>


### PR DESCRIPTION
Update 'What's new' panel of the website homepage. Also fixes a typo in the link text to the accessibility strategy.