### PR TITLE
Add missing `[hidden]` styling on tabs for IE8-10 compatibility

### DIFF
--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -150,6 +150,10 @@
   @include govuk-media-query($from: desktop) {
     margin-top: -2px;
   }
+
+  &[hidden] {
+    display: none;
+  }
 }
 
 .app-tabs__container pre {


### PR DESCRIPTION
Fixes a minor regression from:

* https://github.com/alphagov/govuk-design-system/pull/2242