### PR TITLE
Use Markdown to render all code blocks

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -38,18 +38,10 @@ exports.getNunjucksCode = path => {
   // Omit any `{% extends "foo.njk" %}` nunjucks code, because we extend
   // templates that only exist within the Design System – it's not useful to
   // include this in the code we expect others to copy.
-  const content = parsedFile.content
-    .replace(
-      /{%\s*extends\s*\S*\s*%}\s+/,
-      ''
-    )
-    // Remove empty lines to avoid broken markdown rendering
-    .replace(
-      /^\s*[\r\n]/gm,
-      ''
-    )
-
-  return content
+  return parsedFile.content.replace(
+    /{%\s*extends\s*\S*\s*%}\s+/,
+    ''
+  )
 }
 
 // This helper function takes a path of a *.md.njk file and
@@ -109,15 +101,11 @@ exports.getHTMLCode = path => {
 
   return beautify(html.trim(), {
     indent_size: 2,
-    end_with_newline: false,
     // Remove blank lines
     max_preserve_newlines: 0,
     // set unformatted to a small group of elements, not all inline (the default)
     // otherwise tags like label arent indented properly
-    unformatted: ['code', 'pre', 'em', 'strong'],
-    // Ensure no empty lines after <head> and <body> tags - this breaks markdown
-    // rendering
-    extra_liners: []
+    unformatted: ['code', 'pre', 'em', 'strong']
   })
 }
 

--- a/lib/marked-renderer.js
+++ b/lib/marked-renderer.js
@@ -5,12 +5,17 @@ const { marked } = require('marked')
  */
 class DesignSystemRenderer extends marked.Renderer {
   /**
-   * Ensure code blocks can be focused and scrolled
-   * with the keyboard via `tabindex="0"`
+   * Assume HTML when no code block language provided
+   * (for example, HTML code inside Markdown)
    */
   code (code, language, isEscaped) {
-    return super.code(code, language, isEscaped)
-      .replace('<code', '<code tabindex="0"')
+    return !language
+      ? super.html(code)
+      : super.code(code, language, isEscaped)
+
+        // Ensure code blocks can be focused and scrolled
+        // with the keyboard via `tabindex="0"`
+        .replace('<code', '<code tabindex="0"')
   }
 
   /**

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -245,6 +245,7 @@ module.exports = metalsmith(path.resolve(__dirname, '../'))
 
   // render markdown in source files
   .use(markdown({
+    breaks: true, // Enable line breaks
     mangle: false, // Don't mangle emails
     smartypants: true, // use "smart" typographic punctuation
     highlight: highlighter,

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -60,7 +60,6 @@ const nunjucksOptions = {
   },
 
   filters: {
-    highlight: highlighter,
     slugger,
     kebabCase: (string) => {
       return string.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase()

--- a/src/get-started/focus-states/index.md
+++ b/src/get-started/focus-states/index.md
@@ -46,7 +46,7 @@ How you make focus states accessible depends on if the component is:
 
 If you use Sass, you should include the `govuk-focused-text` mixin in your component's `:focus` selector if that component is focusable text. For example, the component is a link in body text, or the details component:
 
-```
+```scss
 .app-component:focus {
   @include govuk-focused-text;
 }

--- a/src/get-started/updating-your-code/index.md
+++ b/src/get-started/updating-your-code/index.md
@@ -61,10 +61,15 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the skip link by rendering your own,
           which can include custom <code>text</code>
         </p>
-        <pre><code>{% raw %}
+
+```javascript
+{% raw %}
 {% block skipLink %}
   {{ govukSkipLink({ text: "custom text" }) }}
-{% endblock %}{% endraw %}</code></pre>
+{% endblock %}
+{% endraw %}
+```
+
         <p>
           See the <a class="govuk-link" href="/components/skip-link/">skip link component</a> for more details.
         </p>
@@ -83,10 +88,15 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the header component by rendering your own,
           which can include custom <code>classes</code>
         </p>
-        <pre><code>{% raw %}
+
+```javascript
+{% raw %}
 {% block header %}
-    {{ govukHeader({ classes: "app-custom-classes" }) }}
-{% endblock %}{% endraw %}</code></pre>
+  {{ govukHeader({ classes: "app-custom-classes" }) }}
+{% endblock %}
+{% endraw %}
+```
+
         <p>
           See the <a class="govuk-link" href="/components/header/">header component</a> for more details.
         </p>
@@ -99,10 +109,15 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the header component by rendering your own,
           which can include custom <code>homepageUrl</code>
         </p>
-        <pre><code>{% raw %}
+
+```javascript
+{% raw %}
 {% block header %}
-    {{ govukHeader({ homepageUrl: "/custom-url" }) }}
-{% endblock %}{% endraw %}</code></pre>
+  {{ govukHeader({ homepageUrl: "/custom-url" }) }}
+{% endblock %}
+{% endraw %}
+```
+
         <p>
           See the <a class="govuk-link" href="/components/header/">header component</a> for more details.
         </p>
@@ -121,10 +136,15 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the header component by rendering your own,
           which can include a custom <code>serviceName</code>
         </p>
-        <pre><code>{% raw %}
+
+```javascript
+{% raw %}
 {% block header %}
-    {{ govukHeader({ serviceName: "Custom service name" }) }}
-{% endblock %}{% endraw %}</code></pre>
+  {{ govukHeader({ serviceName: "Custom service name" }) }}
+{% endblock %}
+{% endraw %}
+```
+
         <p>
           See the <a class="govuk-link" href="/components/header/">header component</a> for more details.
         </p>
@@ -137,10 +157,15 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the header component by rendering your own,
           which can include a custom <code>navigation</code>
         </p>
-        <pre><code>{% raw %}
+
+```javascript
+{% raw %}
 {% block header %}
-    {{ govukHeader({ navigation: [] }) }}
-{% endblock %}{% endraw %}</code></pre>
+  {{ govukHeader({ navigation: [] }) }}
+{% endblock %}
+{% endraw %}
+```
+
         <p>
           See the <a class="govuk-link" href="/components/header/">header component</a> for more details.
         </p>
@@ -174,10 +199,15 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the footer component by rendering your own,
           which can include a custom <code>navigation</code>
         </p>
-        <pre><code>{% raw %}
+
+```javascript
+{% raw %}
 {% block header %}
-    {{ govukFooter({ navigation: [] }) }}
-{% endblock %}{% endraw %}</code></pre>
+  {{ govukFooter({ navigation: [] }) }}
+{% endblock %}
+{% endraw %}
+```
+
         <p>
           See the <a class="govuk-link" href="/components/footer/">footer component</a> for more details.
         </p>
@@ -190,10 +220,15 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           You can now entirely replace the footer component by rendering your own,
           which can include custom <code>meta</code> links
         </p>
-        <pre><code>{% raw %}
+
+```javascript
+{% raw %}
 {% block header %}
-    {{ govukFooter({ meta: [] }) }}
-{% endblock %}{% endraw %}</code></pre>
+  {{ govukFooter({ meta: [] }) }}
+{% endblock %}
+{% endraw %}
+```
+
         <p>
           See the <a class="govuk-link" href="/components/footer/">footer component</a> for more details.
         </p>

--- a/src/get-started/updating-your-code/index.md
+++ b/src/get-started/updating-your-code/index.md
@@ -202,7 +202,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
 
 ```javascript
 {% raw %}
-{% block header %}
+{% block footer %}
   {{ govukFooter({ navigation: [] }) }}
 {% endblock %}
 {% endraw %}
@@ -223,7 +223,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
 
 ```javascript
 {% raw %}
-{% block header %}
+{% block footer %}
   {{ govukFooter({ meta: [] }) }}
 {% endblock %}
 {% endraw %}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -65,9 +65,11 @@
     {% endif %}
     <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-html" role="tabpanel">
       <div class="app-example__code" data-module="app-copy">
-        <pre><code tabindex="0" class="hljs html">
-          {{- getHTMLCode(examplePath) | highlight('html') | safe -}}
-        </code></pre>
+
+```html
+{{ getHTMLCode(examplePath) | safe }}
+```
+
       </div>
     </div>
   {% endif %}
@@ -144,9 +146,11 @@
         })}}
       {% endif -%}
       <div class="app-example__code" data-module="app-copy">
-        <pre><code tabindex="0" class="hljs js">
-          {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
-        </code></pre>
+
+```javascript
+{{ getNunjucksCode(examplePath) | safe }}
+```
+
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
Line breaks in code blocks are back 🙌

All code blocks are now rendered in Markdown (not Nunjucks) to fix a rendering bug when line breaks are added.

<img width="788" alt="Code block showing how line breaks work again" src="https://user-images.githubusercontent.com/415517/215586337-f5ff325a-4c62-4f0a-b625-56d2b43c6f8b.png">