### PR TITLE
Prevent Browsersync full page reloads on `*.map` changes

### DIFF
--- a/lib/metalsmith-browser-sync.js
+++ b/lib/metalsmith-browser-sync.js
@@ -41,7 +41,7 @@ function browserSyncPlugin (userOptions, callback) {
     const watched = finalOptions.files
     delete finalOptions.files
 
-    bs.watch(watched, { ignoreInitial: true }).on('all', rebuild)
+    bs.watch(watched, { ignored: '*.map', ignoreInitial: true }).on('all', rebuild)
     bs.init(finalOptions, callback || undefined)
 
     done()


### PR DESCRIPTION
Source map files are never found on-page so Browsersync triggers a full page reload (quite slow)

Since their related CSS or JS files will also update, Browsersync will continue to reload as expected. This is also a side effect of Metalsmith "replacing all the files" on rebuild versus per-file incremental changes

**Update:** Full page reloads still happen for the `*.html` changes but not for every `*.map` too