### PR TITLE
Fix broken link in 'step by step navigation' page

### DIFF
--- a/src/patterns/step-by-step-navigation/index.md
+++ b/src/patterns/step-by-step-navigation/index.md
@@ -168,7 +168,7 @@ Visit the UK on a Standard Visitor visa
 **Department for Transport**<br>
 Get a Blue Badge
 
-See a full list of [live services using step by step navigation](https://govuk-formats.herokuapp.com/document-types/step-by-step-nav).
+See a full list of [live services using step by step navigation [Heroku]](https://govuk-formats.herokuapp.com/document-types/step-by-step-nav).
 
 ### Next steps
 

--- a/src/patterns/step-by-step-navigation/index.md
+++ b/src/patterns/step-by-step-navigation/index.md
@@ -168,7 +168,7 @@ Visit the UK on a Standard Visitor visa
 **Department for Transport**<br>
 Get a Blue Badge
 
-See a full list of [live services using step by step navigation](https://live-stuff.herokuapp.com/step-by-steps).
+See a full list of [live services using step by step navigation](https://govuk-formats.herokuapp.com/).
 
 ### Next steps
 

--- a/src/patterns/step-by-step-navigation/index.md
+++ b/src/patterns/step-by-step-navigation/index.md
@@ -168,7 +168,7 @@ Visit the UK on a Standard Visitor visa
 **Department for Transport**<br>
 Get a Blue Badge
 
-See a full list of [live services using step by step navigation](https://govuk-formats.herokuapp.com/).
+See a full list of [live services using step by step navigation](https://govuk-formats.herokuapp.com/document-types/step-by-step-nav).
 
 ### Next steps
 


### PR DESCRIPTION
There is a broken Heroku link in the 'Step by step navigation' pattern guidance. I've sourced a new version of the link, and recommend we swap it in.

## Related documentation
The broken link is in this section: https://design-system.service.gov.uk/patterns/step-by-step-navigation/#services-using-this-pattern

## Suggestion
Old link: https://live-stuff.herokuapp.com/step-by-steps
New link: https://govuk-formats.herokuapp.com/

## Evidence
The new link was provided by Simon Hughesdon, via a Slack thread.