### PR TITLE
Add Nova snippets extension to Resources and Tools page

### DIFF
--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -101,6 +101,7 @@ A complete Rails starter application using GOV.UK Frontend.
 You can download GOV.UK Frontend Nunjucks macro snippets for:
 
 - [Atom](https://atom.io/packages/govuk-design-system-snippets)
+- [Nova](https://extensions.panic.com/extensions/ca/ca.GOVUKDesignSystemSnippets/)
 - [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=simonwhatley.govuk-design-system-snippets)
 
 


### PR DESCRIPTION
Adds the [GOV.UK Design System Snippets](https://extensions.panic.com/extensions/ca/ca.GOVUKDesignSystemSnippets/) extension for [Nova](http://nova.app) to the list of community resources and tools. 

Closes #2256.