### PR TITLE
Ask users to tell us when they've made a proposal

### DIFF
--- a/src/community/propose-a-component-or-pattern/index.md
+++ b/src/community/propose-a-component-or-pattern/index.md
@@ -23,7 +23,7 @@ If you'd like to work on it, read how to [develop a component or pattern](/commu
 
 ## 2. Raise an issue
 
-If your idea is not on the list, [raise an issue](https://github.com/alphagov/govuk-design-system-backlog/issues/new). A member of the Design System team will review your proposal.
+If your idea is not on the list, [raise an issue](https://github.com/alphagov/govuk-design-system-backlog/issues/new). Once you do, [let us know](/get-in-touch/) so a member of the Design System team can review your proposal and add it to the list.
 
 At this stage, you just need to present your idea and evidence of the user needs. You can include screenshots or links to versions of the component or pattern in use, but avoid spending time working on a specific design or writing code.
 


### PR DESCRIPTION
When a user raises an issue in [govuk-design-system-backlog](https://github.com/alphagov/govuk-design-system-backlog), it needs to be manually added to the new [project board](https://github.com/orgs/alphagov/projects/43/views/1) we've created as a list of discussions.

This content change adds an instruction for the user to tell us when they've made a proposal so the team (usually whoever is on support) can do this.

This should solve situations such as this [user that could not see their proposed component](https://ukgovernmentdigital.slack.com/archives/C6DMEH5R6/p1674734113489069?thread_ts=1674732951.858609&cid=C6DMEH5R6).
