### PR TITLE
Ensure mismatched source map URLs are still hashed

### DIFF
--- a/lib/fingerprints/fixtures/src/example-xxx-123.js
+++ b/lib/fingerprints/fixtures/src/example-xxx-123.js
@@ -1,0 +1,2 @@
+export default 'example'
+//# sourceMappingURL=example-xxx-456.map

--- a/lib/fingerprints/fixtures/src/example-xxx-456.map
+++ b/lib/fingerprints/fixtures/src/example-xxx-456.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"example-xxx-123.js","names":[],"sources":[],"mappings":""}

--- a/lib/fingerprints/index.js
+++ b/lib/fingerprints/index.js
@@ -1,5 +1,5 @@
 const { createHmac } = require('crypto')
-const { basename, join, parse } = require('path')
+const { basename, dirname, join, parse } = require('path')
 
 /**
  * Metalsmith files hasher plugin
@@ -24,34 +24,23 @@ const hashAssets = (config) => (files, metalsmith, done) => {
     // Collect fingerprints
     const { fingerprints } = metalsmith.metadata()
 
-    entries
+    // Replace assets with hashed files
+    entries.forEach(([pathAsset, fingerprint]) => {
+      const { ext } = parse(pathAsset)
 
       // Filter assets with source maps
-      .filter(([path]) => ['.css', '.js']
-        .includes(parse(path).ext))
+      if (['.css', '.js'].includes(ext)) {
+        const pathMap = getSourceMapPath(pathAsset, files[pathAsset].contents)
 
-      // Check each asset for source map
-      .forEach(([pathAsset]) => {
-        const pathMap = `${pathAsset}.map`
+        // Check asset for source map
+        if (pathMap && fingerprints[pathMap]) {
+          const hashMap = fingerprints[pathMap].hash
 
-        // Replace source map URL with hashed filename
-        if (fingerprints[pathMap]) {
+          // Replace source map URL with hashed filename
           files[pathAsset].contents = Buffer.from(
             files[pathAsset].contents.toString()
               .replace(basename(pathMap), basename(fingerprints[pathMap].path))
           )
-        }
-      })
-
-    entries
-
-      // Replace assets with hashed files
-      .forEach(([pathAsset, fingerprint]) => {
-        const pathMap = `${pathAsset}.map`
-
-        // Check asset for source map
-        if (fingerprints[pathMap]) {
-          const hashMap = fingerprints[pathMap].hash
 
           // Synchronise file + source map hashes
           fingerprint.path = fingerprint.path.replace(fingerprint.hash, hashMap)
@@ -60,11 +49,12 @@ const hashAssets = (config) => (files, metalsmith, done) => {
           // Update metadata
           fingerprints[pathAsset] = fingerprint
         }
+      }
 
-        // Replace asset with hashed file
-        files[fingerprint.path] = files[pathAsset]
-        delete files[pathAsset]
-      })
+      // Replace asset with hashed file
+      files[fingerprint.path] = files[pathAsset]
+      delete files[pathAsset]
+    })
 
     done()
   } catch (error) {
@@ -89,7 +79,6 @@ const hashAsset = (files, metalsmith) => {
    * File hasher
    *
    * @param {string} pathAsset - File path
-   * @param {import('crypto').BinaryLike} [contents] - File contents
    * @returns {{ path: string; hash: string }} Fingerprint object
    */
   return (pathAsset) => {
@@ -127,6 +116,22 @@ function hashPath (pathAsset, contents) {
   const path = join(dir, `${name}-${hash}${ext}`)
 
   return { path, hash }
+}
+
+/**
+ * Extract source map URL from string
+ *
+ * @param {string} pathAsset - File path
+ * @param {import('crypto').BinaryLike} contents - File contents
+ * @returns {string | undefined} Source map URL
+ */
+function getSourceMapPath (pathAsset, contents) {
+  const sourceMappingURL = /# sourceMappingURL=(?<path>.*\.map)/g
+    .exec(contents.toString())?.groups?.path
+
+  if (sourceMappingURL) {
+    return join(dirname(pathAsset), sourceMappingURL)
+  }
 }
 
 module.exports = {

--- a/lib/fingerprints/index.test.js
+++ b/lib/fingerprints/index.test.js
@@ -51,13 +51,15 @@ describe('Hash fingerprints plugin', () => {
       'example-source-map.css.map': fingerprint,
       'example-source-map.js': fingerprint,
       'example-source-map.js.map': fingerprint,
+      'example-xxx-123.js': fingerprint,
+      'example-xxx-456.map': fingerprint,
       'example.jpg': fingerprint,
       'example.js': fingerprint,
       'example.json': fingerprint
     })
 
     expect(Object.entries(metadata.fingerprints))
-      .toHaveLength(7)
+      .toHaveLength(9)
   })
 
   it('syncs fingerprints for source map metadata', () => {
@@ -66,6 +68,9 @@ describe('Hash fingerprints plugin', () => {
 
     expect(metadata.fingerprints['example-source-map.js'].hash)
       .toEqual(metadata.fingerprints['example-source-map.js.map'].hash)
+
+    expect(metadata.fingerprints['example-xxx-123.js'].hash)
+      .toEqual(metadata.fingerprints['example-xxx-456.map'].hash)
   })
 
   it('renames assets with hash fingerprints', () => {
@@ -77,9 +82,11 @@ describe('Hash fingerprints plugin', () => {
     const fingerprint2 = metadata.fingerprints['example-source-map.css.map']
     const fingerprint3 = metadata.fingerprints['example-source-map.js']
     const fingerprint4 = metadata.fingerprints['example-source-map.js.map']
-    const fingerprint5 = metadata.fingerprints['example.jpg']
-    const fingerprint6 = metadata.fingerprints['example.js']
-    const fingerprint7 = metadata.fingerprints['example.json']
+    const fingerprint5 = metadata.fingerprints['example-xxx-123.js']
+    const fingerprint6 = metadata.fingerprints['example-xxx-456.map']
+    const fingerprint7 = metadata.fingerprints['example.jpg']
+    const fingerprint8 = metadata.fingerprints['example.js']
+    const fingerprint9 = metadata.fingerprints['example.json']
 
     expect(output).toMatchObject({
       [fingerprint1.path]: file,
@@ -88,7 +95,9 @@ describe('Hash fingerprints plugin', () => {
       [fingerprint4.path]: file,
       [fingerprint5.path]: file,
       [fingerprint6.path]: file,
-      [fingerprint7.path]: file
+      [fingerprint7.path]: file,
+      [fingerprint8.path]: file,
+      [fingerprint9.path]: file
     })
   })
 
@@ -98,6 +107,9 @@ describe('Hash fingerprints plugin', () => {
 
     expect(output[metadata.fingerprints['example-source-map.js'].path].contents.toString())
       .toContain(metadata.fingerprints['example-source-map.js.map'].path)
+
+    expect(output[metadata.fingerprints['example-xxx-123.js'].path].contents.toString())
+      .toContain(metadata.fingerprints['example-xxx-456.map'].path)
   })
 
   it('deletes old assets', () => {
@@ -105,6 +117,8 @@ describe('Hash fingerprints plugin', () => {
     expect(output['example-source-map.css.map']).toBeUndefined()
     expect(output['example-source-map.js']).toBeUndefined()
     expect(output['example-source-map.js.map']).toBeUndefined()
+    expect(output['example-xxx-123.js']).toBeUndefined()
+    expect(output['example-xxx-456.map']).toBeUndefined()
     expect(output['example.jpg']).toBeUndefined()
     expect(output['example.js']).toBeUndefined()
     expect(output['example.json']).toBeUndefined()


### PR DESCRIPTION
We added hash fingerprints to source maps recently

But we assumed source maps would follow this pattern:

```mjs
const pathAsset = 'example.js'
const pathMap = `${pathAsset}.map`
```

Sadly we've hit this awkward combo in https://github.com/alphagov/govuk-design-system/pull/2572:

```
iframeResizer.contentWindow.min.js
iframeResizer.contentWindow.map
```

We now follow other libraries and grab the URL using regex:

```mjs
/# sourceMappingURL=(?<path>.*\.map)/g
```