### PR TITLE
Clarify error message in Checkboxes component

### DIFF
--- a/src/components/checkboxes/index.md
+++ b/src/components/checkboxes/index.md
@@ -137,8 +137,11 @@ For example, ‘Select your nationality or nationalities’.
 
 #### If users check both a 'none' checkbox and another checkbox
 
-Say ‘Select [option label text] or select “[none of the above label text]”’<br>
-For example, ‘Select countries you will be travelling to, or select “No, I will not be travelling to any of these countries”’
+Say:
+>Select [option label text] or select ‘[none of the above label text]’
+
+For example:
+>Select countries you will be travelling to, or select ‘No, I will not be travelling to any of these countries’
 
 ## Research on this component
 

--- a/src/components/checkboxes/index.md
+++ b/src/components/checkboxes/index.md
@@ -138,10 +138,10 @@ For example, ‘Select your nationality or nationalities’.
 #### If users check both a 'none' checkbox and another checkbox
 
 Say:
->Select [option label text] or select ‘[none of the above label text]’
+<div class="govuk-inset-text">Select [option label text] or select ‘[none of the above label text]’</div>
 
 For example:
->Select countries you will be travelling to, or select ‘No, I will not be travelling to any of these countries’
+<div class="govuk-inset-text">Select countries you will be travelling to, or select ‘No, I will not be travelling to any of these countries’</div>
 
 ## Research on this component
 


### PR DESCRIPTION
A user [commented on Slack](https://ukgovernmentdigital.slack.com/archives/C6DMEH5R6/p1675263749783979) that their team was confused whether to use single quotes or double quotes to refer to checkboxes in error messages.

On the checkboxes component, error messages are presented as quotes, which creates confusion when the error message itself contains a quote (quotes with quotes). Best practice (according to grammar and the style guide) is to use double quotes within single quotes, but the inconsistency is causing confusion.

This PR proposes using a quote block to avoid using quote marks.