### PR TITLE
[WIP] Use system UI monospace font where available

### DIFF
--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -109,25 +109,6 @@ $app-code-color: #d13118;
       display: none;
     }
   }
-
-  // Fix monospace font size when used with relative typography
-  //
-  // Browsers automatically reduce monospace font size
-  //
-  // [1] restores the normal text size in Mozilla Firefox, Google Chrome,
-  // and Safari; this unusual style rule should also be used anywhere where
-  // you would otherwise set the font-family property to ‘monospace’.
-  // [2] restores the normal text size in Internet Explorer and Opera.
-  //
-  // source:
-  // http://code.iamkate.com/html-and-css/fixing-browsers-broken-monospace-font-handling/
-  pre,
-  code {
-    // stylelint-disable font-family-no-duplicate-names
-    font-family: monospace, monospace; // [1]
-    // stylelint-enable font-family-no-duplicate-names
-    font-size: 1em; // [2]
-  }
 }
 
 .app-example-page__wrapper {
@@ -262,6 +243,23 @@ $colour-list-breakpoint: 980px;
   }
 }
 
+// Add styling for system monospace font family
+
+// ui-monospace - https://drafts.csswg.org/css-fonts-4/#ui-monospace-def
+// Menlo, Monaco - Fonts for older macOS / OSX versions
+// Cascadia Mono, Segoe UI Mono - Fonts for Windows Terminal, Kernel
+// Consolas, Lucida Console - Fonts for older Windows versions
+pre,
+code {
+  font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono", Consolas, "Lucida Console", monospace;
+}
+
+code {
+  @include govuk-typography-responsive($size: 19, $override-line-height: 1.4);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 // Add styling for inline code
 li code,
 td code,
@@ -281,7 +279,6 @@ pre code {
   border: $govuk-focus-width solid transparent;
   outline: 1px solid $govuk-border-colour;
   background-color: $app-light-grey;
-  font-size: 16px;
   @include govuk-responsive-margin(4, "bottom");
 
   &:focus {


### PR DESCRIPTION
Just tidying up previously-unpushed branches

Did we know Chrome renders our code examples differently to other browsers?

Safari uses **Menlo**
Firefox uses **Menlo**
Chrome uses **Courier**

☝️ On macOS 13.2 (Ventura)

**Note:** Firefox changed to Menlo (from Courier) [2 years ago](https://bugzilla.mozilla.org/show_bug.cgi?id=1342741)

## System UI monospace font
Would it be better for us to set a font stack?

For example the [**GOV.UK Frontend** Tech Docs](https://frontend.design-system.service.gov.uk) code font stack
>```css
>font-family: monaco, Consolas, "Lucida Console", monospace;
>```

Some other choices include:

* `"SF Mono"` - System font for macOS
* `"Cascadia Mono"` - System font for Windows 11
* `"Segoe UI Mono"` - System font for Windows 7+

Plus these older ones:

* `Menlo, Monaco` - System fonts for older OS X versions
* `Consolas, "Lucida Console"` - System fonts for older Windows versions

## Generic font families
Support was added for [`ui-monospace` in Safari 13.1](https://webkit.org/blog/10247/new-webkit-features-in-safari-13-1/)

### Safari 16.3

* `ui-monospace` - System font (macOS 13.2) as **SF Mono**

<img width="807" alt="Safari, SF Mono" src="https://user-images.githubusercontent.com/415517/216406836-e94cf253-13eb-4b2b-8146-202b5a3fdf72.png">

There's more useful reading material in the **CSS Fonts Module Level 4** working draft

>[**2.1.3. Generic font families**](https://drafts.csswg.org/css-fonts-4/)
>[**’ui-monospace’**](https://drafts.csswg.org/css-fonts-4/#ui-monospace-def)
>This font family is used for the monospaced variant of the system’s user interface. The purpose of [ui-monospace](https://drafts.csswg.org/css-fonts-4/#valdef-font-family-ui-monospace) is to allow web content to integrate with the look and feel of the native OS.

## Browser differences

### Safari 16.3
Font family `monospace` as **Menlo**

<img width="807" alt="Safari, Menlo" src="https://user-images.githubusercontent.com/415517/216400383-0c3e333e-d29e-4904-9382-dc39aadc3306.png">

### Firefox 109
Font family `monospace` as **Menlo**

<img width="805" alt="Firefox, Menlo" src="https://user-images.githubusercontent.com/415517/216400862-cac748fb-c2db-4039-b686-803f49c16a7f.png">

### Chrome 109
Font family `monospace` as **Courier**

<img width="805" alt="Chrome, Courier" src="https://user-images.githubusercontent.com/415517/216400619-2c595e7b-ca27-480b-9e21-b07f59617a7a.png">