### PR TITLE
Exclude headings in documents in excluded sections from search

### DIFF
--- a/lib/metalsmith-lunr-index/fixtures/src/about-larry.md
+++ b/lib/metalsmith-lunr-index/fixtures/src/about-larry.md
@@ -1,6 +1,11 @@
 ---
 title: Larry the cat
 section: Cats
+show_page_nav: true
 ---
 
-Contents
+# Larry (cat)
+
+## Early life
+
+## Career

--- a/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md
+++ b/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md
@@ -1,5 +1,6 @@
 ---
 title: Page with headings
+section: Components
 show_page_nav: true
 headingAliases:
     Heading level 2: two

--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -5,6 +5,8 @@ module.exports = function lunrPlugin () {
   return (files, metalsmith, done) => {
     const outputPath = 'search-index.json'
 
+    const separator = '<span class="app-site-search__separator" aria-hidden="true">›</span>'
+
     const includedSections = navigationConfig
       .filter(section => section.includeInSearch)
       .map(section => section.label)
@@ -27,7 +29,7 @@ module.exports = function lunrPlugin () {
           permalink,
           title: file.title,
           section: file.section,
-          aliases: file.aliases === null ? undefined : file.aliases
+          aliases: file.aliases ?? undefined
         }
       })
 
@@ -38,11 +40,11 @@ module.exports = function lunrPlugin () {
       })
       // Filter out files that don't have extracted headings
       .filter(path => files[path].headings)
-      .map(path => {
+      .flatMap(path => {
         const file = files[path]
         const permalink = file.permalink || path
-        const headings = file.headings
-        // only use <h2>s
+        return file.headings
+          // only use <h2>s
           .filter(heading => heading.depth === 2)
           .map(heading => {
             return {
@@ -50,15 +52,10 @@ module.exports = function lunrPlugin () {
               title: heading.text,
               page: file.title,
               section: file.section,
-              aliases: heading.aliases === null ? undefined : heading.aliases
+              aliases: heading.aliases ?? undefined
             }
           })
-        return headings
       })
-      // we need a flat array
-      .reduce((arr, curr) => {
-        return arr.concat(curr)
-      }, [])
 
     // The search index only contains what's needed to match and identify a
     // document, but won't give us back anything other than the document's
@@ -94,7 +91,6 @@ module.exports = function lunrPlugin () {
       })
       // store all headings into the Lunr store
       pageHeadingDocuments.forEach(doc => {
-        const separator = '<span class="app-site-search__separator" aria-hidden="true">›</span>'
         store[doc.permalink] = {
           permalink: doc.permalink,
           title: doc.title,

--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -18,48 +18,47 @@ module.exports = function lunrPlugin () {
           const section = files[path].section
           return includedSections.includes(section)
         })
-        .map(path => {
-          const file = files[path]
-          const permalink = file.permalink || path
-          return {
-            permalink,
-            title: file.title,
-            section: file.section,
-            aliases: file.aliases === null ? undefined : file.aliases
-          }
-        })
 
-    const pageHeadingDocuments =
-      Object.keys(files)
-        // Filter out any non html files
-        .filter(path => path.endsWith('.html'))
-        // Only include pages in the with show_page_nav: true
-        .filter(path => {
-          return files[path].show_page_nav
-        })
-        // Filter out files that don't have extracted headings
-        .filter(path => files[path].headings)
-        .map(path => {
-          const file = files[path]
-          const permalink = file.permalink || path
-          const headings = file.headings
-          // only use <h2>s
-            .filter(heading => heading.depth === 2)
-            .map(heading => {
-              return {
-                permalink: `${permalink}/#${heading.url}`,
-                title: heading.text,
-                page: file.title,
-                section: file.section,
-                aliases: heading.aliases === null ? undefined : heading.aliases
-              }
-            })
-          return headings
-        })
-        // we need a flat array
-        .reduce((arr, curr) => {
-          return arr.concat(curr)
-        }, [])
+    const documentResults = documents
+      .map(path => {
+        const file = files[path]
+        const permalink = file.permalink || path
+        return {
+          permalink,
+          title: file.title,
+          section: file.section,
+          aliases: file.aliases === null ? undefined : file.aliases
+        }
+      })
+
+    const pageHeadingDocuments = documents
+      // Only include pages in the with show_page_nav: true
+      .filter(path => {
+        return files[path].show_page_nav
+      })
+      // Filter out files that don't have extracted headings
+      .filter(path => files[path].headings)
+      .map(path => {
+        const file = files[path]
+        const permalink = file.permalink || path
+        const headings = file.headings
+        // only use <h2>s
+          .filter(heading => heading.depth === 2)
+          .map(heading => {
+            return {
+              permalink: `${permalink}/#${heading.url}`,
+              title: heading.text,
+              page: file.title,
+              section: file.section,
+              aliases: heading.aliases === null ? undefined : heading.aliases
+            }
+          })
+        return headings
+      })
+      // we need a flat array
+      .reduce((arr, curr) => {
+        return arr.concat(curr)
+      }, [])
 
     // The search index only contains what's needed to match and identify a
     // document, but won't give us back anything other than the document's
@@ -84,7 +83,7 @@ module.exports = function lunrPlugin () {
       this.pipeline.remove(lunr.stemmer)
       // Disable stemming of search terms run against this index
       this.searchPipeline.remove(lunr.stemmer)
-      documents.forEach(doc => {
+      documentResults.forEach(doc => {
         store[doc.permalink] = {
           permalink: doc.permalink,
           title: doc.title,

--- a/lib/metalsmith-lunr-index/index.test.js
+++ b/lib/metalsmith-lunr-index/index.test.js
@@ -48,39 +48,36 @@ describe('metalsmith-lunr-index plugin', () => {
     })
 
     it('contains the permalink to the document', () => {
-      const checkboxesDocument = Object.values(documentStore).find(document => {
-        return document.title === 'Checkboxes'
-      })
+      const entry = Object.values(documentStore)
+        .find(({ title }) => title === 'Checkboxes')
 
-      expect(checkboxesDocument.permalink).toEqual('checkboxes.html')
+      expect(entry.permalink).toEqual('checkboxes.html')
     })
 
     it('contains the section that the document is in', () => {
-      const checkboxesDocument = Object.values(documentStore).find(document => {
-        return document.title === 'Checkboxes'
-      })
+      const entry = Object.values(documentStore)
+        .find(({ title }) => title === 'Checkboxes')
 
-      expect(checkboxesDocument.section).toEqual('Components')
+      expect(entry.section).toEqual('Components')
     })
 
     it('uses a custom permalink if in document metadata', () => {
-      const withPermalinkDocument = Object.values(documentStore).find(document => {
-        return document.title === 'With Permalink'
-      })
+      const entry = Object.values(documentStore)
+        .find(({ title }) => title === 'With Permalink')
 
-      expect(withPermalinkDocument.permalink).toEqual('/with-permalink/')
+      expect(entry.permalink).toEqual('/with-permalink/')
     })
 
     it('contains the page and heading level 2 entry', () => {
-      const withPageHeadingDocument = Object.values(documentStore).find(document => {
-        return document.title === 'Heading level 2'
-      })
+      const entry = Object.values(documentStore)
+        .find(({ title }) => title === 'Heading level 2')
 
-      expect(withPageHeadingDocument.permalink).toEqual('with-page-headings.html/#heading-level-2')
+      expect(entry.permalink).toEqual('with-page-headings.html/#heading-level-2')
     })
 
     it('does not contain headings from documents in excluded sections', () => {
-      const paths = Object.keys(documentStore).filter(path => path.startsWith('about-larry.html'))
+      const paths = Object.keys(documentStore)
+        .filter(path => path.startsWith('about-larry.html'))
 
       expect(paths).toHaveLength(0)
     })

--- a/lib/metalsmith-lunr-index/index.test.js
+++ b/lib/metalsmith-lunr-index/index.test.js
@@ -78,6 +78,12 @@ describe('metalsmith-lunr-index plugin', () => {
 
       expect(withPageHeadingDocument.permalink).toEqual('with-page-headings.html/#heading-level-2')
     })
+
+    it('does not contain headings from documents in excluded sections', () => {
+      const paths = Object.keys(documentStore).filter(path => path.startsWith('about-larry.html'))
+
+      expect(paths).toHaveLength(0)
+    })
   })
 
   describe('the generated index', () => {
@@ -107,6 +113,12 @@ describe('metalsmith-lunr-index plugin', () => {
       const resultRef = searchResults[0].ref
 
       expect(documentStore[resultRef].title).toEqual('Heading level 2')
+    })
+
+    it('does not store page headings from pages in excluded sections', () => {
+      const searchResults = searchIndex.search('career')
+
+      expect(searchResults).toHaveLength(0)
     })
 
     it('stores the aliases for the page heading of the page in the metadata', () => {


### PR DESCRIPTION
When adding documents to the search index, we do a separate pass of the files to add headings from any documents with `show_page_nav: true` as separate entries, so that searching for things like ‘Links’ (a section within the ‘Typography’ page) works.

However, unlike when adding documents, this pass did not exclude documents that were in sections excluded from search in `config/navigation.json`.

The new accessibility strategy page in the community section uses `show_page_nav: true` which means that the H2s within the accessibility strategy are currently showing up in search results. This is inconsistent with the rest of the 'Community' section which is currently excluded from search.

Refactor the code to do the ‘common’ filtering of files first before creating separate sets of document and page heading results to index, ensuring that both passes take into account the section the documents are in.

I've also tried to tidy up the code a little in a separate commit. It could definitely be improved further but I didn't want to sink too much time into it so just tried to get the 'low-hanging fruit' and leave it slightly better than I found it.