### PR TITLE
Remove video of address lookup that uses Selects

### DIFF
--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -71,6 +71,8 @@ Make sure errors follow the guidance in [error message](/components/error-messag
 
 ## Address lookup
 
+An address lookup helps users find a full address from partial information such as a postcode.
+
 ### When to use an address lookup
 
 Use an address lookup when you’re asking users for a UK address.

--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -71,15 +71,6 @@ Make sure errors follow the guidance in [error message](/components/error-messag
 
 ## Address lookup
 
-<div class="app-video">
-  <video class="app-video__player" role="region" aria-labelledby="passports-address-lookup-video-description" controls muted>
-    <source src="passports-address-lookup.mp4" type="video/mp4">
-  </video>
-  <p class="app-video__description" id="passports-address-lookup-video-description">
-    This video shows the address lookup in practice. It does not have any audio.
-  </p>
-</div>
-
 ### When to use an address lookup
 
 Use an address lookup when you’re asking users for a UK address.


### PR DESCRIPTION
The address lookup shown in the video example uses a Select (dropdown) component on the results page. The Select component's own page in the Design System says it should not be used except "as a last resort" and there are workable alternatives available (for example, a list of radios). 

The video causes confusion as it is widely understood to be "the GDS pattern" for address lookups: service teams then either build lookups that follow it or encounter the issues with Selects in their own testing and develop their own solutions from scratch, which may not be consistent with one another.