### PR TITLE
[SPIKE] `mjs-enabled` added via script with `nomodule` detection

### DIFF
--- a/src/styles/page-template/block-areas/index.njk
+++ b/src/styles/page-template/block-areas/index.njk
@@ -81,7 +81,7 @@ stylesheets:
     <span class="app-annotate-block__label">block: bodyEnd</span>
     {{ super() }}
     {# Since we’re not extending the Design System layout we need to add this manually #}
-    <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
-    <script src="{{ getFingerprint('javascripts/vendor/iframeResizer.contentWindow.min.js') }}"></script>
+    <script type="module" src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
+    <script type="module" src="{{ getFingerprint('javascripts/vendor/iframeResizer.contentWindow.min.js') }}"></script>
   </div>
 {%- endblock %}

--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -147,5 +147,5 @@ ignore_in_sitemap: true
 {% endblock %}
 
 {% block bodyEnd %}
-  <script src="/govuk-frontend/all.js"></script>
+  <script type="module" src="/govuk-frontend/all.js"></script>
 {% endblock %}

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -149,6 +149,6 @@ ignore_in_sitemap: true
 {% endblock %}
 
 {% block bodyEnd %}
-  <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
-  <script src="{{ getFingerprint('javascripts/vendor/iframeResizer.contentWindow.min.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/vendor/iframeResizer.contentWindow.min.js') }}"></script>
 {% endblock %}

--- a/src/styles/page-template/default/code.njk
+++ b/src/styles/page-template/default/code.njk
@@ -15,6 +15,6 @@ ignore_in_sitemap: true
 
 {% block bodyEnd %}
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
-  <script src="/govuk-frontend/all.js"></script>
-  <script>window.GOVUKFrontend.initAll()</script>
+  <script type="module" src="/govuk-frontend/all.js"></script>
+  <script type="module">window.GOVUKFrontend.initAll()</script>
 {% endblock %}

--- a/src/styles/page-template/default/index.njk
+++ b/src/styles/page-template/default/index.njk
@@ -14,6 +14,6 @@ layout: false
 {% endblock %}
 
 {% block bodyEnd %}
-  <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
-  <script src="{{ getFingerprint('javascripts/vendor/iframeResizer.contentWindow.min.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/vendor/iframeResizer.contentWindow.min.js') }}"></script>
 {% endblock %}

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -36,6 +36,6 @@
 {% block footer %}{% endblock %}
 
 {% block bodyEnd %}
-  <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
-  <script src="{{ getFingerprint('javascripts/application.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/application.js') }}"></script>
 {% endblock %}

--- a/views/layouts/govuk/template.njk
+++ b/views/layouts/govuk/template.njk
@@ -28,7 +28,10 @@
     {% endif %}
   </head>
   <body class="govuk-template__body {{ bodyClasses }}" {%- for attribute, value in bodyAttributes %} {{attribute}}="{{value}}"{% endfor %}>
-    <script{% if cspNonce %} nonce="{{ cspNonce }}"{% endif %}>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <script{% if cspNonce %} nonce="{{ cspNonce }}"{% endif %}>
+      ['js-enabled'].concat('noModule' in HTMLScriptElement.prototype ? ['mjs-enabled'] : [])
+        .forEach(function (className) { document.body.classList.add(className) })
+    </script>
     {% block bodyStart %}{% endblock %}
 
     {% block skipLink %}

--- a/views/layouts/govuk/template.njk
+++ b/views/layouts/govuk/template.njk
@@ -1,0 +1,60 @@
+{% from "govuk/components/skip-link/macro.njk" import govukSkipLink -%}
+{% from "govuk/components/header/macro.njk" import govukHeader -%}
+{% from "govuk/components/footer/macro.njk" import govukFooter -%}
+<!DOCTYPE html>
+<html lang="{{ htmlLang | default('en') }}" class="govuk-template {{ htmlClasses }}">
+  <head>
+    <meta charset="utf-8">
+    <title{% if pageTitleLang %} lang="{{ pageTitleLang }}"{% endif %}>{% block pageTitle %}GOV.UK - The best place to find government services and information{% endblock %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="{{ themeColor | default('#0b0c0c') }}"> {# Hardcoded value of $govuk-black #}
+    {# Ensure that older IE versions always render with the correct rendering engine #}
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    {% block headIcons %}
+      <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ assetPath | default('/assets') }}/images/favicon.ico" type="image/x-icon">
+      <link rel="mask-icon" href="{{ assetPath | default('/assets') }}/images/govuk-mask-icon.svg" color="{{ themeColor | default('#0b0c0c') }}"> {# Hardcoded value of $govuk-black #}
+      <link rel="apple-touch-icon" sizes="180x180" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-180x180.png">
+      <link rel="apple-touch-icon" sizes="167x167" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-167x167.png">
+      <link rel="apple-touch-icon" sizes="152x152" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-152x152.png">
+      <link rel="apple-touch-icon" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon.png">
+    {% endblock %}
+
+    {% block head %}{% endblock %}
+
+    {# OpenGraph images needs to be absolute, so we need either a URL for the image or for assetUrl to be set #}
+    {% if opengraphImageUrl or assetUrl %}
+    <meta property="og:image" content="{{ opengraphImageUrl | default(assetUrl + '/images/govuk-opengraph-image.png') }}">
+    {% endif %}
+  </head>
+  <body class="govuk-template__body {{ bodyClasses }}" {%- for attribute, value in bodyAttributes %} {{attribute}}="{{value}}"{% endfor %}>
+    <script{% if cspNonce %} nonce="{{ cspNonce }}"{% endif %}>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    {% block bodyStart %}{% endblock %}
+
+    {% block skipLink %}
+      {{ govukSkipLink({
+        href: '#main-content',
+        text: 'Skip to main content'
+      }) }}
+    {% endblock %}
+
+    {% block header %}
+      {{ govukHeader({}) }}
+    {% endblock %}
+
+    {% block main %}
+      <div class="govuk-width-container {{ containerClasses }}">
+        {% block beforeContent %}{% endblock %}
+        <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
+          {% block content %}{% endblock %}
+        </main>
+      </div>
+    {% endblock %}
+
+    {% block footer %}
+      {{ govukFooter({}) }}
+    {% endblock %}
+
+    {% block bodyEnd %}{% endblock %}
+  </body>
+</html>

--- a/views/layouts/layout-example-full-page-govuk.njk
+++ b/views/layouts/layout-example-full-page-govuk.njk
@@ -22,7 +22,7 @@
   {{ contents | safe }}
 {% endblock %}
 {% block bodyEnd %}
-  <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
-  <script src="{{ getFingerprint('javascripts/example.js') }}"></script>
-  <script src="{{ getFingerprint('javascripts/vendor/iframeResizer.contentWindow.min.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/example.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/vendor/iframeResizer.contentWindow.min.js') }}"></script>
 {% endblock %}

--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -24,7 +24,7 @@
   {{ contents | safe }}
 {% endblock %}
 {% block bodyEnd %}
-  <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
-  <script src="{{ getFingerprint('javascripts/example.js') }}"></script>
-  <script src="{{ getFingerprint('javascripts/vendor/iframeResizer.contentWindow.min.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/example.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/vendor/iframeResizer.contentWindow.min.js') }}"></script>
 {% endblock %}

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -35,9 +35,9 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
-  <script src="{{ getFingerprint('javascripts/example.js') }}"></script>
-  <script src="{{ getFingerprint('javascripts/vendor/iframeResizer.contentWindow.min.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/example.js') }}"></script>
+  <script type="module" src="{{ getFingerprint('javascripts/vendor/iframeResizer.contentWindow.min.js') }}"></script>
 {% endblock %}
 
 {# Example pages shouldn't have a footer, so blank the one provided by the template #}


### PR DESCRIPTION
Spike to investigate:

* https://github.com/alphagov/govuk-frontend/issues/3367

Detecting `'noModule' in HTMLScriptElement.prototype`

Features wise:

1. Safari 10.1 was `type="module"`
2. Safari 11.0 was `nomodule`
3. Safari 11.1 was `import()`

iOS Safari versions may vary