### PR TITLE
Add guidance on how tab values get stored in URL

### DIFF
--- a/src/components/tabs/index.md
+++ b/src/components/tabs/index.md
@@ -64,6 +64,14 @@ The tabs component uses JavaScript. When JavaScript is not available, users will
 
 This is also how the component currently behaves on small screens, though more research is needed on this.
 
+### The current tab gets stored in the URL
+
+When moving between tabs, the URL gets updated with a fragment (`#id-of-the-tab`) corresponding to the current tab's `id` attribute's value.
+
+If the tab's name is "United Kingdom" then the fragment could be `#tab_united-kingdom`.
+
+Because of this feature, pressing the browser's 'back' button should navigate back to the previous tab.
+
 ### Use clear labels
 
 Tabs hide content, so the tab labels need to make it very clear what they link to, otherwise users will not know if they need to click on them.


### PR DESCRIPTION
Added a new section under 'How it works' called "The current tab gets stored in the URL".

This new section explains how navigating to a tab results in a fragment being appended on the URL.

Why? So that developers know how the tabs component functions, and know that current / previous tab is stored and can be navigated to by using the browser's back button.