### PR TITLE
Fix broken link on equality information page

### DIFF
--- a/src/patterns/equality-information/index.md
+++ b/src/patterns/equality-information/index.md
@@ -73,7 +73,7 @@ Start with the harmonised standards, keeping the categories of responses in the 
 
 ### Collecting other types of equality information
 
-See the [full list of Government Statistical Service harmonised standards](https://gss.civilservice.gov.uk/guidances/harmonised-standards-guidance/) if you want to collect other types of equality information. For example, about income or employment status.
+See the [full list of Government Statistical Service harmonised standards](https://analysisfunction.civilservice.gov.uk/government-statistical-service-and-statistician-group/gss-support/gss-harmonisation-support/harmonised-standards-and-guidance/) if you want to collect other types of equality information. For example, about income or employment status.
 
 ### Asking about date of birth (age)
 


### PR DESCRIPTION
Fixes a broken link that should go to the list of harmonised standards on the Government Analysis Function's website. We use the correct link further up the page