### PR TITLE
Make it clearer who the design system is aimed at

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -12,7 +12,7 @@ masthead: true
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
         <h2 class="govuk-heading-l govuk-!-font-weight-bold">Styles</h2>
-        <p class="govuk-body">Make your government service look like GOV.UK with guides for applying layout, typography, colour and&nbsp;images.</p>
+        <p class="govuk-body">Make government services look like GOV.UK with guides for applying layout, typography, colour and&nbsp;images.</p>
         <p class="govuk-body govuk-!-margin-bottom-0"><a href="/styles/" class="govuk-link govuk-!-font-weight-bold">Browse styles</a></p>
       </div>
       <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
@@ -33,7 +33,7 @@ masthead: true
       <div class="govuk-grid-column-two-thirds govuk-!-mb-r4">
         <h2 class="govuk-heading-l">Principles we follow</h2>
         <p class="govuk-body">
-The GOV.UK Design System helps government service teams follow the <a class="govuk-link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a> and <a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a>. This website also follows the <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide">style guide</a> and <a class="govuk-link" href="https://www.gov.uk/guidance/content-design">content design guidance</a> used by GOV.UK.
+The GOV.UK Design System helps teams that work on government services follow the <a class="govuk-link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a> and <a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a>. This website also follows the <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide">style guide</a> and <a class="govuk-link" href="https://www.gov.uk/guidance/content-design">content design guidance</a> used by GOV.UK.
         </p>
 
       <p class="govuk-body">
@@ -47,7 +47,8 @@ The GOV.UK Design System helps government service teams follow the <a class="gov
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 id="community" class="govuk-heading-l">Community</h2>
         <p class="govuk-body">
-          The GOV.UK Design System is for everyone in government, with a strong community sitting behind it. It brings together the latest research, design and development from across government to make sure it’s representative and relevant for its users.</p>
+The GOV.UK Design System is for everyone that works on government services, with a strong community sitting behind it. It brings together the latest research, design and development from across government to make sure it’s representative and relevant for its users.         
+          </p>
 
         <p class="govuk-body">
           You can help improve the Design System by <a class="govuk-link" href="/community/">joining our discussions, events and co-design collaborations</a>.

--- a/src/index.njk
+++ b/src/index.njk
@@ -12,7 +12,7 @@ masthead: true
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
         <h2 class="govuk-heading-l govuk-!-font-weight-bold">Styles</h2>
-        <p class="govuk-body">Make your service look like GOV.UK with guides for applying layout, typography, colour and&nbsp;images.</p>
+        <p class="govuk-body">Make your government service look like GOV.UK with guides for applying layout, typography, colour and&nbsp;images.</p>
         <p class="govuk-body govuk-!-margin-bottom-0"><a href="/styles/" class="govuk-link govuk-!-font-weight-bold">Browse styles</a></p>
       </div>
       <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
@@ -33,7 +33,7 @@ masthead: true
       <div class="govuk-grid-column-two-thirds govuk-!-mb-r4">
         <h2 class="govuk-heading-l">Principles we follow</h2>
         <p class="govuk-body">
-The GOV.UK Design System helps service teams follow the <a class="govuk-link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a> and <a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a>. This website also follows the <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide">style guide</a> and <a class="govuk-link" href="https://www.gov.uk/guidance/content-design">content design guidance</a> used by GOV.UK.
+The GOV.UK Design System helps government service teams follow the <a class="govuk-link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a> and <a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a>. This website also follows the <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide">style guide</a> and <a class="govuk-link" href="https://www.gov.uk/guidance/content-design">content design guidance</a> used by GOV.UK.
         </p>
 
       <p class="govuk-body">
@@ -47,7 +47,7 @@ The GOV.UK Design System helps service teams follow the <a class="govuk-link" hr
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 id="community" class="govuk-heading-l">Community</h2>
         <p class="govuk-body">
-          The GOV.UK Design System is for everyone, with a strong community sitting behind it. It brings together the latest research, design and development from across government to make sure it’s representative and relevant for its users.</p>
+          The GOV.UK Design System is for everyone in government, with a strong community sitting behind it. It brings together the latest research, design and development from across government to make sure it’s representative and relevant for its users.</p>
 
         <p class="govuk-body">
           You can help improve the Design System by <a class="govuk-link" href="/community/">joining our discussions, events and co-design collaborations</a>.

--- a/src/styles/index.md
+++ b/src/styles/index.md
@@ -5,7 +5,7 @@ description: Make your service look and feel like GOV.UK
 show_subnav: true
 ---
 
-Make your service look and feel like GOV.UK.
+Make your government service look and feel like GOV.UK.
 
 If you are using the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk) or have [GOV.UK Frontend](https://frontend.design-system.service.gov.uk/) included in your build, the coded examples in the Design System will not need any additional styling.
 

--- a/src/styles/index.md
+++ b/src/styles/index.md
@@ -5,7 +5,7 @@ description: Make your service look and feel like GOV.UK
 show_subnav: true
 ---
 
-Make your government service look and feel like GOV.UK.
+Make government services look and feel like GOV.UK.
 
 If you are using the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk) or have [GOV.UK Frontend](https://frontend.design-system.service.gov.uk/) included in your build, the coded examples in the Design System will not need any additional styling.
 

--- a/views/partials/_masthead.njk
+++ b/views/partials/_masthead.njk
@@ -5,7 +5,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h1 class="govuk-heading-xl app-masthead__title">Design your service using GOV.UK styles, components and&nbsp;patterns</h1>
-        <p class="app-masthead__description">Use this design system to make your government service consistent with GOV.UK. Learn from the research and experience of other service teams and avoid repeating work that’s already been done.</p>
+        <p class="app-masthead__description">Use this design system to make government services consistent with GOV.UK. Learn from the research and experience of other service teams and avoid repeating work that’s already been done.</p>
 
         {{ govukButton({
           "text": "Get started",

--- a/views/partials/_masthead.njk
+++ b/views/partials/_masthead.njk
@@ -5,7 +5,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h1 class="govuk-heading-xl app-masthead__title">Design your service using GOV.UK styles, components and&nbsp;patterns</h1>
-        <p class="app-masthead__description">Use this design system to make your service consistent with GOV.UK. Learn from the research and experience of other service teams and avoid repeating work that’s already been done.</p>
+        <p class="app-masthead__description">Use this design system to make your government service consistent with GOV.UK. Learn from the research and experience of other service teams and avoid repeating work that’s already been done.</p>
 
         {{ govukButton({
           "text": "Get started",


### PR DESCRIPTION
It’s not obvious that the design system is primarily intended for teams working on government services, which can cause problems. For example, a directory of parish councils adopted the design system wholesale which has lead to them receiving [multiple bad reviews](https://uk.trustpilot.com/review/parish.uk), and has caused their intended audience to label the directory a ‘scam’. 

These small changes should help address that. Once released, we can work towards iterating these messages to make it clearer, if necessary.