### PR TITLE
Add documentation for `.govuk-input--extra-letter-spacing`

### DIFF
--- a/src/components/text-input/code-sequence/index.njk
+++ b/src/components/text-input/code-sequence/index.njk
@@ -1,0 +1,19 @@
+---
+title: Example of a text input asking for a code or sequence
+layout: layout-example.njk
+---
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  label: {
+    text: "Company authentication code"
+  },
+  hint: {
+    text: "This is on the company incorporation letter sent to the registered office address."
+  },
+  classes: "govuk-input--width-5 govuk-input--extra-letter-spacing",
+  id: "authentication-code",
+  name: "authentication-code",
+  spellcheck: false
+}) }}

--- a/src/components/text-input/index.md
+++ b/src/components/text-input/index.md
@@ -43,7 +43,7 @@ There are 2 ways to use the text input component. You can use HTML or, if you’
 
 {{ example({group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
 
-###  If you’re asking more than one question on the page
+### If you’re asking more than one question on the page
 
 If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking multiple questions on question pages](/patterns/question-pages/#asking-multiple-questions-on-a-page).
 
@@ -93,7 +93,7 @@ Do not include links within hint text. While screen readers will read out the li
 
 #### Asking for whole numbers
 
-If you're asking the user to enter a whole number, set the `inputmode` attribute to `numeric` to use the numeric keypad on devices with on-screen keyboards. 
+If you're asking the user to enter a whole number, set the `inputmode` attribute to `numeric` to use the numeric keypad on devices with on-screen keyboards.
 
 See how to do this by opening the HTML and Nunjucks tabs in this example:
 
@@ -115,6 +115,20 @@ Do not set the `inputmode` attribute to `decimal` as it causes some devices to b
 #### Avoid using inputs with a type of number
 
 Do not use `<input type="number">` unless your user research shows that there’s a need for it. With `<input type="number">` there’s a risk of users accidentally incrementing a number when they’re trying to do something else - for example, scroll up or down the page. And if the user tries to enter something that’s not a number, there’s no explicit feedback about what they’re doing wrong.
+
+### Codes and sequences
+
+Help the user visually check the code they've typed is correct by styling the input's text to visually separate each character. This is important if you're asking the user to enter a code or sequence they're unlikely to have memorised, such as an application reference ID, account number or security code. 
+
+You do not need to do this for memorable information, such as phone numbers and postcodes.
+
+{{ example({group: "components", item: "text-input", example: "code-sequence", html: true, nunjucks: true, open: false, size: "m"}) }}
+
+There is specific guidance on how to:
+
+- [ask for bank account details](/patterns/bank-details/)
+- [ask for National Insurance numbers](/patterns/national-insurance-numbers/)
+- [confirm a phone number](/patterns/confirm-a-phone-number/)
 
 ### Prefixes and suffixes
 

--- a/src/patterns/bank-details/default/index.njk
+++ b/src/patterns/bank-details/default/index.njk
@@ -22,7 +22,7 @@ layout: layout-example.njk
   label: {
     text: "Sort code"
   },
-  classes: "govuk-input--width-5",
+  classes: "govuk-input--width-5 govuk-input--extra-letter-spacing",
   hint: {
     text: "Must be 6 digits long"
   },
@@ -36,7 +36,7 @@ layout: layout-example.njk
   label: {
     text: "Account number"
   },
-  classes: "govuk-input--width-10",
+  classes: "govuk-input--width-10 govuk-input--extra-letter-spacing",
   hint: {
     text: "Must be between 6 and 8 digits long"
   },
@@ -50,7 +50,7 @@ layout: layout-example.njk
   label: {
     text: "Building society roll number (if you have one)"
   },
-  classes: "govuk-input--width-10",
+  classes: "govuk-input--width-10 govuk-input--extra-letter-spacing",
   hint: {
     text: "You can find it on your card, statement or passbook"
   },

--- a/src/patterns/bank-details/error/index.njk
+++ b/src/patterns/bank-details/error/index.njk
@@ -9,7 +9,7 @@ layout: layout-example.njk
   label: {
     text: "Sort code"
   },
-  classes: "govuk-input--width-5",
+  classes: "govuk-input--width-5 govuk-input--extra-letter-spacing",
   hint: {
     text: "Must be 6 digits long"
   },

--- a/src/patterns/bank-details/international/index.njk
+++ b/src/patterns/bank-details/international/index.njk
@@ -10,7 +10,7 @@ layout: layout-example.njk
   label: {
     text: "BIC or SWIFT code"
   },
-  classes: "govuk-input--width-10",
+  classes: "govuk-input--width-10 govuk-input--extra-letter-spacing",
   hint: {
     text: "Must be between 8 and 11 characters long. You can ask your bank or check your bank statement"
   },
@@ -23,6 +23,7 @@ layout: layout-example.njk
   label: {
     text: "IBAN"
   },
+  classes: "govuk-input--extra-letter-spacing",
   hint: {
     text: "You can ask your bank or check your bank statement"
   },

--- a/src/patterns/confirm-a-phone-number/default/index.njk
+++ b/src/patterns/confirm-a-phone-number/default/index.njk
@@ -18,7 +18,7 @@ title: Default – Confirm a phone number
   name: "security-code",
   type: "text",
   autocomplete: "one-time-code",
-  classes: "govuk-input--width-4",
+  classes: "govuk-input--width-4 govuk-input--extra-letter-spacing",
   inputmode: "numeric"
 }) }}
 

--- a/src/patterns/national-insurance-numbers/default/index.njk
+++ b/src/patterns/national-insurance-numbers/default/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
   hint: {
     text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
   },
-  classes: "govuk-input--width-10",
+  classes: "govuk-input--width-10 govuk-input--extra-letter-spacing",
   id: "national-insurance-number",
   name: "national-insurance-number",
   spellcheck: false

--- a/src/patterns/national-insurance-numbers/error/index.njk
+++ b/src/patterns/national-insurance-numbers/error/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
   hint: {
     text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
   },
-  classes: "govuk-input--width-10",
+  classes: "govuk-input--width-10 govuk-input--extra-letter-spacing",
   id: "national-insurance-number",
   name: "national-insurance-number",
   value: "12345678",


### PR DESCRIPTION
Preparing some documentation for one of the new features coming in the next release of GOV.UK Frontend. 

> **Note**: I've updated the code examples with the new class name, but the changes won't actually happen until the new version of Frontend has been released and the Design System has been updated to use it. 

Closes #2665.

## Changes
- Adds a section to the Text Input component docs explaining when and how to use the new class.
- Adds an example of the Text Input component using the new class, using a 'company authentication code' from Companies House as an example.
- Updates examples on related patterns to use the new class. 

## Thoughts
- Is the company authentication code example understandable? 
  - I was trying to use something other than 2FA code, NI number or bank details, as we already have examples of these on other pages.
  - Disclaimer: I'm not sure whether the hint text provided is actually accurate. 
  - Company authentication codes are six characters long and composed of a mixture of uppercase letters and digits, by the way.
- Should the example have the input's value pre-populated? 
  - Given the function of the class is to change how the value is presented, having this pre-populated saves a reader having to type to see the differences. 
  - One of the most striking differences (when using the Transport font) is the visual difference between the proportional and tabular versions of '1'. A pre-populated example could make this more obvious. 