### PR TITLE
Add example for showing a field that was optional

### DIFF
--- a/src/patterns/check-answers/default/index.njk
+++ b/src/patterns/check-answers/default/index.njk
@@ -63,6 +63,23 @@ layout: layout-example-full-page.njk
           },
           {
             key: {
+              text: "Customer reference"
+            },
+            value: {
+              text: "Not provided"
+            },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "customer reference"
+                }
+              ]
+            }
+          },
+          {
+            key: {
               text: "Address"
             },
             value: {


### PR DESCRIPTION
The guidance for check your answers mentions hiding sections that the user doesn't see but not optional questions. On discussion in cross-gov slack, teams do play back said fields but say "not provided". This may need to be added to guidance - view separate note - but also would be helpful to change the example