### PR TITLE
Fix argument count in deprecated `this.mql.addListener()`

### DIFF
--- a/src/javascripts/components/navigation.mjs
+++ b/src/javascripts/components/navigation.mjs
@@ -125,14 +125,14 @@ Navigation.prototype.init = function () {
     // Set the matchMedia to the govuk-frontend tablet breakpoint
     this.mql = window.matchMedia('(min-width: 40.0625em)')
 
-    var listenerMethod = 'addEventListener' in this.mql
-      ? 'addEventListener'
-      : 'addListener'
-
-    // addListener is a deprecated function, however addEventListener
-    // isn't supported by Safari < 14. We therefore add this in as
-    // a fallback for those browsers
-    this.mql[listenerMethod]('change', this.setHiddenStates.bind(this))
+    if ('addEventListener' in this.mql) {
+      this.mql.addEventListener('change', this.setHiddenStates.bind(this))
+    } else {
+      // addListener is a deprecated function, however addEventListener
+      // isn't supported by Safari < 14. We therefore add this in as
+      // a fallback for those browsers
+      this.mql.addListener(this.setHiddenStates.bind(this))
+    }
   }
 
   this.setHiddenStates()


### PR DESCRIPTION
This PR partially reverts an unreleased change from https://github.com/alphagov/govuk-design-system/commit/cf8b7265ea5c8119089a6e1c54332aa8eec94b39#diff-77d636446b24955f10521d341aef15533905564e2ac413de8009562f3c9d0ce7R135

Browser testing in Safari 9.1 correctly spotted some recent MediaQueryList argument changes:

```js
var mql = window.matchMedia('(min-width: 48.0625em)')

mql.addEventListener('change', handler)
mql.addListener(handler) // Legacy IE and Safari
```