### PR TITLE
Add a blog post, change 'blog' to 'blog post'

### DIFF
--- a/src/community/blogs-talks-podcasts/index.md
+++ b/src/community/blogs-talks-podcasts/index.md
@@ -13,35 +13,37 @@ To learn more about the GOV.UK Design System and Prototype Kit, check out these 
 
 Find out how the Design System and Prototype Kit work and what they do to make services more accessible and inclusive.
 
-[Making the GOV.UK Frontend typography scale more accessible](https://designnotes.blog.gov.uk/2022/12/12/making-the-gov-uk-frontend-typography-scale-more-accessible/) (blog) — 12 December 2022
+[Making the GOV.UK Frontend typography scale more accessible](https://designnotes.blog.gov.uk/2022/12/12/making-the-gov-uk-frontend-typography-scale-more-accessible/) (blog post) — 12 December 2022
 
-[How we prioritise additions to the GOV.UK Design System](https://designnotes.blog.gov.uk/2022/09/07/how-we-prioritise-additions-to-the-gov-uk-design-system/) (blog) — 7 September 2022
+[How we prioritise additions to the GOV.UK Design System](https://designnotes.blog.gov.uk/2022/09/07/how-we-prioritise-additions-to-the-gov-uk-design-system/) (blog post) — 7 September 2022
 
-[The GOV.UK Design System is now live](https://gds.blog.gov.uk/2022/03/31/the-gov-uk-design-system-is-now-live/) (blog) - 31 March 2022
+[The GOV.UK Design System is now live](https://gds.blog.gov.uk/2022/03/31/the-gov-uk-design-system-is-now-live/) (blog post) - 31 March 2022
 
-[Help us shape the GOV.UK Design System](https://designnotes.blog.gov.uk/2022/02/23/help-us-shape-the-gov-uk-design-system/) (blog) - 23 February 2022
+[Help us shape the GOV.UK Design System](https://designnotes.blog.gov.uk/2022/02/23/help-us-shape-the-gov-uk-design-system/) (blog post) - 23 February 2022
 
-[Letting users tick a ‘none’ checkbox](https://designnotes.blog.gov.uk/2021/11/15/letting-users-tick-a-none-checkbox/) (blog) - 15 November 2021
+[Letting users tick a ‘none’ checkbox](https://designnotes.blog.gov.uk/2021/11/15/letting-users-tick-a-none-checkbox/) (blog post) - 15 November 2021
 
-[An update on the accessibility of conditionally revealed questions](https://accessibility.blog.gov.uk/2021/09/21/an-update-on-the-accessibility-of-conditionally-revealed-questions/) (blog) - 21 September 2021
+[An update on the accessibility of conditionally revealed questions](https://accessibility.blog.gov.uk/2021/09/21/an-update-on-the-accessibility-of-conditionally-revealed-questions/) (blog post) - 21 September 2021
 
-[Making links easier to see and read on GOV.UK](https://designnotes.blog.gov.uk/2021/07/07/making-links-easier-to-see-and-read-on-gov-uk/) (blog) - 7 July 2021
+[Making links easier to see and read on GOV.UK](https://designnotes.blog.gov.uk/2021/07/07/making-links-easier-to-see-and-read-on-gov-uk/) (blog post) - 7 July 2021
 
 [Designing the service behind the GOV.UK Design System](https://www.youtube.com/watch?v=kOXt36nIVPQ) (video) - 9 January 2020
 
 [Inclusive Documentation](https://www.youtube.com/watch?v=dZOf973QzmE) (video) - 4 October 2019
 
-[Making the Design System more accessible](https://designnotes.blog.gov.uk/2019/07/29/weve-made-the-gov-uk-design-system-more-accessible/) (blog) - 29 July 2019
+[Making the Design System more accessible](https://designnotes.blog.gov.uk/2019/07/29/weve-made-the-gov-uk-design-system-more-accessible/) (blog post) - 29 July 2019
 
 [Inclusive forms, Anatomy of a (fictional) GOV.UK service](https://www.youtube.com/watch?v=JHaLzm-FGsc) (video) - 26 February 2019
 
-[Accessibility in the GOV.UK Design System](https://nickcolley.co.uk/2018/11/16/accessibility-in-the-govuk-design-system/) (blog and video) - 30 November 2018
+[Accessibility in the GOV.UK Design System](https://nickcolley.co.uk/2018/11/16/accessibility-in-the-govuk-design-system/) (blog post and video) - 30 November 2018
 
-[Introducing the GOV.UK Design System](https://gds.blog.gov.uk/2018/06/22/introducing-the-gov-uk-design-system/) (blog) - 22 June 2018
+[Introducing the GOV.UK Design System](https://gds.blog.gov.uk/2018/06/22/introducing-the-gov-uk-design-system/) (blog post) - 22 June 2018
 
 [Building Accessible Components and the GOV.UK Design System](https://www.youtube.com/watch?v=wprWuTvhec4) (video) - 11 June 2018
 
-[We've updated the radios and checkboxes on GOV.UK](https://designnotes.blog.gov.uk/2016/11/30/weve-updated-the-radios-and-checkboxes-on-gov-uk/) (blog) - 30 November 2016
+[Building the GOV.UK Design System](https://gds.blog.gov.uk/2017/10/30/building-the-gov-uk-design-system/) (blog post) - 30 October 2017
+
+[We've updated the radios and checkboxes on GOV.UK](https://designnotes.blog.gov.uk/2016/11/30/weve-updated-the-radios-and-checkboxes-on-gov-uk/) (blog post) - 30 November 2016
 
 ## Benefits of the Design System
 
@@ -51,29 +53,29 @@ See how the Design System helps service teams across government.
 
 [Measuring the value of the GOV.UK Design System](https://www.youtube.com/watch?v=eSkVtSEAe98) (video) - 5 February 2020
 
-[How the GOV.UK Design System can work alongside other government design resources](https://designnotes.blog.gov.uk/2019/02/14/how-the-gov-uk-design-system-can-work-alongside-other-government-design-resources/) (blog) - 14 February 2019
+[How the GOV.UK Design System can work alongside other government design resources](https://designnotes.blog.gov.uk/2019/02/14/how-the-gov-uk-design-system-can-work-alongside-other-government-design-resources/) (blog post) - 14 February 2019
 
-[The benefits of migrating GOV.UK Pay’s codebase to the GOV.UK Design System](https://technology.blog.gov.uk/2018/12/21/the-benefits-of-migrating-gov-uk-pays-codebase-to-the-gov-uk-design-system/) (blog) - 21 December 2018
+[The benefits of migrating GOV.UK Pay’s codebase to the GOV.UK Design System](https://technology.blog.gov.uk/2018/12/21/the-benefits-of-migrating-gov-uk-pays-codebase-to-the-gov-uk-design-system/) (blog post) - 21 December 2018
 
 ## How to use the Design System
 
 Get some practical advice on how to use the Design System and Prototype Kit.
 
-[Going beyond the GOV.UK Design System for MoJ Forms professional users](https://designnotes.blog.gov.uk/2022/03/21/going-beyond-the-gov-uk-design-system-for-moj-forms-professional-users/) (blog) - 21 March 2022
+[Going beyond the GOV.UK Design System for MoJ Forms professional users](https://designnotes.blog.gov.uk/2022/03/21/going-beyond-the-gov-uk-design-system-for-moj-forms-professional-users/) (blog post) - 21 March 2022
 
 [Building digital services that work for everyone](https://www.youtube.com/watch?v=1cuZnBqQYKQ&feature=youtu.be) (video) - 21 May 2020
 
-[Adapting the GOV.UK Design System for the NHS](https://gds.blog.gov.uk/2019/06/04/guest-post-adapting-the-gov-uk-design-system-for-the-nhs/) (blog) - 4 June 2019
+[Adapting the GOV.UK Design System for the NHS](https://gds.blog.gov.uk/2019/06/04/guest-post-adapting-the-gov-uk-design-system-for-the-nhs/) (blog post) - 4 June 2019
 
-[How we document components and patterns in the GOV.UK Design System](https://designnotes.blog.gov.uk/2018/11/05/how-we-document-components-and-patterns-in-the-gov-uk-design-system/) (blog) - 5 November 2018
+[How we document components and patterns in the GOV.UK Design System](https://designnotes.blog.gov.uk/2018/11/05/how-we-document-components-and-patterns-in-the-gov-uk-design-system/) (blog post) - 5 November 2018
 
-[We’ve updated the prototype kit](https://designnotes.blog.gov.uk/2016/01/18/weve-updated-the-prototype-kit/) (blog) - 18 January 2016
+[We’ve updated the prototype kit](https://designnotes.blog.gov.uk/2016/01/18/weve-updated-the-prototype-kit/) (blog post) - 18 January 2016
 
 ## Contributing to the community
 
 Find out how our community works and how to be a part of it.
 
-[Why I contribute to the GOV.UK Design System (and why you should too)](https://x-govuk.github.io/posts/contributing-to-govuk-design-system/) (blog) - 7 April 2022
+[Why I contribute to the GOV.UK Design System (and why you should too)](https://x-govuk.github.io/posts/contributing-to-govuk-design-system/) (blog post) - 7 April 2022
 
 [GDS Podcast, Maps in services](https://gds.blog.gov.uk/2021/11/30/podcast-maps-in-services/) (podcast) - 30 November 2021
 
@@ -81,9 +83,9 @@ Find out how our community works and how to be a part of it.
 
 [Contributing the bank details pattern to the GOV.UK Design System](https://mojdigital.blog.gov.uk/2019/10/23/contributing-the-bank-details-pattern-to-the-gov-uk-design-system/) - 23 October 2019
 
-[Opening up the GOV.UK Design System for contributions](https://designnotes.blog.gov.uk/2018/09/26/opening-up-the-gov-uk-design-system-for-contributions/) (blog) - 26 September 2018
+[Opening up the GOV.UK Design System for contributions](https://designnotes.blog.gov.uk/2018/09/26/opening-up-the-gov-uk-design-system-for-contributions/) (blog post) - 26 September 2018
 
-[Looking at design systems across government](https://designnotes.blog.gov.uk/2016/12/21/looking-at-design-systems-across-government/) (blog) - 21 December 2016
+[Looking at design systems across government](https://designnotes.blog.gov.uk/2016/12/21/looking-at-design-systems-across-government/) (blog post) - 21 December 2016
 
 ## Add a link to this page
 


### PR DESCRIPTION
Ollie noticed that we hadn't added [https://gds.blog.gov.uk/2017/10/30/building-the-gov-uk-design-system/](https://gds.blog.gov.uk/2017/10/30/building-the-gov-uk-design-system/) to this page, so I added it. Also changed some instances of `blog` to `blog post` in line with the [GOV.UK style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style).