### PR TITLE
Use Metalsmith's built-in env() method

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -7,7 +7,6 @@ const slugger = require('slugger') // generate slugs from titles
 
 // Third party metalsmith plugins
 const canonical = require('metalsmith-canonical') // add a canonical url property to pages
-const env = require('metalsmith-env') // environment vars plugin
 const inplace = require('@metalsmith/in-place') // render templating syntax in source files
 const layouts = require('@metalsmith/layouts') // apply layouts to source files
 const markdown = require('@metalsmith/markdown') // render markdown in source files
@@ -99,7 +98,8 @@ module.exports = metalsmith(path.resolve(__dirname, '../'))
 
   // include environment variables as metalsmith metadata
   // used to e.g. detect when we're building in a preview environment
-  .use(env())
+  .env(process.env)
+  .use((files, ms) => { ms.metadata(ms.env()) })
 
   // convert *.scss files to *.css
   .use(sass({

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
         "marked": "^4.3.0",
         "metalsmith": "^2.5.1",
         "metalsmith-canonical": "^1.2.0",
-        "metalsmith-env": "^2.2.0",
         "metalsmith-renamer": "^0.5.217",
         "nunjucks": "^3.2.2",
         "outdent": "^0.8.0",
@@ -10358,38 +10357,6 @@
         "lodash": "^4.17.10",
         "multimatch": "^2.1.0",
         "url-join": "^4.0.0"
-      }
-    },
-    "node_modules/metalsmith-env": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-env/-/metalsmith-env-2.2.0.tgz",
-      "integrity": "sha512-kUd5L7AuxiSKFs2DIH7he7JHflNXuMcqqOIKTgEbXH3DOWJ3cZFiLynMO/N/jXOta+zUKI0L2nEzUNGQVPGnAA==",
-      "dev": true,
-      "dependencies": {
-        "extend-shallow": "^3.0.2"
-      }
-    },
-    "node_modules/metalsmith-env/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/metalsmith-env/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/metalsmith-renamer": {
@@ -23169,32 +23136,6 @@
         "lodash": "^4.17.10",
         "multimatch": "^2.1.0",
         "url-join": "^4.0.0"
-      }
-    },
-    "metalsmith-env": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-env/-/metalsmith-env-2.2.0.tgz",
-      "integrity": "sha512-kUd5L7AuxiSKFs2DIH7he7JHflNXuMcqqOIKTgEbXH3DOWJ3cZFiLynMO/N/jXOta+zUKI0L2nEzUNGQVPGnAA==",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "^3.0.2"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
       }
     },
     "metalsmith-renamer": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "marked": "^4.3.0",
     "metalsmith": "^2.5.1",
     "metalsmith-canonical": "^1.2.0",
-    "metalsmith-env": "^2.2.0",
     "metalsmith-renamer": "^0.5.217",
     "nunjucks": "^3.2.2",
     "outdent": "^0.8.0",


### PR DESCRIPTION
We make use of `metalsmith-env` to grab `process.env` variables and include them as Metalsmith metadata. This allows us to use these variables in templates (for instance, [using Netlify's environment variables to determine whether to display a "Preview" banner](https://github.com/alphagov/govuk-design-system/pull/138))

Metalsmith now has a built-in `env` method which we can use instead.

I've checked the local output of Metalsmith.metadata() before and after getting rid of `metalsmith-env` and they're identical. There's also no diff in compiled output.

Closes #2330 