### PR TITLE
Remove unneeded space in notification banner documentation

### DIFF
--- a/src/components/notification-banner/index.md
+++ b/src/components/notification-banner/index.md
@@ -38,7 +38,7 @@ Do not:
 
 Position a notification banner immediately before the page `h1`. The notification banner should be the same width as the page's other content, such as components, headings and body text. For example, if the other content takes up two-thirds of the screen on desktop devices, then the notification banner should also take up two-thirds. [Read about how to lay out pages](https://design-system.service.gov.uk/styles/layout/). 
 
-Use `role ="region"` and `aria-labelledby="govuk-notification-banner-title"` (with `id="govuk-notification-banner-title"` on `<govuk-notification-banner__title>`) so that screen reader users can navigate to the notification banner.
+Use `role="region"` and `aria-labelledby="govuk-notification-banner-title"` (with `id="govuk-notification-banner-title"` on `<govuk-notification-banner__title>`) so that screen reader users can navigate to the notification banner.
 
 Avoid showing more than one notification banner on the same page. Instead, combine the messages in a single notification banner. If the messages are too different to combine, only show the highest priority notification banner.
 


### PR DESCRIPTION
Very minor fix - just corrects an unnecessary space in `role="region"` ([It's valid](https://stackoverflow.com/questions/7064095/spaces-between-html-attributes-and-values), just inconsistent with the other examples)