### PR TITLE
Update Accordion guidance for `rememberExpanded`

### DIFF
--- a/src/components/accordion/index.md
+++ b/src/components/accordion/index.md
@@ -104,9 +104,11 @@ The accordion component shows section headings as `<h2>` headings. If needed, ch
 
 Users might need some sections to be open from the start. If they leave and then return to the page, they might also need sections they opened to stay open.
 
-If the user leaves and then returns to the page within the same page session, the accordion component will use ['session storage'](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) to remember which sections were open. You can configure sections to start and stay open, but not stay closed.
+By default, if the user leaves and then returns to the page within the same page session, the accordion component will use ['session storage'](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) to remember which sections were open. This functionality can be turned off by adding `rememberExpanded: false` to the Nunjucks macro.
 
 To see the changes you've made, you may need to create a new 'session'. For example, by opening a page in a new tab or window.
+
+You can configure sections to start and stay open, but not stay closed.
 
 ### Do not disable sections
 


### PR DESCRIPTION
Updates the Accordion component's guidance to account for the upcoming introduction of the `rememberExpanded` option in 4.6.0.

Closes #2727.

## Changes

- Adds a sentence stating that the session storage functionality can be turned off by setting `rememberExpanded: false` in the Nunjucks macro.
- Moves the "You can configure sections to start and stay open, but not stay closed." sentence to a separate paragraph, as it feels a bit more standalone now. 

## Thoughts

- I've only given mention to the Nunjucks parameter, to the exclusion of the JavaScript configuration option and HTML data-* attribute. This is for consistency with other documentation on the Design System website, which tends to assume the user is using the Nunjucks macros. 