### PR TITLE
Include sources content from `govuk-frontend` source maps

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,12 @@ module.exports = [{
         terser({
           format: { comments: false },
 
+          // Include sources content from source maps
+          // to inspect GOV.UK Frontend code
+          sourceMap: {
+            includeSources: true
+          },
+
           // Compatibility workarounds
           ecma: 5,
           safari10: true

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,6 +17,9 @@ module.exports = [{
       // Output plugins
       plugins: [
         terser({
+          format: { comments: false },
+
+          // Compatibility workarounds
           ecma: 5,
           safari10: true
         })


### PR DESCRIPTION
Aligns our Terser config with `govuk-frontend` and adds source map `{ includesources: true }`

This ensures web inspection and stack traces link back to original JavaScript lines, likely a regression from:

* https://github.com/alphagov/govuk-design-system/pull/2689

<img width="517" alt="Source map content" src="https://user-images.githubusercontent.com/415517/233392456-850c4f2b-ccd0-4c9a-9d70-5d0014842ad2.png">

Found whilst testing:

* https://github.com/alphagov/govuk-design-system/pull/2740