### PR TITLE
Expand and update accessibility statement

### DIFF
--- a/src/accessibility.md
+++ b/src/accessibility.md
@@ -195,6 +195,6 @@ If you’re using these products, you should [update your service to use the lat
 
 If you have any questions or need help, contact the GOV.UK Design System team:
 
-using the #govuk-design-system channel on the cross-government [UK Government Digital Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)
-by email at <govuk-design-system-support@digital.cabinet-office.gov.uk>
+- using the #govuk-design-system channel on the cross-government [UK Government Digital Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)
+- by email at <govuk-design-system-support@digital.cabinet-office.gov.uk>
 

--- a/src/accessibility.md
+++ b/src/accessibility.md
@@ -92,7 +92,13 @@ There is currently no known non-compliant content in the GOV.UK Frontend codebas
 
 We do not currently make any claims of disproportionate burden for any of our products.
 
-#### Accessibility concerns not within the scope of the accessibility regulations
+#### Content that’s not within the scope of the accessibility regulations
+
+The accessibility regulations apply to all portions of the GOV.UK Design System website, GOV.UK Frontend Documentation website and GOV.UK Frontend codebase.
+
+We do not have any content within these products which we consider to be outside the scope of the accessibility regulations.
+
+#### Other identified and tracked accessibility concerns
 
 Above and beyond non-compliant content, we also track accessibility concerns which:
 

--- a/src/accessibility.md
+++ b/src/accessibility.md
@@ -6,23 +6,32 @@ layout: layout-single-page-prose.njk
 
 # Accessibility
 
-The GOV.UK Design System website and the codebase it uses, GOV.UK Frontend, is maintained by a team at the Government Digital Service (GDS).
+The GOV.UK Design System team at the Government Digital Service (<abbr>GDS</abbr>) maintains the following products:
 
-This page explains how the team works to ensure the Design System and Frontend are accessible.
+- [GOV.UK Design System website](https://design-system.service.gov.uk/)
+- [GOV.UK Frontend documentation website](https://frontend.design-system.service.gov.uk/)
+- [GOV.UK Frontend codebase](https://github.com/alphagov/govuk-frontend)
 
-[Read about how to test components using accessibility acceptance criteria.](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/test-components-using-accessibility-acceptance-criteria.md)
+This page explains how the team works to ensure these products are accessible.
 
-## Accessibility statement for the GOV.UK Design System website
+The GOV.UK Prototype Kit website has a separate accessibility statement. [Read the GOV.UK Prototype Kit website accessibility statement](https://prototype-kit.service.gov.uk/docs/accessibility).
 
-This accessibility statement applies to the GOV.UK Design System at <https://design-system.service.gov.uk/>, and the components and patterns from the GOV.UK Frontend codebase which appear in the examples throughout the Design System.
+[Read our accessibility strategy](https://design-system.service.gov.uk/community/accessibility-strategy/) for more information on our current principles and work needed to improve the accessibility of the GOV.UK Design System.
 
-The GOV.UK Design System team wants as many people as possible to be able to use this website. For example, that means you should be able to:
+[Read about how we test components using accessibility acceptance criteria](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/test-components-using-accessibility-acceptance-criteria.md).
+
+## Accessibility statement
+
+This accessibility statement applies to the GOV.UK Design System website at [design-system.service.gov.uk](https://design-system.service.gov.uk/), the GOV.UK Frontend documentation website at [frontend.design-system.service.gov.uk](https://frontend.design-system.service.gov.uk/) and the components and patterns from the GOV.UK Frontend codebase which appear in the examples throughout the Design System.
+
+The GOV.UK Design System team wants as many people as possible to be able to use this website. For example, you should be able to:
 
 - change colours, contrast levels and fonts
 - zoom in up to 300% without the text spilling off the screen
+- listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA, TalkBack and VoiceOver)
 - navigate most of the website using just a keyboard
+- navigate most of the website using just a mouse and on-screen keyboard
 - navigate most of the website using speech recognition software
-- listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
 
 The team has also made the website text as simple as possible to understand.
 
@@ -30,25 +39,89 @@ The team has also made the website text as simple as possible to understand.
 
 ### Feedback and contact information
 
-The GOV.UK Design System team is always looking to improve the accessibility of this website. If you find any problems that are not listed on this page or think this website is not meeting accessibility requirements, email the GOV.UK Design System team at <govuk-design-system-support@digital.cabinet-office.gov.uk>
+The GOV.UK Design System team is always looking to improve the accessibility of this website. If you find any problems that are not listed on this page or think this website is not meeting accessibility requirements, email the team at <govuk-design-system-support@digital.cabinet-office.gov.uk>
 
 The GOV.UK Design System team will review your request and get back to you in 2 working days.
 
 ### Enforcement procedure
 
-The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+The Government Digital Service (<abbr>GDS</abbr>) is committed to making its websites accessible, in accordance with the [Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018](https://www.legislation.gov.uk/uksi/2018/952/contents).
 
-GDS is committed to making its websites accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+The Equality and Human Rights Commission (<abbr>EHRC</abbr>) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you contact us with a complaint and you’re not happy with our response, [contact the Equality Advisory and Support Service (<abbr>EASS</abbr>)](https://www.equalityadvisoryservice.com/).
 
 ### Compliance status
 
-The Design System website at [https://design-system.service.gov.uk/](/) is fully compliant with the Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard.
+The Design System website at [design-system.service.gov.uk](https://design-system.service.gov.uk/) is mostly compliant with the Web Content Accessibility Guidelines (<abbr>WCAG</abbr>) version 2.1 AA standard. Non-accessible content is documented in the next section.
 
-The GOV.UK Frontend documentation website at [http://frontend.design-system.service.gov.uk/](https://frontend.design-system.service.gov.uk/) is fully compliant with the WCAG 2.1 AA standard.
+The GOV.UK Frontend documentation website at [frontend.design-system.service.gov.uk](https://frontend.design-system.service.gov.uk/) is fully compliant with the Web Content Accessibility Guidelines (<abbr>WCAG</abbr>) version 2.1 AA standard.
 
-### How this website has been tested for accessibility
+The GOV.UK Frontend codebase at [github.com/alphagov/govuk-frontend](https://github.com/alphagov/govuk-frontend) is mostly compliant with the Web Content Accessibility Guidelines (<abbr>WCAG</abbr>) version 2.1 AA standard. Non-accessible content is documented in the next section.
 
-The Design System website was last tested on 7 October 2019. The test was carried out by the [Digital Accessibility Centre (DAC)](https://digitalaccessibilitycentre.org/).
+### Non-accessible content
+
+In this section, we only list non-accessible content that has been reported, verified and tracked in the following repositories:
+
+- [GOV.UK Design System GitHub repository](https://github.com/alphagov/govuk-design-system)
+- [GOV.UK Frontend Documentation Github repository](https://github.com/alphagov/govuk-frontend-docs)
+- [GOV.UK Frontend GitHub repository](https://github.com/alphagov/govuk-frontend)
+
+For this section, we define an ‘accessibility concern’ as any question about the accessibility of a portion of one of our products.
+
+#### Non-compliance with the accessibility regulations
+
+These accessibility concerns have been classified as being non-compliant, due to a failure in one or more WCAG 2.1 Level AA criteria.
+
+WCAG 2.1 AA failures are documented in two of our repositories under the ‘accessibility-regulations-failure’ issue label:
+
+- [GOV.UK Design System website label for accessibility regulations failures](https://github.com/alphagov/govuk-design-system/labels/accessibility-regulations-failure)
+- [GOV.UK Frontend codebase label for accessibility regulations failures](https://github.com/alphagov/govuk-frontend/labels/accessibility-regulations-failure)
+
+From the GOV.UK Design System website:
+
+1. The example summary card on our ‘Summary list’ component page includes different links with the same link text. There is no programmatically determinable link context to differentiate between the links. This is technically a failure of WCAG success criterion [2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/WCAG21/#link-purpose-in-context). We plan to fix this within 2023. Track our progress on the [GitHub issue: ‘Duplicate links on example for summary cards’](https://github.com/alphagov/govuk-design-system/issues/2680).
+
+From the GOV.UK Frontend Documentation website:
+
+There is currently no known non-compliant content in the GOV.UK Frontend Documentation website.
+
+From the GOV.UK Frontend codebase:
+
+There is currently no known non-compliant content in the GOV.UK Frontend codebase.
+
+#### Disproportionate burden
+
+We do not currently make any claims of disproportionate burden for any of our products.
+
+#### Accessibility concerns not within the scope of the accessibility regulations
+
+Above and beyond non-compliant content, we also track accessibility concerns which:
+
+- show strong evidence of being accessibility barriers
+- do not constitute a failure in one or more WCAG 2.1 Level AA criteria
+- are not classified as non-compliance with the accessibility regulations
+- are determined as worth featuring in this accessibility statement
+
+These accessibility concerns are documented in two of our repositories under the ‘accessibility-concern’ issue label:
+
+- [GOV.UK Design System website label for accessibility concerns](https://github.com/alphagov/govuk-design-system/labels/accessibility-concern)
+- [GOV.UK Frontend codebase label for accessibility concerns](https://github.com/alphagov/govuk-frontend/labels/accessibility-concern)
+
+From the GOV.UK Design System website:
+
+There are currently no known accessibility concerns in the GOV.UK Design System website which we have determined to be worth featuring in this accessibility statement.
+
+From the GOV.UK Frontend Documentation website:
+
+There are currently no known accessibility concerns in the GOV.UK Frontend Documentation website which we have determined to be worth featuring in this accessibility statement.
+
+From the GOV.UK Frontend codebase:
+
+The accordion component is currently using an `aria-labelledby` ARIA attribute on an unsupported `<div>` element. This is an incorrect implementation of [WAI-ARIA 1.1](https://www.w3.org/TR/wai-aria-1.1/), but is not a failure of WCAG success criterion [4.1.2 Name, Role, Value](https://www.w3.org/TR/WCAG21/#name-role-value). We plan to fix this within 2023. Track our progress on the [GitHub issue: ‘Accordion - Elements must only use allowed ARIA attributes’](https://github.com/alphagov/govuk-frontend/issues/2472).
+
+
+### Testing our products for accessibility
+
+The [GOV.UK Design System website](https://design-system.service.gov.uk/) was last last audited for accessibility issues by an external group on 7 October 2019. The test was carried out by the [Digital Accessibility Centre (DAC)](https://digitalaccessibilitycentre.org/).
 
 DAC tested a sample of pages to cover the different content types in the GOV.UK Design System website. They were:
 
@@ -60,31 +133,45 @@ DAC tested a sample of pages to cover the different content types in the GOV.UK 
 - [a component page](/components/radios/)
 - [a pattern page](/patterns/question-pages/)
 
-They also tested the global search functionality that appears in the header of every page in the Design System.
+DAC also tested the global search functionality that appears in the header of the GOV.UK Design System website.
 
-The [GOV.UK Frontend documentation website](http://frontend.design-system.service.gov.uk/) was last tested for accessibility issues in March 2021.
+#### Frontend documentation website
 
-### How the GOV.UK Design System team makes this website accessible
+The [GOV.UK Frontend documentation website](http://frontend.design-system.service.gov.uk/) was last audited for accessibility issues by an external group in April 2021. The audit was carried out by the [Digital Accessibility Centre (DAC)](https://digitalaccessibilitycentre.org/).
 
-The GOV.UK Design System team works hard to ensure that this Design System and Frontend, the codebase it uses, are accessible.
+DAC tested the [Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/), which is the platform that runs the GOV.UK Frontend documentation website.
+
+To learn more, read the [Technical Documentation Template accessibility statement](https://tdt-documentation.london.cloudapps.digital/accessibility/).
+
+#### Frontend codebase
+
+The GOV.UK Frontend codebase is not a website but a [code repository](https://github.com/alphagov/govuk-frontend) and [npm package](https://www.npmjs.com/package/govuk-frontend).
+
+Read more about the codebase’s accessibility in the [GOV.UK Frontend GitHub repository readme](https://github.com/alphagov/govuk-frontend#accessibility).
+
+### How the GOV.UK Design System team makes their websites accessible
+
+The GOV.UK Design System team works to make sure the Design System and Frontend websites, and the codebase they use, are accessible.
 
 Where possible, the team aims to research components and patterns with a representative range of users, including those with disabilities.
 
-We also test components to ensure they work with a broad range of browsers, devices and assistive technologies - including screen magnifiers, screen readers and speech recognition tools.
+We also test components to make sure they work with a broad range of browsers, devices and assistive technologies - including screen magnifiers, screen readers and speech recognition tools.
 
-When we publish new content, we'll continue to make sure that it meets accessibility standards.
+When we publish new content, we’ll continue to make sure that it meets accessibility standards.
 
 ### Preparation of this accessibility statement
 
-This statement was prepared on 23 October 2019. It was last reviewed on 30 June 2021.
+This statement was prepared on 23 October 2019. It was last reviewed on 26 April 2023.
 
 ## Using the Design System and Frontend in your service
 
 While the GOV.UK Design System team takes steps to ensure the Design System is as accessible as possible by default, you still need to carry out contextual research.
 
-Using Frontend does not mean your service automatically meets level AA of WCAG 2.1. You’ll still need to make sure your service as a whole meets accessibility requirements.
+Using only the code supplied in the GOV.UK Frontend codebase is not enough to accessibly implement the GOV.UK Design System. There is important written guidance in the [GOV.UK Design System website](https://design-system.service.gov.uk/) on how to implement styles, components and patterns in an accessible way. 
 
-You must research styles, components and patterns as part of your service to ensure that they are accessible in context.
+Using the Design System guidance and Frontend codebase does not mean your service automatically meets level AA of WCAG 2.1. You’ll still need to make sure your service as a whole meets accessibility requirements.
+
+You must research styles, components and patterns as part of your service to make sure they are accessible in context.
 
 Find out what you need to do to [make your service accessible](https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction) in the GOV.UK Service Manual.
 
@@ -98,9 +185,10 @@ The Design System and Frontend were introduced in June 2018 to replace the follo
 
 The GOV.UK Design System team no longer supports these products and will not be making updates to help them meet level AA of WCAG 2.1.
 
-If you're using these products, you should start [updating your service to use the Design System and Frontend](/get-started/updating-your-code/).
+If you’re using these products, you should [update your service to use the latest version of GOV.UK Frontend](https://design-system.service.gov.uk/get-started/updating-your-code/).
 
 If you have any questions or need help, contact the GOV.UK Design System team:
 
-- using the [#govuk-design-system channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)
-- by email at <govuk-design-system-support@digital.cabinet-office.gov.uk>
+using the #govuk-design-system channel on the cross-government [UK Government Digital Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)
+by email at <govuk-design-system-support@digital.cabinet-office.gov.uk>
+

--- a/src/accessibility.md
+++ b/src/accessibility.md
@@ -161,7 +161,7 @@ The GOV.UK Design System team works to make sure the Design System and Frontend 
 
 Where possible, the team aims to research components and patterns with a representative range of users, including those with disabilities.
 
-We also test components to make sure they work with a broad range of browsers, devices and assistive technologies - including screen magnifiers, screen readers and speech recognition tools.
+We also test components to make sure they work with a broad range of browsers, devices and assistive technologies — including screen magnifiers, screen readers and speech recognition tools.
 
 When we publish new content, we’ll continue to make sure that it meets accessibility standards.
 

--- a/src/accessibility.md
+++ b/src/accessibility.md
@@ -55,7 +55,7 @@ The Design System website at [design-system.service.gov.uk](https://design-syste
 
 The GOV.UK Frontend documentation website at [frontend.design-system.service.gov.uk](https://frontend.design-system.service.gov.uk/) is fully compliant with the Web Content Accessibility Guidelines (<abbr>WCAG</abbr>) version 2.1 AA standard.
 
-The GOV.UK Frontend codebase at [github.com/alphagov/govuk-frontend](https://github.com/alphagov/govuk-frontend) is mostly compliant with the Web Content Accessibility Guidelines (<abbr>WCAG</abbr>) version 2.1 AA standard. Non-accessible content is documented in the next section.
+The GOV.UK Frontend codebase at [github.com/alphagov/govuk-frontend](https://github.com/alphagov/govuk-frontend) is fully compliant with the Web Content Accessibility Guidelines (<abbr>WCAG</abbr>) version 2.1 AA standard. Non-accessible content is documented in the next section.
 
 ### Non-accessible content
 

--- a/src/accessibility.md
+++ b/src/accessibility.md
@@ -167,7 +167,7 @@ When we publish new content, we’ll continue to make sure that it meets accessi
 
 ### Preparation of this accessibility statement
 
-This statement was prepared on 23 October 2019. It was last reviewed on 26 April 2023.
+This statement was prepared on 23 October 2019. It was last reviewed on 27 April 2023.
 
 ## Using the Design System and Frontend in your service
 

--- a/src/accessibility.md
+++ b/src/accessibility.md
@@ -27,7 +27,7 @@ This accessibility statement applies to the GOV.UK Design System website at [des
 The GOV.UK Design System team wants as many people as possible to be able to use this website. For example, you should be able to:
 
 - change colours, contrast levels and fonts
-- zoom in up to 300% without the text spilling off the screen
+- zoom in up to 400% without the text spilling off the screen
 - listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA, TalkBack and VoiceOver)
 - navigate most of the website using just a keyboard
 - navigate most of the website using just a mouse and on-screen keyboard
@@ -35,7 +35,7 @@ The GOV.UK Design System team wants as many people as possible to be able to use
 
 The team has also made the website text as simple as possible to understand.
 
-[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
+AbilityNet has [advice on making your device easier to use](https://mcmw.abilitynet.org.uk/) if you have a disability.
 
 ### Feedback and contact information
 
@@ -51,7 +51,7 @@ The Equality and Human Rights Commission (<abbr>EHRC</abbr>) is responsible for 
 
 ### Compliance status
 
-The Design System website at [design-system.service.gov.uk](https://design-system.service.gov.uk/) is mostly compliant with the Web Content Accessibility Guidelines (<abbr>WCAG</abbr>) version 2.1 AA standard. Non-accessible content is documented in the next section.
+The Design System website at [design-system.service.gov.uk](https://design-system.service.gov.uk/) is partially compliant with the Web Content Accessibility Guidelines (<abbr>WCAG</abbr>) version 2.1 AA standard. Non-accessible content is documented in the next section.
 
 The GOV.UK Frontend documentation website at [frontend.design-system.service.gov.uk](https://frontend.design-system.service.gov.uk/) is fully compliant with the Web Content Accessibility Guidelines (<abbr>WCAG</abbr>) version 2.1 AA standard.
 
@@ -121,7 +121,7 @@ The accordion component is currently using an `aria-labelledby` ARIA attribute o
 
 ### Testing our products for accessibility
 
-The [GOV.UK Design System website](https://design-system.service.gov.uk/) was last last audited for accessibility issues by an external group on 7 October 2019. The test was carried out by the [Digital Accessibility Centre (DAC)](https://digitalaccessibilitycentre.org/).
+The [GOV.UK Design System website](https://design-system.service.gov.uk/) was last audited for accessibility issues by an external group on 7 October 2019. The test was carried out by the [Digital Accessibility Centre (DAC)](https://digitalaccessibilitycentre.org/).
 
 DAC tested a sample of pages to cover the different content types in the GOV.UK Design System website. They were:
 

--- a/src/accessibility.md
+++ b/src/accessibility.md
@@ -173,7 +173,7 @@ This statement was prepared on 23 October 2019. It was last reviewed on 26 April
 
 While the GOV.UK Design System team takes steps to ensure the Design System is as accessible as possible by default, you still need to carry out contextual research.
 
-Using only the code supplied in the GOV.UK Frontend codebase is not enough to accessibly implement the GOV.UK Design System. There is important written guidance in the [GOV.UK Design System website](https://design-system.service.gov.uk/) on how to implement styles, components and patterns in an accessible way. 
+Simply using code from the GOV.UK Frontend codebase is not enough to accessibly implement the GOV.UK Design System. There is important written guidance in the [GOV.UK Design System website](https://design-system.service.gov.uk/) on how to implement styles, components and patterns in an accessible way. 
 
 Using the Design System guidance and Frontend codebase does not mean your service automatically meets level AA of WCAG 2.1. You’ll still need to make sure your service as a whole meets accessibility requirements.
 


### PR DESCRIPTION
Related to issue 2666: https://github.com/alphagov/govuk-design-system/issues/2666
- Re-adds the section on non-accessible content
- Expands the statement to cover GOV.UK Frontend codebase
- Adds links to our accessibility statement
- Aligns content closer to the model accessibility statement

You can review this PR against the ['accessibility statement update 2023' drafting document (internal Google Doc)](https://docs.google.com/document/d/1nyWLKaSLhGPvG9qQ8RhuwzPvXBDiQmpCmRSv83fS_do/edit?usp=sharing).

The preview for this PR is here: https://deploy-preview-2752--govuk-design-system-preview.netlify.app/accessibility/