### PR TITLE
Fixup examples using `.govuk-input--extra-letter-spacing` class

### DIFF
--- a/src/components/text-input/code-sequence/index.njk
+++ b/src/components/text-input/code-sequence/index.njk
@@ -15,5 +15,6 @@ layout: layout-example.njk
   classes: "govuk-input--width-5 govuk-input--extra-letter-spacing",
   id: "authentication-code",
   name: "authentication-code",
-  spellcheck: false
+  spellcheck: false,
+  value: "NC1701"
 }) }}

--- a/src/patterns/confirm-a-phone-number/error-expired/index.njk
+++ b/src/patterns/confirm-a-phone-number/error-expired/index.njk
@@ -21,7 +21,7 @@ title: Error, security code expired – Confirm a phone number
   name: "security-code",
   type: "text",
   autocomplete: "one-time-code",
-  classes: "govuk-input--width-4",
+  classes: "govuk-input--width-4 govuk-input--extra-letter-spacing",
   inputmode: "numeric"
 }) }}
 

--- a/src/patterns/confirm-a-phone-number/error-incorrect/index.njk
+++ b/src/patterns/confirm-a-phone-number/error-incorrect/index.njk
@@ -21,7 +21,7 @@ title: Error, incorrect security code – Confirm a phone number
   name: "security-code",
   type: "text",
   autocomplete: "one-time-code",
-  classes: "govuk-input--width-4",
+  classes: "govuk-input--width-4 govuk-input--extra-letter-spacing",
   inputmode: "numeric"
 }) }}
 


### PR DESCRIPTION
- Adds a default value to the example on the Text Input page, so the user doesn't need to manually interact with the input to see the differences in text appearance.
- Adds the class to two "Confirm a phone number" examples where it was accidentally omitted. 