### PR TITLE
Fix broken link to GOV.UK Frontend departmental colours stylesheet

### DIFF
--- a/src/styles/colour/index.md
+++ b/src/styles/colour/index.md
@@ -76,7 +76,7 @@ should use the `$govuk-error-colour` Sass variable rather than
 
 If you need to use tints of this palette, use either 25% or 50%.
 
-You can find departmental colours in the GOV.UK Frontend [_colours-organisations](https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/settings/_colours-organisations.scss) file.
+You can find departmental colours in the GOV.UK Frontend [_colours-organisations](https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss) file.
 
 <table class="govuk-body app-colour-list" summary="Table of extended colours">
   <tbody>


### PR DESCRIPTION
This PR fixes a link that will break once we merge:

* https://github.com/alphagov/govuk-frontend/pull/3491