### PR TITLE
Increase Dependabot's open PR limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
   # Update npm packages
   - package-ecosystem: npm
     directory: /
+    open-pull-requests-limit: 10
     reviewers:
       - alphagov/design-system-developers
     schedule:


### PR DESCRIPTION
We've decided to bump Dependabot's max open PR limit back to 10 and see how it goes, since we were falling a bit behind with the default limit of 5.