### PR TITLE
Bump marked to v5.0.2

### DIFF
--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -31,7 +31,12 @@ function addSlugs (option) {
 function renderDescriptionsAsMarkdown (option) {
   if (option.description) {
     try {
-      option.description = marked(option.description, { renderer })
+      // Explicity set deprecated properties to false
+      option.description = marked(option.description, {
+        headerIds: false,
+        mangle: false,
+        renderer
+      })
     } catch (e) {
       console.error(e)
       process.exit(1) // Exit with a failure mode

--- a/lib/marked-renderer.js
+++ b/lib/marked-renderer.js
@@ -4,6 +4,14 @@ const { marked } = require('marked')
  * Custom markdown renderer
  */
 class DesignSystemRenderer extends marked.Renderer {
+  // Explicitly set deprecated properties to false
+  constructor () {
+    super({
+      headerIds: false,
+      mangle: false
+    })
+  }
+
   /**
    * Assume HTML when no code block language provided
    * (for example, HTML code inside Markdown)

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "jest-puppeteer": "^8.0.6",
         "js-beautify": "^1.14.7",
         "jstransformer-nunjucks": "^1.1.0",
-        "marked": "^4.3.0",
+        "marked": "^5.0.2",
         "metalsmith": "^2.5.1",
         "metalsmith-canonical": "^1.2.0",
         "metalsmith-renamer": "^0.5.217",
@@ -2630,6 +2630,17 @@
       },
       "peerDependencies": {
         "metalsmith": "^2.5.0"
+      }
+    },
+    "node_modules/@metalsmith/markdown/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/@metalsmith/permalinks": {
@@ -10194,14 +10205,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.0.2.tgz",
+      "integrity": "sha512-TXksm9GwqXCRNbFUZmMtqNLvy3K2cQHuWmyBDLOrY1e6i9UvZpOTJXoz7fBjYkJkaUFzV9hBFxMuZSyQt8R6KQ==",
+      "dev": true,
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 18"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -17338,6 +17350,13 @@
         "dlv": "^1.1.3",
         "dset": "^3.1.2",
         "marked": "^4.2.12"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+          "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
+        }
       }
     },
     "@metalsmith/permalinks": {
@@ -22970,9 +22989,10 @@
       "dev": true
     },
     "marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.0.2.tgz",
+      "integrity": "sha512-TXksm9GwqXCRNbFUZmMtqNLvy3K2cQHuWmyBDLOrY1e6i9UvZpOTJXoz7fBjYkJkaUFzV9hBFxMuZSyQt8R6KQ==",
+      "dev": true
     },
     "mathml-tag-names": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "jest-puppeteer": "^8.0.6",
     "js-beautify": "^1.14.7",
     "jstransformer-nunjucks": "^1.1.0",
-    "marked": "^4.3.0",
+    "marked": "^5.0.2",
     "metalsmith": "^2.5.1",
     "metalsmith-canonical": "^1.2.0",
     "metalsmith-renamer": "^0.5.217",


### PR DESCRIPTION
[Dependabot previously attempted this](https://github.com/alphagov/govuk-design-system/pull/2766), but we got the following noisy deprecation warnings:

```
marked(): mangle parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Instead use https://www.npmjs.com/package/marked-mangle.

marked(): headerIds and headerPrefix parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Instead use https://www.npmjs.com/package/marked-gfm-heading-id.
```

I [attempted to address these](https://github.com/alphagov/govuk-design-system/pull/2766/commits/15d0bae56de67ccfb570a396d79aeba9c332fbe7) as recommended, but ran into a bug with the recommended plugin, so we decided to ignore the major version instead.

That bug has now been fixed: https://github.com/markedjs/marked-gfm-heading-id/issues/310#issuecomment-1540162596, but the current output doesn't contain any headings, so it may be a step too far to use the plugin. We can always pop it in if we notice it becoming an issue.