### PR TITLE
Include a section on chart colours

### DIFF
--- a/src/styles/colour/index.md
+++ b/src/styles/colour/index.md
@@ -96,4 +96,6 @@ You can find departmental colours in the GOV.UK Frontend [_colours-organisations
 </table>
 
 ### Colour palette for charts
-When creating charts refer to the colour palettes and guidance set out in the Analysis Function [Data visualisation: colours guidance](https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/).
+When creating charts, use the colour palettes and guidance set out in the Government Analysis Function [Data visualisation: colours guidance](https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/).
+
+The colour palettes recommended by the Government Analysis Function are based on the colours shown on this page. They've made some slight changes to improve colour contrast, in line with the Web Content Accessibility Guidelines (WCAG).

--- a/src/styles/colour/index.md
+++ b/src/styles/colour/index.md
@@ -94,3 +94,6 @@ You can find departmental colours in the GOV.UK Frontend [_colours-organisations
   {% endfor %}
  </tbody>
 </table>
+
+### Colour palette for charts
+When creating charts refer to the colour palettes and guidance set out in the Analysis Function [Data visualisation: colours guidance](https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/).


### PR DESCRIPTION
I have added in this change, as the problem with using the GOV.UK design system colours which are already on this page for charts is that, depending on what order the colours are presented in, they would not meet the adjacent colour contrast requirements.

The colours guidance I have linked was developed by a cross government working group led by the Department for Education. The colour palette in this guidance have been designed for use in standard line, bar and pie charts. When all the guidance is followed, the colours mentioned in the Analysis Function colour palette will create charts which are as accessible as possible. This  colour palette is used in the Whitehall publisher on GOV.UK.