### PR TITLE
Minor community page improvements

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -37,7 +37,7 @@ Here’s a few places to join the discussions that help shape the Design System.
       alt: "Github issue illustration.",
       title: "Discuss and give feedback"
     }) %}
-      <p>Tell us your experience using our components and patterns. Look for the ‘Help improve this page’ section at the end of each page to see its issue discussion, or <a href="https://github.com/alphagov/govuk-design-system-backlog/issues">see a list of all discussions</a></p>
+      <p>Tell us your experience using our components and patterns. Look for the ‘Help improve this page’ section at the end of each page to see its issue discussion, or <a href="https://github.com/alphagov/govuk-design-system-backlog/issues">see a list of all discussions</a>.</p>
     {% endcall %}
   </div>
   <div class="govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
@@ -55,7 +55,7 @@ Here’s a few places to join the discussions that help shape the Design System.
       alt: "Github propose a change illustration.",
       title: "Propose a change to pages"
     }) %}
-      <p>Anyone can suggest an improvement, report a bug or correct an error on our pages. Look for the ‘Help improve this page’ section at the end of each page to <a href='https://design-system.service.gov.uk/community/propose-a-content-change-using-github/'>propose a change using GitHub</a></p>
+      <p>Anyone can suggest an improvement, report a bug or correct an error on our pages. Look for the ‘Help improve this page’ section at the end of each page to <a href='https://design-system.service.gov.uk/community/propose-a-content-change-using-github/'>propose a change using GitHub</a>.</p>
     {% endcall %}
   </div>
 </div>
@@ -95,7 +95,7 @@ Join one of our regular events where we share ideas and work together to solve c
       title: "Join a Workshop",
       large: true
     }) %}
-        <p>We often organise workshops to gather ideas and feedback about work we’re doing, particularly when we know it will affect service teams. If you’d like to help the next time we do, <a href="https://mailchi.mp/707ce8dec373/get-updated-by-email-govuk-design-system">sign up to our mailing list</a></p>
+        <p>We often organise workshops to gather ideas and feedback about work we’re doing, particularly when we know it will affect service teams. If you’d like to help the next time we do, <a href="https://mailchi.mp/707ce8dec373/get-updated-by-email-govuk-design-system">sign up to our mailing list</a>.</p>
     {% endcall %}
   </div>
   <div class="govuk-grid-column-full">

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -23,36 +23,40 @@ Here’s a few places to join the discussions that help shape the Design System.
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
-    {{- imageCard({
+    {%- call imageCard({
       src: "/community/images/chat-with-us-on-slack.svg",
       alt: "Slack conversation illustration.",
-      title: "Chat with us on Slack",
-      content: "<p>If you work in government, find us on the <a href='https://ukgovernmentdigital.slack.com/archives/C6DMEH5R6\'>#govuk-design-system Slack channel</a> to get support, give us feedback or share your work with us.</p>"
-    }) }}
+      title: "Chat with us on Slack"
+    }) %}
+      <p>If you work in government, find us on the <a href="https://ukgovernmentdigital.slack.com/archives/C6DMEH5R6\">#govuk-design-system Slack channel</a> to get support, give us feedback or share your work with us.</p>
+    {% endcall %}
   </div>
   <div class="govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
-    {{- imageCard({
+    {%- call imageCard({
       src: "/community/images/discuss-and-give-feedback.svg",
       alt: "Github issue illustration.",
-      title: "Discuss and give feedback",
-      content: "<p>Tell us your experience using our components and patterns. Look for the ‘Help improve this page’ section at the end of each page to see its issue discussion, or <a href='https://github.com/alphagov/govuk-design-system-backlog/issues'>see a list of all discussions</a></p>"
-    }) }}
+      title: "Discuss and give feedback"
+    }) %}
+      <p>Tell us your experience using our components and patterns. Look for the ‘Help improve this page’ section at the end of each page to see its issue discussion, or <a href="https://github.com/alphagov/govuk-design-system-backlog/issues">see a list of all discussions</a></p>
+    {% endcall %}
   </div>
   <div class="govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
-    {{- imageCard({
+    {%- call imageCard({
       src: "/community/images/share-your-examples-and-research.svg",
       alt: "Share your examples and research section illustration.",
-      title: "Share your examples and research",
-      content: "<p>‘<a href='https://design-system.service.gov.uk/community/upcoming-components-patterns/'>Upcoming components and patterns</a>’ shows what we're working on, and how you can help us develop and publish them. Any examples, use cases and research you can share would be very valuable to us.</p>"
-    }) }}
+      title: "Share your examples and research"
+    }) %}
+      <p>‘<a href="https://design-system.service.gov.uk/community/upcoming-components-patterns/">Upcoming components and patterns</a>’ shows what we're working on, and how you can help us develop and publish them. Any examples, use cases and research you can share would be very valuable to us.</p>
+    {% endcall %}
   </div>
   <div class="govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
-    {{- imageCard({
+    {%- call imageCard({
       src: "/community/images/propose-a-change-to-pages.svg",
       alt: "Github propose a change illustration.",
-      title: "Propose a change to pages",
-      content: "<p>Anyone can suggest an improvement, report a bug or correct an error on our pages. Look for the ‘Help improve this page’ section at the end of each page to <a href='https://design-system.service.gov.uk/community/propose-a-content-change-using-github/'>propose a change using GitHub</a></p>"
-    }) }}
+      title: "Propose a change to pages"
+    }) %}
+      <p>Anyone can suggest an improvement, report a bug or correct an error on our pages. Look for the ‘Help improve this page’ section at the end of each page to <a href='https://design-system.service.gov.uk/community/propose-a-content-change-using-github/'>propose a change using GitHub</a></p>
+    {% endcall %}
   </div>
 </div>
 
@@ -75,32 +79,35 @@ Join one of our regular events where we share ideas and work together to solve c
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    {{- imageCard({
+    {%- call imageCard({
       src: "/community/images/catchup-call-groupshot.jpg",
       alt: "Catchup call screenshot.",
       title: "Design systems catchup",
-      content: "<p>Chat with us every other Friday on Google Meet. It’s an informal chat with an agenda set each week by participants. <a href='https://calendar.google.com/event?action=TEMPLATE&tmeid=dGZpZ251Y2ttaHRkY3AwcTBxcHViMmY4ZmNfMjAyMjA5MDlUMTMwMDAwWiBjYWx2aW4ubGF1QGRpZ2l0YWwuY2FiaW5ldC1vZmZpY2UuZ292LnVr&tmsrc=calvin.lau%40digital.cabinet-office.gov.uk&scp=ALL'>Add to calendar</a> or <a href='https://design-system.service.gov.uk/get-in-touch/'>contact the team</a> for an invite.</p>",
       large: true
-    }) }}
+    }) %}
+      <p>Chat with us every other Friday on Google Meet. It’s an informal chat with an agenda set each week by participants. <a href="https://calendar.google.com/event?action=TEMPLATE&tmeid=dGZpZ251Y2ttaHRkY3AwcTBxcHViMmY4ZmNfMjAyMjA5MDlUMTMwMDAwWiBjYWx2aW4ubGF1QGRpZ2l0YWwuY2FiaW5ldC1vZmZpY2UuZ292LnVr&tmsrc=calvin.lau%40digital.cabinet-office.gov.uk&scp=ALL">Add to calendar</a> or <a href="https://design-system.service.gov.uk/get-in-touch/">contact the team</a> for an invite.</p>
+    {% endcall %}
   </div>
   <div class="govuk-grid-column-full">
-    {{- imageCard({
+    {%- call imageCard({
       src: "/community/images/workshop.jpg",
       alt: "Table with post-it notes, pens and paper.",
       title: "Join a Workshop",
-      content: "<p>We often organise workshops to gather ideas and feedback about work we’re doing, particularly when we know it will affect service teams. If you’d like to help the next time we do, <a href='https://mailchi.mp/707ce8dec373/get-updated-by-email-govuk-design-system'>sign up to our mailing list</a></p>",
       large: true
-    }) }}
+    }) %}
+        <p>We often organise workshops to gather ideas and feedback about work we’re doing, particularly when we know it will affect service teams. If you’d like to help the next time we do, <a href="https://mailchi.mp/707ce8dec373/get-updated-by-email-govuk-design-system">sign up to our mailing list</a></p>
+    {% endcall %}
   </div>
   <div class="govuk-grid-column-full">
-    {{- imageCard({
+    {%- call imageCard({
       src: "/community/images/dsday22-logo.svg",
       alt: "Design System Day 2022 Logo.",
       title: "Design System Day",
-      content: "<p>Every year, we host an online conference to collaborate and share knowledge about design systems with like-minded people, covering topics like accessibility, community and decision-making.</p>
-      <p>Design System Day 2022 took place on 15 and 16 November. <a href='https://www.youtube.com/playlist?list=PL5tovFCB3CsDXeEhPWk_FM89oMFQMrY2W'>Watch the keynote and panel discussion from the event on YouTube</a>.</p>",
       large: true
-    }) }}
+    }) %}
+      <p>Every year, we host an online conference to collaborate and share knowledge about design systems with like-minded people, covering topics like accessibility, community and decision-making.</p>
+      <p>Design System Day 2022 took place on 15 and 16 November. <a href="https://www.youtube.com/playlist?list=PL5tovFCB3CsDXeEhPWk_FM89oMFQMrY2W">Watch the keynote and panel discussion from the event on YouTube</a>.</p>
+    {% endcall %}
   </div>
 </div>
 

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -60,17 +60,6 @@ Here’s a few places to join the discussions that help shape the Design System.
   </div>
 </div>
 
-<!-- Commenting out this item to give even number, and cover it in the mailing list CTA instead.
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half">
-    <img src="/styles/images/default/3by2.jpg" alt="Three Olympic cyclists overlayed with a 3 by 2 grid to show the 3 by 2 ratio.">
-    <h3>Complete surveys and test releases</h3>
-    <p>We regularly ask our community to help guide our work or test new features before they’re released. To find out the next time we do, <a href="https://mailchi.mp/707ce8dec373/get-updated-by-email-govuk-design-system">sign up to our mailing list</a></p>
-  </div>
-  <div class="govuk-grid-column-one-half">
-  </div>
-</div>
--->
 <hr class="govuk-section-break govuk-section-break--visible">
 
 ## Attend our events

--- a/views/partials/_image-card.njk
+++ b/views/partials/_image-card.njk
@@ -5,7 +5,7 @@
     </figure>
     <div class="app-image-card__text">
       <h3>{{ params.title }}</h3>
-      {{- params.content | safe -}}
+      {{- caller() if caller else params.content | safe -}}
     </div>
   </div>
 {% endmacro %}


### PR DESCRIPTION
This builds on top of the changes in #2813 to:

- make the `imageCard` macro callable, so we can avoid needing to pass HTML inside a double-quoted string (and therefore use double quotes for attributes consistently)
- consistently add full stop to the end of all sentences
- remove some commented out code

This shouldn't be merged until after #2813 is merged (at which point this PR should automagically 🪄  change to target main).