### PR TITLE
Remove outdated statement about printing `<details>` elements

### DIFF
--- a/src/components/details/index.md
+++ b/src/components/details/index.md
@@ -46,5 +46,3 @@ Make the link text short and descriptive so users can quickly work out if they n
 There is [evidence that some users avoid clicking the link to show more details](https://github.com/alphagov/govuk-design-system-backlog/issues/44#issuecomment-629122091), as they think it will take them away from the page.
 
 There are [concerns that some users of voice assist software will not be able to interact with the component](https://github.com/alphagov/govuk-design-system-backlog/issues/44#issuecomment-628082040). Some software might require the user to specifically refer to the link to show more details as a button in order to interact with it.
-
-When printing, there is currently no way to force the page to show details hidden inside a details component. [This issue has been raised with the W3C](https://github.com/w3c/csswg-drafts/issues/2084).


### PR DESCRIPTION
It is now possible to force `<details>` elements to be forcibly opened prior to printing by using [the `beforeprint` event binding](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeprint_event). 

We don't do anything in Frontend to forcibly open `<details>` elements, but [past precedent on the accordion component](https://github.com/alphagov/govuk-frontend/issues/573#issuecomment-472465913) would imply that this lack of intervention is desirable, in order to only print what the user has chosen to show.

Given the overall statement is outdated, and we seemingly don't expect services to automatically expand `<details>` elements anyway, I propose that it is removed outright rather than being modified or reworded.