### PR TITLE
Add alias “telephone number” to “Confirm a phone number” page

### DIFF
--- a/src/patterns/confirm-a-phone-number/index.md
+++ b/src/patterns/confirm-a-phone-number/index.md
@@ -3,7 +3,7 @@ title: Confirm a phone number
 description: Identifying users when they sign in
 section: Patterns
 theme: Help users to…
-aliases: 2FA, MFA, multi-factor authentication, security code, text message, two-factor authentication
+aliases: 2FA, MFA, multi-factor authentication, security code, telephone number, text message, two-factor authentication
 backlog_issue_id: 25
 layout: layout-pane.njk
 ---


### PR DESCRIPTION
We include lots of content that can’t be searched using the “telephone” keyword:

* Check your **phone**
* I do not have access to the **phone**
* …no longer have access to the **phone** used to sign up
* …partially show the user the **phone** number

This is now resolved

<img width="364" alt="Search result for the  Confirm a phone number  page showing up for  telephone number  query" src="https://github.com/alphagov/govuk-design-system/assets/415517/f6c3d8f2-fd39-4d8a-95fe-02d6e5320285">

From a possibly-related-but-not comment https://github.com/alphagov/govuk-frontend/pull/3838#issuecomment-1602898777