### PR TITLE
Group Dependabot package updates into shared PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,13 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - alphagov/design-system-developers
+
+    # Schedule run every Monday, local time
     schedule:
-      # Defaults to weekly on Monday
       interval: weekly
-      time: "10:30"
-      # Setting a timezone so we let dependabot worry about BST
-      timezone: "Europe/London"
+      time: '10:30'
+      timezone: 'Europe/London'
+
     versioning-strategy: increase
 
     allow:
@@ -24,9 +25,9 @@ updates:
     directory: /
     reviewers:
       - alphagov/design-system-developers
+
+    # Schedule run every Monday, local time
     schedule:
-      # Defaults to weekly on Monday
       interval: weekly
-      time: "10:30"
-      # Setting a timezone so we let dependabot worry about BST
-      timezone: "Europe/London"
+      time: '10:30'
+      timezone: 'Europe/London'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,46 @@ updates:
   - package-ecosystem: npm
     directory: /
     open-pull-requests-limit: 10
+
+    # Group packages into shared PR
+    groups:
+      babel:
+        patterns:
+          - '@babel/*'
+
+      lint:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - 'standard'
+          - 'stylelint'
+          - 'stylelint-*'
+
+      metalsmith:
+        patterns:
+          - '@metalsmith/*'
+          - 'jstransformer-*'
+          - 'metalsmith'
+          - 'metalsmith-*'
+
+      postcss:
+        patterns:
+          - 'autoprefixer'
+          - 'postcss'
+          - 'postcss-*'
+
+      rollup:
+        patterns:
+          - '@rollup/*'
+          - 'rollup'
+
+      test:
+        patterns:
+          - '@axe-core/*'
+          - 'jest'
+          - 'jest-*'
+          - 'puppeteer'
+
     reviewers:
       - alphagov/design-system-developers
 


### PR DESCRIPTION
Sets up Dependabot groups for packages that can be grouped together as we did for:

* https://github.com/alphagov/govuk-frontend/pull/3883

Some groups like `@babel/*` and `@metalsmith/*` will avoid compatibility issues
Others are to reduce the noise of all the separate PRs on Mondays