### PR TITLE
Add usage survey to contact panel partial

### DIFF
--- a/src/components/exit-this-page/index.md
+++ b/src/components/exit-this-page/index.md
@@ -104,8 +104,6 @@ However, we decided this was more likely to confuse users. We're also confident 
 
 The design of this component is based on research with people with a lived experience of domestic abuse and people with accessibility needs, and in consultation with the Ministry of Justice, Department for Work and Pensions and the Scottish Government.
 
-Tell us if your service uses this component on our [usage survey (opens in a new tab)](https://surveys.publishing.service.gov.uk/s/MPR0MV/). This will help us improve this component to better meet the needs of the services that use it.
-
 We plan to show more information about how many services use this component.
 
 ### Known issues and gaps

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -1,5 +1,5 @@
 {%- set fileEditURL = "https://github.com/alphagov/govuk-design-system/edit/main/src/" + permalink + "/index.md" -%}
-{% if section === 'Styles' or section === 'Components' or section === 'Patterns'%}
+{% if section === 'Styles' or section === 'Components' or section === 'Patterns' %}
   <h2 class="govuk-heading-l govuk-!-padding-top-7" id="help-improve-this-page">Help improve this {{ section.slice(0, -1) | lower }}</h2>
 
   {% if backlog_issue_id %}
@@ -29,6 +29,12 @@
         If you’re not sure how to do this, read guidance on
         <a class="govuk-link app-contact-panel__link" href="/community/propose-a-content-change-using-github/">how to propose changes in GitHub</a>.
       </p>
+  {% endif %}
+        {% if section === 'Components' or section === 'Patterns' %}
+    <h3 class="govuk-heading-m govuk-!-padding-top-7" id="tell-us-if-your-service-uses">Tell us if your service uses this {{ section.slice(0, -1) | lower }}</h3>
+    <p class="govuk-body"><a class="govuk-link app-contact-panel__link" target="_blank" href="https://surveys.publishing.service.gov.uk/s/MPR0MV/">Take part in our usage survey (opens in a new tab)</a> to help us improve this {{ section.slice(0, -1) | lower }} to better meet the needs of the services that use it.
+    </p>
+  {% elseif section === 'Styles' %}
   {% endif %}
 {% endif %}
 

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -1,5 +1,5 @@
 {%- set fileEditURL = "https://github.com/alphagov/govuk-design-system/edit/main/src/" + permalink + "/index.md" -%}
-{% if section === 'Styles' or section === 'Components' or section === 'Patterns' %}
+{% if ["Components", "Patterns", "Styles"].includes(section) %}
   <h2 class="govuk-heading-l govuk-!-padding-top-7" id="help-improve-this-page">Help improve this {{ section.slice(0, -1) | lower }}</h2>
 
   {% if backlog_issue_id %}
@@ -30,11 +30,10 @@
         <a class="govuk-link app-contact-panel__link" href="/community/propose-a-content-change-using-github/">how to propose changes in GitHub</a>.
       </p>
   {% endif %}
-        {% if section === 'Components' or section === 'Patterns' %}
+  {% if ["Components", "Patterns"].includes(section) %}
     <h3 class="govuk-heading-m govuk-!-padding-top-7" id="tell-us-if-your-service-uses">Tell us if your service uses this {{ section.slice(0, -1) | lower }}</h3>
     <p class="govuk-body"><a class="govuk-link app-contact-panel__link" target="_blank" href="https://surveys.publishing.service.gov.uk/s/MPR0MV/">Take part in our usage survey (opens in a new tab)</a> to help us improve this {{ section.slice(0, -1) | lower }} to better meet the needs of the services that use it.
     </p>
-  {% elseif section === 'Styles' %}
   {% endif %}
 {% endif %}
 

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -4,7 +4,7 @@
 
   {% if backlog_issue_id %}
     <p class="govuk-body">
-    To help make sure that this page is useful, relevant and up to date, you can:
+      To help make sure that this page is useful, relevant and up to date, you can:
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
@@ -21,18 +21,21 @@
       </li>
     </ul>
   {% else %}
-      <p class="govuk-body">
-        If you spot a problem with this guidance you can
-        <a class="govuk-link app-contact-panel__link" href="{{ fileEditURL }}">propose a change</a>.
-      </p>
-      <p class="govuk-body">
-        If you’re not sure how to do this, read guidance on
-        <a class="govuk-link app-contact-panel__link" href="/community/propose-a-content-change-using-github/">how to propose changes in GitHub</a>.
-      </p>
+    <p class="govuk-body">
+      If you spot a problem with this guidance you can
+      <a class="govuk-link app-contact-panel__link" href="{{ fileEditURL }}">propose a change</a>.
+    </p>
+    <p class="govuk-body">
+      If you’re not sure how to do this, read guidance on
+      <a class="govuk-link app-contact-panel__link" href="/community/propose-a-content-change-using-github/">how to propose changes in GitHub</a>.
+    </p>
   {% endif %}
   {% if ["Components", "Patterns"].includes(section) %}
-    <h3 class="govuk-heading-m govuk-!-padding-top-7" id="tell-us-if-your-service-uses">Tell us if your service uses this {{ section.slice(0, -1) | lower }}</h3>
-    <p class="govuk-body"><a class="govuk-link app-contact-panel__link" target="_blank" href="https://surveys.publishing.service.gov.uk/s/MPR0MV/">Take part in our usage survey (opens in a new tab)</a> to help us improve this {{ section.slice(0, -1) | lower }} to better meet the needs of the services that use it.
+    <h3 class="govuk-heading-m govuk-!-padding-top-7" id="tell-us-if-your-service-uses">
+      Tell us if your service uses this {{ section.slice(0, -1) | lower }}
+    </h3>
+    <p class="govuk-body">
+      <a class="govuk-link app-contact-panel__link" target="_blank" href="https://surveys.publishing.service.gov.uk/s/MPR0MV/">Take part in our usage survey (opens in a new tab)</a> to help us improve this {{ section.slice(0, -1) | lower }} to better meet the needs of the services that use it.
     </p>
   {% endif %}
 {% endif %}


### PR DESCRIPTION
## What

Add the usage survey to components and pattern guidance pages.

## Why

This will allow services to tell us which components and patterns they're using, so that we can measure adoption of the design system.

## Who needs to work on this

Steve

## Who needs to review this

Calvin, and one developer.

## Notes

After chatting with @calvin-lau-sig7, we decided to add this to the 'Help improve this [element]' section on each guidance page. However, I've omitted it from Styles pages as it doesn't feel as useful there: most services needing to keep their look consistent with GOV.‌UK are required to use the styles, it's not really optional.  