### PR TITLE
Allow macro options to wrap at full stops and capital letters

### DIFF
--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -37,21 +37,16 @@ function renderDescriptionsAsMarkdown(option) {
 
 // To display nested options that such as rows in a table, we need to make a separate group to be displayed.
 function getNestedOptions(options) {
-  return (
-    options
-      .filter((option) => option.params)
-      .map((option) => {
-        let output = [option]
-        if (option.params) {
-          output = output.concat(getNestedOptions(option.params))
-        }
-        return output
-      })
-      // Flatten array
-      .reduce((a, b) => {
-        return a.concat(b)
-      }, [])
-  )
+  return options
+    .filter((option) => option.params)
+    .map((option) => {
+      let output = [option]
+      if (option.params) {
+        output = output.concat(getNestedOptions(option.params))
+      }
+      return output
+    })
+    .flat()
 }
 
 // Some which are only used in other components are intentionally not displayed in the GOV.UK Design System guidance.
@@ -70,10 +65,7 @@ function getAdditionalComponentOptions(options) {
       }
       return output
     })
-    // Flatten array
-    .reduce((a, b) => {
-      return a.concat(b)
-    }, [])
+    .flat()
 
   const namesWithoutDuplicates = names.filter((optionName, index) => {
     return names.indexOf(optionName) === index

--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -17,10 +17,14 @@ function getMacroOptionsJson(componentName) {
 
 function addSlugs(option) {
   // camelCase into kebab-case
-  option.slug = option.name.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
+  option.slug = option.name
+    .replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2')
+    .toLowerCase()
+
   if (option.params) {
     option.params = option.params.map(addSlugs)
   }
+
   return option
 }
 
@@ -51,26 +55,30 @@ function getNestedOptions(options) {
 // Some which are only used in other components are intentionally not displayed in the GOV.UK Design System guidance.
 // We want to add these as a separate group of options that can be linked to from the original options for the component.
 function getAdditionalComponentOptions(options) {
-  const names = options
+  const optionsFlattened = options
     .map((option) => {
       let output = []
-      if (option.isComponent) {
-        if (option.name === 'hint' || option.name === 'label') {
-          output.push(option.name)
-        }
+
+      if (option.isComponent && ['hint', 'label'].includes(option.slug)) {
+        output.push(option)
       }
+
       if (option.params) {
         output = output.concat(getAdditionalComponentOptions(option.params))
       }
+
       return output
     })
     .flat()
 
-  const namesWithoutDuplicates = names.filter((optionName, index) => {
-    return names.indexOf(optionName) === index
-  })
+  // Component names with duplicates
+  const componentNames = optionsFlattened.map((option) => option.name)
 
-  return namesWithoutDuplicates
+  // Macro options with duplicates removed
+  // For example, Checkboxes have `hint` for fieldset and items
+  return optionsFlattened.filter(
+    (option, index) => componentNames.indexOf(option.name) === index
+  )
 }
 
 /**
@@ -153,25 +161,20 @@ function getMacroOptions(componentName) {
     }
   ]
     .concat(
-      nestedOptions.map((option) => {
-        return {
-          name: 'Options for ' + option.name,
-          id: option.name,
-          options: option.params
-        }
-      })
+      nestedOptions.map((option) => ({
+        name: 'Options for ' + option.name,
+        id: option.slug,
+        options: option.params
+      }))
     )
     .concat(
-      additionalComponents.map((name) => {
-        const additionalComponentOptions = getMacroOptionsJson(name).map(
+      additionalComponents.map((option) => ({
+        name: 'Options for ' + option.name,
+        id: option.slug,
+        options: getMacroOptionsJson(option.name).map(
           renderDescriptionsAsMarkdown
         )
-        return {
-          name: 'Options for ' + name,
-          id: name,
-          options: additionalComponentOptions
-        }
-      })
+      }))
     )
 
   return optionGroups

--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -1,4 +1,3 @@
-const fs = require('fs')
 const { dirname, join } = require('path')
 
 const { marked } = require('marked')
@@ -13,7 +12,7 @@ function getMacroOptionsJson(componentName) {
     dirname(require.resolve('govuk-frontend')),
     `components/${componentName}/macro-options.json`
   )
-  return JSON.parse(fs.readFileSync(optionsFilePath, 'utf8'))
+  return structuredClone(require(optionsFilePath))
 }
 
 function addSlugs(option) {

--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -28,6 +28,22 @@ function addSlugs(option) {
   return option
 }
 
+function renderNameWithBreaks(option) {
+  if (option.params) {
+    option.params = option.params.map(renderNameWithBreaks)
+  }
+
+  // Add suggested word breaks before capital letters to allow
+  // browsers to break long option names in sensible places
+  option.name = option.name.replace(/(?<!<wbr>)([A-Z])/g, '<wbr>$1')
+
+  // Also add suggested word breaks after full stops for options
+  // that are manually given parent prefixes like `summary.text`
+  option.name = option.name.replace(/(\.)(?!<wbr>)/g, '$1<wbr>')
+
+  return option
+}
+
 function renderDescriptionsAsMarkdown(option) {
   if (option.description) {
     option.description = marked(option.description, { renderer })
@@ -146,34 +162,39 @@ function getMacroOptions(componentName) {
     componentName = 'input'
   }
 
-  const options = getMacroOptionsJson(componentName)
-    .map(addSlugs)
+  // Macro options
+  const options = getMacroOptionsJson(componentName).map(addSlugs)
+
+  // Macro options with formatting
+  const optionsFormatted = structuredClone(options)
+    .map(renderNameWithBreaks)
     .map(renderDescriptionsAsMarkdown)
 
-  const nestedOptions = getNestedOptions(options)
+  const nestedOptions = getNestedOptions(optionsFormatted)
   const additionalComponents = getAdditionalComponentOptions(options)
 
   const optionGroups = [
     {
       name: 'Primary options',
       id: 'primary',
-      options
+      options: optionsFormatted
     }
   ]
     .concat(
       nestedOptions.map((option) => ({
-        name: 'Options for ' + option.name,
+        name: `Options for ${option.name}`,
         id: option.slug,
         options: option.params
       }))
     )
     .concat(
       additionalComponents.map((option) => ({
-        name: 'Options for ' + option.name,
+        name: `Options for ${option.name}`,
         id: option.slug,
-        options: getMacroOptionsJson(option.name).map(
-          renderDescriptionsAsMarkdown
-        )
+        options: getMacroOptionsJson(option.name)
+          .map(addSlugs)
+          .map(renderNameWithBreaks)
+          .map(renderDescriptionsAsMarkdown)
       }))
     )
 

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -60,12 +60,7 @@ const nunjucksOptions = {
   },
 
   filters: {
-    slugger,
-    kebabCase: (string) => {
-      return string
-        .replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2')
-        .toLowerCase()
-    }
+    slugger
   }
 }
 

--- a/src/stylesheets/components/_options.scss
+++ b/src/stylesheets/components/_options.scss
@@ -16,7 +16,10 @@
     .govuk-table__header,
     .govuk-table__cell {
       padding-right: govuk-spacing(2);
-      word-break: break-word;
+
+      // Automatic wrapping for unbreakable option names
+      word-wrap: break-word; // Fallback for older browsers only
+      overflow-wrap: break-word;
     }
   }
 }

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -114,14 +114,14 @@
                       {{ option.description | safe }}
                       {% if (option.isComponent) -%}
                         {# Create separate table data for components that are hidden in the Design System -#}
-                        {% if (option.name === "hint" or option.name === "label") %}
-                          See <a href="#options-{{ exampleId }}--{{ option.name }}">{{ option.name }}</a>.
+                        {% if ["hint", "label"].includes(option.slug) %}
+                          See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name }}</a>.
                         {% else %}
-                          See <a href="/components/{{ option.slug }}/#options-{{ option.name | kebabCase }}-example">{{ option.name }}</a>.
+                          See <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ option.name }}</a>.
                         {% endif %}
                       {% endif %}
                       {% if (option.params) %}
-                        See <a href="#options-{{ exampleId }}--{{ option.name }}">{{ option.name }}</a>.
+                        See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name }}</a>.
                       {% endif -%}
                     </td>
                   </tr>

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -94,7 +94,7 @@
           </p>
           {% for table in macroOptions %}
             <table class="govuk-table app-options__table" id="options-{{ exampleId }}--{{ table.id }}">
-              <caption class="govuk-table__caption govuk-heading-m {% if table.id == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name }}</caption>
+              <caption class="govuk-table__caption govuk-heading-m {% if table.id == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name | safe }}</caption>
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                   <th class="govuk-table__header app-options__limit-table-cell" scope="col">Name</th>
@@ -105,9 +105,9 @@
               <tbody class="govuk-table__body">
                 {% for option in table.options -%}
                   <tr class="govuk-table__row">
-                    <th class="govuk-table__header" scope="row">{{option.name}}</th>
-                    <td class="govuk-table__cell ">{{option.type}}</td>
-                    <td class="govuk-table__cell ">
+                    <th class="govuk-table__header" scope="row">{{ option.name | safe }}</th>
+                    <td class="govuk-table__cell">{{ option.type }}</td>
+                    <td class="govuk-table__cell">
                       {% if (option.required === true) %}
                         <strong>Required.</strong>
                       {% endif %}
@@ -115,13 +115,13 @@
                       {% if (option.isComponent) -%}
                         {# Create separate table data for components that are hidden in the Design System -#}
                         {% if ["hint", "label"].includes(option.slug) %}
-                          See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name }}</a>.
+                          See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name | safe }}</a>.
                         {% else %}
-                          See <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ option.name }}</a>.
+                          See <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ option.name | safe }}</a>.
                         {% endif %}
                       {% endif %}
                       {% if (option.params) %}
-                        See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name }}</a>.
+                        See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name | safe }}</a>.
                       {% endif -%}
                     </td>
                   </tr>


### PR DESCRIPTION
This PR lets macro option names wrap at full stops and capital letters

It includes:

1. Prefer `overflow-wrap` like we did in [**govuk-frontend**/pull/1185](https://github.com/alphagov/govuk-frontend/pull/1185)
2. Consistently use option `slug` so that `name` can contain HTML
3. Add line break opportunities using [`<wbr>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr)

## Wrapping examples

By formatting option names with `<wbr>` they wrap without affecting copy & paste

<br>
<img src="https://github.com/alphagov/govuk-design-system/assets/415517/2c92a3ac-f70c-42e3-bea4-afd088e55f4f" width="75%" alt="Animation to show improved wrapping with 'wbr' tag word break opportunities">
<br>
<br>

Other long option names break in hard-to-read places, such as:

```
charactersAtLimitText
charactersOverLimitText
charactersUnderLimitText
hideAllSectionsText
hideSectionAriaLabelText
pressOneMoreTimeText
pressTwoMoreTimesText
preventDoubleClick
showAllSectionsText
showSectionAriaLabelText
textareaDescriptionText
visuallyHiddenText
visuallyHiddenTitle
wordsOverLimitText
wordsUnderLimitText
```