### PR TITLE
Show nested option type in table captions

### DIFF
--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -219,6 +219,11 @@ function getMacroOptions(componentName) {
   ]
     .concat(
       nestedOptions.map(([option]) => {
+        const names = option.name.split(' ')
+
+        // Wrap option name with `<code>` (excluding parents)
+        names[names.length - 1] = `<code>${names.at(-1)}</code>`
+
         return {
           ...option,
 
@@ -226,8 +231,8 @@ function getMacroOptions(componentName) {
           // to clarify that the options are for arrays of objects, not arrays
           name:
             option.type === 'array' && option.params
-              ? `Options for ${option.name} ${option.type} objects`
-              : `Options for ${option.name} ${option.type}`,
+              ? `Options for ${names.join(' ')} ${option.type} objects`
+              : `Options for ${names.join(' ')} ${option.type}`,
 
           options: option.params
         }
@@ -237,7 +242,7 @@ function getMacroOptions(componentName) {
       additionalComponents.map(([option, parent]) => ({
         ...option,
 
-        name: `Options for ${option.name} component`,
+        name: `Options for <code>${option.name}</code> component`,
         options: getMacroOptionsJson(option.slug)
           .map((option) => addSlugs(option, parent))
           .map(renderNameWithBreaks)

--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -218,18 +218,26 @@ function getMacroOptions(componentName) {
     }
   ]
     .concat(
-      nestedOptions.map(([option]) => ({
-        ...option,
+      nestedOptions.map(([option]) => {
+        return {
+          ...option,
 
-        name: `Options for ${option.name}`,
-        options: option.params
-      }))
+          // Append "objects" to the table caption for arrays of nested objects
+          // to clarify that the options are for arrays of objects, not arrays
+          name:
+            option.type === 'array' && option.params
+              ? `Options for ${option.name} ${option.type} objects`
+              : `Options for ${option.name} ${option.type}`,
+
+          options: option.params
+        }
+      })
     )
     .concat(
       additionalComponents.map(([option, parent]) => ({
         ...option,
 
-        name: `Options for ${option.name}`,
+        name: `Options for ${option.name} component`,
         options: getMacroOptionsJson(option.slug)
           .map((option) => addSlugs(option, parent))
           .map(renderNameWithBreaks)

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -248,6 +248,7 @@ $colour-list-breakpoint: 980px;
 
 // Add styling for inline code
 li code,
+caption code,
 td code,
 p code {
   padding: 1px 3px;
@@ -257,6 +258,14 @@ p code {
   @include govuk-media-query($from: tablet) {
     padding: 2px 4px;
   }
+}
+
+// Add styling for code in headings
+.govuk-heading-s code,
+.govuk-heading-m code,
+.govuk-heading-l code,
+.govuk-heading-xl code {
+  font-size: inherit;
 }
 
 // Add styling for block code


### PR DESCRIPTION
Just splitting out some ideas from https://github.com/alphagov/govuk-design-system/pull/2892

This PR adds the nested option `type` to macro option table captions

## Before

* **Options for `example`** – Used for nested arrays, objects and components

## After

* **Options for `example` object** – Used for nested objects
* **Options for `example` array** – Used for nested arrays (without params)
* **Options for `example` array objects** – Used for nested arrays (with params)
* **Options for `example` component** – Used for nested components

| Before  | After |
| ------- | ----- |
| <img width="782" alt="Table captions for nested options" src="https://github.com/alphagov/govuk-design-system/assets/415517/3023e100-4cab-4a8d-a4ad-c37aeba2daf0"> | <img width="780" alt="Table captions for nested options showing types" src="https://github.com/alphagov/govuk-design-system/assets/415517/523e4604-2a99-4bc6-a813-75501eed8456"> |
