### PR TITLE
Show nested options description in table caption

### DIFF
--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -191,6 +191,7 @@ function getMacroOptions (componentName) {
       .map(option => ({
         name: `Options for ${option.name}`,
         id: option.slug,
+        description: option.description,
         options: option.params
       }))
   ).concat(
@@ -198,6 +199,7 @@ function getMacroOptions (componentName) {
       .map(option => ({
         name: `Options for ${option.name}`,
         id: option.slug,
+        description: option.description,
         options: getMacroOptionsJson(option.name)
           .map(addSlugs)
           .map(renderNameWithBreaks)

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -96,7 +96,12 @@
           </p>
           {% for table in macroOptions %}
             <table class="govuk-table app-options__table" id="options-{{ exampleId }}--{{ table.id }}">
-              <caption class="govuk-table__caption govuk-heading-m {% if table.id == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name | safe }}</caption>
+              <caption class="govuk-table__caption{% if table.id == 'primary' %} govuk-visually-hidden{% endif %}">
+                <h3 class="govuk-heading-m">{{ table.name | safe }}</h3>
+                {% if table.description %}
+                <p class="govuk-body">{{ table.description | safe }}</p>
+                {% endif %}
+              </caption>
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                   <th class="govuk-table__header app-options__limit-table-cell" scope="col">Name</th>


### PR DESCRIPTION
We don't currently show the `description` field for nested macro options

It's quite useful to see it, although touches on:

* https://github.com/alphagov/govuk-frontend/issues/3881

<img width="781" alt="Nested macro options with description field" src="https://github.com/alphagov/govuk-design-system/assets/415517/a1ebab4f-ceb0-4150-abe5-5abe6c9b78e1">
