### PR TITLE
Use front matter for component examples

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -1,14 +1,16 @@
 const fs = require('fs')
-const { join, normalize } = require('path')
+const { join, normalize, dirname } = require('path')
 
 const matter = require('gray-matter')
 const beautify = require('js-beautify')
-const nunjucks = require('nunjucks')
+const Nunjucks = require('nunjucks')
 const slash = require('slash')
 
 const { paths } = require('../config')
 
-nunjucks.configure(join(paths.views, 'layouts'))
+const nunjucks = new Nunjucks.Environment(new Nunjucks.FileSystemLoader(
+  [join(paths.views, 'layouts'), join(dirname(require.resolve('govuk-frontend')), '../')]
+))
 
 // This helper function takes a path of a file and
 // returns the contents as string
@@ -87,17 +89,22 @@ exports.getFingerprint = function (file) {
 
 // This helper function takes a path of a *.md.njk file and
 // returns the HTML rendered by Nunjucks without markdown data
-exports.getHTMLCode = path => {
-  const fileContents = this.getFileContents(path)
-
-  const parsedFile = matter(fileContents)
-  const content = parsedFile.content
+exports.getHTMLCode = (path, file) => {
+  let content
+  if (file) {
+    content = file.contents.toString()
+  } else {
+    const fileContents = this.getFileContents(path)
+    const parsedFile = matter(fileContents)
+    content = parsedFile.content
+  }
 
   let html = ''
   try {
     html = nunjucks.renderString(content).trim()
   } catch (err) {
     if (err) {
+      console.log(err)
       console.log('Could not get HTML code from ' + path)
     }
   }

--- a/lib/metalsmith-enrich-examples.js
+++ b/lib/metalsmith-enrich-examples.js
@@ -1,0 +1,83 @@
+const { sep, join, dirname } = require('path')
+
+const slash = require('slash')
+const slugger = require('slugger') // generate slugs from titles
+
+const fileHelper = require('./file-helper.js')
+
+/**
+ * Plugin that enriches and remaps `file.examples` with custom computed properties
+ * @example
+ * const files = {}
+ * // before
+ * files['components/accordion/index.md'] = {
+ *   examples: {
+ *     default: {
+ *       nunjucks: true,
+ *       html: true,
+ *       titleSuffix: 'Extra',
+ *       example: 'default'
+ *     }
+ *   }
+ * }
+ *
+ * enrichExamples(files, metalsmith)
+ *
+ * // after
+ * files['components/accordion/index.md'].examples.default === {
+ *   nunjucks: '<nunjucks source of matching example>',
+ *   html: '<html rendering of the component>',
+ *   title: 'Accordion Extra',
+ *   titleSuffix: 'Extra',
+ *   url: `components/accordion/default/index.njk`,
+ *   example: 'default',
+ *   id: 'accordion-extra-example'
+ * }
+ */
+module.exports = function enrichExamples (files, metalsmith) {
+  const debug = metalsmith.debug('metalsmith-enrich-examples')
+  Object.entries(files).forEach(([parentPath, file]) => {
+    if (!file.examples) return
+
+    // allow omitting group, item in file frontmatter and infer them from dir structure
+    // dirname(parentPath) === ':group/:item'
+    const defaults = {
+      group: dirname(parentPath).split(sep).slice(-2)[0],
+      item: dirname(parentPath).split(sep).slice(-1)[0],
+      displayExample: true,
+      html: false,
+      nunjucks: false
+    }
+
+    // for each example, transform frontmatter examples input objects into example specs objects
+    // ready for input to the nunjucks example macro
+    Object.keys(file.examples).forEach(name => {
+      debug.info('Computing metadata for examples.%s at "%s"', name, parentPath)
+      const ex = file.examples[name] = { ...defaults, ...file.examples[name] }
+      const { group, item, example, customCode, open, id, html, nunjucks } = ex
+
+      const path = join(group, item, example, `${customCode ? 'code' : 'index'}.njk`)
+      const url = '/' + slash(join(group, item, example, 'index.html'))
+      const exampleFile = files[path]
+
+      if (!exampleFile) {
+        debug.error('Skipping example "examples.%s", file "%s" not found.', example, path)
+        return
+      }
+
+      // Omit any `{% extends "foo.njk" %}` nunjucks code, because we extend
+      // templates that only exist within the Design System – it's not useful to
+      // include this in the code we expect others to copy.
+      if (nunjucks) ex.nunjucks = exampleFile.contents.toString().replace(/{%\s*extends\s*\S*\s*%}\s+/, '')
+      if (html) ex.html = fileHelper.getHTMLCode(path, exampleFile)
+
+      // eslint missreads the ternaries below as 'no-unneeded-ternary'
+      const suffix = ex.titleSuffix ? ` ${ex.titleSuffix}` : ''
+      ex.title = `${exampleFile.title}${suffix}`
+      ex.url = url
+
+      ex.id = slugger(id || `${ex.title} example`)
+      ex.id += open ? '-open' : ''
+    })
+  })
+}

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -26,6 +26,7 @@ const generateSitemap = require('./generate-sitemap.js') // generate sitemap
 const getMacroOptions = require('./get-macro-options/index.js')
 const highlighter = require('./highlighter.js')
 const DesignSystemRenderer = require('./marked-renderer.js')
+const enrichExamples = require('./metalsmith-enrich-examples.js')
 const lunr = require('./metalsmith-lunr-index') // generate search index
 const titleChecker = require('./metalsmith-title-checker.js')
 const navigation = require('./navigation.js') // navigation plugin
@@ -201,6 +202,8 @@ module.exports = metalsmith
 
   // check titles are set
   .use(titleChecker())
+
+  .use(enrichExamples)
 
   // render templating syntax in source files
   .use(inplace({

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "npm run lint:js && npm run lint:scss && npm run lint:html --ignore-scripts",
     "prelint:html": "npm run build",
     "lint:html": "html-validate \"deploy/public/**/index.html\"",
-    "lint:js": "eslint --cache --cache-location .cache/eslint --cache-strategy content --color --ignore-path .gitignore \"**/*.{cjs,js,mjs}\"",
+    "lint:js": "eslint --color --ignore-path .gitignore \"**/*.{cjs,js,mjs}\"",
     "lint:scss": "stylelint \"**/*.scss\"",
     "check-links": "hyperlink --canonicalroot https://design-system.service.gov.uk/ --internal --recursive --source-maps deploy/public/sitemap.xml | tap-mocha-reporter min"
   },

--- a/src/components/accordion/index.md
+++ b/src/components/accordion/index.md
@@ -7,13 +7,35 @@ backlogIssueId: 1
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This component is currently experimental because <a class="govuk-link" href="#known-issues-and-gaps">more research</a> is needed to validate it.
+examples:
+  default:
+    example: default
+    html: true
+    nunjucks: true
+    open: false
+    size: xl
+  section_heading_buttons:
+    example: default
+    html: true
+    nunjucks: true
+    open: false
+    size: xl
+    titleSuffix: second
+  with_summary_section:
+    group: components
+    item: accordion
+    example: with-summary-section
+    html: true
+    nunjucks: true
+    open: false
+    size: xl
 ---
 
-{% from "_example.njk" import example %}
+{% from "_example-v2.njk" import example %}
 
 The accordion component lets users show and hide sections of related content on a page.
 
-{{ example({group: "components", item: "accordion", example: "default", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example(examples.default) }}
 
 ## When to use this component
 
@@ -79,7 +101,7 @@ The heading button includes all of these areas:
 
 For users of screen readers, all the text in the button will be read as a single statement (separated by commas to allow for slight pauses). There’s also some visually hidden content in the heading text to help announce the call-to-action as 'show this section' or 'hide this section'.
 
-{{ example({group: "components", item: "accordion", example: "default", html: true, nunjucks: true, open: false, size: "xl", titleSuffix: "second"}) }}
+{{ example(examples.section_heading_buttons) }}
 
 #### Write clear button text
 
@@ -94,7 +116,7 @@ Only add a summary line if it’s actually needed, as it's likely to make the bu
 
 If you’ve decided that you need the summary line, you must make it as short as possible.
 
-{{ example({group: "components", item: "accordion", example: "with-summary-section", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example(examples.with_summary_section) }}
 
 #### Structure section headings with the rest of the page
 

--- a/views/partials/_example-v2.njk
+++ b/views/partials/_example-v2.njk
@@ -1,0 +1,135 @@
+{% macro example(params) %}
+
+{% set multipleTabs = params.html and params.nunjucks %}
+
+<div class="app-example-wrapper" id="{{ params.id }}" data-module="app-tabs" {%- if params.open %} data-open{% endif %}>
+  {% if params.displayExample %}
+    <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
+      <div class="app-example__toolbar">
+        <a href="{{ params.url }}" class="app-example__new-window" target="_blank">
+          Open this
+          {#- Don't use full title visually as the context is shown based on location of this link #}
+          <span class="govuk-visually-hidden">{{ params.title | lower }}</span>
+          example in a new tab
+        </a>
+      </div>
+      <iframe title="{{ params.title + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ params.url }}" loading="lazy"></iframe>
+    </div>
+  {% endif %}
+
+  {%- if (multipleTabs) %}
+    <span id="options-{{ params.id }}"></span>
+    <ul class="app-tabs" role="tablist">
+      <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ params.id }}-html" role="tab" aria-controls="{{ params.id }}-html" data-track="tab-html">HTML</a></li>
+      <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ params.id }}-nunjucks" role="tab" aria-controls="{{ params.id }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></li>
+    </ul>
+  {% elif not (params.hideTab) %}
+    {% set tabType = "html" if params.html else ("nunjucks" if params.nunjucks ) %}
+    {#- if at least one tab is set to true show the list -#}
+    {% if tabType %}
+      <ul class="app-tabs" role="tablist">
+        <li class="app-tabs__item js-tabs__item" role="presentation">
+          <a href="#{{ params.id }}-{{ tabType }}" role="tab" aria-controls="{{ params.id }}-{{ tabType }}" data-track="tab-{{ tabType }}">{{ "HTML" if params.html else ("Nunjucks" if params.nunjucks )}}</a>
+        </li>
+      </ul>
+    {% endif %}
+  {% endif %}
+
+  {%- if (params.html) %}
+    {%- if (multipleTabs) or (not params.hideTab) %}
+      <div class="app-tabs__heading js-tabs__heading"><a href="#{{ params.id }}-html" aria-controls="{{ params.id }}-html" data-track="tab-html">HTML</a></div>
+    {% endif %}
+    <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ params.id }}-html" role="tabpanel">
+      <div class="app-example__code" data-module="app-copy">
+
+```html
+{{ params.html | safe }}
+```
+
+      </div>
+    </div>
+  {% endif %}
+
+  {%- if (params.nunjucks) %}
+    {%- if (multipleTabs) %}
+      <div class="app-tabs__heading js-tabs__heading"><a class="app-tabs__heading-link" href="#{{ params.id }}-nunjucks" aria-controls="{{ params.id }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
+    {% elif not (params.hideTab) %}
+      <div class="app-tabs__heading js-tabs__heading"><a href="#{{ params.id }}-nunjucks" role="tab" aria-controls="{{ params.id }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
+    {% endif -%}
+    <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ params.id }}-nunjucks" role="tabpanel">
+      {%- if (params.group == 'components') %}
+        {% set macroOptions = getMacroOptions(params.item) %}
+
+        {% set macroOptionsHTML %}
+          <p>
+          Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
+          </p>
+          <p>
+          Some options are required for the macro to work; these are marked as "Required" in the option description.
+          </p>
+          <p>
+          If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must sanitise the HTML to protect against  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting exploits</a>.
+          </p>
+          {% for table in macroOptions %}
+            <table class="govuk-table app-options__table" id="options-{{ params.id }}--{{ table.id }}">
+              <caption class="govuk-table__caption govuk-heading-m {% if table.id == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name }}</caption>
+              <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th class="govuk-table__header app-options__limit-table-cell" scope="col">Name</th>
+                  <th class="govuk-table__header app-options__limit-table-cell" scope="col">Type</th>
+                  <th class="govuk-table__header" scope="col">Description</th>
+                </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                {% for option in table.options -%}
+                  <tr class="govuk-table__row">
+                    <th class="govuk-table__header" scope="row">{{option.name}}</th>
+                    <td class="govuk-table__cell ">{{option.type}}</td>
+                    <td class="govuk-table__cell ">
+                      {% if (option.required === true) %}
+                        <strong>Required.</strong>
+                      {% endif %}
+                      {{ option.description | safe }}
+                      {% if (option.isComponent) -%}
+                        {# Create separate table data for components that are hidden in the Design System -#}
+                        {% if (option.name === "hint" or option.name === "label") %}
+                          See <a href="#options-{{ params.id }}--{{ option.name }}">{{ option.name }}</a>.
+                        {% else %}
+                          See <a href="/components/{{ option.slug }}/#options-{{ option.name | kebabCase }}-example">{{ option.name }}</a>.
+                        {% endif %}
+                      {% endif %}
+                      {% if (option.params) %}
+                        See <a href="#options-{{ params.id }}--{{ option.name }}">{{ option.name }}</a>.
+                      {% endif -%}
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          {% endfor %}
+
+        {%- endset %}
+
+        {%- from "govuk/components/details/macro.njk" import govukDetails %}
+
+        {{- govukDetails({
+          summaryHtml: "<span data-components='github-component-arguments'>Nunjucks macro options</span>",
+          html: macroOptionsHTML,
+          classes: "app-options",
+          attributes:{
+            id: "options-" + params.id + "-details"
+          }
+        })}}
+      {% endif -%}
+      <div class="app-example__code" data-module="app-copy">
+
+```javascript
+{{ params.nunjucks | safe }}
+```
+
+      </div>
+    </div>
+  {% endif %}
+</div>
+
+{% endmacro %}


### PR DESCRIPTION
Note this PR includes the first 2 commits relevant to https://github.com/alphagov/govuk-design-system/pull/2933, but only the third is relevant: 19363fb077e59b57fce4fb1b8748d40dad2a6c80

This contribution is a POC with components/accordion that can be gradually implemented for all pages with examples better build performance:

- moves @metalsmith/in-place to further in the build chain
- moves njk example() macro parameters to the component index frontmatter (data-ification of component params)
- allows omitting 'group' & 'item' properties of macro params when referring to direct child examples
- adds a separate metalsmith plugin tasked with adding computed frontmatter to files with '.examples' property.
  This moves the bulk of logic in _example.njk to the plugin
- renders fileHelpers getFileContents, getNunjucksCode and getFrontMatter obsolete sparing a lot of fs.*Sync calls.

If all components are migrated to use macro params from the `examples` front-matter property, and all examples use the `_example-v2.njk` template, only the `getFingerprints` method of fileHelpers is still in use (and that could probably be optimized too, but I was short of time)