### PR TITLE
Simplify and document Metalsmith navigation plugin

### DIFF
--- a/config/navigation.js
+++ b/config/navigation.js
@@ -1,3 +1,8 @@
+/**
+ * Navigation menu items
+ *
+ * @type {NavigationItem[]}
+ */
 module.exports = [
   {
     label: 'Get started',
@@ -25,3 +30,21 @@ module.exports = [
     includeInSearch: true
   }
 ]
+
+/**
+ * @typedef {object} NavigationItem
+ * @property {string} label - Navigation item text
+ * @property {string} url - URL path without leading slash
+ * @property {boolean} includeInSearch - Include in search index
+ * @property {NavigationSubItem[]} [items] - Navigation sub items
+ */
+
+/**
+ * @typedef {object} NavigationSubItem
+ * @property {string} label - Navigation item text
+ * @property {string} url - URL path without leading slash
+ * @property {string[]} [aliases] - Additional search terms (optional)
+ * @property {string[]} [headings] - Markdown extracted headings (optional)
+ * @property {string} [order] - Menu item sort order (optional)
+ * @property {string} [theme] - Menu heading to group by (optional)
+ */

--- a/docs/contributing/archiving-deleted-urls.md
+++ b/docs/contributing/archiving-deleted-urls.md
@@ -36,7 +36,7 @@ Along with the pull request to delete or rename the URL you want to change, you 
     title: {Title of the page you are archiving}
     layout: layout-archived.njk
     ignore_in_sitemap: true
-    —
+    ---
     ```
 
 3. Below the new metadata you’ve added, write some brief content explaining to users that you have archived or renamed the page. As a minimum, you should include:

--- a/docs/contributing/archiving-deleted-urls.md
+++ b/docs/contributing/archiving-deleted-urls.md
@@ -35,7 +35,7 @@ Along with the pull request to delete or rename the URL you want to change, you 
     ---
     title: {Title of the page you are archiving}
     layout: layout-archived.njk
-    ignore_in_sitemap: true
+    ignoreInSitemap: true
     ---
     ```
 

--- a/lib/extract-page-headings/fixtures/src/example-with-aliases.md
+++ b/lib/extract-page-headings/fixtures/src/example-with-aliases.md
@@ -1,9 +1,9 @@
 ---
 title: Example with aliases
 headingAliases:
-    Heading level 1: one
-    Heading level 2: two
-    Heading level 3: three
+  Heading level 1: one
+  Heading level 2: two
+  Heading level 3: three
 ---
 
 Contents

--- a/lib/generate-sitemap.js
+++ b/lib/generate-sitemap.js
@@ -69,7 +69,7 @@ const plugin = (opts) => {
       }
 
       // Ignore files if set to true
-      if (frontmatter.ignore_in_sitemap) {
+      if (frontmatter.ignoreInSitemap) {
         return false
       }
       return true

--- a/lib/metalsmith-lunr-index/fixtures/src/about-larry.md
+++ b/lib/metalsmith-lunr-index/fixtures/src/about-larry.md
@@ -1,7 +1,7 @@
 ---
 title: Larry the cat
 section: Cats
-show_page_nav: true
+showPageNav: true
 ---
 
 # Larry (cat)

--- a/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md
+++ b/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md
@@ -3,7 +3,7 @@ title: Page with headings
 section: Components
 show_page_nav: true
 headingAliases:
-    Heading level 2: two
+  Heading level 2: two
 ---
 
 # Heading level 1

--- a/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md
+++ b/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md
@@ -1,7 +1,7 @@
 ---
 title: Page with headings
 section: Components
-show_page_nav: true
+showPageNav: true
 headingAliases:
   Heading level 2: two
 ---

--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -35,9 +35,9 @@ module.exports = function lunrPlugin () {
       })
 
     const pageHeadingDocuments = documents
-      // Only include pages in the with show_page_nav: true
+      // Only include pages in the with showPageNav: true
       .filter(path => {
-        return files[path].show_page_nav
+        return files[path].showPageNav
       })
       // Filter out files that don't have extracted headings
       .filter(path => files[path].headings)

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -15,7 +15,7 @@ const renamer = require('metalsmith-renamer') // rename files
 const slugger = require('slugger') // generate slugs from titles
 
 // Helpers and config
-const { paths } = require('../config')
+const { paths, navigation: menuItems } = require('../config')
 const colours = require('../lib/colours.js') // get colours data
 const extractPageHeadings = require('../lib/extract-page-headings/index.js') // extract page headings into file meta data
 const fileHelper = require('../lib/file-helper.js') // helper function to operate on files
@@ -207,7 +207,9 @@ module.exports = metalsmith(resolve(__dirname, '../'))
   }))
 
   // apply navigation
-  .use(navigation())
+  .use(navigation({
+    items: menuItems
+  }))
 
   // generate a search index
   .use(lunr())

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -47,7 +47,7 @@ module.exports = function () {
                 label: frontmatter.title
               }
 
-              if (frontmatter.headings && frontmatter.show_page_nav) {
+              if (frontmatter.headings && frontmatter.showPageNav) {
                 subitem.headings = frontmatter.headings
               }
 

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -31,43 +31,36 @@ module.exports = function () {
       // Convert directory into a navigation item adding url, label and theme
       for (const itemPath of itemPaths) {
         const frontmatter = files[join(itemPath, 'index.html')]
-        // if we have frontmatter for that file, create subitem
-        if (frontmatter) {
-          if (frontmatter.status && frontmatter.status === 'Draft') {
-            // If the page is labelled as a draft, do not show in the navigation.
-            continue
-          }
 
-          // If the page has been archived, do not show in the navigation.
-          if (frontmatter.ignoreInSitemap) {
-            continue
-          }
-
-          /** @type {NavigationSubItem} */
-          const subitem = {
-            url: itemPath,
-            label: frontmatter.title
-          }
-
-          if (frontmatter.headings && frontmatter.showPageNav) {
-            subitem.headings = frontmatter.headings
-          }
-
-          // if frontmatter contains `theme` data, attach it to navigation item for grouping
-          if (frontmatter.theme) {
-            subitem.theme = frontmatter.theme
-          }
-          // if frontmatter contains 'order' data, use it for ordering the navigation
-          if (frontmatter.order) {
-            subitem.order = frontmatter.order
-          }
-          if (frontmatter.aliases) {
-            subitem.aliases = frontmatter.aliases.split(',').map(string => string.trim())
-          }
-
-          // add subitem to navigation
-          item.items.push(subitem)
+        // Do not show drafts or ignored pages in navigation
+        if (!frontmatter || frontmatter.status === 'Draft' || frontmatter.ignoreInSitemap) {
+          continue
         }
+
+        /** @type {NavigationSubItem} */
+        const subitem = {
+          url: itemPath,
+          label: frontmatter.title
+        }
+
+        if (frontmatter.headings && frontmatter.showPageNav) {
+          subitem.headings = frontmatter.headings
+        }
+
+        // if frontmatter contains `theme` data, attach it to navigation item for grouping
+        if (frontmatter.theme) {
+          subitem.theme = frontmatter.theme
+        }
+        // if frontmatter contains 'order' data, use it for ordering the navigation
+        if (frontmatter.order) {
+          subitem.order = frontmatter.order
+        }
+        if (frontmatter.aliases) {
+          subitem.aliases = frontmatter.aliases.split(',').map(string => string.trim())
+        }
+
+        // add subitem to navigation
+        item.items.push(subitem)
       }
 
       // If 'order' is set, use it to sort the navigation

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -25,9 +25,6 @@ module.exports = function () {
         continue
       }
 
-      // initialise child navigation items as array
-      item.items = []
-
       // Convert directory into a navigation item adding url, label and theme
       for (const itemPath of itemPaths) {
         const frontmatter = files[join(itemPath, 'index.html')]
@@ -37,30 +34,24 @@ module.exports = function () {
           continue
         }
 
-        /** @type {NavigationSubItem} */
-        const subitem = {
+        item.items ??= []
+
+        // Add subitem to navigation
+        item.items.push({
           url: itemPath,
-          label: frontmatter.title
-        }
+          label: frontmatter.title,
+          order: frontmatter.order,
+          theme: frontmatter.theme,
 
-        if (frontmatter.headings && frontmatter.showPageNav) {
-          subitem.headings = frontmatter.headings
-        }
+          // Override Markdown extracted headings plugin (optional)
+          headings: frontmatter.headings && frontmatter.showPageNav
+            ? frontmatter.headings
+            : undefined,
 
-        // if frontmatter contains `theme` data, attach it to navigation item for grouping
-        if (frontmatter.theme) {
-          subitem.theme = frontmatter.theme
-        }
-        // if frontmatter contains 'order' data, use it for ordering the navigation
-        if (frontmatter.order) {
-          subitem.order = frontmatter.order
-        }
-        if (frontmatter.aliases) {
-          subitem.aliases = frontmatter.aliases.split(',').map(string => string.trim())
-        }
-
-        // add subitem to navigation
-        item.items.push(subitem)
+          // Additional search terms (optional)
+          aliases: frontmatter.aliases?.split(',')
+            .map(string => string.trim())
+        })
       }
 
       // If 'order' is set, use it to sort the navigation
@@ -75,7 +66,3 @@ module.exports = function () {
     done()
   }
 }
-
-/**
- * @typedef {import('../config/navigation.js').NavigationSubItem} NavigationSubItem
- */

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -14,58 +14,56 @@ const { compare } = new Intl.Collator('en', {
  *
  * @returns {import('metalsmith').Plugin} Metalsmith plugin
  */
-module.exports = function () {
-  return function (files, metalsmith, done) {
-    const paths = Object.keys(files)
+module.exports = () => (files, metalsmith, done) => {
+  const paths = Object.keys(files)
 
-    for (const item of navigation) {
-      // Match navigation item child directories
-      // (for example, ['components/breadcrumbs', 'components/checkboxes', ...])
-      const itemPaths = metalsmith
-        .match(`${item.url}/*/index.html`, paths)
-        .map((itemPath) => dirname(itemPath))
+  for (const item of navigation) {
+    // Match navigation item child directories
+    // (for example, ['components/breadcrumbs', 'components/checkboxes', ...])
+    const itemPaths = metalsmith
+      .match(`${item.url}/*/index.html`, paths)
+      .map((itemPath) => dirname(itemPath))
 
-      // No sub items required for this path
-      if (!itemPaths.length) {
+    // No sub items required for this path
+    if (!itemPaths.length) {
+      continue
+    }
+
+    // Convert directory into a navigation item adding url, label and theme
+    for (const itemPath of itemPaths) {
+      const frontmatter = files[join(itemPath, 'index.html')]
+
+      // Do not show drafts or ignored pages in navigation
+      if (!frontmatter || frontmatter.status === 'Draft' || frontmatter.ignoreInSitemap) {
         continue
       }
 
-      // Convert directory into a navigation item adding url, label and theme
-      for (const itemPath of itemPaths) {
-        const frontmatter = files[join(itemPath, 'index.html')]
+      item.items ??= []
 
-        // Do not show drafts or ignored pages in navigation
-        if (!frontmatter || frontmatter.status === 'Draft' || frontmatter.ignoreInSitemap) {
-          continue
-        }
+      // Add subitem to navigation
+      item.items.push({
+        url: itemPath,
+        label: frontmatter.title,
+        order: frontmatter.order,
+        theme: frontmatter.theme,
 
-        item.items ??= []
+        // Override Markdown extracted headings plugin (optional)
+        headings: frontmatter.headings && frontmatter.showPageNav
+          ? frontmatter.headings
+          : undefined,
 
-        // Add subitem to navigation
-        item.items.push({
-          url: itemPath,
-          label: frontmatter.title,
-          order: frontmatter.order,
-          theme: frontmatter.theme,
-
-          // Override Markdown extracted headings plugin (optional)
-          headings: frontmatter.headings && frontmatter.showPageNav
-            ? frontmatter.headings
-            : undefined,
-
-          // Additional search terms (optional)
-          aliases: frontmatter.aliases?.split(',')
-            .map(string => string.trim())
-        })
-      }
-
-      // Sort navigation sub items using 'order' (optional)
-      item.items.sort((a, b) => compare(a.order, b.order))
+        // Additional search terms (optional)
+        aliases: frontmatter.aliases?.split(',')
+          .map(string => string.trim())
+      })
     }
 
-    // Add navigation to global variables
-    metalsmith.metadata().navigation = navigation
-
-    done()
+    // Sort navigation sub items using 'order' (optional)
+    item.items.sort((a, b) => compare(a.order, b.order))
   }
+
+  // Add navigation to global variables
+  metalsmith.metadata().navigation = navigation
+
+  done()
 }

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -37,7 +37,7 @@ module.exports = function () {
               }
 
               // If the page has been archived, do not show in the navigation.
-              if (frontmatter.ignore_in_sitemap) {
+              if (frontmatter.ignoreInSitemap) {
                 continue
               }
 

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -1,7 +1,5 @@
 const { dirname, join } = require('path')
 
-const { navigation } = require('../config')
-
 // Navigation item sorting function
 const { compare } = new Intl.Collator('en', {
   numeric: true
@@ -12,12 +10,17 @@ const { compare } = new Intl.Collator('en', {
  *
  * Builds a navigation object based on config file and folder structure
  *
+ * @param {object} config - Plugin config
+ * @param {Navigation} config.items - Navigation menu items
  * @returns {import('metalsmith').Plugin} Metalsmith plugin
  */
-module.exports = () => (files, metalsmith, done) => {
+module.exports = (config) => (files, metalsmith, done) => {
+  const items = structuredClone(config.items)
+
+  // Metalsmith file paths
   const paths = Object.keys(files)
 
-  for (const item of navigation) {
+  for (const item of items) {
     // Match navigation item child directories
     // (for example, ['components/breadcrumbs', 'components/checkboxes', ...])
     const itemPaths = metalsmith
@@ -63,7 +66,11 @@ module.exports = () => (files, metalsmith, done) => {
   }
 
   // Add navigation to global variables
-  metalsmith.metadata().navigation = navigation
+  metalsmith.metadata().navigation = items
 
   done()
 }
+
+/**
+ * @typedef {import('../config/navigation.js')} Navigation
+ */

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -13,65 +13,62 @@ module.exports = function () {
   return function (files, metalsmith, done) {
     const paths = Object.keys(files)
 
-    // iterate main navigation item defined in navigation.json
     for (const item of navigation) {
-      // if we have a navigation url and it is not homepage then look for subitems
-      if (item.url && item.url !== '') {
-        // get directories under main navigation item (e.g. ['breadcrumbs', 'checkboxes', ...])
-        const itemPaths = metalsmith
-          .match(`${item.url}/*/index.html`, paths)
-          .map((itemPath) => dirname(itemPath))
+      // Match navigation item child directories
+      // (for example, ['components/breadcrumbs', 'components/checkboxes', ...])
+      const itemPaths = metalsmith
+        .match(`${item.url}/*/index.html`, paths)
+        .map((itemPath) => dirname(itemPath))
 
-        // if we have directories convert them into menu items
-        if (itemPaths.length) {
-          // initialise child navigation items as array
-          item.items = []
-          // convert directory into a navigation item adding url, label and theme
-          for (const itemPath of itemPaths) {
-            const frontmatter = files[join(itemPath, 'index.html')]
-            // if we have frontmatter for that file, create subitem
-            if (frontmatter) {
-              if (frontmatter.status && frontmatter.status === 'Draft') {
-                // If the page is labelled as a draft, do not show in the navigation.
-                continue
-              }
-
-              // If the page has been archived, do not show in the navigation.
-              if (frontmatter.ignoreInSitemap) {
-                continue
-              }
-
-              /** @type {NavigationSubItem} */
-              const subitem = {
-                url: itemPath,
-                label: frontmatter.title
-              }
-
-              if (frontmatter.headings && frontmatter.showPageNav) {
-                subitem.headings = frontmatter.headings
-              }
-
-              // if frontmatter contains `theme` data, attach it to navigation item for grouping
-              if (frontmatter.theme) {
-                subitem.theme = frontmatter.theme
-              }
-              // if frontmatter contains 'order' data, use it for ordering the navigation
-              if (frontmatter.order) {
-                subitem.order = frontmatter.order
-              }
-              if (frontmatter.aliases) {
-                subitem.aliases = frontmatter.aliases.split(',').map(string => string.trim())
-              }
-
-              // add subitem to navigation
-              item.items.push(subitem)
+      // if we have directories convert them into menu items
+      if (itemPaths.length) {
+        // initialise child navigation items as array
+        item.items = []
+        // convert directory into a navigation item adding url, label and theme
+        for (const itemPath of itemPaths) {
+          const frontmatter = files[join(itemPath, 'index.html')]
+          // if we have frontmatter for that file, create subitem
+          if (frontmatter) {
+            if (frontmatter.status && frontmatter.status === 'Draft') {
+              // If the page is labelled as a draft, do not show in the navigation.
+              continue
             }
-          }
 
-          // if 'order' is set, use it to sort the navigation
-          if (item.items[0].order !== undefined) {
-            item.items.sort((a, b) => a.order - b.order)
+            // If the page has been archived, do not show in the navigation.
+            if (frontmatter.ignoreInSitemap) {
+              continue
+            }
+
+            /** @type {NavigationSubItem} */
+            const subitem = {
+              url: itemPath,
+              label: frontmatter.title
+            }
+
+            if (frontmatter.headings && frontmatter.showPageNav) {
+              subitem.headings = frontmatter.headings
+            }
+
+            // if frontmatter contains `theme` data, attach it to navigation item for grouping
+            if (frontmatter.theme) {
+              subitem.theme = frontmatter.theme
+            }
+            // if frontmatter contains 'order' data, use it for ordering the navigation
+            if (frontmatter.order) {
+              subitem.order = frontmatter.order
+            }
+            if (frontmatter.aliases) {
+              subitem.aliases = frontmatter.aliases.split(',').map(string => string.trim())
+            }
+
+            // add subitem to navigation
+            item.items.push(subitem)
           }
+        }
+
+        // if 'order' is set, use it to sort the navigation
+        if (item.items[0].order !== undefined) {
+          item.items.sort((a, b) => a.order - b.order)
         }
       }
     }

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -1,14 +1,14 @@
-// Navigation metalsmith plugin
-// builds a navigation object based on config file and folder structure
-
-// files: array containing information about every page
-// metalsmith: object containing global information such as meta data
-// done: function which must be called when the plugin has finished working
-
-const { join, dirname } = require('path')
+const { dirname, join } = require('path')
 
 const { navigation } = require('../config')
 
+/**
+ * Metalsmith navigation plugin
+ *
+ * Builds a navigation object based on config file and folder structure
+ *
+ * @returns {import('metalsmith').Plugin} Metalsmith plugin
+ */
 module.exports = function () {
   return function (files, metalsmith, done) {
     const paths = Object.keys(files)
@@ -41,6 +41,7 @@ module.exports = function () {
                 continue
               }
 
+              /** @type {NavigationSubItem} */
               const subitem = {
                 url: itemPath,
                 label: frontmatter.title
@@ -81,3 +82,7 @@ module.exports = function () {
     done()
   }
 }
+
+/**
+ * @typedef {import('../config/navigation.js').NavigationSubItem} NavigationSubItem
+ */

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -20,60 +20,63 @@ module.exports = function () {
         .match(`${item.url}/*/index.html`, paths)
         .map((itemPath) => dirname(itemPath))
 
-      // if we have directories convert them into menu items
-      if (itemPaths.length) {
-        // initialise child navigation items as array
-        item.items = []
-        // convert directory into a navigation item adding url, label and theme
-        for (const itemPath of itemPaths) {
-          const frontmatter = files[join(itemPath, 'index.html')]
-          // if we have frontmatter for that file, create subitem
-          if (frontmatter) {
-            if (frontmatter.status && frontmatter.status === 'Draft') {
-              // If the page is labelled as a draft, do not show in the navigation.
-              continue
-            }
+      // No sub items required for this path
+      if (!itemPaths.length) {
+        continue
+      }
 
-            // If the page has been archived, do not show in the navigation.
-            if (frontmatter.ignoreInSitemap) {
-              continue
-            }
+      // initialise child navigation items as array
+      item.items = []
 
-            /** @type {NavigationSubItem} */
-            const subitem = {
-              url: itemPath,
-              label: frontmatter.title
-            }
-
-            if (frontmatter.headings && frontmatter.showPageNav) {
-              subitem.headings = frontmatter.headings
-            }
-
-            // if frontmatter contains `theme` data, attach it to navigation item for grouping
-            if (frontmatter.theme) {
-              subitem.theme = frontmatter.theme
-            }
-            // if frontmatter contains 'order' data, use it for ordering the navigation
-            if (frontmatter.order) {
-              subitem.order = frontmatter.order
-            }
-            if (frontmatter.aliases) {
-              subitem.aliases = frontmatter.aliases.split(',').map(string => string.trim())
-            }
-
-            // add subitem to navigation
-            item.items.push(subitem)
+      // Convert directory into a navigation item adding url, label and theme
+      for (const itemPath of itemPaths) {
+        const frontmatter = files[join(itemPath, 'index.html')]
+        // if we have frontmatter for that file, create subitem
+        if (frontmatter) {
+          if (frontmatter.status && frontmatter.status === 'Draft') {
+            // If the page is labelled as a draft, do not show in the navigation.
+            continue
           }
-        }
 
-        // if 'order' is set, use it to sort the navigation
-        if (item.items[0].order !== undefined) {
-          item.items.sort((a, b) => a.order - b.order)
+          // If the page has been archived, do not show in the navigation.
+          if (frontmatter.ignoreInSitemap) {
+            continue
+          }
+
+          /** @type {NavigationSubItem} */
+          const subitem = {
+            url: itemPath,
+            label: frontmatter.title
+          }
+
+          if (frontmatter.headings && frontmatter.showPageNav) {
+            subitem.headings = frontmatter.headings
+          }
+
+          // if frontmatter contains `theme` data, attach it to navigation item for grouping
+          if (frontmatter.theme) {
+            subitem.theme = frontmatter.theme
+          }
+          // if frontmatter contains 'order' data, use it for ordering the navigation
+          if (frontmatter.order) {
+            subitem.order = frontmatter.order
+          }
+          if (frontmatter.aliases) {
+            subitem.aliases = frontmatter.aliases.split(',').map(string => string.trim())
+          }
+
+          // add subitem to navigation
+          item.items.push(subitem)
         }
+      }
+
+      // If 'order' is set, use it to sort the navigation
+      if (item.items[0].order !== undefined) {
+        item.items.sort((a, b) => a.order - b.order)
       }
     }
 
-    // add navigation to global variables
+    // Add navigation to global variables
     metalsmith.metadata().navigation = navigation
 
     done()

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -2,6 +2,11 @@ const { dirname, join } = require('path')
 
 const { navigation } = require('../config')
 
+// Navigation item sorting function
+const { compare } = new Intl.Collator('en', {
+  numeric: true
+})
+
 /**
  * Metalsmith navigation plugin
  *
@@ -54,10 +59,8 @@ module.exports = function () {
         })
       }
 
-      // If 'order' is set, use it to sort the navigation
-      if (item.items[0].order !== undefined) {
-        item.items.sort((a, b) => a.order - b.order)
-      }
+      // Sort navigation sub items using 'order' (optional)
+      item.items.sort((a, b) => compare(a.order, b.order))
     }
 
     // Add navigation to global variables

--- a/src/__canary__.html
+++ b/src/__canary__.html
@@ -1,6 +1,6 @@
 ---
 layout: false
-ignore_in_sitemap: true
+ignoreInSitemap: true
 ---
 <!DOCTYPE html>
 <html lang="en">

--- a/src/community/accessibility-strategy/index.md
+++ b/src/community/accessibility-strategy/index.md
@@ -4,7 +4,7 @@ description: Outlines the current principles and work needed to improve the acce
 section: Community
 theme: How we work
 layout: layout-pane.njk
-show_page_nav: true
+showPageNav: true
 order: 9
 ---
 
@@ -28,22 +28,22 @@ The GOV.UK Design System team follows 3 sets of principles to increase the acces
 
 We follow the [4 principles of web accessibility](https://www.w3.org/WAI/WCAG21/Understanding/intro#understanding-the-four-principles-of-accessibility) upon which WCAG is based:
 
-1.  Perceivable – Information and user interface components must be presentable to users in ways they can perceive.   
-2.  Operable – User interface components and navigation must be operable.   
-3.  Understandable – Information and the operation of the user interface must be understandable. 
-4.  Robust – Content must be robust enough that it can be interpreted reliably by a wide variety of user agents, including assistive technologies.   
+1.  Perceivable – Information and user interface components must be presentable to users in ways they can perceive.
+2.  Operable – User interface components and navigation must be operable.
+3.  Understandable – Information and the operation of the user interface must be understandable.
+4.  Robust – Content must be robust enough that it can be interpreted reliably by a wide variety of user agents, including assistive technologies.
 
 ### Universal design
 
 When designing accessible styles, components and patterns, we aim to follow [the 7 principles of universal design](https://universaldesign.ie/What-is-Universal-Design/The-7-Principles/):
 
-1.  Equitable use – The design is useful and marketable to people with diverse abilities. 
+1.  Equitable use – The design is useful and marketable to people with diverse abilities.
 2.  Flexibility in use – The design accommodates a wide range of individual preferences and abilities.
 3.  Simple and intuitive use – The design is easy to understand, regardless of the user's experience, knowledge, language skills, or current concentration level.
 4.  Perceptible information – The design communicates necessary information effectively to the user, regardless of ambient conditions or the user's sensory abilities.
 5.  Tolerance for error – The design minimises hazards and the adverse consequences of accidental or unintended actions.
 6.  Low physical and cognitive effort – The design can be used efficiently and comfortably and with minimum fatigue.
-7.  Size and space for approach and use – The design provides appropriate sizing and spacing of elements, allowing the user to interact successfully.    
+7.  Size and space for approach and use – The design provides appropriate sizing and spacing of elements, allowing the user to interact successfully.
 
 Modifications to principles 6 and 7 are to make sure they apply to web-based designs rather than physical spaces.
 
@@ -81,7 +81,7 @@ Our goal is to focus first on high-risk and high-impact accessibility concerns i
 
 The team puts accessibility concerns in 2 categories:
 
-1.  Theoretical: A question or statement regarding the accessibility of an implementation within the Design System without evidence of real-world impact. 
+1.  Theoretical: A question or statement regarding the accessibility of an implementation within the Design System without evidence of real-world impact.
 2.  Evidenced: Sharing new research, data or evidence showing that an implementation within the Design System could cause barriers for disabled people.
 
 The team will usually prioritise evidenced issues and queries over theoretical ones.
@@ -112,7 +112,7 @@ This approach supports the team closing accessibility concerns which do not incl
 
 Many types of evidence can indicate an evidenced accessibility concern, but some of the most common examples are:
 
--   new findings from user research    
+-   new findings from user research
 -   service team usability testing results
 -   new global best-practises or standards
 -   direct feedback from users of a service or product

--- a/src/community/backlog.md
+++ b/src/community/backlog.md
@@ -1,8 +1,7 @@
 ---
 title: This page has been archived
 layout: layout-archived.njk
-ignore_in_sitemap: true
+ignoreInSitemap: true
 ---
 
 To find out what we’re working on right now, and what we plan to work on next, see the [Upcoming components and patterns](/community/upcoming-components-patterns/) page.
-

--- a/src/community/how-you-can-contribute.md
+++ b/src/community/how-you-can-contribute.md
@@ -1,7 +1,7 @@
 ---
 title: How you can contribute
 layout: layout-archived.njk
-ignore_in_sitemap: true
+ignoreInSitemap: true
 ---
 
 For up to date information, see [the community section](/community/).

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -2,7 +2,7 @@
 layout: layout-pane.njk
 title: Community
 description:  Everyone can help improve the Design System by joining our community discussions, events and co-design collaborations
-show_subnav: true
+showSubNav: true
 ---
 
 {% from "_image-card.njk" import imageCard %}

--- a/src/components/accordion/index.md
+++ b/src/components/accordion/index.md
@@ -3,7 +3,7 @@ title: Accordion
 description: The accordion component lets users show and hide sections of related content on a page
 section: Components
 aliases:
-backlog_issue_id: 1
+backlogIssueId: 1
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This component is currently experimental because <a class="govuk-link" href="#known-issues-and-gaps">more research</a> is needed to validate it.

--- a/src/components/back-link/index.md
+++ b/src/components/back-link/index.md
@@ -3,7 +3,7 @@ title: Back link
 description: Use the back link component to help users go back to the previous page in a multi-page transaction
 section: Components
 aliases: return link, back button
-backlog_issue_id: 32
+backlogIssueId: 32
 layout: layout-pane.njk
 ---
 

--- a/src/components/breadcrumbs/index.md
+++ b/src/components/breadcrumbs/index.md
@@ -3,7 +3,7 @@ title: Breadcrumbs
 description: Help users orientate themselves and navigate pages within a hierarchical structure
 section: Components
 aliases: navigation path, cookie crumb
-backlog_issue_id: 33
+backlogIssueId: 33
 layout: layout-pane.njk
 ---
 

--- a/src/components/button/index.md
+++ b/src/components/button/index.md
@@ -3,7 +3,7 @@ title: Button
 description: Use the button component to help users carry out an action
 section: Components
 aliases:
-backlog_issue_id: 34
+backlogIssueId: 34
 layout: layout-pane.njk
 ---
 

--- a/src/components/character-count/index.md
+++ b/src/components/character-count/index.md
@@ -3,7 +3,7 @@ title: Character count
 description: Tell users how many characters or words they can enter into a textarea
 section: Components
 aliases: word count
-backlog_issue_id: 67
+backlogIssueId: 67
 layout: layout-pane.njk
 ---
 

--- a/src/components/checkboxes/index.md
+++ b/src/components/checkboxes/index.md
@@ -3,7 +3,7 @@ title: Checkboxes
 description: Let users select one or more options by using the checkboxes component
 section: Components
 aliases: check boxes, tickboxes, tick boxes
-backlog_issue_id: 37
+backlogIssueId: 37
 layout: layout-pane.njk
 ---
 

--- a/src/components/cookie-banner/index.md
+++ b/src/components/cookie-banner/index.md
@@ -3,7 +3,7 @@ title: Cookie banner
 description: Allow users to accept or reject cookies which are not essential to making your service work.
 section: Components
 aliases: Cookies banner, consent banner, GDPR banner, tracking banner, analytics banner
-backlog_issue_id: 12
+backlogIssueId: 12
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This component is currently experimental because <a class="govuk-link" href="#research-on-this-component">more research</a> is needed to validate it.

--- a/src/components/date-input/index.md
+++ b/src/components/date-input/index.md
@@ -3,7 +3,7 @@ title: Date input
 description: Use the date input component to help users enter a memorable date
 section: Components
 aliases:
-backlog_issue_id: 42
+backlogIssueId: 42
 layout: layout-pane.njk
 ---
 

--- a/src/components/details/index.md
+++ b/src/components/details/index.md
@@ -3,7 +3,7 @@ title: Details
 description: Make a page easier to scan by letting users reveal more detailed information only if they need it
 section: Components
 aliases: reveal, progressive disclosure, hidden text, show and hide, ShowyHideyThing
-backlog_issue_id: 44
+backlogIssueId: 44
 layout: layout-pane.njk
 ---
 

--- a/src/components/error-message/index.md
+++ b/src/components/error-message/index.md
@@ -3,7 +3,7 @@ title: Error message
 description: When there's a validation error, use an error message to explain what went wrong and how to fix it
 section: Components
 aliases: validation message
-backlog_issue_id: 47
+backlogIssueId: 47
 layout: layout-pane.njk
 ---
 

--- a/src/components/error-summary/index.md
+++ b/src/components/error-summary/index.md
@@ -3,7 +3,7 @@ title: Error summary
 description: Use an error summary when there is a validation error
 section: Components
 aliases:
-backlog_issue_id: 46
+backlogIssueId: 46
 layout: layout-pane.njk
 ---
 

--- a/src/components/exit-this-page/index.md
+++ b/src/components/exit-this-page/index.md
@@ -3,7 +3,7 @@ title: Exit this page
 description: Give users a way to quickly and safely exit a service, website or application.
 section: Components
 aliases:
-backlog_issue_id: 213
+backlogIssueId: 213
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This component is currently experimental. <a class="govuk-link" href="#known-issues-and-gaps">You'll need to do your own research</a> to decide whether to add this component to your service.

--- a/src/components/exit-this-page/index.md
+++ b/src/components/exit-this-page/index.md
@@ -34,7 +34,7 @@ You can also use this component for standalone content pages, such as dashboards
 
 Do not use this component if the service or content is unlikely to put a user at risk. See the [Exit a page quickly](/patterns/exit-a-page-quickly/) pattern for examples of at-risk and sensitive topics.
 
-The 'Exit this page' component is a [button component](/components/button/) that has been marked up with addtional CSS and JavaScript functionality, to make it work in a specific way. 
+The 'Exit this page' component is a [button component](/components/button/) that has been marked up with addtional CSS and JavaScript functionality, to make it work in a specific way.
 
 Keep in mind that seeing this component might discourage certain users from using your service. If the user does not identify themselves as being at risk, they might see the button on a service and decide it’s not relevant to them.
 
@@ -96,7 +96,7 @@ The keyboard option, where the user can press shift 3 times, gives users a discr
 
 The 'secondary link' option is a hidden link in the tab order of the page. This gives users of assistive technology an easier way to reliably activate the component.
 
-To help users of speech recognition software activate the 'secondary link' more discreetly, we considered changing the link text to something else that hid its real purpose. 
+To help users of speech recognition software activate the 'secondary link' more discreetly, we considered changing the link text to something else that hid its real purpose.
 
 However, we decided this was more likely to confuse users. We're also confident about the other ways users can use speech recognition software to activate the 'secondary link' without saying the text out loud, such as choosing the link as an item number on a list.
 
@@ -114,6 +114,6 @@ Before using this component, you should do research with your users. If you do, 
 
 We're particularly interested in investigations into how well this component works on static pages of information ('flat content').
 
-Share your feedback, use cases and research findings on the [Exit this page discussion space on GitHub](https://github.com/alphagov/govuk-design-system/discussions/categories/exit-this-page). 
+Share your feedback, use cases and research findings on the [Exit this page discussion space on GitHub](https://github.com/alphagov/govuk-design-system/discussions/categories/exit-this-page).
 
 We also share notes about our decisions, work and research in the GitHub discussion space and welcome your feedback on those.

--- a/src/components/fieldset/index.md
+++ b/src/components/fieldset/index.md
@@ -3,7 +3,7 @@ title: Fieldset
 description: Use the fieldset component to group related form inputs
 section: Components
 aliases:
-backlog_issue_id: 48
+backlogIssueId: 48
 layout: layout-pane.njk
 ---
 

--- a/src/components/file-upload/index.md
+++ b/src/components/file-upload/index.md
@@ -3,7 +3,7 @@ title: File upload
 description: Help users select and upload a file
 section: Components
 aliases:
-backlog_issue_id: 49
+backlogIssueId: 49
 layout: layout-pane.njk
 ---
 

--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -3,7 +3,7 @@ title: Footer
 description: The footer provides copyright, licensing and other information about your service and department
 section: Components
 aliases: privacy notice, accessibility statement, terms and conditions
-backlog_issue_id: 96
+backlogIssueId: 96
 layout: layout-pane.njk
 ---
 

--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -26,7 +26,7 @@ Use the footer at the bottom of every page of your service.
 Add a copyright notice to the footer to clarify who owns the copyright. For GOV.UK services, add the coat of arms to keep things consistent with the rest of GOV.UK.
 
 Make it clear whether content is available for re-use - and if it is, under what sort of licence. Use an [Open Government Licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) unless you have permission from the National Archives to use a [different type of licence](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/other-licences/).
- 
+
 ### Footer without links
 
 {{ example({group: "components", item: "footer", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}

--- a/src/components/header/index.md
+++ b/src/components/header/index.md
@@ -2,7 +2,7 @@
 title: Header
 description: The GOV.UK header shows users that they are on GOV.UK and which service they are using
 section: Components
-backlog_issue_id: 97
+backlogIssueId: 97
 layout: layout-pane.njk
 ---
 

--- a/src/components/index.md
+++ b/src/components/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout-pane.njk
 title: Components
-show_subnav: true
+showSubNav: true
 ---
 
 Components are reusable parts of the user interface that have been made to support a variety of applications.

--- a/src/components/inset-text/index.md
+++ b/src/components/inset-text/index.md
@@ -3,7 +3,7 @@ title: Inset text
 description: Use the inset text component to differentiate a block of text from the content that surrounds it
 section: Components
 aliases: highlighted text, callout
-backlog_issue_id: 136
+backlogIssueId: 136
 layout: layout-pane.njk
 ---
 

--- a/src/components/notification-banner/index.md
+++ b/src/components/notification-banner/index.md
@@ -3,7 +3,7 @@ title: Notification banner
 description: Use a notification banner to tell the user about something they need to know about, but that’s not directly related to the page content
 section: Components
 aliases: alert, warning, success message, important message, flash message
-backlog_issue_id: 2
+backlogIssueId: 2
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This component is currently experimental because <a class="govuk-link" href="#research-on-this-component">more research</a> is needed to validate it.

--- a/src/components/notification-banner/index.md
+++ b/src/components/notification-banner/index.md
@@ -36,7 +36,7 @@ Do not:
 
 ## How it works
 
-Position a notification banner immediately before the page `h1`. The notification banner should be the same width as the page's other content, such as components, headings and body text. For example, if the other content takes up two-thirds of the screen on desktop devices, then the notification banner should also take up two-thirds. [Read about how to lay out pages](https://design-system.service.gov.uk/styles/layout/). 
+Position a notification banner immediately before the page `h1`. The notification banner should be the same width as the page's other content, such as components, headings and body text. For example, if the other content takes up two-thirds of the screen on desktop devices, then the notification banner should also take up two-thirds. [Read about how to lay out pages](https://design-system.service.gov.uk/styles/layout/).
 
 Use `role="region"` and `aria-labelledby="govuk-notification-banner-title"` (with `id="govuk-notification-banner-title"` on `<govuk-notification-banner__title>`) so that screen reader users can navigate to the notification banner.
 

--- a/src/components/pagination/index.md
+++ b/src/components/pagination/index.md
@@ -44,7 +44,7 @@ Use 'Previous' and 'Next' links to let users navigate through a small number of 
 
 {{ example({group: "components", item: "pagination", example: "labels", html: true, nunjucks: true }) }}
 
-### Add link labels to describe pages 
+### Add link labels to describe pages
 
 You can use link labels to give more context:
 
@@ -69,7 +69,7 @@ For smaller screens, show page numbers for:
 For larger screens, show page numbers for:
 
 - the current page
-- at least one page immediately before and after the current page 
+- at least one page immediately before and after the current page
 - first and last pages
 
 Use ellipses (…) to replace any skipped pages. For example:

--- a/src/components/pagination/index.md
+++ b/src/components/pagination/index.md
@@ -3,7 +3,7 @@ title: Pagination
 description: Help users navigate collections of numbered pages like search results
 section: Components
 aliases:
-backlog_issue_id: 77
+backlogIssueId: 77
 layout: layout-pane.njk
 ---
 

--- a/src/components/panel/index.md
+++ b/src/components/panel/index.md
@@ -3,7 +3,7 @@ title: Panel
 description: The panel component is a visible container used on confirmation or results pages
 section: Components
 aliases: confirmation box, results box, reference number, application complete, application number
-backlog_issue_id: 55
+backlogIssueId: 55
 layout: layout-pane.njk
 ---
 

--- a/src/components/phase-banner/index.md
+++ b/src/components/phase-banner/index.md
@@ -3,7 +3,7 @@ title: Phase banner
 description: Use the phase banner component to show users your service is still being worked on
 section: Components
 aliases: alpha banner, beta banner, prototype banner, status banner, feedback banner
-backlog_issue_id: 57
+backlogIssueId: 57
 layout: layout-pane.njk
 ---
 

--- a/src/components/radios/index.md
+++ b/src/components/radios/index.md
@@ -3,7 +3,7 @@ title: Radios
 description: Let users select a single option from a list using the radios component
 section: Components
 aliases: radio buttons, option buttons
-backlog_issue_id: 59
+backlogIssueId: 59
 layout: layout-pane.njk
 ---
 

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -3,7 +3,7 @@ title: Select
 description: Help users select an item from a list
 section: Components
 aliases: drop down menu, list box, drop down list, combo box, pop-up menu
-backlog_issue_id: 60
+backlogIssueId: 60
 layout: layout-pane.njk
 ---
 

--- a/src/components/skip-link/index.md
+++ b/src/components/skip-link/index.md
@@ -3,7 +3,7 @@ title: Skip link
 description: Use the skip link component to help keyboard-only users skip to the main content on a page
 section: Components
 aliases: Skip navigation link
-backlog_issue_id: 66
+backlogIssueId: 66
 layout: layout-pane.njk
 ---
 

--- a/src/components/summary-list/index.md
+++ b/src/components/summary-list/index.md
@@ -3,7 +3,7 @@ title: Summary list
 description: Use the summary list to summarise information, for example, a user’s responses at the end of a form.
 section: Components
 aliases: Summary card
-backlog_issue_id: 182
+backlogIssueId: 182
 layout: layout-pane.njk
 ---
 

--- a/src/components/summary-list/index.md
+++ b/src/components/summary-list/index.md
@@ -131,6 +131,6 @@ The summary card is also used in services run by other departments, such us:
 
 ### Next steps
 
-We still want to learn more about when this component works well. 
+We still want to learn more about when this component works well.
 
 If you use this component in your service, we'd like to hear about how you use the summary list and summary card, as well as any research findings you might have.

--- a/src/components/table/index.md
+++ b/src/components/table/index.md
@@ -3,7 +3,7 @@ title: Table
 description: Use the table component to make information easier to compare and scan for users
 section: Components
 aliases:
-backlog_issue_id: 61
+backlogIssueId: 61
 layout: layout-pane.njk
 ---
 

--- a/src/components/tabs/index.md
+++ b/src/components/tabs/index.md
@@ -3,7 +3,7 @@ title: Tabs
 description: Tabs can be a helpful way of letting users quickly switch between related information
 section: Components
 aliases:
-backlog_issue_id: 100
+backlogIssueId: 100
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This component is currently experimental because <a class="govuk-link" href="#next-steps">more research</a> is needed to validate it.

--- a/src/components/tag/index.md
+++ b/src/components/tag/index.md
@@ -3,7 +3,7 @@ title: Tag
 description: The tag component indicates the status of something, such as an item on a task list or a phase banner
 section: Components
 aliases: chip, badge, flag, token
-backlog_issue_id: 62
+backlogIssueId: 62
 layout: layout-pane.njk
 ---
 

--- a/src/components/text-input/index.md
+++ b/src/components/text-input/index.md
@@ -3,7 +3,7 @@ title: Text input
 description: Help users enter information with the text input component
 section: Components
 aliases: text box, text field, input field, text entry box
-backlog_issue_id: 51
+backlogIssueId: 51
 layout: layout-pane.njk
 ---
 

--- a/src/components/text-input/index.md
+++ b/src/components/text-input/index.md
@@ -118,7 +118,7 @@ Do not use `<input type="number">` unless your user research shows that there’
 
 ### Codes and sequences
 
-Help the user visually check the code they've typed is correct by styling the input's text to visually separate each character. This is important if you're asking the user to enter a code or sequence they're unlikely to have memorised, such as an application reference ID, account number or security code. 
+Help the user visually check the code they've typed is correct by styling the input's text to visually separate each character. This is important if you're asking the user to enter a code or sequence they're unlikely to have memorised, such as an application reference ID, account number or security code.
 
 You do not need to do this for memorable information, such as phone numbers and postcodes.
 

--- a/src/components/textarea/index.md
+++ b/src/components/textarea/index.md
@@ -3,7 +3,7 @@ title: Textarea
 description: Help users provide detailed information using the textarea component
 section: Components
 aliases: multi-line text box, multi-line text field
-backlog_issue_id: 65
+backlogIssueId: 65
 layout: layout-pane.njk
 ---
 

--- a/src/components/warning-text/index.md
+++ b/src/components/warning-text/index.md
@@ -3,7 +3,7 @@ title: Warning text
 description: Use the warning text component when you need to warn users about something important, such as legal consequences of an action, or lack of action, that they might take
 section: Components
 aliases: important text, legal text
-backlog_issue_id: 71
+backlogIssueId: 71
 layout: layout-pane.njk
 ---
 

--- a/src/errors/404.njk
+++ b/src/errors/404.njk
@@ -1,7 +1,7 @@
 ---
 title: Page not found
 layout: layout-single-page.njk
-ignore_in_sitemap: true
+ignoreInSitemap: true
 ---
 
 <div class="govuk-grid-row">

--- a/src/errors/generic.njk
+++ b/src/errors/generic.njk
@@ -1,7 +1,7 @@
 ---
 title: Sorry, there is a problem with the service
 layout: layout-single-page.njk
-ignore_in_sitemap: true
+ignoreInSitemap: true
 ---
 
 <div class="govuk-grid-row">

--- a/src/get-started/index.md
+++ b/src/get-started/index.md
@@ -2,7 +2,7 @@
 layout: layout-pane.njk
 title: Get started
 description: The following introductory guides will help you to get set up
-show_subnav: true
+showSubNav: true
 ---
 
 The examples in the GOV.UK Design System come with code to make it easy for you to use them in your project.

--- a/src/google921002f57f264802.html
+++ b/src/google921002f57f264802.html
@@ -2,6 +2,6 @@
 permalink: false
 title: N/A
 layout: false
-ignore_in_sitemap: true
+ignoreInSitemap: true
 ---
 google-site-verification: google921002f57f264802.html

--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -4,7 +4,7 @@ description: Help users provide an address
 section: Patterns
 theme: Ask users for…
 aliases:
-backlog_issue_id: 31
+backlogIssueId: 31
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/bank-details/index.md
+++ b/src/patterns/bank-details/index.md
@@ -4,7 +4,7 @@ description: How to ask users for their bank details
 section: Patterns
 theme: Ask users for…
 aliases:
-backlog_issue_id: 149
+backlogIssueId: 149
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#next-steps">more research</a> is needed to validate it.

--- a/src/patterns/check-a-service-is-suitable/index.md
+++ b/src/patterns/check-a-service-is-suitable/index.md
@@ -4,7 +4,7 @@ description: Ask users questions to help them work out if they can or should use
 section: Patterns
 theme: Help users to…
 aliases:
-backlog_issue_id: 35
+backlogIssueId: 35
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/check-answers/index.md
+++ b/src/patterns/check-answers/index.md
@@ -4,7 +4,7 @@ description: Let users check their answers before submitting information to a se
 section: Patterns
 theme: Help users to…
 aliases:
-backlog_issue_id: 36
+backlogIssueId: 36
 layout: layout-pane.njk
 ---
 {% from "_example.njk" import example %}

--- a/src/patterns/confirm-a-phone-number/index.md
+++ b/src/patterns/confirm-a-phone-number/index.md
@@ -4,7 +4,7 @@ description: Identifying users when they sign in
 section: Patterns
 theme: Help users to…
 aliases: 2FA, MFA, multi-factor authentication, security code, telephone number, text message, two-factor authentication
-backlog_issue_id: 25
+backlogIssueId: 25
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/confirm-an-email-address/index.md
+++ b/src/patterns/confirm-an-email-address/index.md
@@ -4,7 +4,7 @@ description: Use an email confirmation loop to check that a user has access to a
 section: Patterns
 theme: Help users to…
 aliases:
-backlog_issue_id: 39
+backlogIssueId: 39
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/confirmation-pages/index.md
+++ b/src/patterns/confirmation-pages/index.md
@@ -4,7 +4,7 @@ description: Let users know they’ve completed a transaction
 section: Patterns
 theme: Pages
 aliases: completion pages, receipts, finish pages
-backlog_issue_id: 40
+backlogIssueId: 40
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/confirmation-pages/index.md
+++ b/src/patterns/confirmation-pages/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-Use this pattern to let users know they’ve completed a transaction. 
+Use this pattern to let users know they’ve completed a transaction.
 
 Include a link to the [GOV.UK feedback page](https://www.gov.uk/service-manual/service-assessments/get-feedback-page) to allow users to tell you what they think of your transaction.
 
@@ -30,7 +30,7 @@ Your confirmation page must include:
 - details of what happens next and when
 - contact details for the service
 - links to information or services that users are likely to need next
-- a link to your [feedback page](https://www.gov.uk/service-manual/service-assessments/get-feedback-page) 
+- a link to your [feedback page](https://www.gov.uk/service-manual/service-assessments/get-feedback-page)
 - a way for users to save a record of the transaction, for example, as a PDF
 
 {{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second", size: "xl"}) }}

--- a/src/patterns/contact-a-department-or-service-team/index.md
+++ b/src/patterns/contact-a-department-or-service-team/index.md
@@ -4,7 +4,7 @@ description: Contact a department or service team
 section: Patterns
 theme: Help users to…
 aliases:
-backlog_issue_id: 10
+backlogIssueId: 10
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#next-steps">more research</a> is needed to validate it.

--- a/src/patterns/cookies-page/index.md
+++ b/src/patterns/cookies-page/index.md
@@ -43,9 +43,9 @@ List all the cookies you’re using in the service. Divide the list into:
 - analytics cookies - cookies that let you collect analytics data to use within your own organisation
 - any other types of cookie you’re using
 
-You should also identify if each cookie is set on the server or client. 
+You should also identify if each cookie is set on the server or client.
 
-The result of your audit will guide your cookie policy and how the service should use a cookies page and cookie banner. 
+The result of your audit will guide your cookie policy and how the service should use a cookies page and cookie banner.
 
 The [cookie banner component](/components/cookie-banner/) shows several options for using a cookie banner for services that:
 

--- a/src/patterns/cookies-page/index.md
+++ b/src/patterns/cookies-page/index.md
@@ -4,7 +4,7 @@ description: Tell users about the cookies you’re setting on their device and l
 section: Patterns
 theme: Pages
 aliases: Privacy settings, Cookie settings, tracking settings
-backlog_issue_id: 13
+backlogIssueId: 13
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because more research is needed to validate it.

--- a/src/patterns/create-a-username/index.md
+++ b/src/patterns/create-a-username/index.md
@@ -4,7 +4,7 @@ description: Help users to create a unique and memorable username to sign into a
 section: Patterns
 theme: Help users to…
 aliases:
-backlog_issue_id: 63
+backlogIssueId: 63
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/create-accounts/index.md
+++ b/src/patterns/create-accounts/index.md
@@ -4,7 +4,7 @@ description: Help users create an account for your service
 section: Patterns
 theme: Help users to…
 aliases:
-backlog_issue_id: 41
+backlogIssueId: 41
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/dates/index.md
+++ b/src/patterns/dates/index.md
@@ -4,7 +4,7 @@ description: Help users enter or select a date
 section: Patterns
 theme: Ask users for…
 aliases:
-backlog_issue_id: 43
+backlogIssueId: 43
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/email-addresses/index.md
+++ b/src/patterns/email-addresses/index.md
@@ -4,7 +4,7 @@ description: Help users enter a valid email address
 section: Patterns
 theme: Ask users for…
 aliases:
-backlog_issue_id: 45
+backlogIssueId: 45
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/equality-information/index.md
+++ b/src/patterns/equality-information/index.md
@@ -4,7 +4,7 @@ description: This pattern explains how to ask users for equality information
 section: Patterns
 theme: Ask users for…
 aliases: protected characteristics, ethnic group, diversity, demographic, age, disability, marriage, civil partnership, religion, sex, gender identity, sexual orientation
-backlog_issue_id: 180
+backlogIssueId: 180
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/ethnic-group/index.md
+++ b/src/patterns/ethnic-group/index.md
@@ -1,7 +1,7 @@
 ---
 title: Ethnic groups
 layout: layout-archived.njk
-ignore_in_sitemap: true
+ignoreInSitemap: true
 ---
 
 In March 2021, we published a new pattern to [ask users for equality information](/patterns/equality-information/), based on data standards set by the Government Statistical Service (GSS).

--- a/src/patterns/exit-a-page-quickly/index.md
+++ b/src/patterns/exit-a-page-quickly/index.md
@@ -55,7 +55,7 @@ This pattern is not a complete solution to eliminating all possible risk to the 
 
 Create a page to explain Exit this page to users.
 
-You must show this page after the start point of your service, but before the page where the user will see the Exit this page button for the first time. 
+You must show this page after the start point of your service, but before the page where the user will see the Exit this page button for the first time.
 
 On longer services, you might need more than one interruption page.
 

--- a/src/patterns/exit-a-page-quickly/index.md
+++ b/src/patterns/exit-a-page-quickly/index.md
@@ -4,7 +4,7 @@ description: Give users a way to quickly and safely exit a service, website or a
 section: Patterns
 theme: Help users to…
 aliases:
-backlog_issue_id: 213
+backlogIssueId: 213
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This component is currently experimental. You'll need to do your own research to decide whether to use this pattern and add the <a class="govuk-link" href="/components/exit-this-page/">Exit this page</a> component to your service.

--- a/src/patterns/gender-or-sex/index.md
+++ b/src/patterns/gender-or-sex/index.md
@@ -4,7 +4,7 @@ description: This pattern explains how to ask users about gender or sex
 section: Patterns
 theme: Ask users for…
 aliases: title, titles, pronoun, pronouns
-backlog_issue_id: 69
+backlogIssueId: 69
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/index.md
+++ b/src/patterns/index.md
@@ -2,7 +2,7 @@
 layout: layout-pane.njk
 title: Patterns
 description: Patterns are best practice design solutions for specific user-focused tasks and page types
-show_subnav: true
+showSubNav: true
 ---
 
 Patterns are best practice design solutions for specific user-focused tasks and page&nbsp;types.

--- a/src/patterns/names/index.md
+++ b/src/patterns/names/index.md
@@ -4,7 +4,7 @@ description: Help users correctly enter their name
 section: Patterns
 theme: Ask users for…
 aliases:
-backlog_issue_id: 53
+backlogIssueId: 53
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/national-insurance-numbers/index.md
+++ b/src/patterns/national-insurance-numbers/index.md
@@ -4,7 +4,7 @@ description: Ask users to provide their National Insurance number
 section: Patterns
 theme: Ask users for…
 aliases:
-backlog_issue_id: 54
+backlogIssueId: 54
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/page-not-found-pages/index.md
+++ b/src/patterns/page-not-found-pages/index.md
@@ -4,7 +4,7 @@ description: A page not found tells someone we cannot find the page they were tr
 section: Patterns
 theme: Pages
 aliases: '404'
-backlog_issue_id: 130
+backlogIssueId: 130
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.

--- a/src/patterns/passwords/index.md
+++ b/src/patterns/passwords/index.md
@@ -4,7 +4,7 @@ description: Help users to create and enter secure and memorable passwords
 section: Patterns
 theme: Ask users for…
 aliases:
-backlog_issue_id: 56
+backlogIssueId: 56
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/payment-card-details/index.md
+++ b/src/patterns/payment-card-details/index.md
@@ -4,7 +4,7 @@ description: How to ask users for their payment card details
 section: Patterns
 theme: Ask users for…
 aliases:
-backlog_issue_id: 80
+backlogIssueId: 80
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/payment-card-details/index.md
+++ b/src/patterns/payment-card-details/index.md
@@ -102,4 +102,3 @@ Local Land Charges
 
 **Environment Agency**<br>
 Waste Permitting
-

--- a/src/patterns/problem-with-the-service-pages/index.md
+++ b/src/patterns/problem-with-the-service-pages/index.md
@@ -4,7 +4,7 @@ description: This is a page that tells someone there is something wrong with the
 section: Patterns
 theme: Pages
 aliases: '500'
-backlog_issue_id: 129
+backlogIssueId: 129
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.

--- a/src/patterns/question-pages/index.md
+++ b/src/patterns/question-pages/index.md
@@ -4,7 +4,7 @@ description: Follow this pattern whenever you need to ask users questions within
 section: Patterns
 theme: Pages
 aliases:
-backlog_issue_id: 58
+backlogIssueId: 58
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/service-unavailable-pages/index.md
+++ b/src/patterns/service-unavailable-pages/index.md
@@ -4,7 +4,7 @@ description: This is a page that tells someone a service is unavailable. It shou
 section: Patterns
 theme: Pages
 aliases: '503'
-backlog_issue_id: 124
+backlogIssueId: 124
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.

--- a/src/patterns/start-pages/index.md
+++ b/src/patterns/start-pages/index.md
@@ -1,7 +1,7 @@
 ---
 title: Start pages
 layout: layout-archived.njk
-ignore_in_sitemap: true
+ignoreInSitemap: true
 ---
 
 In March 2022, we replaced the 'Start pages' pattern with a new, expanded pattern to help users [Start using a service](/patterns/start-using-a-service/).

--- a/src/patterns/start-using-a-service/index.md
+++ b/src/patterns/start-using-a-service/index.md
@@ -56,7 +56,7 @@ Use a simple start page if users can start using the service without needing muc
 
 ![A screenshot showing an example of a simple start page from the coronavirus shielding support service. The page includes a heading, text to explain who can use the service, and a start button labelled 'Register or update your details'.](simple-start-page.png)
 
-If the start point is linked to a wider process that needs more explanation, create an ‘Apply’ section within a multipart guide. 
+If the start point is linked to a wider process that needs more explanation, create an ‘Apply’ section within a multipart guide.
 
 For example, before a user applies for probate (the right to manage someone’s estate after they die) they need to understand whether probate is required, whether they’re the right person to apply, how the details of the will and the tax situation affect what they’re supposed to do, how to get the relevant information together and how the different outcomes affect what they'll need to do next.
 

--- a/src/patterns/start-using-a-service/index.md
+++ b/src/patterns/start-using-a-service/index.md
@@ -4,7 +4,7 @@ description: Create a starting point for your digital service on GOV.UK
 section: Patterns
 theme: Help users to…
 aliases: start page, start pages
-backlog_issue_id: 111
+backlogIssueId: 111
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/step-by-step-navigation/index.md
+++ b/src/patterns/step-by-step-navigation/index.md
@@ -4,7 +4,7 @@ description: A starting point for your digital service on GOV.UK
 section: Patterns
 theme: Pages
 aliases:
-backlog_issue_id: 171
+backlogIssueId: 171
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/task-list-pages/index.md
+++ b/src/patterns/task-list-pages/index.md
@@ -4,7 +4,7 @@ description: Task list pages help users understand tasks involved in completing 
 section: Patterns
 theme: Pages
 aliases:
-backlog_issue_id: 72
+backlogIssueId: 72
 layout: layout-pane.njk
 status: Being worked on
 statusMessage: A cross-government group is collaborating on work to <a class="govuk-link" href="#next-steps">update this pattern and build it as a component</a>.

--- a/src/patterns/telephone-numbers/index.md
+++ b/src/patterns/telephone-numbers/index.md
@@ -4,7 +4,7 @@ description: Help users enter a valid telephone number
 section: Patterns
 theme: Ask users for…
 aliases: phone numbers
-backlog_issue_id: 101
+backlogIssueId: 101
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.

--- a/src/patterns/understand-the-impact-of-an-emergency/index.md
+++ b/src/patterns/understand-the-impact-of-an-emergency/index.md
@@ -1,7 +1,7 @@
 ---
 title: Understand the impact of an emergency on your service
 layout: layout-archived.njk
-ignore_in_sitemap: true
+ignoreInSitemap: true
 ---
 
 For up to date information, see [the notification banner component](/components/notification-banner/).

--- a/src/patterns/validation/index.md
+++ b/src/patterns/validation/index.md
@@ -4,7 +4,6 @@ description: Check the answers users give to make sure they’re valid - and if 
 section: Patterns
 theme: Help users to…
 aliases:
-backlog_issue_id:
 layout: layout-pane.njk
 ---
 

--- a/src/styles/colour/index.md
+++ b/src/styles/colour/index.md
@@ -3,7 +3,7 @@ title: Colour
 description: Always use the GOV.UK colour palette
 section: Styles
 aliases: palette
-backlog_issue_id: 38
+backlogIssueId: 38
 layout: layout-pane.njk
 ---
 

--- a/src/styles/images/index.md
+++ b/src/styles/images/index.md
@@ -84,7 +84,7 @@ Examples of unnecessary ‘images of text’ include images that show:
 - the contents of a post from social media
 - an excerpt from a document
 - key facts from a slide presentation
- 
+
 If you do choose to use the image anyway, include written content nearby that conveys the same meaning and context.
 
 [Find out more about ‘images of text’](https://www.w3.org/WAI/tutorials/images/textual/#image-of-styled-text-with-decorative-effect) on the Web Accessibility Initiative website.
@@ -114,7 +114,7 @@ Text in an image is considered essential if:
 
 In other words, you cannot give this same information as written content or any other way.
 
-Essential text must be relevant to the information you need to give. 
+Essential text must be relevant to the information you need to give.
 
 Examples of essential text in images might be:
 - a portion of the Magna Carta, showing its handwriting style
@@ -142,7 +142,7 @@ Be sure to follow the guidance on this page about writing good alt text.
 
 If it's not practical to avoid using an image that contains text (and replace it with written content), there’s a few other ways to replace it.
 
-You should consider these options even if the text in an image is essential, as it will make your information easier to read for users that customise the way they look at web pages. 
+You should consider these options even if the text in an image is essential, as it will make your information easier to read for users that customise the way they look at web pages.
 
 In any case, make sure that the contrast ratio of text colour and all portions of the image that overlap the text [meets level AA of the Web Content Accessibility Guidelines (WCAG 2.1)](https://www.w3.org/TR/WCAG21/#contrast-minimum).
 

--- a/src/styles/images/index.md
+++ b/src/styles/images/index.md
@@ -6,7 +6,7 @@ backlogIssueId: 70
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This guidance is currently experimental because <a class="govuk-link" href="#research-on-images">we want to get feedback</a> to validate how useful it is for service teams.
-show_page_nav: true
+showPageNav: true
 ---
 
 {% from "_example.njk" import example %}

--- a/src/styles/images/index.md
+++ b/src/styles/images/index.md
@@ -2,7 +2,7 @@
 title: Images
 description: Only use images if there’s a real user need
 section: Styles
-backlog_issue_id: 70
+backlogIssueId: 70
 layout: layout-pane.njk
 status: Experimental
 statusMessage: This guidance is currently experimental because <a class="govuk-link" href="#research-on-images">we want to get feedback</a> to validate how useful it is for service teams.

--- a/src/styles/index.md
+++ b/src/styles/index.md
@@ -2,7 +2,7 @@
 layout: layout-pane.njk
 title: Styles
 description: Make your service look and feel like GOV.UK
-show_subnav: true
+showSubNav: true
 ---
 
 Make government services look and feel like GOV.UK.

--- a/src/styles/layout/index.md
+++ b/src/styles/layout/index.md
@@ -3,7 +3,7 @@ title: Layout
 description: Organise the layout of the page into blocks
 section: Styles
 layout: layout-pane.njk
-show_page_nav: true
+showPageNav: true
 ---
 
 {% from "_example.njk" import example %}

--- a/src/styles/layout/index.md
+++ b/src/styles/layout/index.md
@@ -2,7 +2,6 @@
 title: Layout
 description: Organise the layout of the page into blocks
 section: Styles
-backlog_issue_id:
 layout: layout-pane.njk
 show_page_nav: true
 ---

--- a/src/styles/page-template/block-areas/index.njk
+++ b/src/styles/page-template/block-areas/index.njk
@@ -1,7 +1,7 @@
 ---
 title: Block areas – Page template
 layout: false
-ignore_in_sitemap: true
+ignoreInSitemap: true
 stylesheets:
 - styles/page-template/block-areas/block-areas-annotate.css
 ---

--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -1,7 +1,7 @@
 ---
 title: Customised – Page template
 layout: false
-ignore_in_sitemap: true
+ignoreInSitemap: true
 ---
 
 {# Example that changes every setting in the template #}

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -1,7 +1,7 @@
 ---
 title: Customised – Page template
 layout: false
-ignore_in_sitemap: true
+ignoreInSitemap: true
 ---
 
 {# Example that changes every setting in the template #}

--- a/src/styles/page-template/default/code.njk
+++ b/src/styles/page-template/default/code.njk
@@ -1,7 +1,7 @@
 ---
 title: Default – Page template
 layout: false
-ignore_in_sitemap: true
+ignoreInSitemap: true
 ---
 {% extends "govuk/template.njk" %}
 

--- a/src/styles/spacing/index.md
+++ b/src/styles/spacing/index.md
@@ -4,7 +4,7 @@ description: The Design System uses a responsive spacing scale which adapts base
 section: Styles
 aliases: margin, padding
 layout: layout-pane.njk
-show_page_nav: true
+showPageNav: true
 ---
 
 {% from "_example.njk" import example %}

--- a/src/styles/spacing/index.md
+++ b/src/styles/spacing/index.md
@@ -3,7 +3,6 @@ title: Spacing
 description: The Design System uses a responsive spacing scale which adapts based on screen size
 section: Styles
 aliases: margin, padding
-backlog_issue_id:
 layout: layout-pane.njk
 show_page_nav: true
 ---

--- a/src/styles/typography/index.md
+++ b/src/styles/typography/index.md
@@ -4,7 +4,7 @@ description: If your service is on the service.gov.uk subdomain you must use the
 section: Styles
 backlogIssueId: 64
 layout: layout-pane.njk
-show_page_nav: true
+showPageNav: true
 headingAliases:
   Section break: horizontal rule, hr
 ---

--- a/src/styles/typography/index.md
+++ b/src/styles/typography/index.md
@@ -2,7 +2,7 @@
 title: Typography
 description: If your service is on the service.gov.uk subdomain you must use the GDS Transport font
 section: Styles
-backlog_issue_id: 64
+backlogIssueId: 64
 layout: layout-pane.njk
 show_page_nav: true
 headingAliases:

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -33,7 +33,7 @@
         {% endif %}
       </h1>
 
-      {% if show_page_nav %}
+      {% if showPageNav %}
         <ul class="app-page-navigation">
           {% for heading in headings %}
             {% if heading.depth == 2 %}

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -52,7 +52,7 @@
       </div>
 
       {# No JS fallback to show overview #}
-      {% if show_subnav %}
+      {% if showSubNav %}
         {% include "_category-nav.njk" %}
       {% endif %}
 

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -2,13 +2,13 @@
 {% if ["Components", "Patterns", "Styles"].includes(section) %}
   <h2 class="govuk-heading-l govuk-!-padding-top-7" id="help-improve-this-page">Help improve this {{ section.slice(0, -1) | lower }}</h2>
 
-  {% if backlog_issue_id %}
+  {% if backlogIssueId %}
     <p class="govuk-body">
       To help make sure that this page is useful, relevant and up to date, you can:
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        <a class="govuk-link app-contact-panel__link" href="https://github.com/alphagov/govuk-design-system-backlog/issues/{{ backlog_issue_id }}">
+        <a class="govuk-link app-contact-panel__link" href="https://github.com/alphagov/govuk-design-system-backlog/issues/{{ backlogIssueId }}">
           take part in the ‘{{ title }}’ discussion on GitHub and share your research
         </a>
       </li>


### PR DESCRIPTION
We've had a build improvement PR from the Metalsmith maintainer to merge first:

* https://github.com/alphagov/govuk-design-system/pull/2933

But at the same time our navigation plugin wasn't very easy to understand

These changes add:

1. JSDoc for navigation items
2. Consistently use camel case for front matter
3. Code and comment tweaks for familiarity with our other plugins
4. Cached `Intl.Collator()` for navigation item sorting