### PR TITLE
Added entry for GOV.UK Laravel

### DIFF
--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -64,6 +64,11 @@ A walkthrough for how to import the GOV.UK Design System into a MVC project and 
 [GOV.UK Design System for ASP.NET MVC and Umbraco](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions) -
 GOV.UK Frontend ASP.NET tag helpers, and Umbraco CMS support.
 
+### Laravel / PHP
+
+[GOV.UK Laravel](https://github.com/AnthonyEdmonds/govuk-laravel) -
+GOV.UK Frontend blade components and classes for Laravel 10 and PHP 8.2.
+
 ### Node.js
 
 Guidance on [building a hapi service using GOV.UK Frontend](https://github.com/DEFRA/hapi-govuk-examples).


### PR DESCRIPTION
My GOV.UK Laravel library allows rapid development of Laravel / PHP projects, utilising pre-made blade components and helper classes.

I am open to changing the title header to just Laravel, if desired.