### PR TITLE
Remove hard to read postcode from example

### DIFF
--- a/src/components/error-summary/default/index.njk
+++ b/src/components/error-summary/default/index.njk
@@ -9,11 +9,11 @@ layout: layout-example.njk
   titleText: "There is a problem",
   errorList: [
     {
-      text: "The date your passport was issued must be in the past",
+      text: "Enter your full name",
       href: "#"
     },
     {
-      text: "Enter a postcode, like AA1 1AA",
+      text: "The date your passport was issued must be in the past",
       href: "#"
     }
   ]


### PR DESCRIPTION
It’s been flagged that [the example postcode may be hard to read by users with dyscalculia, dyslexia, dyspraxia or ADHD because the example repeats the same numbers and letters with the same shape so they ‘merge’ visually][1].

Additionally, [the examples of error states in the current pattern for ‘asking users for addresses’][2] is inconsistent with this and does not include an example postcode, only:

> Enter a real postcode

We can avoid both problems by not including an error that mentions postcodes in the error summary example.

Remove the postcode error and add a new error relating to the user’s name. Add the error for the user’s name to the top as this reflects the order the questions would likely be asked in.

We may want to revisit the example in ‘asking users for addresses’ in the future. If we choose to include an example postcode, we should use a postcode that does not include repeated or visually similar characters.

[1]: https://github.com/alphagov/govuk-design-system-backlog/issues/46#issuecomment-1485134578
[2]: https://webarchive.nationalarchives.gov.uk/ukgwa/20230601111732/https://design-system.service.gov.uk/patterns/addresses/#error-messages