### PR TITLE
[SPIKE] Check all pages' accessibility

### DIFF
--- a/__tests__/accessibility-audit.test.js
+++ b/__tests__/accessibility-audit.test.js
@@ -97,12 +97,15 @@ function getFilesToCheck() {
   const componentIndexes = globSync('components/*{,/*}.html', {
     cwd: paths.public
   })
+  const patternIndexes = globSync('patterns/*{,/*}.html', {
+    cwd: paths.public
+  })
   const pageIndexes = globSync('**/index.html', {
     cwd: paths.public,
-    ignore: ['components/**/index.html']
+    ignore: ['components/**/index.html', 'patterns/*{,/*}.html']
   })
 
-  return [...componentIndexes, ...pageIndexes]
+  return [...componentIndexes, ...patternIndexes, ...pageIndexes]
 }
 
 describe('Accessibility audit', () => {

--- a/__tests__/accessibility-audit.test.js
+++ b/__tests__/accessibility-audit.test.js
@@ -11,21 +11,28 @@ async function analyze(page, path) {
 
   const axe = new AxePuppeteer(page)
     .include('body')
-    // axe reports there is "no label associated with the text field", when there is one.
-    .exclude('#app-site-search__input')
-    // axe reports that the phase banner is not inside a landmark, which is intentional.
-    .exclude('.app-phase-banner')
-    // axe reports that the skip link is not inside a landmark, which is intentional.
-    // https://design-system.service.gov.uk/components/skip-link/#when-to-use-this-component
-    .exclude('.govuk-skip-link')
-    // axe reports that the back to top button is not inside a landmark, which is intentional.
-    .exclude('.app-back-to-top')
-    // axe reports that the Browsersync banner is not inside a landmark, which is intentional.
-    .exclude('#__bs_notify__')
-    // axe reports that the frame "does not have a main landmark" and example <h1> headings
-    // violate "Heading levels should only increase by one", which is intentional.
-    // https://github.com/alphagov/govuk-design-system/pull/2442#issuecomment-1326600528
-    .exclude('.app-example__frame')
+    .exclude([
+      // Axe reports there is "no label associated with the text field", when there is one.
+      '#app-site-search__input',
+
+      // Axe reports that the phase banner is not inside a landmark, which is intentional.
+      '.app-phase-banner',
+
+      // Axe reports that the skip link is not inside a landmark, which is intentional.
+      // https://design-system.service.gov.uk/components/skip-link/#when-to-use-this-component
+      '.govuk-skip-link',
+
+      // Axe reports that the back to top button is not inside a landmark, which is intentional.
+      '.app-back-to-top',
+
+      // Axe reports that the Browsersync banner is not inside a landmark, which is intentional.
+      '#__bs_notify__',
+
+      // Axe reports that the frame "does not have a main landmark" and example <h1> headings
+      // violate "Heading levels should only increase by one", which is intentional.
+      // https://github.com/alphagov/govuk-design-system/pull/2442#issuecomment-1326600528
+      '.app-example__frame'
+    ])
 
   return axe.analyze()
 }

--- a/__tests__/accessibility-audit.test.js
+++ b/__tests__/accessibility-audit.test.js
@@ -69,8 +69,12 @@ describe('Accessibility audit', () => {
   it.each(globSync('**/index.html', { cwd: paths.public }))(
     'validates %s',
     async (path) => {
+      const page = await browser.newPage()
+
       await goTo(page, `/${slash(path)}`)
       await expect(axe(page)).resolves.toHaveNoViolations()
+
+      await page.close()
     },
     10000
   )

--- a/__tests__/accessibility-audit.test.js
+++ b/__tests__/accessibility-audit.test.js
@@ -43,8 +43,19 @@ async function axe(page) {
       // Additionally, we are relying on accessibility testing in govuk-frontend to cover these.
       '.app-example__frame'
     )
-    // TODO
+
+    // TODO: govuk-breadcrumbs sets off the "must be contained in landmarks" rule. Needs investigation.
     .exclude('.govuk-breadcrumbs')
+
+    // TODO: figure out how and whether to re-enable these rules, or target them better
+    .disableRules([
+      'region',
+      'color-contrast-enhanced',
+      'aria-allowed-attr',
+      'target-size',
+      'aria-allowed-role'
+    ])
+
     .withTags([
       'best-practice',
 
@@ -62,7 +73,7 @@ async function axe(page) {
     ])
 
   // Create report
-  const report = await reporter.options({}).analyze()
+  const report = await reporter.analyze()
 
   // Add preview URL to report violations
   report.violations.forEach((violation) => {

--- a/__tests__/accessibility-audit.test.js
+++ b/__tests__/accessibility-audit.test.js
@@ -16,10 +16,6 @@ async function axe(page) {
   const reporter = new AxePuppeteer(page)
     .include('body')
     .exclude(
-      // Axe reports there is "no label associated with the text field", when there is one.
-      '#app-site-search__input'
-    )
-    .exclude(
       // Axe reports that the phase banner is not inside a landmark, which is intentional.
       '.app-phase-banner'
     )

--- a/__tests__/accessibility-audit.test.js
+++ b/__tests__/accessibility-audit.test.js
@@ -48,8 +48,7 @@ async function axe(page) {
       'region',
       'color-contrast-enhanced',
       'aria-allowed-attr',
-      'target-size',
-      'aria-allowed-role'
+      'target-size'
     ])
 
     .withTags([

--- a/__tests__/accessibility-audit.test.js
+++ b/__tests__/accessibility-audit.test.js
@@ -16,15 +16,6 @@ async function axe(page) {
   const reporter = new AxePuppeteer(page)
     .include('body')
     .exclude(
-      // Axe reports that the skip link is not inside a landmark, which is intentional.
-      // https://design-system.service.gov.uk/components/skip-link/#when-to-use-this-component
-      '.govuk-skip-link'
-    )
-    .exclude(
-      // Axe reports that the back to top button is not inside a landmark, which is intentional.
-      '.app-back-to-top'
-    )
-    .exclude(
       // Axe reports that the Browsersync banner is not inside a landmark, which is intentional.
       '#__bs_notify__'
     )
@@ -35,9 +26,6 @@ async function axe(page) {
       // Additionally, we are relying on accessibility testing in govuk-frontend to cover these.
       '.app-example__frame'
     )
-
-    // TODO: govuk-breadcrumbs sets off the "must be contained in landmarks" rule. Needs investigation.
-    .exclude('.govuk-breadcrumbs')
 
     // TODO: figure out how and whether to re-enable these rules, or target them better
     .disableRules([

--- a/__tests__/accessibility-audit.test.js
+++ b/__tests__/accessibility-audit.test.js
@@ -1,7 +1,8 @@
-const fs = require('fs')
-const path = require('path')
-
 const { AxePuppeteer } = require('@axe-core/puppeteer')
+const { globSync } = require('glob')
+const slash = require('slash')
+
+const { paths } = require('../config')
 
 const { goTo } = require('./helpers/puppeteer.js')
 
@@ -29,44 +30,11 @@ async function analyze(page, path) {
   return axe.analyze()
 }
 
-function getDirectoriesWithIndexHTML(directory) {
-  const result = []
-
-  function traverse(currentDir, depth) {
-    if (depth === 0) {
-      return
-    }
-
-    const files = fs.readdirSync(currentDir)
-
-    if (files.includes('index.html')) {
-      result.push(currentDir)
-    }
-
-    for (const file of files) {
-      const filePath = path.join(currentDir, file)
-      const stat = fs.statSync(filePath)
-
-      if (stat.isDirectory()) {
-        traverse(filePath, depth - 1)
-      }
-    }
-  }
-
-  traverse(directory, 3)
-
-  return result.map((dir) => path.relative(directory, dir))
-}
-
-// Usage example
-const directory = 'deploy/public'
-const relativeDirectories = getDirectoriesWithIndexHTML(directory)
-
-describe('Accessibility Audit', () => {
-  it.each(relativeDirectories)(
+describe('Accessibility audit', () => {
+  it.each(globSync('**/index.html', { cwd: paths.public }))(
     'validates %s',
     async (path) => {
-      const results = await analyze(page, path)
+      const results = await analyze(page, `/${slash(path)}`)
       expect(results).toHaveNoViolations()
     },
     10000

--- a/__tests__/accessibility-audit.test.js
+++ b/__tests__/accessibility-audit.test.js
@@ -16,10 +16,6 @@ async function axe(page) {
   const reporter = new AxePuppeteer(page)
     .include('body')
     .exclude(
-      // Axe reports that the phase banner is not inside a landmark, which is intentional.
-      '.app-phase-banner'
-    )
-    .exclude(
       // Axe reports that the skip link is not inside a landmark, which is intentional.
       // https://design-system.service.gov.uk/components/skip-link/#when-to-use-this-component
       '.govuk-skip-link'

--- a/__tests__/accessibility-audit.test.js
+++ b/__tests__/accessibility-audit.test.js
@@ -1,3 +1,6 @@
+const fs = require('fs')
+const path = require('path')
+
 const { AxePuppeteer } = require('@axe-core/puppeteer')
 
 const { goTo } = require('./helpers/puppeteer.js')
@@ -26,39 +29,46 @@ async function analyze(page, path) {
   return axe.analyze()
 }
 
+function getDirectoriesWithIndexHTML(directory) {
+  const result = []
+
+  function traverse(currentDir, depth) {
+    if (depth === 0) {
+      return
+    }
+
+    const files = fs.readdirSync(currentDir)
+
+    if (files.includes('index.html')) {
+      result.push(currentDir)
+    }
+
+    for (const file of files) {
+      const filePath = path.join(currentDir, file)
+      const stat = fs.statSync(filePath)
+
+      if (stat.isDirectory()) {
+        traverse(filePath, depth - 1)
+      }
+    }
+  }
+
+  traverse(directory, 3)
+
+  return result.map((dir) => path.relative(directory, dir))
+}
+
+// Usage example
+const directory = 'deploy/public'
+const relativeDirectories = getDirectoriesWithIndexHTML(directory)
+
 describe('Accessibility Audit', () => {
-  describe('Home page - layout.njk', () => {
-    it('validates', async () => {
-      const results = await analyze(page, '/')
+  it.each(relativeDirectories)(
+    'validates %s',
+    async (path) => {
+      const results = await analyze(page, path)
       expect(results).toHaveNoViolations()
-    })
-  })
-
-  describe('Component page - layout-pane.njk', () => {
-    it('validates', async () => {
-      const results = await analyze(page, '/components/radios/')
-      expect(results).toHaveNoViolations()
-    })
-  })
-
-  describe('Patterns page - layout-pane.njk', () => {
-    it('validates', async () => {
-      const results = await analyze(page, '/patterns/addresses/')
-      expect(results).toHaveNoViolations()
-    })
-  })
-
-  describe('Get in touch page - layout-single-page.njk', () => {
-    it('validates', async () => {
-      const results = await analyze(page, '/contact/')
-      expect(results).toHaveNoViolations()
-    })
-  })
-
-  describe('Site Map page - layout-sitemap.njk', () => {
-    it('validates', async () => {
-      const results = await analyze(page, '/sitemap/')
-      expect(results).toHaveNoViolations()
-    })
-  })
+    },
+    10000
+  )
 })

--- a/__tests__/accessibility-audit.test.js
+++ b/__tests__/accessibility-audit.test.js
@@ -1,10 +1,7 @@
 const { AxePuppeteer } = require('@axe-core/puppeteer')
 const { globSync } = require('glob')
-const slash = require('slash')
 
-const { paths } = require('../config')
-
-const { goTo } = require('./helpers/puppeteer.js')
+const { paths, ports } = require('../config')
 
 /**
  * Axe Puppeteer reporter
@@ -28,12 +25,7 @@ async function axe(page) {
     )
 
     // TODO: figure out how and whether to re-enable these rules, or target them better
-    .disableRules([
-      'region',
-      'color-contrast-enhanced',
-      'aria-allowed-attr',
-      'target-size'
-    ])
+    .disableRules(['region', 'color-contrast-enhanced', 'aria-allowed-attr'])
 
     .withTags([
       'best-practice',
@@ -92,7 +84,11 @@ function getFilesToCheck() {
   })
   const pageIndexes = globSync('**/index.html', {
     cwd: paths.public,
-    ignore: ['components/**/index.html', 'patterns/*{,/*}.html']
+    ignore: [
+      'components/**/index.html',
+      'patterns/*{,/*}.html',
+      '__canary__/**'
+    ]
   })
 
   return [...componentIndexes, ...patternIndexes, ...pageIndexes]
@@ -103,8 +99,9 @@ describe('Accessibility audit', () => {
     'validates %s',
     async (path) => {
       const page = await browser.newPage()
+      const { href } = new URL(path, `http://localhost:${ports.preview}`)
+      await page.goto(href, { waitUntil: 'networkidle0' })
 
-      await goTo(page, `/${slash(path)}`)
       await expect(axe(page)).resolves.toHaveNoViolations()
 
       await page.close()

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -10,12 +10,23 @@ module.exports = {
    * Puppeteer launch options
    */
   launch: {
+    args: [
+      /**
+       * Prevent empty Chrome startup window
+       * Tests use their own `browser.newPage()` instead
+       */
+      '--no-startup-window'
+    ],
+
     /**
      * Allow headless mode switching using `HEADLESS=false`
      *
      * {@link https://developer.chrome.com/articles/new-headless/}
      */
-    headless: process.env.HEADLESS !== 'false'
+    headless: process.env.HEADLESS !== 'false',
+
+    // See launch arg '--no-startup-window'
+    waitForInitialPage: false
   },
 
   /**
@@ -25,6 +36,9 @@ module.exports = {
     command: 'npm run serve',
     port: ports.preview,
     host: 'localhost',
+
+    // Allow 30 seconds to start server
+    launchTimeout: 30000,
 
     // Skip when already running
     usedPortAction: 'ignore'

--- a/src/patterns/payment-card-details/index.md
+++ b/src/patterns/payment-card-details/index.md
@@ -33,7 +33,7 @@ Show logos for the cards you accept as icons so users can see whether their card
 Use Issuer Identification Number (IIN) lookups to validate the card number as the user enters it. Once you’ve been able to identify the user’s card type, leave only the relevant logo highlighted and grey out the others.
 
 <div class="app-video">
-  <video class="app-video__player" role="region" aria-labelledby="card-number-video-description" controls muted>
+  <video class="app-video__player" aria-labelledby="card-number-video-description" controls muted>
     <source src="card-number.mp4" type="video/mp4">
   </video>
   <p class="app-video__description" id="card-number-video-description">


### PR DESCRIPTION
Popped this together to check how long it'd take to run accessibility tests on ALL our pages. Just a hacky function to get all directories with an `index.html` file, then running an axe validation test on each of those.

Takes around 80 seconds on my machine, but open for ways to speed it up.

There's a few failures flagged, mostly to do with our heading order.

If taken forward, the code would need to be cleaned up and optimised.

Edit: looks like the tests took about 2m 45s.