### PR TITLE
Fix missing Expires headers for JavaScript

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -103,7 +103,7 @@ http {
     default                         off;
     text/html                       epoch;
     text/css                        max;
-    application/javascript          max;
+    text/javascript                 max;
     application/json                max;
     ~application/x-font             max;
     ~application/font               max;


### PR DESCRIPTION
In b16393df117a0b499b6288ea0041054093f94d58 We changed the MIME type for JavaScript from `application/javascript` to `text/javascript` in line with [IETF RFC 9239][1].

However we missed that the caching logic needed updating too, so we’ve not been sending `Expires` headers for our JS since. This means that the JS is not currently being cached by CloudFront or in browsers.

Update the mime type to match the mime type now being served.

[1]: https://www.rfc-editor.org/rfc/rfc9239