### PR TITLE
Increase amount of text in character count threshold example

### DIFF
--- a/src/components/character-count/index.md
+++ b/src/components/character-count/index.md
@@ -69,9 +69,9 @@ When using a character count, try to set the limit higher than most users will n
 
 #### If the limit is far higher than users are likely to reach
 
-You can choose to display a character count message if the length of text within the textarea more than a certain 'threshold' of characters. This is useful when a character limit is needed due to the technical limitations of the service, but users are unlikely to reach the limit.
+You can choose to display a character count message when the length of text within the textarea passes a certain 'threshold' of characters. This is useful when a character limit is needed due to the technical limitations of the service, but users are unlikely to reach that limit.
 
-To do this, set the threshold in the component markup as a percentage. For example, `data-threshold="75"` will show the count message only when users have entered 75% of the limit.
+To do this, set the threshold in the component markup as a percentage. For example, `data-threshold="75"` will show the count message only when the user has entered a length of text that's 75% of the limit or more.
 
 Screen reader users will hear the character limit when they first interact with a textarea using the threshold option. Sighted users will not see anything until the count message is shown — though you might choose to include the character limit in the hint text.
 

--- a/src/components/character-count/index.md
+++ b/src/components/character-count/index.md
@@ -67,9 +67,11 @@ Do this by setting `data-maxwords` in the component markup. For example, `data-m
 
 When using a character count, try to set the limit higher than most users will need. Find out what this is by doing user research and data analysis.
 
-If the limit is much higher than most users are likely to reach, you can choose to only display the message after a user has entered a certain amount.
+#### If the limit is far higher than users are likely to reach
 
-To do this, set a threshold in the component markup. For example, `data-threshold="75"` will show the count message only when users have entered 75% of the limit.
+You can choose to display a character count message if the length of text within the textarea more than a certain 'threshold' of characters. This is useful when a character limit is needed due to the technical limitations of the service, but users are unlikely to reach the limit.
+
+To do this, set the threshold in the component markup as a percentage. For example, `data-threshold="75"` will show the count message only when users have entered 75% of the limit.
 
 Screen reader users will hear the character limit when they first interact with a textarea using the threshold option. Sighted users will not see anything until the count message is shown — though you might choose to include the character limit in the hint text.
 

--- a/src/components/character-count/threshold/index.njk
+++ b/src/components/character-count/threshold/index.njk
@@ -5,12 +5,20 @@ layout: layout-example.njk
 
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 
+{% set textareaValue -%}
+This example of a textarea has a character limit of 1000 characters. The character count is hidden, but will appear when there are more than 850 characters entered into this textarea. Type some more text into this textarea to see the character count appear. This paragraph is repeated below.
+  
+This example of a textarea has a character limit of 1000 characters. The character count is hidden, but will appear when there are more than 850 characters entered into this textarea. Type some more text into this textarea to see the character count appear. This paragraph is repeated below.
+
+This example of a textarea has a character limit of 1000 characters. The character count is hidden, but will appear when there are more than 850 characters entered into this textarea. Type some more text into this textarea to see the character count appear.
+{%- endset %}
+
 {{ govukCharacterCount({
   name: "threshold",
   id: "threshold",
-  maxlength: 112,
-  threshold: 75,
-  value: "Type another letter into this field after this message to see the threshold feature",
+  maxlength: 1000,
+  threshold: 85,
+  value: textareaValue,
   label: {
     text: "Can you provide more detail?",
     classes: "govuk-label--l",

--- a/src/components/character-count/threshold/index.njk
+++ b/src/components/character-count/threshold/index.njk
@@ -6,11 +6,11 @@ layout: layout-example.njk
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 
 {% set textareaValue -%}
-This example of a textarea has a character limit of 1000 characters. The character count is hidden, but will appear when there are more than 850 characters entered into this textarea. Type some more text into this textarea to see the character count appear. This paragraph is repeated below.
+This example of a textarea has a character limit of 1000 characters. The character count is hidden, but will appear when more than 850 characters are entered in this textarea. Type some more text into this textarea to see the character count appear. This paragraph will now repeat 2 more times.
   
-This example of a textarea has a character limit of 1000 characters. The character count is hidden, but will appear when there are more than 850 characters entered into this textarea. Type some more text into this textarea to see the character count appear. This paragraph is repeated below.
-
-This example of a textarea has a character limit of 1000 characters. The character count is hidden, but will appear when there are more than 850 characters entered into this textarea. Type some more text into this textarea to see the character count appear.
+This example of a textarea has a character limit of 1000 characters. The character count is hidden, but will appear when more than 850 characters are entered in this textarea. Type some more text into this textarea to see the character count appear. This paragraph will now repeat 1 more time.
+  
+This example of a textarea has a character limit of 1000 characters. The character count is hidden, but will appear when more than 850 characters are entered in this textarea. Type some more text into this textarea to see the character count appear.
 {%- endset %}
 
 {{ govukCharacterCount({


### PR DESCRIPTION
Increases the amount of text in the Character Count's 'threshold' example, to better reflect the intended usage being fields with very high character limits that a user is unlikely to encounter naturally. 

Suggested by @davidc-gds on https://github.com/alphagov/govuk-frontend/issues/3689. 

## Thoughts
I'm personally a little dubious as to the efficacy of this change, for a couple of reasons:
- It makes the HTML/Nunjucks examples harder to parse, as now a significant portion of them are taken up by the placeholder text.
- In my mind, a limit of 800 characters (as in David's suggestion) or 840 characters (as in this PR) is still much lower than the intended use for the threshold feature. 
  - In my mind, the threshold feature is best used where the only limit to value length is technical, such as MySQL's `text` type having a limit of ≈64,000 characters. This is a limitation a user is unlikely to actually reach in normal use, but one that does _technically_ exist, so only flagging it if the user is approaching it is sensible. This doesn't feel as appropriate for limits of only one or two thousand characters. 