### PR TITLE
Fix preview banner

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -86,8 +86,17 @@ module.exports = metalsmith
   // enable plugin optimisations in production etc
   .env({
     DEBUG: process.env.DEBUG,
-    CONTEXT: process.env.CONTEXT ?? 'production', // Netlify deployment context
-    NODE_ENV: process.env.NODE_ENV ?? 'production' // Node.js build environment
+
+    // Node.js build environment
+    NODE_ENV: process.env.NODE_ENV ?? 'production',
+
+    // Netlify deployment context
+    CONTEXT: process.env.CONTEXT ?? 'production',
+
+    // Netlify variables for preview banner
+    BRANCH: process.env.BRANCH,
+    REVIEW_ID: process.env.REVIEW_ID,
+    PULL_REQUEST: process.env.PULL_REQUEST
   })
 
   // global variables used in layout files

--- a/views/partials/_banner.njk
+++ b/views/partials/_banner.njk
@@ -1,11 +1,11 @@
-{% if PULL_REQUEST === "true" %}
+{% if env("PULL_REQUEST") === "true" %}
   {% set bannerTag = "Preview" %}
   {% set bannerText %}
     This is a preview of
-    a <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/pull/{{ REVIEW_ID  }}">proposed change</a> to the
+    a <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/pull/{{ env("REVIEW_ID")  }}">proposed change</a> to the
     <a class="govuk-link" href="https://design-system.service.gov.uk">Design System</a>.
   {% endset %}
-{% elif PULL_REQUEST === "false" %}
+{% elif env("PULL_REQUEST") === "false" %}
   {% set bannerTag = "Archive" %}
   {% set bannerText %}
     This is an archived version of


### PR DESCRIPTION
The preview banner hasn't worked since:

* https://github.com/alphagov/govuk-design-system/pull/2942

Metalsmith and Nunjucks environment variables must be added manually, so we've restored:

* `BRANCH`
* `PULL_REQUEST`
* `REVIEW_ID`

<img width="681" alt="Preview banner" src="https://github.com/alphagov/govuk-design-system/assets/415517/d9fd10c4-6021-491a-88e1-d366ebdecf04">