### PR TITLE
Preview v5: Replace `.js-enabled` with `.govuk-frontend-supported` in docs

### DIFF
--- a/src/styles/page-template/index.md
+++ b/src/styles/page-template/index.md
@@ -12,7 +12,7 @@ Use this template to keep your pages consistent with the rest of GOV.UK.
 
 This page template combines the boilerplate markup and [components](/components/) needed for a basic GOV.UK page. It includes:
 
-- JavaScript that adds a `.js-enabled` class, which is required by components with JavaScript behaviour
+- JavaScript that adds a `.govuk-frontend-supported` class, which is required by components with JavaScript behaviour
 - the [skip link](/components/skip-link/), [header](/components/header/) and [footer](/components/footer/) components
 - the favicon, and other related theme icons
 


### PR DESCRIPTION
This PR makes a separate documentation change to go along with:

* https://github.com/alphagov/govuk-design-system/pull/2961

Whilst the class `.js-enabled` is still added, the line for JavaScript behaviour needed updating

<img width="608" alt="Page template showing new class" src="https://github.com/alphagov/govuk-design-system/assets/415517/86449698-d632-4f50-bddd-4aabd1608b02">
