### PR TITLE
Remove hard line break before "Name" in summary list documentation

### DIFF
--- a/src/components/summary-list/index.md
+++ b/src/components/summary-list/index.md
@@ -30,8 +30,7 @@ Do not use it for tabular data or a simple list of information or tasks, like a 
 ## How it works
 
 Each row of a summary list is made up of a:
- - ‘key’ that’s a description or label of a piece of information, like
-   “Name”
+ - ‘key’ that’s a description or label of a piece of information, like “Name”
  - ‘value’ which is the piece of information itself, such as “John Smith”
 
 You can show a single or multiple summary lists on a page. If you’re showing multiple summary lists on a page, you can add structure by using headings or summary cards.


### PR DESCRIPTION
Removes a hard line break which gets converted to a `<br>` in the Design System, forcing the line to wrap prematurely

Before:
![Each row of a summary list is made up of a: ‘key’ that’s a description or label of a piece of information, like“Name”. ‘value’ which is the piece of information itself, such as “John Smith”](https://github.com/alphagov/govuk-design-system/assets/1935173/bc2c6dae-98c2-40c9-be66-5867c4b67df8)

After:
![The same image as above but without a line break before "Name"](https://github.com/alphagov/govuk-design-system/assets/1935173/3f7bca43-29d7-4855-a4ff-a6cad60c1fbd)
