### PR TITLE
Fix missing branch and empty link text in banner

### DIFF
--- a/views/partials/_banner.njk
+++ b/views/partials/_banner.njk
@@ -9,7 +9,7 @@
   {% set bannerTag = "Archive" %}
   {% set bannerText %}
     This is an archived version of
-    the <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/tree/{{ BRANCH }}">{{ BRANCH }}</a> branch for the
+    the <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/tree/{{ env("BRANCH") }}">{{ env("BRANCH") }}</a> branch for the
     <a class="govuk-link" href="https://design-system.service.gov.uk">Design System</a>.
   {% endset %}
 {% endif %}


### PR DESCRIPTION
Following on from the changes in #2979, we also need to fix the references to the BRANCH environment variable so that the banner renders correctly.

(You can see it in it's currently broken state on https://govuk-design-system-preview.netlify.app/)

Before:

```html
This is an archived version of the <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/tree/"></a> branch for the <a class="govuk-link" href="https://design-system.service.gov.uk">Design System</a>.
```

After:

```html
This is an archived version of the <a class="govuk-link" href="https://github.com/alphagov/govuk-design-system/tree/main">main</a> branch for the <a class="govuk-link" href="https://design-system.service.gov.uk">Design System</a>.
```