### PR TITLE
Update link text on component examples

### DIFF
--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -31,10 +31,8 @@
     <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
       <div class="app-example__toolbar">
         <a href="{{ exampleURL }}" class="app-example__new-window" target="_blank">
-          Open this
           {#- Don't use full title visually as the context is shown based on location of this link #}
-          <span class="govuk-visually-hidden">{{ exampleTitle | lower }}</span>
-          example in a new tab
+          Open this example in a new tab<span class="govuk-visually-hidden">: {{ exampleTitle | lower }}</span>
         </a>
       </div>
       <iframe title="{{ exampleTitle + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" loading="{% if params.loading %}{{ params.loading }}{% else %}lazy{% endif %}"></iframe>


### PR DESCRIPTION
Updates the "Open this example in a new tab" link above examples to not have visually-hidden text in the middle of the link. This was making it difficult for voice control users to activate the links, as the visual text did not match what they needed to say.

This PR moves the visually hidden content to the end of the link instead.

Resolves #2853.