### PR TITLE
Add usability issue to file upload component

### DIFF
--- a/src/components/file-upload/index.md
+++ b/src/components/file-upload/index.md
@@ -66,4 +66,10 @@ Say ‘The selected file must use the template’.
 
 ## Research on this component
 
+An accessibility audit has shown some users have encountered a problem when using file upload.
+
+### Known issues and gaps
+
+The file upload component does not show a visual target area when dragging and dropping a file. We do not plan on fixing this at the moment, as the component inherits and uses the browser's default behaviour. We will revisit this issue if we publish a custom file upload component. For more detail, and to track our progress we have the [GitHub issue: ‘Upload file component has no visual target area when dragging and dropping a file’](https://github.com/alphagov/govuk-frontend/issues/3685).
+
 Read a blog post about [design tips for helping users upload things](https://designnotes.blog.gov.uk/2017/02/14/some-design-tips-for-uploading-things/).


### PR DESCRIPTION
Adding the issue to the component page in favour of adding it to the accessibility statement. Similar issues with Select component and Step-by-step pattern have been put within their respective guidance pages.