### PR TITLE
Enable ESLint + Stylelint for code inside Markdown

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,13 @@ module.exports = {
         'plugin:promise/recommended',
         'prettier'
       ],
-      files: ['**/*.{cjs,js,mjs}'],
+      files: [
+        '**/*.{cjs,js,mjs}',
+
+        // Check markdown `*.md` contains valid code blocks
+        // https://github.com/eslint/eslint-plugin-markdown#advanced-configuration
+        '**/*.md/*.{cjs,js,mjs}'
+      ],
       parserOptions: {
         ecmaVersion: 'latest'
       },
@@ -60,6 +66,20 @@ module.exports = {
         page: 'readonly',
         browser: 'readonly',
         jestPuppeteer: 'readonly'
+      }
+    },
+    {
+      // Add plugin for markdown `*.md` code blocks
+      extends: ['plugin:markdown/recommended'],
+      files: ['**/*.md'],
+      plugins: ['markdown'],
+      processor: 'markdown/markdown'
+    },
+    {
+      // Assume markdown `*.md` JavaScript code blocks use browser globals
+      files: ['**/*.md/*.{cjs,js,mjs}'],
+      env: {
+        browser: true
       }
     }
   ],

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,10 +1,9 @@
 ---
 name: "🐛 Bug report"
 about: Report a bug or regression
-title: ''
+title: ""
 labels: "\U0001F41B bug, awaiting triage"
-assignees: ''
-
+assignees: ""
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,10 +1,9 @@
 ---
 name: "📖 Documentation"
 about: Add new documentation, or report missing, incorrect or unclear documentation
-title: ''
+title: ""
 labels: "documentation, awaiting triage"
-assignees: ''
-
+assignees: ""
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,10 +1,9 @@
 ---
 name: "✨ Feature request"
 about: Suggest a new feature or idea
-title: ''
+title: ""
 labels: "feature request, awaiting triage"
-assignees: ''
-
+assignees: ""
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/internal-story.md
+++ b/.github/ISSUE_TEMPLATE/internal-story.md
@@ -1,10 +1,9 @@
 ---
 name: "Internal story template"
 about: For internal use only
-title: ''
+title: ""
 labels: "awaiting triage"
-assignees: ''
-
+assignees: ""
 ---
 
 <!--

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you're an external contributor make sure to [fork this project first](https:/
 
 ### Clone repository
 
-```
+```shell
 git clone git@github.com:alphagov/govuk-design-system.git # or clone your own fork
 
 cd govuk-design-system
@@ -31,7 +31,7 @@ To enable this we use [nvm (Node Version Manager)](https://github.com/creationix
 
 ### Install npm dependencies
 
-```
+```shell
 npm install
 ```
 
@@ -39,7 +39,7 @@ npm install
 
 This will build sources, serve pages and watch for changes.
 
-```
+```shell
 npm start
 ```
 
@@ -47,7 +47,7 @@ npm start
 
 Build `./src` to `./deploy/public`
 
-```
+```shell
 npm run build
 ```
 
@@ -56,7 +56,7 @@ npm run build
 We are using the tool [stylelint][stylelint] to lint the Sass files in
 `source/stylesheets`. You can run the linter from command line by running:
 
-```
+```shell
 npm run lint
 ```
 

--- a/docs/contributing/archiving-deleted-urls.md
+++ b/docs/contributing/archiving-deleted-urls.md
@@ -32,7 +32,7 @@ Along with the pull request to delete or rename the URL you want to change, you 
 1. If the URL being archived is from a folder with an `index.md` file, you will need to replace the folder with a `.md file` of the same name - for example `/juggling/index.md` becomes `juggling.md`.
 2. In the file you want to archive, keep it in the same location, but replace the contents with the following code:
 
-   ```
+   ```plaintext
    ---
    title: {Title of the page you are archiving}
    layout: layout-archived.njk

--- a/lib/colours.js
+++ b/lib/colours.js
@@ -54,7 +54,7 @@ const palette = function () {
  *
  * Example output:
  *
- * ```
+ * ```js
  * { Text: [
  *     { name: '$govuk-text-colour', colour: '#0b0c0c', 'notes': '' },
  *     { name: '$govuk-secondary-text-colour', colour: '#6f777b', 'notes': '' },

--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -100,7 +100,7 @@ function getAdditionalComponentOptions(options) {
 /**
  * The data structure that options are defined as is a nested one.
  *
- * ```javascript
+ * ```js
  * [
  *   {
  *     name: 'top level item without params'
@@ -125,7 +125,7 @@ function getAdditionalComponentOptions(options) {
  * In order to display it on the website we want to flatten it into groups,
  * which allows them to be displayed as individual tables that can link to each other.
  *
- * ```javascript
+ * ```js
  * [
  *   {
  *     name: 'Primary options',

--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -1,5 +1,8 @@
 const hljs = require('highlight.js')
 
+// Highlight Nunjucks as JavaScript
+hljs.registerLanguage('njk', require('highlight.js/lib/languages/javascript'))
+
 /**
  * Format code with syntax highlighting
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-import": "^2.28.0",
+        "eslint-plugin-markdown": "^3.0.1",
         "eslint-plugin-n": "^16.0.1",
         "eslint-plugin-promise": "^6.1.1",
         "glob": "^10.3.3",
@@ -6753,6 +6754,21 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-markdown": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-markdown/-/eslint-plugin-markdown-3.0.1.tgz",
+      "integrity": "sha512-8rqoc148DWdGdmYF6WSQFT3uQ6PO7zXYgeBpHAOAakX/zpq+NvFYbDA/H7PYzHajwtmaOzAwfxyl++x0g1/N9A==",
+      "dev": true,
+      "dependencies": {
+        "mdast-util-from-markdown": "^0.8.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "multimatch": "^6.0.0",
         "nunjucks": "^3.2.4",
         "outdent": "^0.8.0",
+        "postcss-markdown": "^1.2.0",
         "postcss-scss": "^4.0.6",
         "prettier": "^3.0.1",
         "puppeteer": "^21.0.3",
@@ -3304,6 +3305,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/mdast": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
+      "integrity": "sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -3346,6 +3356,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
+      "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -5099,6 +5115,36 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -7334,6 +7380,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "dev": true,
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -7633,6 +7692,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/fraction.js": {
@@ -8768,6 +8836,30 @@
       "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
       "dev": true
     },
+    "node_modules/is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "dev": true,
+      "dependencies": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
@@ -8880,6 +8972,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extendable": {
       "version": "0.1.1",
       "dev": true,
@@ -8924,6 +9026,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-module": {
@@ -10758,6 +10870,46 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "micromark": "~2.11.0",
+        "parse-entities": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-0.2.0.tgz",
+      "integrity": "sha512-FHKL4w4S5fdt1KjJCwB0178WJ0evnyyQr5kXTM3wrOVpytD0hrkvd+AOOjU9Td8onOejCkmZ+HQRT3CZ3coHHQ==",
+      "dev": true,
+      "dependencies": {
+        "micromark-extension-frontmatter": "^0.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
@@ -10984,6 +11136,62 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/micromark": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "debug": "^4.0.0",
+        "parse-entities": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-0.2.2.tgz",
+      "integrity": "sha512-q6nPLFCMTLtfsctAuS0Xh4vaolxSFUWUWR6PZSrXXiRy+SANGllpcqdXFv2z07l0Xz/6Hl40hK0ffNCJPH2n1A==",
+      "dev": true,
+      "dependencies": {
+        "fault": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -11742,6 +11950,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "dev": true,
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -12194,6 +12420,22 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/postcss-markdown": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-1.2.0.tgz",
+      "integrity": "sha512-sO7eeu6pq5F0lx3XavY/rBVmifXbMTd6fGRuXaT/Q7wEuIAWTi0E2t747nQ57iVz99WynTPls4mw5wlLvZLFzw==",
+      "dev": true,
+      "dependencies": {
+        "mdast-util-from-markdown": "^0.8.5",
+        "mdast-util-frontmatter": "^0.2.0",
+        "micromark-extension-frontmatter": "^0.2.2",
+        "postcss": "^8.4.0",
+        "postcss-safe-parser": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12 || >=14"
       }
     },
     "node_modules/postcss-media-query-parser": {
@@ -14011,8 +14253,9 @@
     },
     "node_modules/slugger": {
       "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/slugger/-/slugger-1.0.1.tgz",
+      "integrity": "sha512-0DEO4OPN3jhyOtuyazZ0+8+E0n6IGoAoqHio7lOGDRDjzS09KyZf2u/WasxYMBJkzf/4IQwNPiO1sxc1nsLckA==",
+      "dev": true
     },
     "node_modules/slugify": {
       "version": "1.6.5",
@@ -15923,6 +16166,19 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:html": "html-validate \"deploy/public/**/index.html\"",
     "lint:js": "eslint --cache --cache-location .cache/eslint --cache-strategy content --color --ignore-path .gitignore \"**/*.{cjs,js,mjs}\"",
     "lint:prettier": "prettier --cache --cache-location .cache/prettier --cache-strategy content --check \"**/*.{cjs,js,json,md,mjs,scss,yaml,yml}\"",
-    "lint:scss": "stylelint \"**/*.scss\"",
+    "lint:scss": "stylelint \"**/*.{md,scss}\"",
     "check-links": "hyperlink --canonicalroot https://design-system.service.gov.uk/ --internal --recursive --source-maps deploy/public/sitemap.xml | tap-mocha-reporter min"
   },
   "dependencies": {
@@ -76,6 +76,7 @@
     "multimatch": "^6.0.0",
     "nunjucks": "^3.2.4",
     "outdent": "^0.8.0",
+    "postcss-markdown": "^1.2.0",
     "postcss-scss": "^4.0.6",
     "prettier": "^3.0.1",
     "puppeteer": "^21.0.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prelint:html": "npm run build",
     "lint:editorconfig": "editorconfig-checker",
     "lint:html": "html-validate \"deploy/public/**/index.html\"",
-    "lint:js": "eslint --cache --cache-location .cache/eslint --cache-strategy content --color --ignore-path .gitignore \"**/*.{cjs,js,mjs}\"",
+    "lint:js": "eslint --cache --cache-location .cache/eslint --cache-strategy content --color --ignore-path .gitignore \"**/*.{cjs,js,md,mjs}\"",
     "lint:prettier": "prettier --cache --cache-location .cache/prettier --cache-strategy content --check \"**/*.{cjs,js,json,md,mjs,scss,yaml,yml}\"",
     "lint:scss": "stylelint \"**/*.{md,scss}\"",
     "check-links": "hyperlink --canonicalroot https://design-system.service.gov.uk/ --internal --recursive --source-maps deploy/public/sitemap.xml | tap-mocha-reporter min"
@@ -56,6 +56,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.28.0",
+    "eslint-plugin-markdown": "^3.0.1",
     "eslint-plugin-n": "^16.0.1",
     "eslint-plugin-promise": "^6.1.1",
     "glob": "^10.3.3",

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout-pane.njk
 title: Community
-description:  Everyone can help improve the Design System by joining our community discussions, events and co-design collaborations
+description: Everyone can help improve the Design System by joining our community discussions, events and co-design collaborations
 showSubNav: true
 ---
 

--- a/src/get-started/extending-and-modifying-components/index.md
+++ b/src/get-started/extending-and-modifying-components/index.md
@@ -59,8 +59,8 @@ For example, if you want to override the button component you could do the follo
 
 ```css
 .app-interruption-card .govuk-button {
-  background-color: white;
-  color: blue;
+  color: govuk-colour("blue");
+  background-color: govuk-colour("white");
 }
 ```
 
@@ -120,8 +120,8 @@ For example, if you wanted to override the button component you could do the fol
 
 ```css
 .app-button--inverse {
-  background-color: govuk-colour("white");
   color: govuk-colour("blue");
+  background-color: govuk-colour("white");
 }
 ```
 

--- a/src/get-started/updating-your-code/index.md
+++ b/src/get-started/updating-your-code/index.md
@@ -62,7 +62,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           which can include custom <code>text</code>
         </p>
 
-```javascript
+```njk
 {% raw %}
 {% block skipLink %}
   {{ govukSkipLink({ text: "custom text" }) }}
@@ -89,7 +89,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           which can include custom <code>classes</code>
         </p>
 
-```javascript
+```njk
 {% raw %}
 {% block header %}
   {{ govukHeader({ classes: "app-custom-classes" }) }}
@@ -110,7 +110,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           which can include custom <code>homepageUrl</code>
         </p>
 
-```javascript
+```njk
 {% raw %}
 {% block header %}
   {{ govukHeader({ homepageUrl: "/custom-url" }) }}
@@ -137,7 +137,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           which can include a custom <code>serviceName</code>
         </p>
 
-```javascript
+```njk
 {% raw %}
 {% block header %}
   {{ govukHeader({ serviceName: "Custom service name" }) }}
@@ -158,7 +158,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           which can include a custom <code>navigation</code>
         </p>
 
-```javascript
+```njk
 {% raw %}
 {% block header %}
   {{ govukHeader({ navigation: [] }) }}
@@ -200,7 +200,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           which can include a custom <code>navigation</code>
         </p>
 
-```javascript
+```njk
 {% raw %}
 {% block footer %}
   {{ govukFooter({ navigation: [] }) }}
@@ -221,7 +221,7 @@ The main change is changing variables from [snake_case](https://en.wikipedia.org
           which can include custom <code>meta</code> links
         </p>
 
-```javascript
+```njk
 {% raw %}
 {% block footer %}
   {{ govukFooter({ meta: [] }) }}

--- a/src/patterns/page-not-found-pages/index.md
+++ b/src/patterns/page-not-found-pages/index.md
@@ -3,7 +3,7 @@ title: Page not found pages
 description: A page not found tells someone we cannot find the page they were trying to view. They are also known as 404 pages.
 section: Patterns
 theme: Pages
-aliases: '404'
+aliases: "404"
 backlogIssueId: 130
 layout: layout-pane.njk
 status: Experimental

--- a/src/patterns/problem-with-the-service-pages/index.md
+++ b/src/patterns/problem-with-the-service-pages/index.md
@@ -3,7 +3,7 @@ title: There is a problem with the service pages
 description: This is a page that tells someone there is something wrong with the service. They are also known as 500 pages
 section: Patterns
 theme: Pages
-aliases: '500'
+aliases: "500"
 backlogIssueId: 129
 layout: layout-pane.njk
 status: Experimental

--- a/src/patterns/service-unavailable-pages/index.md
+++ b/src/patterns/service-unavailable-pages/index.md
@@ -3,7 +3,7 @@ title: Service unavailable pages
 description: This is a page that tells someone a service is unavailable. It should say when the service will be available or what to do if it is permanently closed
 section: Patterns
 theme: Pages
-aliases: '503'
+aliases: "503"
 backlogIssueId: 124
 layout: layout-pane.njk
 status: Experimental

--- a/src/styles/page-template/index.md
+++ b/src/styles/page-template/index.md
@@ -46,7 +46,7 @@ How you set an option depends on whether it's a 'variable' option or a 'block' o
 
 To set a 'variable' option, use `set` to pass in a single value or string. For example, to add a class to the `<body>` element using the `bodyClasses` option:
 
-```javascript
+```njk
 {% raw %}
 {% set bodyClasses = "EXAMPLE-CLASS" %}
 {% endraw %}
@@ -56,7 +56,7 @@ By default, the template contains a [skip link](/components/skip-link/), [header
 
 To set a 'block' option, use `block` to pass in a multiline value or HTML markup. For example, to add a block of HTML before the closing `</body>` element in the page template using the `bodyEnd` option:
 
-```javascript
+```njk
 {% raw %}
 {% block bodyEnd %}
   <div>
@@ -68,7 +68,7 @@ To set a 'block' option, use `block` to pass in a multiline value or HTML markup
 
 To change the components that are included in the page template by default, set their equivalent blocks. For example:
 
-```javascript
+```njk
 {% raw %}
 {% block header %}
   {{ govukHeader ({

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -3,6 +3,10 @@ module.exports = {
   ignoreFiles: ['**/?(.)*.{cjs,js,mjs}', 'deploy/public/**/*'],
   overrides: [
     {
+      customSyntax: 'postcss-markdown',
+      files: ['**/*.md']
+    },
+    {
       customSyntax: 'postcss-scss',
       files: ['**/*.scss']
     }

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -7,6 +7,14 @@ module.exports = {
       files: ['**/*.md']
     },
     {
+      customSyntax: 'postcss-markdown',
+      files: ['**/extending-and-modifying-components/index.md'],
+      rules: {
+        // Allow markdown `*.md` CSS example with !important
+        'declaration-no-important': null
+      }
+    },
+    {
       customSyntax: 'postcss-scss',
       files: ['**/*.scss']
     }

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -145,7 +145,7 @@
       {% endif -%}
       <div class="app-example__code" data-module="app-copy">
 
-```javascript
+```njk
 {{ getNunjucksCode(examplePath) | safe }}
 ```
 


### PR DESCRIPTION
Some of our Sass Markdown blocks don't pass Stylelint checks

For example, CSS property order in [Small modifications to components](https://design-system.service.gov.uk/get-started/extending-and-modifying-components/#small-modifications-to-components):

````patch
--- a/src/get-started/extending-and-modifying-components/index.md
+++ b/src/get-started/extending-and-modifying-components/index.md
 
@@ -120,8 +120,8 @@ For example, if you wanted to override the button component you could do the fol
 
 ```css
 .app-button--inverse {
-  background-color: govuk-colour("white");
   color: govuk-colour("blue");
+  background-color: govuk-colour("white");
 }
 ```
````

This PR brings over the following from GOV.UK Frontend:

* https://github.com/alphagov/govuk-frontend/pull/3698