### PR TITLE
Apply “smart” punctuation to macro options, titles, meta tags

### DIFF
--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -1,13 +1,17 @@
 const { dirname, join } = require('path')
 
-const { marked } = require('marked')
+const { Marked, Renderer } = require('marked')
+const { markedSmartypants } = require('marked-smartypants')
 
 const { kebabCase, slugify } = require('../nunjucks/filters')
 
 // Get reference to marked.js
-const renderer = new marked.Renderer()
+const renderer = new Renderer()
 // Override marking up paragraphs
 renderer.paragraph = (text) => text
+
+// Custom Marked instance with "smart" typographic punctuation
+const marked = new Marked().setOptions({ renderer }).use(markedSmartypants())
 
 function getMacroOptionsJson(componentName) {
   const optionsFilePath = join(
@@ -45,7 +49,7 @@ function renderNameWithBreaks(option) {
 
 function renderDescriptionsAsMarkdown(option) {
   if (option.description) {
-    option.description = marked(option.description, { renderer })
+    option.description = marked.parse(option.description)
   }
   if (option.params) {
     option.params = option.params.map(renderDescriptionsAsMarkdown)

--- a/lib/nunjucks/filters.js
+++ b/lib/nunjucks/filters.js
@@ -1,4 +1,9 @@
+const { markedSmartypants } = require('marked-smartypants')
+const filters = require('nunjucks/src/filters')
 const slug = require('slug')
+
+// Marked extension for "smart" typographic punctuation
+const smartypants = markedSmartypants()
 
 /**
  * Format strings into kebab case but also
@@ -23,4 +28,14 @@ exports.kebabCase = function (string) {
  */
 exports.slugify = function (string) {
   return slug(string, { lower: true })
+}
+
+/**
+ * Format strings with "smart" typographic punctuation
+ *
+ * @param {string} string - String to format
+ * @returns {string} Formatted string
+ */
+exports.smartypants = function (string) {
+  return filters.safe(smartypants.hooks.postprocess(string))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "jstransformer-marked": "^1.4.0",
         "jstransformer-nunjucks": "^1.2.0",
         "marked": "^7.0.5",
+        "marked-smartypants": "^1.1.0",
         "metalsmith": "^2.6.1",
         "metalsmith-canonical": "^1.2.0",
         "multimatch": "^6.0.0",
@@ -10906,6 +10907,18 @@
         "node": ">= 16"
       }
     },
+    "node_modules/marked-smartypants": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/marked-smartypants/-/marked-smartypants-1.1.0.tgz",
+      "integrity": "sha512-7pu/8Zpr8rWIXmtab8XPleNuaD+xZ5DQRfjGp3pqAo+SmmDBZ66+fAn5CSQPysAwBzd/qrpOmLg7KSRlwyPHKA==",
+      "dev": true,
+      "dependencies": {
+        "smartypants": "^0.2.2"
+      },
+      "peerDependencies": {
+        "marked": "^4 || ^5 || ^6 || ^7"
+      }
+    },
     "node_modules/mathml-tag-names": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -14323,6 +14336,16 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/smartypants": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.2.2.tgz",
+      "integrity": "sha512-TzobUYoEft/xBtb2voRPryAUIvYguG0V7Tt3de79I1WfXgCwelqVsGuZSnu3GFGRZhXR90AeEYIM+icuB/S06Q==",
+      "dev": true,
+      "bin": {
+        "smartypants": "bin/smartypants.js",
+        "smartypantsu": "bin/smartypantsu.js"
       }
     },
     "node_modules/smob": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "jstransformer-marked": "^1.4.0",
     "jstransformer-nunjucks": "^1.2.0",
     "marked": "^7.0.5",
+    "marked-smartypants": "^1.1.0",
     "metalsmith": "^2.6.1",
     "metalsmith-canonical": "^1.2.0",
     "multimatch": "^6.0.0",

--- a/src/components/accordion/default/index.njk
+++ b/src/components/accordion/default/index.njk
@@ -13,7 +13,7 @@ layout: layout-example.njk
         text: "Writing well for the web"
       },
       content: {
-        html: "<p class='govuk-body'>This is the content for Writing well for the web.</p>"
+        html: '<p class="govuk-body">This is the content for Writing well for the web.</p>'
       }
     },
     {
@@ -21,7 +21,7 @@ layout: layout-example.njk
         text: "Writing well for specialists"
       },
       content: {
-        html: "<p class='govuk-body'>This is the content for Writing well for specialists.</p>"
+        html: '<p class="govuk-body">This is the content for Writing well for specialists.</p>'
       }
     },
     {
@@ -29,7 +29,7 @@ layout: layout-example.njk
         text: "Know your audience"
       },
       content: {
-        html: "<p class='govuk-body'>This is the content for Know your audience.</p>"
+        html: '<p class="govuk-body">This is the content for Know your audience.</p>'
       }
     },
     {
@@ -37,7 +37,7 @@ layout: layout-example.njk
         text: "How people read"
       },
       content: {
-        html: "<p class='govuk-body'>This is the content for How people read.</p>"
+        html: '<p class="govuk-body">This is the content for How people read.</p>'
       }
     }
   ]

--- a/src/components/breadcrumbs/collapse-mobile/index.njk
+++ b/src/components/breadcrumbs/collapse-mobile/index.njk
@@ -17,15 +17,15 @@ layout: layout-example.njk
     },
     {
       text: "Rural and countryside",
-      href: '#'
+      href: "#"
     },
     {
       text: "Rural development and land management",
-      href: '#'
+      href: "#"
     },
     {
       text: "Economic growth in rural areas",
-      href: '#'
+      href: "#"
     }
   ]
 }) }}

--- a/src/components/error-summary/full-page-example/index.njk
+++ b/src/components/error-summary/full-page-example/index.njk
@@ -34,12 +34,12 @@ layout: layout-example-full-page.njk
           fieldset: {
             legend: {
               isPageHeading: true,
-              text: 'When was your passport issued?',
-              classes: 'govuk-fieldset__legend--l'
+              text: "When was your passport issued?",
+              classes: "govuk-fieldset__legend--l"
             }
           },
-          id: 'passport-issued',
-          namePrefix: 'passport-issued',
+          id: "passport-issued",
+          namePrefix: "passport-issued",
           errorMessage: {
             text: "Passport issue date must include a year"
           },

--- a/src/components/error-summary/linking-multiple-fields/index.njk
+++ b/src/components/error-summary/linking-multiple-fields/index.njk
@@ -20,12 +20,12 @@ layout: layout-example.njk
   fieldset: {
     legend: {
       isPageHeading: true,
-      text: 'When was your passport issued?',
-      classes: 'govuk-fieldset__legend--l'
+      text: "When was your passport issued?",
+      classes: "govuk-fieldset__legend--l"
     }
   },
-  id: 'passport-issued',
-  namePrefix: 'passport-issued',
+  id: "passport-issued",
+  namePrefix: "passport-issued",
   errorMessage: {
     text: "Passport issue date must include a year"
   },

--- a/src/components/error-summary/linking/index.njk
+++ b/src/components/error-summary/linking/index.njk
@@ -20,7 +20,7 @@ layout: layout-example.njk
 
 {{ govukInput({
   label: {
-    text: 'Full name'
+    text: "Full name"
   },
   id: "full-name-input",
   name: "name",
@@ -29,4 +29,3 @@ layout: layout-example.njk
     text: "Enter your full name"
   }
 }) }}
-

--- a/src/components/fieldset/address-group/index.njk
+++ b/src/components/fieldset/address-group/index.njk
@@ -18,7 +18,7 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      text: 'Address line 1'
+      text: "Address line 1"
     },
     id: "address-line-1",
     name: "address-line-1",
@@ -27,7 +27,7 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      text: 'Address line 2 (optional)'
+      text: "Address line 2 (optional)"
     },
     id: "address-line-2",
     name: "address-line-2",

--- a/src/components/notification-banner/success/index.njk
+++ b/src/components/notification-banner/success/index.njk
@@ -14,5 +14,5 @@ layout: layout-example.njk
 
 {{ govukNotificationBanner({
   html: html,
-  type: 'success'
+  type: "success"
 }) }}

--- a/src/components/notification-banner/whole-service/index.njk
+++ b/src/components/notification-banner/whole-service/index.njk
@@ -6,5 +6,5 @@ layout: layout-example.njk
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {{ govukNotificationBanner({
-  text: 'There may be a delay in processing your application because of the coronavirus outbreak.'
+  text: "There may be a delay in processing your application because of the coronavirus outbreak."
 }) }}

--- a/src/components/summary-list/without-borders/index.njk
+++ b/src/components/summary-list/without-borders/index.njk
@@ -6,7 +6,7 @@ layout: layout-example.njk
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {{ govukSummaryList({
-  classes: 'govuk-summary-list--no-border',
+  classes: "govuk-summary-list--no-border",
   rows: [
     {
       key: {

--- a/src/components/table/column-widths-custom-classes/index.njk
+++ b/src/components/table/column-widths-custom-classes/index.njk
@@ -14,15 +14,15 @@ stylesheets:
   head: [
     {
       text: "Date",
-      classes: 'app-custom-class'
+      classes: "app-custom-class"
     },
     {
       text: "Rate for vehicles",
-      classes: 'app-custom-class'
+      classes: "app-custom-class"
     },
     {
       text: "Rate for bicycles",
-      classes: 'app-custom-class'
+      classes: "app-custom-class"
     }
   ],
   rows: [

--- a/src/components/table/column-widths/index.njk
+++ b/src/components/table/column-widths/index.njk
@@ -12,15 +12,15 @@ layout: layout-example.njk
   head: [
     {
       text: "Date",
-      classes: 'govuk-!-width-one-half'
+      classes: "govuk-!-width-one-half"
     },
     {
       text: "Rate for vehicles",
-      classes: 'govuk-!-width-one-quarter'
+      classes: "govuk-!-width-one-quarter"
     },
     {
       text: "Rate for bicycles",
-      classes: 'govuk-!-width-one-quarter'
+      classes: "govuk-!-width-one-quarter"
     }
   ],
   rows: [

--- a/src/cookies.njk
+++ b/src/cookies.njk
@@ -130,7 +130,7 @@ layout: layout-single-page.njk
         }) }}
 
         {{ govukButton({
-          text: 'Save cookie settings',
+          text: "Save cookie settings",
           classes: "js-cookies-form-button",
           attributes: {
             hidden: ""

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -18,7 +18,7 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      text: 'Address line 1'
+      text: "Address line 1"
     },
     id: "address-line-1",
     name: "address-line-1",
@@ -27,7 +27,7 @@ stylesheets:
 
   {{ govukInput({
     label: {
-      text: 'Address line 2 (optional)'
+      text: "Address line 2 (optional)"
     },
     id: "address-line-2",
     name: "address-line-2",

--- a/src/patterns/check-answers/default/index.njk
+++ b/src/patterns/check-answers/default/index.njk
@@ -25,7 +25,7 @@ layout: layout-example-full-page.njk
       <h2 class="govuk-heading-m">Personal details</h2>
 
       {{ govukSummaryList({
-        classes: 'govuk-!-margin-bottom-9',
+        classes: "govuk-!-margin-bottom-9",
         rows: [
           {
             key: {
@@ -119,7 +119,7 @@ layout: layout-example-full-page.njk
       <h2 class="govuk-heading-m">Application details</h2>
 
       {{ govukSummaryList({
-        classes: 'govuk-!-margin-bottom-9',
+        classes: "govuk-!-margin-bottom-9",
         rows: [
           {
             key: {

--- a/src/patterns/contact-a-department-or-service-team/expanding-contact-information/index.njk
+++ b/src/patterns/contact-a-department-or-service-team/expanding-contact-information/index.njk
@@ -21,6 +21,6 @@ layout: layout-example.njk
 {% endset %}
 
 {{ govukDetails({
-  summaryText: 'If you need help completing this form',
+  summaryText: "If you need help completing this form",
   html: contactInformation
 }) }}

--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -43,7 +43,7 @@ ignoreInSitemap: true
       {
         headingText: "Cookies on [name of service]",
         html: "<p class=\"govuk-body\">We use some essential cookies to make this service work.</p>
-          <p class=\"govuk-body\">We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>",
+          <p class=\"govuk-body\">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>",
         actions: [
           {
             text: "Accept analytics cookies",

--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -21,8 +21,8 @@ ignoreInSitemap: true
 {% set themeColor = "blue" %}
 {% set bodyClasses = "app-body-class" %}
 {% set bodyAttributes = {
-  'data-test': 'My value',
-  'data-other': 'report:details'
+  "data-test": "My value",
+  "data-other": "report:details"
 } %}
 {% set containerClasses = "app-width-container" %}
 

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -21,8 +21,8 @@ ignoreInSitemap: true
 {% set themeColor = "blue" %}
 {% set bodyClasses = "app-body-class" %}
 {% set bodyAttributes = {
-  'data-test': 'My value',
-  'data-other': 'report:details'
+  "data-test": "My value",
+  "data-other": "report:details"
 } %}
 {% set containerClasses = "app-width-container" %}
 

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -2,16 +2,16 @@
 
 {% set assetUrl = 'https://design-system.service.gov.uk/assets' %}
 
-{% block pageTitle %}{{ title }} – GOV.UK Design System{% endblock %}
+{% block pageTitle %}{{ title | smartypants }} – GOV.UK Design System{% endblock %}
 
 {% block head %}
   {#- Prevent search engine indexing for preview and development builds -#}
   {% if ["deploy-preview", "dev"].includes(env("CONTEXT")) or env("NODE_ENV") != 'production' %}
     <meta name="robots" content="noindex, nofollow">
   {% endif %}
-  <meta name="og:title" content="{{title}}">
-  <meta name="description" content="{{description}}">
-  <meta name="og:description" content="{{description}}">
+  <meta name="og:title" content="{{ title | smartypants }}">
+  <meta name="description" content="{{ description | smartypants }}">
+  <meta name="og:description" content="{{ description | smartypants }}">
   <link rel="canonical" href="{{ canonical }}">
   <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all">
 {% endblock %}

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -3,13 +3,13 @@
 {% set htmlClasses = 'app-example-page__wrapper' %}
 {% set assetUrl = 'https://design-system.service.gov.uk/assets' %}
 
-{% block pageTitle %}{{ title }} – Example – GOV.UK Design System{% endblock %}
+{% block pageTitle %}{{ title | smartypants }} – Example – GOV.UK Design System{% endblock %}
 
 {% block head %}
   <meta name="robots" content="noindex, nofollow">
-  <meta name="og:title" content="{{title}}">
-  <meta name="description" content="{{description}}">
-  <meta name="og:description" content="{{description}}">
+  <meta name="og:title" content="{{ title | smartypants }}">
+  <meta name="description" content="{{ description | smartypants }}">
+  <meta name="og:description" content="{{ description | smartypants }}">
   <link rel="canonical" href="{{ canonical }}">
 
   <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all">

--- a/views/partials/_banner.njk
+++ b/views/partials/_banner.njk
@@ -22,7 +22,7 @@
       "text": bannerTag,
       "classes": "govuk-tag--red"
     },
-    "classes": 'app-width-container' + (' app-phase-banner--no-border' if masthead),
+    "classes": "app-width-container" + (" app-phase-banner--no-border" if masthead),
     "html": bannerText
   }) }}
 {% endif %}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -32,10 +32,10 @@
       <div class="app-example__toolbar">
         <a href="{{ exampleURL }}" class="app-example__new-window" target="_blank">
           {#- Don't use full title visually as the context is shown based on location of this link #}
-          Open this example in a new tab<span class="govuk-visually-hidden">: {{ exampleTitle | lower }}</span>
+          Open this example in a new tab<span class="govuk-visually-hidden">: {{ exampleTitle | lower | smartypants }}</span>
         </a>
       </div>
-      <iframe title="{{ exampleTitle + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" loading="{% if params.loading %}{{ params.loading }}{% else %}lazy{% endif %}"></iframe>
+      <iframe title="{{ exampleTitle | smartypants + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" loading="{% if params.loading %}{{ params.loading }}{% else %}lazy{% endif %}"></iframe>
     </div>
   {% endif %}
 


### PR DESCRIPTION
This PR follows up on a Slack chat with @stevenjmesser

It adds "smart" typographic punctuation in lots more places

>SmartyPants can perform the following transformations:
>
>* Straight quotes ( " and ' ) into “curly” quote HTML entities
>* Backticks-style quotes (``like this'') into “curly” quote HTML entities
>* Dashes (“--” and “---”) into en- and em-dash entities
>* Three consecutive dots (“...”) into an ellipsis entity

It includes:

1. Automatic smart quotes in macro option descriptions
1. Automatic smart quotes in preview example titles
1. Automatic smart quotes in page `<title>` and meta tags
1. Automatic smart quotes in `*.njk` via `| smartypants` filter
1. Manual smart quotes in `*.njk` templates (not processed by Marked)