### PR TITLE
Add `rel` attribute to EtP secondary link example

### DIFF
--- a/src/components/exit-this-page/secondary-link/index.njk
+++ b/src/components/exit-this-page/secondary-link/index.njk
@@ -8,7 +8,10 @@ layout: layout-example.njk
 <p class="govuk-body">To view the secondary link, tab to or click inside this example and then press tab.</p>
 
 {{ govukSkipLink({
-  text: 'Exit this page',
+  text: "Exit this page",
   href: "https://bbc.co.uk/weather/",
-  classes: "govuk-js-exit-this-page-skiplink"
+  classes: "govuk-js-exit-this-page-skiplink",
+  attributes: {
+    "rel": "nofollow noreferrer"
+  }
 }) }}


### PR DESCRIPTION
As per https://github.com/alphagov/govuk-frontend/issues/3921, we don't want the Exit this Page functionality to expose information about the current webpage to the website being linked to. 

However, as we re-purpose the Skip Link component for the secondary link, users must apply the change manually through their Nunjucks include or in their HTML for this link. 

The change to the EtP button itself is here: https://github.com/alphagov/govuk-frontend/pull/4054