### PR TITLE
Add error message section and example to select component docs

### DIFF
--- a/src/components/select/error/index.njk
+++ b/src/components/select/error/index.njk
@@ -1,0 +1,63 @@
+---
+title: Select with error
+layout: layout-example.njk
+---
+
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{{ govukSelect({
+  id: "subject",
+  name: "subject",
+  label: {
+    text: "Choose location"
+  },
+  hint: {
+    text: "This can be different to where you went before"
+  },
+  errorMessage: {
+    text: "Select a location"
+  },
+  items: [
+    {
+      value: "choose",
+      text: "Choose location",
+      selected: true
+    },
+    {
+      value: "eastmidlands",
+      text: "East Midlands"
+    },
+    {
+      value: "eastofengland",
+      text: "East of England"
+    },
+    {
+      value: "london",
+      text: "London"
+    },
+    {
+      value: "northeast",
+      text: "North East"
+    },
+    {
+      value: "northwest",
+      text: "North West"
+    },
+    {
+      value: "southeast",
+      text: "South East"
+    },
+    {
+      value: "southwest",
+      text: "South West"
+    },
+    {
+      value: "westmidlands",
+      text: "West Midlands"
+    },
+    {
+      value: "yorkshire",
+      text: "Yorkshire and the Humber"
+    }
+  ]
+}) }}

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -37,6 +37,14 @@ You can add hint text to help the user understand the options and choose one of 
 
 {{ example({group: "components", item: "select", example: "with-hint", html: true, nunjucks: true, open: false}) }}
 
+### Error messages
+
+Display an error message if the user has not selected an option.
+
+Style error messages as shown in the example:
+
+{{ example({group: "components", item: "select", example: "error", html: true, nunjucks: true, open: false }) }}
+
 ## Research on this component
 
 User research has shown that some users struggle with selects.


### PR DESCRIPTION
Adds a brief section about error messages and an example of a Select component's error state to the Select component documentation, which was curiously absent.

Both the wording of the guidance and the error message itself is pulled from the [radio button guidance on error messages](https://design-system.service.gov.uk/components/radios/#error-messages), with the omission of multiple states, as the only invalid choice in a select tends to be the initial 'placeholder' option, if one is present. 

Closes #1049.