### PR TITLE
Set up redirects for security.txt file

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -176,6 +176,17 @@ http {
       location /__canary__ {
         auth_basic off;
       }
+      
+      # Redirect to the Cabinet Office's responsible disclosure policy
+      # https://github.com/alphagov/security.txt
+      
+      location /security.txt {
+        return 302 https://vdp.cabinetoffice.gov.uk/.well-known/security.txt;
+      }
+      
+      location /.well-known/security.txt {
+        return 302 https://vdp.cabinetoffice.gov.uk/.well-known/security.txt;
+      }
     }
   }
 }


### PR DESCRIPTION
Modifies the nginx configuration so that the below URLs redirect to the Cabinet Office's centrally managed [security and responsible disclosure policies](https://vdp.cabinetoffice.gov.uk/.well-known/security.txt):

- https://design-system.service.gov.uk/security.txt
- https://design-system.service.gov.uk/.well-known/security.txt

More information is in the [security.txt repo](https://github.com/alphagov/security.txt). 

Related to #1678.