### PR TITLE
Step-by-step to meet WCAG 2.1

### DIFF
--- a/src/patterns/step-by-step-navigation/index.md
+++ b/src/patterns/step-by-step-navigation/index.md
@@ -101,11 +101,15 @@ If there is not a set order, they should be listed in an order that helps the us
 
 For example, ‘Agree a contract and salary’ is listed as step 4 in ‘Employ someone: step by step’ although it can be completed earlier.
 
+Ensure the number of the step is read out to screen-reader users when navigating to information within the `button` element.
+
 ### Use both ‘and’ and ‘or’
 
 Use ‘and’ to show when you can or must complete steps at the same time. You can use ‘and’ for more than 2 steps.
 
 Use ‘or’ to show when there’s a choice between 2 steps, or when a task must be completed in a different way based the user’s circumstances or eligibility.
+
+When using ‘and’ or ‘or’ nest the non-sequential steps as sub-headings of the step they relate to as level 3 headings in the list. This will convey that the ‘and’ or ‘or’ steps are not the next steps in the sequential order for screen reader users.
 
 ![A screenshot showing an example of the step by step navigation pattern with an 'and' step](step-by-step-and.png)
 

--- a/src/patterns/step-by-step-navigation/index.md
+++ b/src/patterns/step-by-step-navigation/index.md
@@ -101,7 +101,7 @@ If there is not a set order, they should be listed in an order that helps the us
 
 For example, ‘Agree a contract and salary’ is listed as step 4 in ‘Employ someone: step by step’ although it can be completed earlier.
 
-Ensure the number of the step is read out to screen-reader users when navigating to information within the `button` element.
+Make sure the number of the step is read out to screen-reader users when navigating to information within the `button` element.
 
 ### Use both ‘and’ and ‘or’
 

--- a/src/patterns/step-by-step-navigation/index.md
+++ b/src/patterns/step-by-step-navigation/index.md
@@ -109,7 +109,7 @@ Use ‘and’ to show when you can or must complete steps at the same time. You 
 
 Use ‘or’ to show when there’s a choice between 2 steps, or when a task must be completed in a different way based the user’s circumstances or eligibility.
 
-When using ‘and’ or ‘or’ nest the non-sequential steps as sub-headings of the step they relate to as level 3 headings in the list. This will convey that the ‘and’ or ‘or’ steps are not the next steps in the sequential order for screen reader users.
+When adding ‘and‘ or ‘or‘ steps, make sure screen reader users can easily tell the difference between additional information or actions included in this step and the other numbered steps. Do this by nesting non-sequential ‘and‘ or ‘or‘ step names as sub-headings (usually `<h3>`) within the related step.
 
 ![A screenshot showing an example of the step by step navigation pattern with an 'and' step](step-by-step-and.png)
 


### PR DESCRIPTION
There are two guidance changes needed to ensure users implement the Step-by-step pattern in accordance with WCAG 2.1

This closes the following issues:

- [Step-by-step navigation 'or' headings must be nested under their parent step headings #2794](https://github.com/alphagov/govuk-design-system/issues/2794)
- [Step-by-step navigation does not convey all of the information for screen reader users when viewing them as forms #3021](https://github.com/alphagov/govuk-design-system/issues/3021)