### PR TITLE
[SPIKE] Configure `iframe-resizer` for reduced CPU usage

### DIFF
--- a/src/javascripts/components/example.mjs
+++ b/src/javascripts/components/example.mjs
@@ -21,14 +21,28 @@ Example.prototype.init = function () {
     return
   }
 
+  var options = {
+    // Initial resize only, no event listeners
+    autoResize: false,
+
+    // Calculate height from `data-iframe-height` only
+    heightCalculationMethod: 'taggedElement',
+
+    // Calculate height from iframe contents only
+    resizeFrom: 'child',
+
+    // Skip iframe `scrolling` attribute
+    scrolling: 'omit'
+  }
+
   // Initialise asap for eager iframes or browsers which don't support lazy loading
   if (!('loading' in $module) || $module.loading !== 'lazy') {
-    return iFrameResize({ scrolling: 'omit' }, $module)
+    return iFrameResize(options, $module)
   }
 
   $module.addEventListener('load', function () {
     try {
-      iFrameResize({ scrolling: 'omit' }, $module)
+      iFrameResize(options, $module)
     } catch (err) {
       if (err) {
         console.error(err.message)

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -24,6 +24,7 @@
 {% block header %}{% endblock %}
 
 {% set bodyClasses = "app-example-page" %}
+{% set bodyAttributes = { "data-iframe-height": "" } %}
 
 {% block main %}
   <!-- Disable browser validation for any examples that include form elements -->


### PR DESCRIPTION
This PR configures `iframe-resizer` for reduced CPU usage by [configuring](https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/parent_page/options.md):

1. Initial resize only, no event listeners
1. Calculate height from child contents changes only
1. Calculate height from `data-iframe-height` only

This is to investigate:

* https://github.com/alphagov/govuk-design-system/issues/2594

For more information, see:

* https://github.com/alphagov/govuk-design-system/pull/2572
* https://github.com/alphagov/govuk-design-system/pull/2687