### PR TITLE
Passwords to meet WCAG 2.1

### DIFF
--- a/src/patterns/passwords/index.md
+++ b/src/patterns/passwords/index.md
@@ -69,6 +69,8 @@ To help users meet your password constraints and prevent mistyped passwords, you
 - show the last typed character of their password
 - make them enter their password twice and automatically compare them
 
+If you use a button to show a password make sure that the label is unique to each password input that it relates to.
+
 ### Allow users to paste their password
 
 Do not disable paste on password fields. People may have very good reasons why they want to paste their password, for example if they’re using a password manager.


### PR DESCRIPTION
There is a guidance change needed to ensure users implement the passwords pattern in accordance with WCAG 2.1.

This closes issue:

- [Pages with 2+ password fields must use different programmatic labels for 'show' and 'hide' buttons on those password fields #2795](https://github.com/alphagov/govuk-design-system/issues/2795)