### PR TITLE
Tabs to meet WCAG 2.1

### DIFF
--- a/src/components/tabs/index.md
+++ b/src/components/tabs/index.md
@@ -90,6 +90,10 @@ Disabling elements is normally confusing for users. If there is no content for a
 
 If you use too many tabs or they have long labels then they may wrap over more than one line. This makes it harder for users to see the connection between the selected tab and its content.
 
+### Add headings to tab content
+
+Use headings within each tab for screen reader users.
+
 ## Research and testing
 
 This component is experimental because it has not yet been tried in research with users.

--- a/src/components/tabs/index.md
+++ b/src/components/tabs/index.md
@@ -92,7 +92,7 @@ If you use too many tabs or they have long labels then they may wrap over more t
 
 ### Add headings to tab content
 
-Use headings within each tab for screen reader users.
+Include a heading at the beginning of each tab that duplicates the information in the tab label. Providing a heading improves navigation on smaller screen sizes and for screen reader users.
 
 ## Research and testing
 


### PR DESCRIPTION
There is a guidance change needed to ensure users implement the Tabs pattern in accordance with WCAG 2.1

This closes the following issue:

- [Tab components should show visible headings for all sections on mobile screen sizes #2797](https://github.com/alphagov/govuk-design-system/issues/2797)