### PR TITLE
Explain that Friday call is on pause

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -74,7 +74,9 @@ Join one of our regular events where we share ideas and work together to solve c
       title: "Design systems catchup",
       large: true
     }) %}
-      <p>Chat with us every other Friday on Google Meet. It’s an informal chat with an agenda set each week by participants. <a href="https://calendar.google.com/event?action=TEMPLATE&tmeid=dGZpZ251Y2ttaHRkY3AwcTBxcHViMmY4ZmNfMjAyMjA5MDlUMTMwMDAwWiBjYWx2aW4ubGF1QGRpZ2l0YWwuY2FiaW5ldC1vZmZpY2UuZ292LnVr&tmsrc=calvin.lau%40digital.cabinet-office.gov.uk&scp=ALL">Add to calendar</a> or <a href="https://design-system.service.gov.uk/get-in-touch/">contact the team</a> for an invite.</p>
+      <p>We regularly host informal chats with our community.</p>
+      <p>We've currently paused our usual fortnightly catchup call whilst we work on improving the way we have these conversations with our community.</p>
+      <p>We're keen to hear what you'd like to see and encourage you to <a href="https://surveys.publishing.service.gov.uk/s/1YTI43/">take our survey</a>.</p>
     {% endcall %}
   </div>
   <div class="govuk-grid-column-full">


### PR DESCRIPTION
Minor edit on the Community landing page.
Removes link to Google Calendar link, explains we plan to survey the community. Further updated needed by autumn 2023.