### PR TITLE
[SPIKE] Configure `iframe-resizer` using Intersection Observer

### DIFF
--- a/__tests__/tabs.test.js
+++ b/__tests__/tabs.test.js
@@ -57,8 +57,7 @@ describe('Component page', () => {
 
     describe('when the tab closed and clicked twice', () => {
       it('should indicate the closed state of the tab', async () => {
-        await $tabsLinks[0].click()
-        await $tabsLinks[0].click()
+        await $tabsLinks[0].click({ count: 2 })
 
         // Tab item not marked current
         await expect(getAttribute($tabsItems[0], 'class')).resolves
@@ -66,10 +65,9 @@ describe('Component page', () => {
       })
 
       it('should indicate the closed state by setting aria-expanded attribute to false', async () => {
-        await $tabsLinks[0].click()
-        await $tabsLinks[0].click()
+        await $tabsLinks[0].click({ count: 2 })
 
-        // Tab link control expanded
+        // Tab link control collapsed
         await expect(getAttribute($tabsLinks[0], 'aria-expanded')).resolves
           .toBe('false')
       })

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -29,8 +29,8 @@ if (userConsent && isValidConsentCookie(userConsent) && userConsent.analytics) {
   Analytics()
 }
 
-// Initialise example frames
-const $examples = document.querySelectorAll('[data-module="app-example-frame"]')
+// Initialise examples
+const $examples = document.querySelectorAll('[data-module="app-example"]')
 $examples.forEach(($example) => {
   new Example($example)
 })

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -29,10 +29,41 @@ if (userConsent && isValidConsentCookie(userConsent) && userConsent.analytics) {
   Analytics()
 }
 
+// Register of examples by module
+const exampleRegister = /** @type {Map<Element, Example>} */ (
+  new Map()
+)
+
+// Defer init until viewport intersection
+const exampleObserver = 'IntersectionObserver' in window
+  ? new window.IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (!entry.isIntersecting) {
+        return
+      }
+
+      console.log('init', { $module: entry.target })
+
+      // Stop observing, initialise
+      exampleObserver.unobserve(entry.target)
+      exampleRegister.get(entry.target).init()
+    }
+  })
+  : undefined
+
 // Initialise examples
 const $examples = document.querySelectorAll('[data-module="app-example"]')
 $examples.forEach(($example) => {
-  new Example($example)
+  const example = new Example($example)
+
+  // Initialise iframes immediately
+  if (!exampleObserver) {
+    return example.init()
+  }
+
+  // Add to register, start observing
+  exampleRegister.set(example.$module, example)
+  exampleObserver.observe(example.$module)
 })
 
 // Initialise tabs

--- a/src/javascripts/components/example.mjs
+++ b/src/javascripts/components/example.mjs
@@ -13,20 +13,34 @@ class Example {
    * @param {Element} $module - HTML element
    */
   constructor ($module) {
-    if (!($module instanceof HTMLIFrameElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
       return
     }
 
     this.$module = $module
 
-    // Initialise asap for eager iframes or browsers which don't support lazy loading
-    if (!('loading' in this.$module) || this.$module.loading !== 'lazy') {
-      return iFrameResize({ scrolling: 'omit' }, this.$module)
+    const $placeholder = $module.querySelector('.js-example-placeholder')
+    const $iframe = document.createElement('iframe')
+
+    // Configure iframe
+    $iframe.className = 'app-example__frame app-example__frame--resizable'
+    $iframe.title = $placeholder.getAttribute('data-title')
+    $iframe.src = $placeholder.getAttribute('data-src')
+    $iframe.loading = $placeholder.getAttribute('data-lazy')
+
+    // Optional preview size
+    const previewSize = $placeholder.getAttribute('data-size')
+    if (previewSize) {
+      $iframe.className += ` app-example__frame--${previewSize}`
     }
 
-    this.$module.addEventListener('load', () => {
+    // Replace placeholder with preview iframe
+    $placeholder.replaceWith($iframe)
+
+    // Resize once loaded
+    $iframe.addEventListener('load', () => {
       try {
-        iFrameResize({ scrolling: 'omit' }, this.$module)
+        iFrameResize({ scrolling: 'omit' }, $iframe)
       } catch (err) {
         if (err) {
           console.error(err.message)

--- a/src/javascripts/components/example.mjs
+++ b/src/javascripts/components/example.mjs
@@ -19,8 +19,6 @@ class Example {
 
     this.$module = $module
     this.$placeholder = this.$module.querySelector('.js-example-placeholder')
-
-    this.init()
   }
 
   init () {

--- a/src/javascripts/components/example.mjs
+++ b/src/javascripts/components/example.mjs
@@ -18,29 +18,38 @@ class Example {
     }
 
     this.$module = $module
+    this.$placeholder = this.$module.querySelector('.js-example-placeholder')
 
-    const $placeholder = $module.querySelector('.js-example-placeholder')
-    const $iframe = document.createElement('iframe')
+    this.init()
+  }
+
+  init () {
+    if (this.$iframe || !this.$placeholder) {
+      return
+    }
+
+    // Create iframe
+    this.$iframe = document.createElement('iframe')
 
     // Configure iframe
-    $iframe.className = 'app-example__frame app-example__frame--resizable'
-    $iframe.title = $placeholder.getAttribute('data-title')
-    $iframe.src = $placeholder.getAttribute('data-src')
-    $iframe.loading = $placeholder.getAttribute('data-lazy')
+    this.$iframe.className = 'app-example__frame app-example__frame--resizable'
+    this.$iframe.title = this.$placeholder.getAttribute('data-title')
+    this.$iframe.src = this.$placeholder.getAttribute('data-src')
+    this.$iframe.loading = this.$placeholder.getAttribute('data-lazy')
 
     // Optional preview size
-    const previewSize = $placeholder.getAttribute('data-size')
+    const previewSize = this.$placeholder.getAttribute('data-size')
     if (previewSize) {
-      $iframe.className += ` app-example__frame--${previewSize}`
+      this.$iframe.className += ` app-example__frame--${previewSize}`
     }
 
     // Replace placeholder with preview iframe
-    $placeholder.replaceWith($iframe)
+    this.$placeholder.replaceWith(this.$iframe)
 
     // Resize once loaded
-    $iframe.addEventListener('load', () => {
+    this.$iframe.addEventListener('load', () => {
       try {
-        iFrameResize({ scrolling: 'omit' }, $iframe)
+        iFrameResize({ scrolling: 'omit' }, this.$iframe)
       } catch (err) {
         if (err) {
           console.error(err.message)

--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -39,7 +39,7 @@
 }
 
 // Default size
-.app-example__iframe,
+.app-example__frame,
 .app-example__frame--xs {
   height: 150px;
 }

--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -29,6 +29,14 @@
   @include govuk-font(14);
 }
 
+.app-example__placeholder {
+  padding: govuk-spacing(4);
+
+  .govuk-frontend-supported & .govuk-body {
+    display: none;
+  }
+}
+
 .app-example__frame {
   display: block;
   width: 100%;
@@ -39,6 +47,7 @@
 }
 
 // Default size
+.app-example__placeholder,
 .app-example__frame,
 .app-example__frame--xs {
   height: 150px;

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -28,14 +28,16 @@
 
 <div class="app-example-wrapper" id="{{ exampleId }}" data-module="app-tabs" {%- if params.open %} data-open{% endif %}>
   {% if display %}
-    <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
+    <div data-module="app-example" class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
       <div class="app-example__toolbar">
         <a href="{{ exampleURL }}" class="app-example__new-window" target="_blank">
           {#- Don't use full title visually as the context is shown based on location of this link #}
           Open this example in a new tab<span class="govuk-visually-hidden">: {{ exampleTitle | lower }}</span>
         </a>
       </div>
-      <iframe title="{{ exampleTitle + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" loading="{% if params.loading %}{{ params.loading }}{% else %}lazy{% endif %}"></iframe>
+      <div class="app-example__placeholder js-example-placeholder" data-src="{{ exampleURL }}" data-title="{{ exampleTitle + " example" }}" data-loading="{{ params.loading if params.loading else "lazy" }}" {%- if params.size %} data-size="{{ params.size }}"{% endif %}>
+        <p class="govuk-body govuk-!-margin-0">Enable JavaScript to view component preview</p>
+      </div>
     </div>
   {% endif %}
 


### PR DESCRIPTION
This PR removes all `<iframe>` previews and loads them via JavaScript instead

Intersection Observer is used to inject each `<iframe>` only when scrolling into view, to investigate:

* https://github.com/alphagov/govuk-design-system/issues/2594

For more information, see:

* https://github.com/alphagov/govuk-design-system/pull/2572
* https://github.com/alphagov/govuk-design-system/pull/2687