### PR TITLE
Fix typo affecting default iframe height

### DIFF
--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -39,7 +39,7 @@
 }
 
 // Default size
-.app-example__iframe,
+.app-example__frame,
 .app-example__frame--xs {
   height: 150px;
 }


### PR DESCRIPTION
This fixes a flicker loading `<iframe>` examples with no custom height set