### PR TITLE
Re-prioritise security redirect rules

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -145,6 +145,17 @@ http {
 
       auth_basic $auth_enabled;
       auth_basic_user_file nginx/.htpasswd;
+      
+      # Redirect to the Cabinet Office's responsible disclosure policy
+      # https://github.com/alphagov/security.txt
+      
+      location = /security.txt {
+        return 302 https://vdp.cabinetoffice.gov.uk/.well-known/security.txt;
+      }
+      
+      location = /.well-known/security.txt {
+        return 302 https://vdp.cabinetoffice.gov.uk/.well-known/security.txt;
+      }
 
       # Handle form submissions from examples that contain forms by redirecting
       # them back to the referring example. This relies on form examples within
@@ -175,17 +186,6 @@ http {
 
       location /__canary__ {
         auth_basic off;
-      }
-      
-      # Redirect to the Cabinet Office's responsible disclosure policy
-      # https://github.com/alphagov/security.txt
-      
-      location /security.txt {
-        return 302 https://vdp.cabinetoffice.gov.uk/.well-known/security.txt;
-      }
-      
-      location /.well-known/security.txt {
-        return 302 https://vdp.cabinetoffice.gov.uk/.well-known/security.txt;
       }
     }
   }


### PR DESCRIPTION
Follow up to #3025.

Places the new redirect rules above the rule that forbids access to files and directories starting with a `.`, as one security redirect involves the `.well-known` directory.