### PR TITLE
Links to meet WCAG 2.1

### DIFF
--- a/src/styles/typography/index.md
+++ b/src/styles/typography/index.md
@@ -165,7 +165,7 @@ When offering links to content in other languages, make sure:
 
 - the link's text includes the name of the alternative language in both English and the source language
 - the link's purpose is always clear, even when taken out of context
-- the link element includes an [`hreflang attribute`](https://www.w3schools.com/tags/att_a_hreflang.asp) that identifies the language of the linked page.
+- the link element includes an [`hreflang` attribute](https://www.w3schools.com/tags/att_a_hreflang.asp) that identifies the language of the linked page.
 
 For example, your link text could be 'use [Service name] in [language]'.
 

--- a/src/styles/typography/index.md
+++ b/src/styles/typography/index.md
@@ -162,6 +162,7 @@ For example, links in a header or side navigation might not need underlines. Use
 Links can be used to allow a user to access the current content in a different language.
 
 When offering links to content in other languages, make sure:
+
 - the link's content includes the language name in both English and the source language
 - the link's purpose is always clear, even when taken out of context
 - the link element includes an [hreflang attribute](https://www.w3schools.com/tags/att_a_hreflang.asp) that identifies the language of the linked page.

--- a/src/styles/typography/index.md
+++ b/src/styles/typography/index.md
@@ -165,7 +165,7 @@ When offering links to content in other languages, make sure:
 
 - the link's text includes the name of the alternative language in both English and the source language
 - the link's purpose is always clear, even when taken out of context
-- the link element includes an [hreflang attribute](https://www.w3schools.com/tags/att_a_hreflang.asp) that identifies the language of the linked page.
+- the link element includes an [`hreflang attribute`](https://www.w3schools.com/tags/att_a_hreflang.asp) that identifies the language of the linked page.
 
 For example, your link text could be 'use [Service name] in [language]'.
 

--- a/src/styles/typography/index.md
+++ b/src/styles/typography/index.md
@@ -159,7 +159,12 @@ For example, links in a header or side navigation might not need underlines. Use
 
 ### Links to change a language
 
-Ensure that links that allow a user to change a language are understandable even when out of context.
+Links can be used to allow a user to access the current content in a different language.
+
+When offering links to content in other languages, make sure:
+- the link's content includes the language name in both English and the source language
+- the link's purpose is always clear, even when taken out of context
+- the link element includes an [hreflang attribute](https://www.w3schools.com/tags/att_a_hreflang.asp) that identifies the language of the linked page.
 
 For example, you can link over 'use [Service name] in [language]'.
 

--- a/src/styles/typography/index.md
+++ b/src/styles/typography/index.md
@@ -157,6 +157,12 @@ For example, links in a header or side navigation might not need underlines. Use
 
 {{ example({group: "styles", item: "typography", example: "link-no-underline", html: true, open: true}) }}
 
+### Links to change a language
+
+Ensure that links that allow a user to change a language are understandable even when out of context.
+
+For example, you can link over 'use [Service name] in [language]'.
+
 ## Lists
 
 Use lists to make blocks of text easier to read, and to break information into manageable chunks.

--- a/src/styles/typography/index.md
+++ b/src/styles/typography/index.md
@@ -159,15 +159,15 @@ For example, links in a header or side navigation might not need underlines. Use
 
 ### Links to change a language
 
-Links can be used to allow a user to access the current content in a different language.
+You can use links to allow a user to access the current content in a different language.
 
 When offering links to content in other languages, make sure:
 
-- the link's content includes the language name in both English and the source language
+- the link's text includes the name of the alternative language in both English and the source language
 - the link's purpose is always clear, even when taken out of context
 - the link element includes an [hreflang attribute](https://www.w3schools.com/tags/att_a_hreflang.asp) that identifies the language of the linked page.
 
-For example, you can link over 'use [Service name] in [language]'.
+For example, your link text could be 'use [Service name] in [language]'.
 
 ## Lists
 


### PR DESCRIPTION
There is a guidance change needed to ensure users implement links in accordance with WCAG 2.1

This closes the following issue:
- [Links to Welsh versions of content should be understandable even when out of context #2796](https://github.com/alphagov/govuk-design-system/issues/2796)