### PR TITLE
Add call for speakers

### DIFF
--- a/src/community/call-for-speakers-2023/index.md
+++ b/src/community/call-for-speakers-2023/index.md
@@ -1,0 +1,129 @@
+---
+title: Speak at Design System Day 2023
+description: Design System Day is a community-driven event, and we want to hear diverse perspectives from new and seasoned speakers.
+section: Community
+theme: Events and workshops
+layout: layout-pane.njk
+order: 12
+---
+
+<img src="/community/images/dsd23-announcement-banner.svg" alt="Design System Day 2023 logo" class="app-image--no-border govuk-!-margin-bottom-6" loading="lazy">
+
+## Call for speakers: Design System Day 2023
+
+This year Design System Day will run over 2 days on 10 and 11 October 2023.
+
+For the first time, part of our event will be in person! Day 1 will be a live event at <a href="https://dynamicearth.org.uk/plan-your-visit/getting-here/">Dynamic Earth</a> in Edinburgh, and day 2 will be fully online.
+
+As ever, we want the conference to be a community-driven event. So please come and take part in making Design System Day 2023 special.
+
+We are looking for keynote speakers and panel members to be part of day 1. We are also looking for workshop leads and breakout session hosts for day 2.
+
+We appreciate diverse perspectives and would love to hear from first-time speakers.
+
+## Shaping your your pitch
+
+If you’re interested in doing a talk, a panel or running a workshop about design systems, now is your opportunity. Send us the details of your pitch by 11:59pm on 31 August 2023. Any pitches submitted after this date will not be assessed as we will not have the capacity to do so.
+
+Here are some tips on what we’re looking for.
+
+### Topics
+
+Our audience is a mix of teams that run design systems, use design systems, and those that are interested in design systems. As you can expect, the level of expertise can vary. We get people who are new to design and want to figure out how design systems work, through to consultants who are experts in the sector.
+
+You can cover any topic related to design systems, but we are especially interested in the following:
+
+- Working at scale
+- Systems thinking
+- Dealing with tech debt
+- New web capabilities
+- Managing contributions
+- Equity in design systems
+- Design ethics
+- Designing for marginalised groups
+
+### Length
+
+**Day 1**
+
+- Talks: 45 minute slot, 10 to 15 minutes of this can be used for questions.
+- Panels: 45 minute slot, some of this will be questions from the audience. You can suggest a panel topic as well as putting yourself forward as a panellist.
+
+**Day 2**
+
+- Workshops: There are 60 and 90 minute slots, you can pitch for your preferred length of session.
+- Breakout sessions: There are 30 and 45 minute slots for this type of session.
+
+### Title
+
+- Make it clear in the title what the session is about
+- Make your title engaging
+
+### A short summary
+
+- This will be what we use to promote your session
+- Keep it short - 20 to 50 words
+- Be honest and informative so you get the right people at your session
+
+### Session description
+
+- This is where we want details about your session, including anything you want participants to take away
+- Tell us what you will be covering and what you expect your outcomes to be
+- Tell us whether this is session for beginners or more advanced
+- Let us know if your session is going to be interactive or not, so that participants can be aware of what will be expected of them
+
+## Types of session
+
+Let us know what type of session you are planning to run. If you’re not sure, these are some suggestions.
+
+### Day 1
+
+#### Case study
+
+This is a presentation and discussion of real life experiences you or others have had as a result of applying techniques or methodologies. These can be positive or negative experiences. You should include the lessons learnt as a result, and explain how recently the case study was conducted.
+
+#### Talk
+
+This is a presentation and discussion of a specific topic or issue you have faced. You should include real life examples and draw on your own experiences.
+
+### Day 2
+
+#### Workshop
+
+This is a hands-on session where participants get to interact with you as a facilitator. You will be focusing on a specific thing, such an issue you’ve faced, or a technique you’ve implemented. These sessions are usually more interactive and therefore you might want to consider the use of breakout rooms for group discussions.
+
+#### Breakout sessions
+
+A more informal session - like ‘goldfish bowl’, ’fireside chat’, ‘lean coffee’ or something else that allows the participants to bring thoughts, ideas, questions and problems on a topic.
+
+With all of these session types, let us know if you need to cap the number of participants.
+
+## What we don’t want
+
+### Rants
+
+Things don’t always turn out the way we want, that’s fine as long as you learn from them. The audience will want to know what lessons you took away so that they can be sure to learn from any issues you faced.
+
+### A hard sell
+
+We know that there are lots of really interesting things going on in the digital space right now, and that getting new talent is hard work, but this is not why people will be here. Feel free to make connections with people, but please remember that they are here for a conference, not a job fair.
+
+### Rudeness
+
+The people attending this conference are all specialists at something. They will also have unique and interesting ways of doing things that will probably differ from how you do them. This is a great thing! In government we want new and interesting ideas, so please be respectful and inclusive of innovative ideas that others have.
+
+## What we’re offering
+
+You’ll receive a free ticket to both days, if there are one or two main speakers. If there are more than two speakers, please contact us directly.
+
+We plan to record video of the keynote speakers and panel talks (but not workshops or breakout sessions).
+
+We will be assessing all of your pitches and have a decision for you by 10 September. We will be looking for diverse perspectives and people who are passionate about their roles. We welcome your pitch, whether this be your first time with us or your third!
+
+We hope you can join us!
+
+## Submit your session
+
+Head over to <a href="https://surveys.publishing.service.gov.uk/s/DSday23/">this form</a> to submit your session.
+
+If you have any further questions, please <a href="/get-in-touch/">contact us</a>.

--- a/src/community/design-system-day-2022/index.md
+++ b/src/community/design-system-day-2022/index.md
@@ -4,7 +4,7 @@ description: Videos, slides and notes from Design System Day 2022.
 section: Community
 theme: Events and workshops
 layout: layout-pane.njk
-order: 12
+order: 13
 ---
 
 ## Inclusivity by design

--- a/src/community/design-system-day/index.md
+++ b/src/community/design-system-day/index.md
@@ -40,7 +40,11 @@ We'll also be hosting get-togethers and after-parties for people attending the E
 
 The first day will be hosted in Dynamic Earth, Edinburgh and streamed online. The second day will be online-only.
 
-We'll be releasing our call for speakers soon. <a href='https://mailchi.mp/707ce8dec373/get-updated-by-email-govuk-design-system'>Sign up to our mailing list</a> to find out when it's ready.
+As ever, we want the conference to be a community-driven event. So please take part in making Design System Day 2023 special through our <a href="/community/call-for-speakers-2023/">call for speakers</a>.
+
+We are looking for keynote speakers and panel members to be part of day 1. We are also looking for workshop leads and breakout session hosts for day 2. We appreciate diverse perspectives and would love to hear from first-time speakers.
+
+Find out how to structure and submit your pitch in our <a href="/community/call-for-speakers-2023/">call for speakers</a>.
 
 <!--
 


### PR DESCRIPTION
Here's the call for speakers on its own page, so that we can provide users with guidance on how to prepare a pitch. This means they'll be able to start preparing a pitch in a document, following the guidance, before opening the form to submit their pitch.

We can delete this page once the call for speakers is closed.