### PR TITLE
Reformat example `<title>`s for consistency

### DIFF
--- a/src/components/accordion/with-summary-section/index.njk
+++ b/src/components/accordion/with-summary-section/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Accordion with summary sections
+title: Accordion with summary sections – Accordion
 layout: layout-example.njk
 ---
 

--- a/src/components/back-link/inverse/index.njk
+++ b/src/components/back-link/inverse/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Inverse back link
+title: Inverse back link – Back link
 layout: layout-example.njk
 stylesheets:
 - ../../../stylesheets/example-inverse.css

--- a/src/components/breadcrumbs/collapse-mobile/index.njk
+++ b/src/components/breadcrumbs/collapse-mobile/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Breadcrumbs that collapse on mobile
+title: Breadcrumbs that collapse on mobile – Breadcrumbs
 layout: layout-example.njk
 ---
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}

--- a/src/components/breadcrumbs/inverse/index.njk
+++ b/src/components/breadcrumbs/inverse/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Inverse breadcrumbs
+title: Inverse breadcrumbs – Breadcrumbs
 layout: layout-example.njk
 stylesheets:
 - ../../../stylesheets/example-inverse.css

--- a/src/components/button/button-group/index.njk
+++ b/src/components/button/button-group/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Button group
+title: Button group – Button
 layout: layout-example.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/components/button/disabled/index.njk
+++ b/src/components/button/disabled/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Disabled button
+title: Disabled button – Button
 layout: layout-example.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/components/button/inverse/index.njk
+++ b/src/components/button/inverse/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Inverse button
+title: Inverse button – Button
 layout: layout-example.njk
 stylesheets:
 - ../../../stylesheets/example-inverse.css

--- a/src/components/button/prevent-double-click/index.njk
+++ b/src/components/button/prevent-double-click/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Button with prevent double click
+title: Button with prevent double click – Button
 layout: layout-example.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/components/button/secondary-combo/index.njk
+++ b/src/components/button/secondary-combo/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Secondary button combo
+title: Button group with mixed button types – Button
 layout: layout-example.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/components/button/secondary/index.njk
+++ b/src/components/button/secondary/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Secondary button
+title: Secondary button – Button
 layout: layout-example.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/components/button/start/index.njk
+++ b/src/components/button/start/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Start now button
+title: Start now button – Button
 layout: layout-example.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/components/button/warning/index.njk
+++ b/src/components/button/warning/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Warning button
+title: Warning button – Button
 layout: layout-example.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/components/character-count/without-heading/index.njk
+++ b/src/components/character-count/without-heading/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Character count without a heading
+title: Character count without a heading – Character count
 layout: layout-example.njk
 ---
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}

--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Checkboxes with conditionally revealing content
+title: Checkboxes with conditionally revealing content – Checkboxes
 layout: layout-example.njk
 ---
 

--- a/src/components/checkboxes/error/index.njk
+++ b/src/components/checkboxes/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Checkbox items with error
+title: Checkbox items with error – Checkboxes
 layout: layout-example.njk
 ---
 

--- a/src/components/checkboxes/hint/index.njk
+++ b/src/components/checkboxes/hint/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Checkbox items with hint
+title: Checkbox items with hint – Checkboxes
 layout: layout-example.njk
 ---
 

--- a/src/components/checkboxes/small/index.njk
+++ b/src/components/checkboxes/small/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Small checkboxes
+title: Small checkboxes – Checkboxes
 layout: layout-example.njk
 ---
 

--- a/src/components/checkboxes/with-none-option-in-error/index.njk
+++ b/src/components/checkboxes/with-none-option-in-error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Checkboxes with 'none' option showing an error
+title: Checkboxes with 'none' option showing an error – Checkboxes
 layout: layout-example.njk
 ---
 

--- a/src/components/checkboxes/with-none-option/index.njk
+++ b/src/components/checkboxes/with-none-option/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Checkboxes with 'none' option
+title: Checkboxes with 'none' option – Checkboxes
 layout: layout-example.njk
 ---
 

--- a/src/components/checkboxes/without-heading/index.njk
+++ b/src/components/checkboxes/without-heading/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Checkboxes without a heading
+title: Checkboxes without a heading – Checkboxes
 layout: layout-example.njk
 ---
 

--- a/src/components/cookie-banner/client-side-accepted/index.njk
+++ b/src/components/cookie-banner/client-side-accepted/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Accepted replacement message – Cookie Banner
+title: Accepted replacement message – Cookie banner
 layout: layout-example.njk
 ---
 

--- a/src/components/cookie-banner/client-side-rejected/index.njk
+++ b/src/components/cookie-banner/client-side-rejected/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Rejected replacement message – Cookie Banner
+title: Rejected replacement message – Cookie banner
 layout: layout-example.njk
 ---
 

--- a/src/components/cookie-banner/client-side/index.njk
+++ b/src/components/cookie-banner/client-side/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Client-side implementation – Cookie Banner
+title: Client-side implementation – Cookie banner
 layout: layout-example.njk
 ---
 

--- a/src/components/cookie-banner/default/index.njk
+++ b/src/components/cookie-banner/default/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Default – Cookie Banner
+title: Cookie banner
 layout: layout-example.njk
 ---
 

--- a/src/components/cookie-banner/multiple-cookies/index.njk
+++ b/src/components/cookie-banner/multiple-cookies/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Non-essential Cookies - Cookie Banner
+title: Non-essential cookies – Cookie banner
 layout: layout-example.njk
 ---
 

--- a/src/components/cookie-banner/server-side-confirmation/index.njk
+++ b/src/components/cookie-banner/server-side-confirmation/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Server-side implementation with confirmation – Cookie Banner
+title: Server-side implementation with confirmation – Cookie banner
 layout: layout-example.njk
 ---
 

--- a/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Server-side implementation with multiple messages and confirmation visible – Cookie Banner
+title: Server-side implementation with multiple messages and confirmation visible – Cookie banner
 layout: layout-example.njk
 ---
 

--- a/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Server-side implementation with multiple messages and question visible – Cookie Banner
+title: Server-side implementation with multiple messages and question visible – Cookie banner
 layout: layout-example.njk
 ---
 

--- a/src/components/cookie-banner/server-side/index.njk
+++ b/src/components/cookie-banner/server-side/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Server-side implementation – Cookie Banner
+title: Server-side implementation – Cookie banner
 layout: layout-example.njk
 ---
 

--- a/src/components/date-input/date-of-birth/index.njk
+++ b/src/components/date-input/date-of-birth/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Date input to ask for date of birth
+title: Date input to ask for date of birth – Date input
 layout: layout-example.njk
 ---
 

--- a/src/components/date-input/error-single/index.njk
+++ b/src/components/date-input/error-single/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Dates with errors
+title: Dates with errors – Date input
 layout: layout-example.njk
 ---
 

--- a/src/components/date-input/error/index.njk
+++ b/src/components/date-input/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Date input with errors
+title: Date input with errors – Date input
 layout: layout-example.njk
 ---
 

--- a/src/components/date-input/without-heading/index.njk
+++ b/src/components/date-input/without-heading/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Date input without a heading
+title: Date input without a heading – Date input
 layout: layout-example.njk
 ---
 

--- a/src/components/error-message/custom-prefix/index.njk
+++ b/src/components/error-message/custom-prefix/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Error message with a custom visually hidden prefix
+title: Error message with a custom visually hidden prefix – Error message
 layout: layout-example.njk
 ---
 

--- a/src/components/error-message/label/index.njk
+++ b/src/components/error-message/label/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Error message with Label
+title: Error message with label – Error message
 layout: layout-example.njk
 ---
 

--- a/src/components/error-message/legend/index.njk
+++ b/src/components/error-message/legend/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Error message with Legend
+title: Error message with legend – Error message
 layout: layout-example.njk
 ---
 

--- a/src/components/error-summary/full-page-example/index.njk
+++ b/src/components/error-summary/full-page-example/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Full page example
+title: Full page example – Error summary
 layout: layout-example-full-page.njk
 ---
 

--- a/src/components/error-summary/linking-checkboxes-radios/index.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Linking from the error summary to checkboxes
+title: Linking from the error summary to checkboxes – Error summary
 layout: layout-example.njk
 ---
 

--- a/src/components/error-summary/linking-multiple-fields/index.njk
+++ b/src/components/error-summary/linking-multiple-fields/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Linking from the error summary to an answer that uses multiple fields
+title: Linking from the error summary to an answer that uses multiple fields – Error summary
 layout: layout-example.njk
 ---
 

--- a/src/components/error-summary/linking/index.njk
+++ b/src/components/error-summary/linking/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Linking from the error summary to an answer that uses a single field
+title: Linking from the error summary to an answer that uses a single field – Error summary
 layout: layout-example.njk
 ---
 

--- a/src/components/exit-this-page/secondary-link/index.njk
+++ b/src/components/exit-this-page/secondary-link/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Secondary link
+title: Secondary link – Exit this page
 layout: layout-example.njk
 ---
 

--- a/src/components/fieldset/address-group/index.njk
+++ b/src/components/fieldset/address-group/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Fieldset address group
+title: Address group – Fieldset
 layout: layout-example.njk
 stylesheets:
 - address-wrapper.css

--- a/src/components/footer/full/index.njk
+++ b/src/components/footer/full/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Footer with secondary navigation and links to meta information
+title: Footer with secondary navigation and links to meta information – Footer
 layout: layout-example.njk
 ---
 

--- a/src/components/footer/with-meta/index.njk
+++ b/src/components/footer/with-meta/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Footer with links to meta information
+title: Footer with links to meta information – Footer
 layout: layout-example.njk
 ---
 

--- a/src/components/footer/with-navigation/index.njk
+++ b/src/components/footer/with-navigation/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Footer with secondary navigation
+title: Footer with secondary navigation – Footer
 layout: layout-example.njk
 ---
 

--- a/src/components/header/with-service-name-and-navigation/index.njk
+++ b/src/components/header/with-service-name-and-navigation/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Header with service name and navigation
+title: Header with service name and navigation – Header
 layout: layout-example.njk
 ---
 {% from "govuk/components/header/macro.njk" import govukHeader %}

--- a/src/components/header/with-service-name/index.njk
+++ b/src/components/header/with-service-name/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Header with service name
+title: Header with service name – Header
 layout: layout-example.njk
 ---
 {% from "govuk/components/header/macro.njk" import govukHeader %}

--- a/src/components/notification-banner/default/index.njk
+++ b/src/components/notification-banner/default/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Default – notification banner
+title: Notification banner
 layout: layout-example.njk
 ---
 

--- a/src/components/notification-banner/success/index.njk
+++ b/src/components/notification-banner/success/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Success banner – notification banner
+title: Success banner – Notification banner
 layout: layout-example.njk
 ---
 

--- a/src/components/notification-banner/whole-service/index.njk
+++ b/src/components/notification-banner/whole-service/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Whole service – notification banner
+title: Whole service – Notification banner
 layout: layout-example.njk
 ---
 

--- a/src/components/pagination/ellipses/index.njk
+++ b/src/components/pagination/ellipses/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Ellipses
+title: Ellipses – Pagination
 layout: layout-example.njk
 ---
 

--- a/src/components/pagination/first-page/index.njk
+++ b/src/components/pagination/first-page/index.njk
@@ -1,5 +1,5 @@
 ---
-title: First page
+title: First page – Pagination
 layout: layout-example.njk
 ---
 

--- a/src/components/pagination/for-content-pages/index.njk
+++ b/src/components/pagination/for-content-pages/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Pagination with text labels
+title: Pagination with text labels – Pagination
 layout: layout-example.njk
 ---
 

--- a/src/components/pagination/for-list-pages/index.njk
+++ b/src/components/pagination/for-list-pages/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Large number of pages
+title: Pagination with numbered labels – Pagination
 layout: layout-example.njk
 ---
 

--- a/src/components/pagination/in-page/index.njk
+++ b/src/components/pagination/in-page/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Pagination - full page examples
+title: Full page example – Pagination
 layout: layout-example-full-page.njk
 ---
 

--- a/src/components/pagination/last-page/index.njk
+++ b/src/components/pagination/last-page/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Last page
+title: Last page – Pagination
 layout: layout-example.njk
 ---
 

--- a/src/components/phase-banner/beta/index.njk
+++ b/src/components/phase-banner/beta/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Phase banner with beta text
+title: Phase banner with beta text – Phase banner
 layout: layout-example.njk
 ---
 

--- a/src/components/radios/conditional-reveal-error/index.njk
+++ b/src/components/radios/conditional-reveal-error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Radios with conditionally revealing content showing an error
+title: Radios with conditionally revealing content showing an error – Radios
 layout: layout-example.njk
 ---
 

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Radios with conditionally revealing content
+title: Radios with conditionally revealing content – Radios
 layout: layout-example.njk
 ---
 

--- a/src/components/radios/default/index.njk
+++ b/src/components/radios/default/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Stacked radios
+title: Radios
 layout: layout-example.njk
 ---
 

--- a/src/components/radios/divider/index.njk
+++ b/src/components/radios/divider/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Radios with a text divider
+title: Radios with a text divider – Radios
 layout: layout-example.njk
 ---
 

--- a/src/components/radios/error/index.njk
+++ b/src/components/radios/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Inline radios with error
+title: Inline radios with error – Radios
 layout: layout-example.njk
 ---
 

--- a/src/components/radios/hint/index.njk
+++ b/src/components/radios/hint/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Radio items with hint
+title: Radio items with hint – Radios
 layout: layout-example.njk
 ---
 

--- a/src/components/radios/inline/index.njk
+++ b/src/components/radios/inline/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Inline radios
+title: Inline radios – Radios
 layout: layout-example.njk
 ---
 

--- a/src/components/radios/small/index.njk
+++ b/src/components/radios/small/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Small radios
+title: Small radios – Radios
 layout: layout-example.njk
 ---
 

--- a/src/components/radios/without-heading/index.njk
+++ b/src/components/radios/without-heading/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Radios without a heading
+title: Radios without a heading – Radios
 layout: layout-example.njk
 ---
 

--- a/src/components/select/error/index.njk
+++ b/src/components/select/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Select with error
+title: Select with error – Select
 layout: layout-example.njk
 ---
 

--- a/src/components/select/with-hint/index.njk
+++ b/src/components/select/with-hint/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Select with hint
+title: Select with hint – Select
 layout: layout-example.njk
 ---
 

--- a/src/components/summary-list/card-with-actions/index.njk
+++ b/src/components/summary-list/card-with-actions/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Summary in a card with a title and actions
+title: Summary in a card with a title and actions – Summary list
 layout: layout-example.njk
 ---
 

--- a/src/components/summary-list/card-with-title/index.njk
+++ b/src/components/summary-list/card-with-title/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Summary in a card with a title
+title: Summary in a card with a title – Summary list
 layout: layout-example.njk
 ---
 

--- a/src/components/summary-list/mixed-actions/index.njk
+++ b/src/components/summary-list/mixed-actions/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Summary list with a mix of rows with and without actions
+title: Summary list with a mix of rows with and without actions – Summary list
 layout: layout-example.njk
 ---
 

--- a/src/components/table/caption-l/index.njk
+++ b/src/components/table/caption-l/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Custom caption size
+title: Custom caption size – Table
 layout: layout-example.njk
 ---
 

--- a/src/components/table/numbers/index.njk
+++ b/src/components/table/numbers/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Numbers in a table
+title: Numbers in a table – Table
 layout: layout-example.njk
 ---
 

--- a/src/components/tag/all-colours/index.njk
+++ b/src/components/tag/all-colours/index.njk
@@ -1,5 +1,5 @@
 ---
-title: All tag colours
+title: All tag colours – Tag
 layout: layout-example.njk
 ---
 

--- a/src/components/tag/coloured-tags/index.njk
+++ b/src/components/tag/coloured-tags/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Coloured tags
+title: Coloured tags – Tag
 layout: layout-example.njk
 ---
 

--- a/src/components/tag/multiple-tags/index.njk
+++ b/src/components/tag/multiple-tags/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Multiple tags
+title: Multiple tags – Tag
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/code-sequence/index.njk
+++ b/src/components/text-input/code-sequence/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Example of a text input asking for a code or sequence
+title: Example of a text input asking for a code or sequence – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/decimal-input/index.njk
+++ b/src/components/text-input/decimal-input/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Example of an input asking for numbers with decimal places
+title: Example of an input asking for numbers with decimal places – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/error/index.njk
+++ b/src/components/text-input/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Text input with errors
+title: Text input with errors – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/input-autocomplete-attribute/index.njk
+++ b/src/components/text-input/input-autocomplete-attribute/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Text input with autocomplete attribute
+title: Text input with autocomplete attribute – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/input-fixed-width/index.njk
+++ b/src/components/text-input/input-fixed-width/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Fixed width inputs
+title: Fixed width inputs – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/input-fluid-width/index.njk
+++ b/src/components/text-input/input-fluid-width/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Fluid width inputs
+title: Fluid width inputs – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/input-hint-text/index.njk
+++ b/src/components/text-input/input-hint-text/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Hint text
+title: Hint text – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/input-prefix-suffix-error/index.njk
+++ b/src/components/text-input/input-prefix-suffix-error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Text input with prefix and suffix with error
+title: Text input with prefix and suffix with error – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/input-prefix-suffix/index.njk
+++ b/src/components/text-input/input-prefix-suffix/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Text input with prefix and suffix
+title: Text input with prefix and suffix – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/input-prefix/index.njk
+++ b/src/components/text-input/input-prefix/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Text input with prefix
+title: Text input with prefix – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/input-spellcheck-disabled/index.njk
+++ b/src/components/text-input/input-spellcheck-disabled/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Text input with spellcheck disabled
+title: Text input with spellcheck disabled – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/input-suffix/index.njk
+++ b/src/components/text-input/input-suffix/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Text input with suffix
+title: Text input with suffix – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/number-input/index.njk
+++ b/src/components/text-input/number-input/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Number input
+title: Number input – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/text-input/without-heading/index.njk
+++ b/src/components/text-input/without-heading/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Text input without a heading
+title: Text input without a heading – Text input
 layout: layout-example.njk
 ---
 

--- a/src/components/textarea/error/index.njk
+++ b/src/components/textarea/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Textarea with error
+title: Textarea with error – Textarea
 layout: layout-example.njk
 ---
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}

--- a/src/components/textarea/specifying-rows/index.njk
+++ b/src/components/textarea/specifying-rows/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Textarea appropriately-sized with rows
+title: Textarea appropriately-sized with rows – Textarea
 layout: layout-example.njk
 ---
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}

--- a/src/components/textarea/without-heading/index.njk
+++ b/src/components/textarea/without-heading/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Textarea without a heading
+title: Textarea without a heading – Textarea
 layout: layout-example.njk
 ---
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}

--- a/src/get-started/labels-legends-headings/label-h1/index.njk
+++ b/src/get-started/labels-legends-headings/label-h1/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Labels as page headings - Making labels and legends headings
+title: Labels as page headings – Making labels and legends headings
 layout: layout-example.njk
 ---
 

--- a/src/get-started/labels-legends-headings/label-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/label-m-s/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Styling labels - Making labels and legends headings
+title: Styling labels – Making labels and legends headings
 layout: layout-example.njk
 ---
 

--- a/src/get-started/labels-legends-headings/legend-h1/index.njk
+++ b/src/get-started/labels-legends-headings/legend-h1/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Legends as page headings - Making labels and legends headings
+title: Legends as page headings – Making labels and legends headings
 layout: layout-example.njk
 ---
 

--- a/src/get-started/labels-legends-headings/legend-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/legend-m-s/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Styling legends - Making labels and legends headings
+title: Styling legends – Making labels and legends headings
 layout: layout-example.njk
 ---
 

--- a/src/patterns/addresses/error/index.njk
+++ b/src/patterns/addresses/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Postcode error
+title: Postcode error – Addresses
 layout: layout-example.njk
 ---
 

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Multiple text inputs Addresses
+title: Multiple text inputs – Addresses
 layout: layout-example.njk
 stylesheets:
 - address-wrapper.css

--- a/src/patterns/addresses/textarea/index.njk
+++ b/src/patterns/addresses/textarea/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Textarea addresses
+title: Textarea – Addresses
 layout: layout-example.njk
 ---
 

--- a/src/patterns/bank-details/branch/index.njk
+++ b/src/patterns/bank-details/branch/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Branch question
+title: Branch question – Bank details
 layout: layout-example.njk
 ---
 

--- a/src/patterns/bank-details/default/index.njk
+++ b/src/patterns/bank-details/default/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Bank or building society account details
+title: Bank details
 layout: layout-example.njk
 ---
 

--- a/src/patterns/bank-details/error/index.njk
+++ b/src/patterns/bank-details/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Errors
+title: Errors – Bank details
 layout: layout-example.njk
 ---
 

--- a/src/patterns/bank-details/international/index.njk
+++ b/src/patterns/bank-details/international/index.njk
@@ -1,5 +1,5 @@
 ---
-title: International bank account details
+title: International bank account details – Bank details
 layout: layout-example.njk
 ---
 

--- a/src/patterns/confirm-a-phone-number/default/index.njk
+++ b/src/patterns/confirm-a-phone-number/default/index.njk
@@ -1,6 +1,6 @@
 ---
 layout: layout-example.njk
-title: Default – Confirm a phone number
+title: Confirm a phone number
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/confirm-a-phone-number/resend-first-time/index.njk
+++ b/src/patterns/confirm-a-phone-number/resend-first-time/index.njk
@@ -1,6 +1,6 @@
 ---
 layout: layout-example.njk
-title: Request a new security code (first time) – Security code
+title: Request a new security code (first time) – Confirm a phone number
 ---
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}

--- a/src/patterns/confirm-a-phone-number/resend/index.njk
+++ b/src/patterns/confirm-a-phone-number/resend/index.njk
@@ -1,6 +1,6 @@
 ---
 layout: layout-example.njk
-title: Request a new security code – Security code
+title: Request a new security code – Confirm a phone number
 ---
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}

--- a/src/patterns/contact-a-department-or-service-team/all-contact-information/index.njk
+++ b/src/patterns/contact-a-department-or-service-team/all-contact-information/index.njk
@@ -1,5 +1,5 @@
 ---
-title: All contact information
+title: All contact information – Contact a department or service team
 layout: layout-example.njk
 ---
 

--- a/src/patterns/contact-a-department-or-service-team/expanding-contact-information/index.njk
+++ b/src/patterns/contact-a-department-or-service-team/expanding-contact-information/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Contact information details component
+title: Contact information details component – Contact a department or service team
 layout: layout-example.njk
 ---
 

--- a/src/patterns/contact-a-department-or-service-team/inset-contact-information/index.njk
+++ b/src/patterns/contact-a-department-or-service-team/inset-contact-information/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Contact information inset text
+title: Contact information inset text – Contact a department or service team
 layout: layout-example.njk
 ---
 

--- a/src/patterns/cookies-page/cookies-form/index.njk
+++ b/src/patterns/cookies-page/cookies-form/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Cookie preferences form - Cookies page
+title: Cookie preferences form – Cookies page
 layout: layout-example.njk
 ---
 

--- a/src/patterns/cookies-page/cookies-updated/index.njk
+++ b/src/patterns/cookies-page/cookies-updated/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Cookie preferences updated - Cookies page
+title: Cookie preferences updated – Cookies page
 layout: layout-example.njk
 ---
 

--- a/src/patterns/cookies-page/no-js/index.njk
+++ b/src/patterns/cookies-page/no-js/index.njk
@@ -1,5 +1,5 @@
 ---
-title: No JavaScript - Cookies page
+title: No JavaScript – Cookies page
 layout: layout-example.njk
 ---
 

--- a/src/patterns/dates/default/index.njk
+++ b/src/patterns/dates/default/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Asking for dates from documents
+title: Dates
 layout: layout-example.njk
 ---
 

--- a/src/patterns/dates/memorable-date/index.njk
+++ b/src/patterns/dates/memorable-date/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Asking for memorable dates
+title: Asking for memorable dates – Dates
 layout: layout-example.njk
 ---
 

--- a/src/patterns/email-addresses/error/index.njk
+++ b/src/patterns/email-addresses/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Email input with errors
+title: Email input with errors – Email addresses
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/asian/index.njk
+++ b/src/patterns/equality-information/asian/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Asian ethnicity equality question
+title: Asian ethnicity equality question – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/black/index.njk
+++ b/src/patterns/equality-information/black/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Black ethnicity equality question
+title: Black ethnicity equality question – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/date-of-birth/index.njk
+++ b/src/patterns/equality-information/date-of-birth/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Date of birth equality question
+title: Date of birth equality question – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/disability-impact/index.njk
+++ b/src/patterns/equality-information/disability-impact/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Disability impact equality question
+title: Disability impact equality question – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/disability/index.njk
+++ b/src/patterns/equality-information/disability/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Disability equality question
+title: Disability equality question – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/error-date-of-birth/index.njk
+++ b/src/patterns/equality-information/error-date-of-birth/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Date of birth equality question with error
+title: Date of birth equality question with error – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/error-ethnicity/index.njk
+++ b/src/patterns/equality-information/error-ethnicity/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Ethnicity question with error
+title: Ethnicity question with error – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/ethnic-group/index.njk
+++ b/src/patterns/equality-information/ethnic-group/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Ethnic group equality question
+title: Ethnic group equality question – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/explainer-screen/index.njk
+++ b/src/patterns/equality-information/explainer-screen/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Explainer screen for equality information questions
+title: Explainer screen for equality information questions – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/marriage-status/index.njk
+++ b/src/patterns/equality-information/marriage-status/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Marriage or civil partnership status equality question
+title: Marriage or civil partnership status equality question – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/multiple/index.njk
+++ b/src/patterns/equality-information/multiple/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Multiple ethnicity equality question
+title: Multiple ethnicity equality question – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/other/index.njk
+++ b/src/patterns/equality-information/other/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Other ethnicity equality question
+title: Other ethnicity equality question – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/religion/index.njk
+++ b/src/patterns/equality-information/religion/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Religion equality question
+title: Religion equality question – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/sex-gender/index.njk
+++ b/src/patterns/equality-information/sex-gender/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Sex and gender equality question
+title: Sex and gender equality question – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/sexual-orientation/index.njk
+++ b/src/patterns/equality-information/sexual-orientation/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Sexual orientation equality question
+title: Sexual orientation equality question – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/equality-information/white/index.njk
+++ b/src/patterns/equality-information/white/index.njk
@@ -1,5 +1,5 @@
 ---
-title: White ethnicity equality question
+title: White ethnicity equality question – Equality information
 layout: layout-example.njk
 ---
 

--- a/src/patterns/exit-a-page-quickly/safety-content-example/index.njk
+++ b/src/patterns/exit-a-page-quickly/safety-content-example/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Example of safety content page
+title: Example of safety content page – Exit a page safely
 layout: layout-example-full-page.njk
 ---
 

--- a/src/patterns/names/error/index.njk
+++ b/src/patterns/names/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Name input with errors
+title: Name input with errors – Names
 layout: layout-example.njk
 ---
 

--- a/src/patterns/national-insurance-numbers/error/index.njk
+++ b/src/patterns/national-insurance-numbers/error/index.njk
@@ -1,5 +1,5 @@
 ---
-title: National insurance number input with errors
+title: National insurance number input with errors – National Insurance numbers
 layout: layout-example.njk
 ---
 

--- a/src/patterns/problem-with-the-service-pages/index.md
+++ b/src/patterns/problem-with-the-service-pages/index.md
@@ -16,7 +16,7 @@ This guidance is for government teams that build online services. [To find infor
 
 Tell the user there is something wrong with the service. These are also known as 500 and internal server error pages.
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager"}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "offline-support-link", html: true, nunjucks: true, open: false, size: "xl", loading: "eager"}) }}
 
 ## When to use this pattern
 
@@ -51,7 +51,7 @@ Have clear and concise content and do not use:
 
 ### Service has a specific page that includes numbers and opening times
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second", size: "xl"}) }}
+{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "offline-support-link", html: true, nunjucks: true, open: false, titleSuffix: "second", size: "xl"}) }}
 
 ### Service has offline support but no specific page that includes numbers and opening times
 

--- a/src/patterns/problem-with-the-service-pages/offline-support-link/index.njk
+++ b/src/patterns/problem-with-the-service-pages/offline-support-link/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Service has a specific page that includes numbers and opening times
+title: Service has a specific page that includes numbers and opening times – There is a problem with the service pages
 layout: layout-example-full-page.njk
 ---
 

--- a/src/patterns/problem-with-the-service-pages/offline-support/index.njk
+++ b/src/patterns/problem-with-the-service-pages/offline-support/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Service has offline support but no specific page that includes numbers and opening times
+title: Service has offline support but no specific page that includes numbers and opening times – There is a problem with the service pages
 layout: layout-example-full-page.njk
 ---
 

--- a/src/patterns/question-pages/explanatory-text/index.njk
+++ b/src/patterns/question-pages/explanatory-text/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Explanatory text – Question pages
+title: Explanatory text – Question pages
 layout: layout-example-full-page.njk
 ---
 

--- a/src/patterns/service-unavailable-pages/after-service-closes/index.njk
+++ b/src/patterns/service-unavailable-pages/after-service-closes/index.njk
@@ -1,5 +1,5 @@
 ---
-title: After a service closes
+title: After a service closes – Service unavailable pages
 layout: layout-example-full-page.njk
 ---
 

--- a/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
+++ b/src/patterns/service-unavailable-pages/available-at-known-date/index.njk
@@ -1,5 +1,5 @@
 ---
-title: When you know when a service will be available
+title: When you know when a service will be available – Service unavailable pages
 layout: layout-example-full-page.njk
 ---
 

--- a/src/patterns/service-unavailable-pages/before-service-opens/index.njk
+++ b/src/patterns/service-unavailable-pages/before-service-opens/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Before a service opens
+title: Before a service opens – Service unavailable pages
 layout: layout-example-full-page.njk
 ---
 

--- a/src/patterns/service-unavailable-pages/default/index.njk
+++ b/src/patterns/service-unavailable-pages/default/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Service unavailable
+title: Service unavailable pages
 layout: layout-example-full-page.njk
 ---
 

--- a/src/patterns/service-unavailable-pages/general/index.njk
+++ b/src/patterns/service-unavailable-pages/general/index.njk
@@ -1,5 +1,5 @@
 ---
-title: General page
+title: General page – Service unavailable pages
 layout: layout-example-full-page.njk
 ---
 

--- a/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
+++ b/src/patterns/service-unavailable-pages/no-replacement-service/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Nothing has replaced the service
+title: Nothing has replaced the service – Service unavailable pages
 layout: layout-example-full-page.njk
 ---
 

--- a/src/patterns/service-unavailable-pages/service-replaced/index.njk
+++ b/src/patterns/service-unavailable-pages/service-replaced/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Something has replaced the service
+title: Something has replaced the service – Service unavailable pages
 layout: layout-example-full-page.njk
 ---
 

--- a/src/patterns/start-using-a-service/default/index.njk
+++ b/src/patterns/start-using-a-service/default/index.njk
@@ -1,5 +1,5 @@
 ---
-title: Start pages
+title: Start using a service
 layout: layout-example-full-page-govuk.njk
 stylesheets:
 - related-items.css

--- a/src/patterns/telephone-numbers/default/index.njk
+++ b/src/patterns/telephone-numbers/default/index.njk
@@ -1,6 +1,6 @@
 ---
 layout: layout-example.njk
-title: Default – Telephone numbers
+title: Telephone numbers
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/styles/page-template/block-areas/index.njk
+++ b/src/styles/page-template/block-areas/index.njk
@@ -8,6 +8,8 @@ stylesheets:
 
 {% extends "govuk/template.njk" %}
 
+{% block pageTitle %}{{ title }} – Example - GOV.UK Design System{% endblock %}
+
 {% block head -%}
   {# Since we’re not extending the Design System layout we need to add this manually #}
   <meta name="robots" content="noindex, nofollow">

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -26,7 +26,7 @@ ignoreInSitemap: true
 } %}
 {% set containerClasses = "app-width-container" %}
 
-{% block pageTitle %}GOV.UK - Customised page template{% endblock %}
+{% block pageTitle %}{{ title }} – Example - GOV.UK Design System{% endblock %}
 
 {% block headIcons %}
     {{ super() }}

--- a/src/styles/page-template/default/index.njk
+++ b/src/styles/page-template/default/index.njk
@@ -4,6 +4,8 @@ layout: false
 ---
 {% extends "govuk/template.njk" %}
 
+{% block pageTitle %}{{ title }} – Example - GOV.UK Design System{% endblock %}
+
 {% block head %}
   <meta name="robots" content="noindex, nofollow">
   <link href="{{ getFingerprint('stylesheets/main.css') }}" rel="stylesheet" media="all">

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -3,7 +3,7 @@
 {% set htmlClasses = 'app-example-page__wrapper' %}
 {% set assetUrl = 'https://design-system.service.gov.uk/assets' %}
 
-{% block pageTitle %}{{ title }} – Example - GOV.UK Design System{% endblock %}
+{% block pageTitle %}{{ title }} – Example – GOV.UK Design System{% endblock %}
 
 {% block head %}
   <meta name="robots" content="noindex, nofollow">


### PR DESCRIPTION
There are various examples embedded within the Design System website via iframes. These examples can be opened in their own tabs, and thus have `<title>`s that are intended to be unique and descriptive of what the example is showing.

There are currently various inconsistencies with these titles, including: 

- Titles including the name of the SCP[^1] as standalone information, whilst others only include it as part of the example name.
- 'Default' examples including the word 'Default' in their title whilst others only list the name of the SCP.
- Inconsistent casing.
- Inconsistent use of hyphens and en-dashes. 
- Titles that are irrelevant to the example being shown.

[^1]: SCP: The Style, Component, or Pattern the example relates to. 

Resolves #922, though this will need to be maintained over future changes to avoid divergence in future.

## Changes

This PR goes rewrites their titles to consistently use sentence case and en-dashes, and reformats them to match one of the two following formats:

- `[SCP name] – Example – GOV.UK Design System` if an example of a default state
- `[Example name] – [SCP name] – Example – GOV.UK Design System` if not a default example

In a couple of cases, I renamed examples to be more descriptive of what they were showing, to match the SCP name where it didn't already, or to designate it as/strip it of being the 'default'. 

### Sample of renamed examples
|Example|Old title|New title|
|:-|:-|:-|
|Page template style, blocks areas|GOV.UK - The best place to find government services and information|Block areas – Page template – Example – GOV.UK Design System|
|Button component, prevent double click functionality |Button with prevent double click – Example - GOV.UK Design System|Button with prevent double click – Button – Example – GOV.UK Design System|
|Cookie banner component, non-essential cookies|Non-essential Cookies - Cookie Banner – Example - GOV.UK Design System|Non-essential cookies – Cookie banner – Example – GOV.UK Design System|
|Error summary component, full page|Full page example – Example - GOV.UK Design System|Full page example – Error summary – Example – GOV.UK Design System|
|Notification banner component, default|Default – notification banner – Example - GOV.UK Design System|Notification banner – Example – GOV.UK Design System|
|Addresses pattern, multiple inputs|Multiple text inputs Addresses – Example - GOV.UK Design System|Multiple text inputs – Addresses – Example – GOV.UK Design System|
