### PR TITLE
Configure Nunjucks from `lib/nunjucks`, consolidate slugs

### DIFF
--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -2,6 +2,8 @@ const { dirname, join } = require('path')
 
 const { marked } = require('marked')
 
+const { kebabCase, slugify } = require('../nunjucks/filters')
+
 // Get reference to marked.js
 const renderer = new marked.Renderer()
 // Override marking up paragraphs
@@ -16,10 +18,7 @@ function getMacroOptionsJson(componentName) {
 }
 
 function addSlugs(option) {
-  // camelCase into kebab-case
-  option.slug = option.name
-    .replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2')
-    .toLowerCase()
+  option.slug = slugify(kebabCase(option.name))
 
   if (option.params) {
     option.params = option.params.map(addSlugs)

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -10,13 +10,13 @@ const sass = require('@metalsmith/sass') // convert Sass files to CSS using Dart
 const { glob } = require('glob') // Match files using glob patterns
 const Metalsmith = require('metalsmith') // static site generator
 const canonical = require('metalsmith-canonical') // add a canonical url property to pages
-const slugger = require('slugger') // generate slugs from titles
 
 // Helpers and config
 const { paths, navigation: menuItems } = require('../config')
 const colours = require('../lib/colours.js') // get colours data
 const extractPageHeadings = require('../lib/extract-page-headings/index.js') // extract page headings into file meta data
 const fileHelper = require('../lib/file-helper.js') // helper function to operate on files
+const { filters } = require('../lib/nunjucks/index.js') // nunjucks filters
 
 // Local metalsmith plugins
 const { hashAssets } = require('./fingerprints') // rename files with hash fingerprints
@@ -59,9 +59,7 @@ const nunjucksOptions = {
     getMacroOptions
   },
 
-  filters: {
-    slugger
-  }
+  filters
 }
 
 module.exports = metalsmith

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -15,13 +15,11 @@ const canonical = require('metalsmith-canonical') // add a canonical url propert
 const { paths, navigation: menuItems } = require('../config')
 const colours = require('../lib/colours.js') // get colours data
 const extractPageHeadings = require('../lib/extract-page-headings/index.js') // extract page headings into file meta data
-const fileHelper = require('../lib/file-helper.js') // helper function to operate on files
-const { filters } = require('../lib/nunjucks/index.js') // nunjucks filters
+const { filters, globals } = require('../lib/nunjucks/index.js') // nunjucks options
 
 // Local metalsmith plugins
 const { hashAssets } = require('./fingerprints') // rename files with hash fingerprints
 const generateSitemap = require('./generate-sitemap.js') // generate sitemap
-const getMacroOptions = require('./get-macro-options/index.js')
 const highlighter = require('./highlighter.js')
 const DesignSystemRenderer = require('./marked-renderer.js')
 const lunr = require('./metalsmith-lunr-index') // generate search index
@@ -51,14 +49,7 @@ const nunjucksOptions = {
     join(dirname(require.resolve('govuk-frontend')), '../')
   ],
 
-  globals: {
-    getFrontmatter: fileHelper.getFrontmatter,
-    getNunjucksCode: fileHelper.getNunjucksCode,
-    getHTMLCode: fileHelper.getHTMLCode,
-    getFingerprint: fileHelper.getFingerprint,
-    getMacroOptions
-  },
-
+  globals,
   filters
 }
 

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -15,7 +15,7 @@ const canonical = require('metalsmith-canonical') // add a canonical url propert
 const { paths, navigation: menuItems } = require('../config')
 const colours = require('../lib/colours.js') // get colours data
 const extractPageHeadings = require('../lib/extract-page-headings/index.js') // extract page headings into file meta data
-const { filters, globals } = require('../lib/nunjucks/index.js') // nunjucks options
+const nunjucksOptions = require('../lib/nunjucks/index.js') // nunjucks options
 
 // Local metalsmith plugins
 const { hashAssets } = require('./fingerprints') // rename files with hash fingerprints
@@ -32,26 +32,6 @@ const metalsmith = Metalsmith(resolve(__dirname, '../'))
 
 // Flag production mode (to skip plugins in development)
 const isProduction = process.env.NODE_ENV !== 'development'
-
-// Nunjucks engine options
-const nunjucksOptions = {
-  noCache: true, // never use a cache and recompile templates each time
-  trimBlocks: true, // automatically remove trailing newlines
-  lstripBlocks: true, // automatically remove leading whitespace
-
-  // store views paths for rendering nunjucks syntax
-  path: [
-    join(paths.views, 'layouts'),
-    join(paths.views, 'partials'),
-    join(paths.source, 'components'),
-
-    // Path to `govuk-frontend` export without `govuk/` suffix
-    join(dirname(require.resolve('govuk-frontend')), '../')
-  ],
-
-  globals,
-  filters
-}
 
 module.exports = metalsmith
 

--- a/lib/nunjucks/filters.js
+++ b/lib/nunjucks/filters.js
@@ -1,6 +1,11 @@
-const slugger = require('slugger')
+const slug = require('slug')
 
 /**
  * Format strings into URL friendly "slug"
+ *
+ * @param {string} string - String to format
+ * @returns {string} URL friendly "slug"
  */
-exports.slugger = slugger
+exports.slugify = function (string) {
+  return slug(string, { lower: true })
+}

--- a/lib/nunjucks/filters.js
+++ b/lib/nunjucks/filters.js
@@ -1,6 +1,17 @@
 const slug = require('slug')
 
 /**
+ * Format strings into kebab case but also
+ * handles `errorMessage` → `error-message`
+ *
+ * @param {string} string - String to format
+ * @returns {string} Kebab case string
+ */
+exports.kebabCase = function (string) {
+  return string.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase()
+}
+
+/**
  * Format strings into URL friendly "slug"
  *
  * @param {string} string - String to format

--- a/lib/nunjucks/filters.js
+++ b/lib/nunjucks/filters.js
@@ -8,7 +8,11 @@ const slug = require('slug')
  * @returns {string} Kebab case string
  */
 exports.kebabCase = function (string) {
-  return string.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase()
+  return string
+    .replace(/\W+/g, '-')
+    .replace(/\B([A-Z])(?=[a-z])/g, '-$1')
+    .replace(/\B([a-z0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase()
 }
 
 /**

--- a/lib/nunjucks/filters.js
+++ b/lib/nunjucks/filters.js
@@ -1,0 +1,6 @@
+const slugger = require('slugger')
+
+/**
+ * Format strings into URL friendly "slug"
+ */
+exports.slugger = slugger

--- a/lib/nunjucks/filters.test.mjs
+++ b/lib/nunjucks/filters.test.mjs
@@ -1,0 +1,26 @@
+import { kebabCase } from './filters.js'
+
+describe('Filters', () => {
+  describe('kebabCase', () => {
+    it.each([
+      {
+        input: 'exampleErrorSummary',
+        output: 'example-error-summary'
+      },
+      {
+        input: 'example.errorSummary',
+        output: 'example-error-summary'
+      },
+      {
+        input: 'exampleERRORSummary',
+        output: 'example-error-summary'
+      },
+      {
+        input: 'not camel case example',
+        output: 'not-camel-case-example'
+      }
+    ])("Formats '$input' to '$output'", ({ input, output }) => {
+      expect(kebabCase(input)).toEqual(output)
+    })
+  })
+})

--- a/lib/nunjucks/filters.test.mjs
+++ b/lib/nunjucks/filters.test.mjs
@@ -1,4 +1,4 @@
-import { kebabCase } from './filters.js'
+import { kebabCase, slugify } from './filters.js'
 
 describe('Filters', () => {
   describe('kebabCase', () => {
@@ -21,6 +21,37 @@ describe('Filters', () => {
       }
     ])("Formats '$input' to '$output'", ({ input, output }) => {
       expect(kebabCase(input)).toEqual(output)
+    })
+  })
+
+  describe('slugify', () => {
+    it.each([
+      {
+        input: 'Example heading',
+        output: 'example-heading'
+      },
+      {
+        input: 'Example   heading',
+        output: 'example-heading'
+      },
+      {
+        input: 'Example: Heading',
+        output: 'example-heading'
+      },
+      {
+        input: 'Example - Heading',
+        output: 'example-heading'
+      },
+      {
+        input: 'Example -- Heading',
+        output: 'example-heading'
+      },
+      {
+        input: "Example's Heading",
+        output: 'examples-heading'
+      }
+    ])("Formats '$input' to '$output'", ({ input, output }) => {
+      expect(slugify(input)).toEqual(output)
     })
   })
 })

--- a/lib/nunjucks/globals.js
+++ b/lib/nunjucks/globals.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+const { readFileSync } = require('fs')
 const { join, normalize } = require('path')
 
 const matter = require('gray-matter')
@@ -6,49 +6,35 @@ const beautify = require('js-beautify')
 const nunjucks = require('nunjucks')
 const slash = require('slash')
 
-const { paths } = require('../config')
+const { paths } = require('../../config')
+const getMacroOptions = require('../get-macro-options/index.js')
 
 nunjucks.configure(join(paths.views, 'layouts'))
 
-// This helper function takes a path of a file and
-// returns the contents as string
-exports.getFileContents = (path) => {
-  let fileContents
-  try {
-    fileContents = fs.readFileSync(path)
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      console.log(err.message)
-    } else {
-      throw err
-    }
-  }
-  return fileContents.toString()
-}
-
-// This helper function takes a path of a *.md.njk file and
-// returns the Nunjucks syntax inside that file without markdown data and imports
-exports.getNunjucksCode = (path) => {
-  const fileContents = this.getFileContents(path)
-
-  const parsedFile = matter(fileContents)
+/**
+ * This helper function takes a path of a *.md.njk file and
+ * returns the Nunjucks syntax inside that file without markdown data and imports
+ */
+exports.getNunjucksCode = function (path) {
+  const { content } = matter(readFileSync(path, 'utf-8'))
 
   // Omit any `{% extends "foo.njk" %}` nunjucks code, because we extend
   // templates that only exist within the Design System – it's not useful to
   // include this in the code we expect others to copy.
-  return parsedFile.content.replace(/{%\s*extends\s*\S*\s*%}\s+/, '')
+  return content.replace(/{%\s*extends\s*\S*\s*%}\s+/, '')
 }
 
-// This helper function takes a path of a *.md.njk file and
-// returns the frontmatter as an object
-exports.getFrontmatter = (path) => {
-  const fileContents = this.getFileContents(path)
-
-  const parsedFile = matter(fileContents)
-  return parsedFile.data
+/**
+ * This helper function takes a path of a *.md.njk file and
+ * returns the frontmatter as an object
+ */
+exports.getFrontmatter = function (path) {
+  return matter(readFileSync(path, 'utf-8')).data
 }
 
-// Get 'fingerprinted' version of a given asset file.
+/**
+ * Get 'fingerprinted' version of a given asset file
+ */
 exports.getFingerprint = function (file) {
   file = normalize(file)
 
@@ -82,13 +68,12 @@ exports.getFingerprint = function (file) {
   return '/' + slash(fingerprints[file].path)
 }
 
-// This helper function takes a path of a *.md.njk file and
-// returns the HTML rendered by Nunjucks without markdown data
-exports.getHTMLCode = (path) => {
-  const fileContents = this.getFileContents(path)
-
-  const parsedFile = matter(fileContents)
-  const content = parsedFile.content
+/**
+ * This helper function takes a path of a *.md.njk file and
+ * returns the HTML rendered by Nunjucks without markdown data
+ */
+exports.getHTMLCode = function (path) {
+  const { content } = matter(readFileSync(path, 'utf-8'))
 
   let html = ''
   try {
@@ -111,3 +96,5 @@ exports.getHTMLCode = (path) => {
     wrap_attributes: 'preserve'
   })
 }
+
+exports.getMacroOptions = getMacroOptions

--- a/lib/nunjucks/index.js
+++ b/lib/nunjucks/index.js
@@ -1,3 +1,7 @@
+const { dirname, join } = require('path')
+
+const { paths } = require('../../config')
+
 /**
  * Nunjucks options
  */
@@ -5,6 +9,20 @@ const filters = require('./filters')
 const globals = require('./globals')
 
 module.exports = {
-  filters,
-  globals
+  noCache: true, // never use a cache and recompile templates each time
+  trimBlocks: true, // automatically remove trailing newlines from a block/tag
+  lstripBlocks: true, // automatically remove leading whitespace from a block/tag
+
+  // Store views paths for rendering nunjucks syntax
+  path: [
+    join(paths.views, 'layouts'),
+    join(paths.views, 'partials'),
+    join(paths.source, 'components'),
+
+    // Path to `govuk-frontend` export without `govuk/` suffix
+    join(dirname(require.resolve('govuk-frontend')), '../')
+  ],
+
+  globals,
+  filters
 }

--- a/lib/nunjucks/index.js
+++ b/lib/nunjucks/index.js
@@ -2,7 +2,9 @@
  * Nunjucks options
  */
 const filters = require('./filters')
+const globals = require('./globals')
 
 module.exports = {
-  filters
+  filters,
+  globals
 }

--- a/lib/nunjucks/index.js
+++ b/lib/nunjucks/index.js
@@ -1,0 +1,8 @@
+/**
+ * Nunjucks options
+ */
+const filters = require('./filters')
+
+module.exports = {
+  filters
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "serve-static": "^1.15.0",
         "sitemap": "^7.1.1",
         "slash": "^3.0.0",
-        "slugger": "^1.0.1",
+        "slug": "^8.2.3",
         "standard": "^17.1.0",
         "stylelint": "^15.10.3",
         "stylelint-config-gds": "^1.0.0",
@@ -14297,11 +14297,14 @@
         "node": ">=8"
       }
     },
-    "node_modules/slugger": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/slugger/-/slugger-1.0.1.tgz",
-      "integrity": "sha512-0DEO4OPN3jhyOtuyazZ0+8+E0n6IGoAoqHio7lOGDRDjzS09KyZf2u/WasxYMBJkzf/4IQwNPiO1sxc1nsLckA==",
-      "dev": true
+    "node_modules/slug": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/slug/-/slug-8.2.3.tgz",
+      "integrity": "sha512-fXjhAZszNecz855GUNIwW0+sFPi9WV4bMiEKDOCA4wcq1ts1UnUVNy/F78B0Aat7/W3rA+se//33ILKNMrbeYQ==",
+      "dev": true,
+      "bin": {
+        "slug": "cli.js"
+      }
     },
     "node_modules/slugify": {
       "version": "1.6.5",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "serve-static": "^1.15.0",
     "sitemap": "^7.1.1",
     "slash": "^3.0.0",
-    "slugger": "^1.0.1",
+    "slug": "^8.2.3",
     "standard": "^17.1.0",
     "stylelint": "^15.10.3",
     "stylelint-config-gds": "^1.0.0",

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -15,7 +15,7 @@
 {% if params.id %}
   {% set exampleId = params.id %}
 {% else %}
-  {% set exampleId = (exampleTitle + " example") | slugger %}
+  {% set exampleId = (exampleTitle + " example") | slugify %}
 {% endif %}
 
 {% if params.open %}


### PR DESCRIPTION
This PR configures Nunjucks filters, globals and options from a single place

We previously had three ways to generate a slug, which was hard to follow:

1. [`slugger` npm package](https://www.npmjs.com/package/slugger)
2. [`kebabCase` Nunjucks filter](https://github.com/alphagov/govuk-design-system/blob/6cf12f37f28c0b9575d48e9e75af29669887e4f1/lib/metalsmith.js#L64-L66)
3. [`options.slug` for macro options](https://github.com/alphagov/govuk-design-system/blob/6cf12f37f28c0b9575d48e9e75af29669887e4f1/lib/get-macro-options/index.js#L17-L18)

This caused differences in output HTML, for example `formGroup` versus `form-group`

I've already consolidated 1) and 2) in https://github.com/alphagov/govuk-design-system/pull/2927, but now have a [single `slugify` filter to match GOV.UK Frontend](https://github.com/alphagov/govuk-frontend/pull/3963)