### PR TITLE
Fix layout page heading hierarchy

### DIFF
--- a/src/components/table/index.md
+++ b/src/components/table/index.md
@@ -19,7 +19,7 @@ Use the table component to let users compare information in rows and columns.
 
 ## When not to use this component
 
-Never use the table component to layout content on a page. Instead, use the [grid system](/styles/layout/#grid-system).
+Never use the table component to layout content on a page. Instead, use the [grid system](/styles/layout/#using-the-grid-system).
 
 ## How it works
 

--- a/src/get-started/updating-your-code/index.md
+++ b/src/get-started/updating-your-code/index.md
@@ -452,7 +452,7 @@ GOV.UK Frontend uses ["Block, Element, Modifier" (BEM)](http://getbem.com/) and 
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell ">#content</td>
-      <td class="govuk-table__cell "><a class="govuk-link" href="/styles/layout/#page-wrappers">Page wrappers</a></td>
+      <td class="govuk-table__cell "><a class="govuk-link" href="/styles/layout/#setting-up-page-wrappers">Page wrappers</a></td>
     </tr>
 
   </tbody>

--- a/src/styles/layout/index.md
+++ b/src/styles/layout/index.md
@@ -34,11 +34,9 @@ The default maximum page width is 1020px, but you can make it wider if your cont
 
 {{ example({group: "styles", item: "layout", example: "common-two-thirds-two-thirds-one-third", html: true, open: true, size: "l"}) }}
 
-## Building your own layout
+## Setting up page wrappers
 
-If you want to build your layout from scratch, or understand what each of the parts are responsible for, here’s an explanation of how the page wrappers and grid system works.
-
-## Page wrappers
+If you want to build your layout from scratch, or understand what each of the parts are responsible for, here’s an explanation of how the page wrappers work.
 
 ### Limiting width of content
 
@@ -63,7 +61,7 @@ If you’re not using the [breadcrumbs](/components/breadcrumbs/), [back link](/
 
 {{ example({group: "styles", item: "layout", example: "layout-wrappers-l", html: true, open: true, size: "l"}) }}
 
-## Grid system
+## Using the grid system
 
 Use the grid system to lay out the content on your service’s pages.
 


### PR DESCRIPTION
Currently we have a `h2` ("Building your own layout") which appears to be acting as a section heading for the two subsequent `h2`s ("Page wrappers" and "Grid system"), which is an incorrect heading hierarchy. 

Normally we might move the child `h2`s to become `h3`s (and `h3`s to `h4`s, etc.), however the Design System website uses `h2`s to generate its table of contents and search index. As we want to preserve these sections in those locations, we're instead opting to remove the "Building your own layout" section and integrating its content into the subsequent sections. 