### PR TITLE
Improvements to document statuses HTML

### DIFF
--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -16,22 +16,23 @@
         {{ theme if theme else section }}
       </span>
       {% endif %}
-      <h1 class="govuk-heading-xl">
+      <h1 class="govuk-heading-xl {%- if status %} govuk-!-margin-bottom-5{% endif %}">
         {% if includeThemeInPageHeading %}
         <span class="govuk-caption-xl">
           {{ theme | replace("…", "") }}
         </span>
         {% endif %}
         {{ title }}
-        {% if status %}
-        <div>
-          <strong class="govuk-tag govuk-!-margin-top-4 govuk-!-margin-bottom-2">
-            {{ status }}
-          </strong>
-          <p class="govuk-body">{{ statusMessage | safe }}</p>
-        </div>
-        {% endif %}
       </h1>
+
+      {% if status %}
+      <aside class="govuk-!-margin-bottom-8" aria-label="Guidance status">
+        <strong class="govuk-tag govuk-!-margin-bottom-2">
+          {{ status }}
+        </strong>
+        <p class="govuk-body">{{ statusMessage | safe }}</p>
+      </aside>
+      {% endif %}
 
       {% if showPageNav %}
         <ul class="app-page-navigation">


### PR DESCRIPTION
When working on #3048, part of how I checked page titles for consistency was by scraping each page for the `title` and `h1` and comparing them, a task that was complicated by our component and guidance statuses being housed within the `h1` element.

As it turns out, [this is invalid HTML](https://github.com/alphagov/govuk-design-system/issues/2606), so I figured I'd whack it on the head while it's on my mind. 

Resolves #2606.

## Changes
- Moves the status content outside of the `h1` element to directly below it.
- Adjusts the margin classes to maintain the existing spacing between elements.
  - This includes a new if-block to override the `h1`'s bottom margin if a status is present.
- Changes the status container from a `div` to an `aside`. This seems potentially semantically appropriate if you consider the status to be _about_ the guidance, rather than part of the guidance. 
  - Adds an `aria-label` of 'Guidance status' so that the landmark has a useful name to expose to assistive technology.

## Screenshots

### Before

![Screenshot of the task list page header, showing the caption, heading, status tag, status text, and part of the first line of copy.](https://github.com/alphagov/govuk-design-system/assets/1253214/5a44975e-9c89-44c3-a040-3c223ccebdce)

### After

![Screenshot of the task list page header, showing the caption, heading, status tag, status text, and part of the first line of copy.](https://github.com/alphagov/govuk-design-system/assets/1253214/2f1a155c-d07b-48d4-be04-591e5bfad5ab)

### Diff

I've aimed to maintain the existing visual spacing between different elements, however there is a difference of about two pixels.

![The previous two screenshots overlaid by a diffing program, showing that everything below the status tag has shifted downwards by about two pixels.](https://github.com/alphagov/govuk-design-system/assets/1253214/dfed69ef-8552-4fcc-9764-c11ba15035b5)
