### PR TITLE
Enable `continue-on-error` for Prettier check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -93,6 +93,7 @@ jobs:
 
           - description: Prettier
             run: npm run lint:prettier
+            continue-on-error: true
 
           - description: JavaScript tests
             run: npx jest --color --maxWorkers=2
@@ -121,3 +122,4 @@ jobs:
 
       - name: Run task
         run: ${{ matrix.task.run }}
+        continue-on-error: ${{ matrix.task.continue-on-error || false }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,5 +121,10 @@ jobs:
           path: deploy/public
 
       - name: Run task
+        id: task
         run: ${{ matrix.task.run }}
         continue-on-error: ${{ matrix.task.continue-on-error || false }}
+
+      - name: Task warnings
+        if: steps.task.outcome == 'failure'
+        run: echo "::warning title=${{ matrix.task.description }} task failed::Check has been temporarily ignored"


### PR DESCRIPTION
Temporarily prevent the Prettier formatting check from failing build/deploy