### PR TITLE
Minor fixes for 'copy code' buttons

### DIFF
--- a/src/javascripts/components/copy.mjs
+++ b/src/javascripts/components/copy.mjs
@@ -10,42 +10,65 @@ class Copy {
   constructor($module) {
     if (
       !($module instanceof HTMLElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
+      !document.body.classList.contains('govuk-frontend-supported') ||
+      !ClipboardJS.isSupported()
     ) {
       return this
     }
 
     this.$module = $module
 
+    /** @type {number | null} */
+    this.resetTimeoutId = null
+
     this.$button = document.createElement('button')
     this.$button.className = 'app-copy-button'
-    this.$button.setAttribute('aria-live', 'assertive')
     this.$button.textContent = 'Copy code'
 
+    this.$status = document.createElement('span')
+    this.$status.className = 'govuk-visually-hidden'
+    this.$status.setAttribute('aria-live', 'assertive')
+
+    this.$module.insertAdjacentElement('beforebegin', this.$status)
     this.$module.insertAdjacentElement('beforebegin', this.$button)
-    this.copyAction()
+
+    const $clipboard = new ClipboardJS(this.$button, {
+      target: (trigger) => trigger.nextElementSibling
+    })
+
+    $clipboard.on('success', (event) => this.successAction(event))
+    $clipboard.on('error', (event) => this.resetAction(event))
   }
 
   /**
-   * Set up button copy action
+   * Copy to clipboard success
+   *
+   * @param {import('clipboard').Event} event - Clipboard event
    */
-  copyAction() {
-    // Copy to clipboard
-    try {
-      new ClipboardJS(this.$button, {
-        target: (trigger) => trigger.nextElementSibling
-      }).on('success', (event) => {
-        this.$button.textContent = 'Code copied'
-        event.clearSelection()
-        setTimeout(() => {
-          this.$button.textContent = 'Copy code'
-        }, 5000)
-      })
-    } catch (error) {
-      if (error instanceof Error) {
-        console.log(error.message)
-      }
+  successAction(event) {
+    this.$button.textContent = this.$status.textContent = 'Code copied'
+    // Reset button after 5 seconds
+    this.resetAction(event, 5000)
+  }
+
+  /**
+   * Copy to clipboard reset
+   *
+   * @param {import('clipboard').Event} event - Clipboard event
+   * @param {number} [timeout] - Button text reset timeout
+   */
+  resetAction(event, timeout = 0) {
+    event.clearSelection()
+
+    if (this.resetTimeoutId) {
+      window.clearTimeout(this.resetTimeoutId)
     }
+
+    // Reset button after timeout
+    this.resetTimeoutId = window.setTimeout(() => {
+      this.$button.textContent = 'Copy code'
+      this.$status.textContent = ''
+    }, timeout)
   }
 }
 


### PR DESCRIPTION
Currently, the copy code button JS:

- Forcibly announces the 'Copy code' text when the button returns to its default text after being used, even if the user has since navigated away from the button.
- Initialises `ClipboardJS` function multiple times for each button on the page.

> [!NOTE]
> This is being merged into the v5 release branch. It will not be published to the live Design System website until v5 of Frontend is released.

## Changes
Removes `aria-live="assertive"` from the button. Removing the attribute means that nothing is announced when the text changes back to 'Copy code', unless the button is still focused when that happens. Fixes #2342. 

Adds a new assertive 'status' span that makes the 'Code copied' announcement instead of the button. This is still necessary because without it, [some screen readers won't announce anything](https://github.com/alphagov/govuk-design-system/pull/3080#issuecomment-1684127182).

Changes `ClipboardJS` function call to bind to the specific button created by the JS, rather than finding and binding to all 'copy code' buttons on the page. The loop in `application.mjs` already ensures that an instance of Copy is created for each button on the page.

This additionally allows for removing the `js-copy-button` class from the button, as it's no longer used. 

## Thoughts

The new 'status' span doesn't make use of `role="status"`. I've opted not to use it as it _seems_ like this role is more suited to an element that provides a variety of updates about things that the user has not necessarily initiated directly by clicking a button (i.e. the upload progress of a list of files).

I've kept the `aria-live` attribute as assertive, as giving immediate feedback to a user action (activating the button) seems important so that the user knows their action has worked, whereas they may try to activate the button multiple times if any feedback from it is deferred. 