### PR TITLE
Fix duplicate macro options table captions and IDs

### DIFF
--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -23,6 +23,7 @@ function getMacroOptionsJson(componentName) {
 
 function addSlugs(option) {
   option.slug = slugify(kebabCase(option.name))
+  option.id = option.slug
 
   if (option.params) {
     option.params = option.params.map(addSlugs)
@@ -91,12 +92,12 @@ function getAdditionalComponentOptions(options) {
     .flat()
 
   // Component names with duplicates
-  const componentNames = optionsFlattened.map((option) => option.name)
+  const componentNames = optionsFlattened.map((option) => option.slug)
 
   // Macro options with duplicates removed
   // For example, Checkboxes have `hint` for fieldset and items
   return optionsFlattened.filter(
-    (option, index) => componentNames.indexOf(option.name) === index
+    (option, index) => componentNames.indexOf(option.slug) === index
   )
 }
 
@@ -179,22 +180,25 @@ function getMacroOptions(componentName) {
   const optionGroups = [
     {
       name: 'Primary options',
+      slug: 'primary',
       id: 'primary',
       options: optionsFormatted
     }
   ]
     .concat(
       nestedOptions.map((option) => ({
+        ...option,
+
         name: `Options for ${option.name}`,
-        id: option.slug,
         options: option.params
       }))
     )
     .concat(
       additionalComponents.map((option) => ({
+        ...option,
+
         name: `Options for ${option.name}`,
-        id: option.slug,
-        options: getMacroOptionsJson(option.name)
+        options: getMacroOptionsJson(option.slug)
           .map(addSlugs)
           .map(renderNameWithBreaks)
           .map(renderDescriptionsAsMarkdown)

--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -38,6 +38,20 @@ function addSlugs(option, parent) {
   return option
 }
 
+function addParentPrefix(option, parent) {
+  // Prefix nested option names with parent name to avoid duplicates
+  // such as summary list row "items" versus card action "items"
+  if (parent?.name) {
+    option.name = `${parent.name} ${option.name}`
+  }
+
+  if (option.params) {
+    option.params = option.params.map((param) => addParentPrefix(param, option))
+  }
+
+  return option
+}
+
 function renderNameWithBreaks(option) {
   if (option.params) {
     option.params = option.params.map(renderNameWithBreaks)
@@ -177,6 +191,7 @@ function getMacroOptions(componentName) {
   // Macro options
   const options = getMacroOptionsJson(componentName)
     .map((option) => addSlugs(option))
+    .map((option) => addParentPrefix(option))
 
   // Macro options with formatting
   const optionsFormatted = structuredClone(options)

--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -21,12 +21,18 @@ function getMacroOptionsJson(componentName) {
   return structuredClone(require(optionsFilePath))
 }
 
-function addSlugs(option) {
+function addSlugs(option, parent) {
   option.slug = slugify(kebabCase(option.name))
   option.id = option.slug
 
+  // Prefix nested option slugs with parent slug to avoid duplicates
+  // such as summary list row `items` versus card action `items`
+  if (!option.isComponent && parent?.slug) {
+    option.slug = `${parent.slug}-${option.slug}`
+  }
+
   if (option.params) {
-    option.params = option.params.map(addSlugs)
+    option.params = option.params.map((param) => addSlugs(param, option))
   }
 
   return option
@@ -59,14 +65,16 @@ function renderDescriptionsAsMarkdown(option) {
 }
 
 // To display nested options that such as rows in a table, we need to make a separate group to be displayed.
-function getNestedOptions(options) {
+function getNestedOptions(options, parent) {
   return options
     .filter((option) => option.params)
     .map((option) => {
-      let output = [option]
+      const output = [[option, parent]]
+
       if (option.params) {
-        output = output.concat(getNestedOptions(option.params))
+        output.push(...getNestedOptions(option.params, option))
       }
+
       return output
     })
     .flat()
@@ -74,17 +82,17 @@ function getNestedOptions(options) {
 
 // Some which are only used in other components are intentionally not displayed in the GOV.UK Design System guidance.
 // We want to add these as a separate group of options that can be linked to from the original options for the component.
-function getAdditionalComponentOptions(options) {
+function getAdditionalComponentOptions(options, parent) {
   const optionsFlattened = options
     .map((option) => {
-      let output = []
+      const output = []
 
       if (option.isComponent && ['hint', 'label'].includes(option.slug)) {
-        output.push(option)
+        output.push([option, parent])
       }
 
       if (option.params) {
-        output = output.concat(getAdditionalComponentOptions(option.params))
+        output.push(...getAdditionalComponentOptions(option.params, option))
       }
 
       return output
@@ -92,12 +100,12 @@ function getAdditionalComponentOptions(options) {
     .flat()
 
   // Component names with duplicates
-  const componentNames = optionsFlattened.map((option) => option.slug)
+  const componentNames = optionsFlattened.map(([option]) => option.slug)
 
   // Macro options with duplicates removed
   // For example, Checkboxes have `hint` for fieldset and items
   return optionsFlattened.filter(
-    (option, index) => componentNames.indexOf(option.slug) === index
+    ([option], index) => componentNames.indexOf(option.slug) === index
   )
 }
 
@@ -167,7 +175,8 @@ function getMacroOptions(componentName) {
   }
 
   // Macro options
-  const options = getMacroOptionsJson(componentName).map(addSlugs)
+  const options = getMacroOptionsJson(componentName)
+    .map((option) => addSlugs(option))
 
   // Macro options with formatting
   const optionsFormatted = structuredClone(options)
@@ -186,7 +195,7 @@ function getMacroOptions(componentName) {
     }
   ]
     .concat(
-      nestedOptions.map((option) => ({
+      nestedOptions.map(([option]) => ({
         ...option,
 
         name: `Options for ${option.name}`,
@@ -194,12 +203,12 @@ function getMacroOptions(componentName) {
       }))
     )
     .concat(
-      additionalComponents.map((option) => ({
+      additionalComponents.map(([option, parent]) => ({
         ...option,
 
         name: `Options for ${option.name}`,
         options: getMacroOptionsJson(option.slug)
-          .map(addSlugs)
+          .map((option) => addSlugs(option, parent))
           .map(renderNameWithBreaks)
           .map(renderDescriptionsAsMarkdown)
       }))

--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -7,8 +7,6 @@ backlogIssueId: 96
 layout: layout-pane.njk
 ---
 
-<!-- [html-validate-disable no-dup-id -- See https://github.com/alphagov/govuk-design-system/issues/2260] -->
-
 {% from "_example.njk" import example %}
 
 The footer provides copyright, licensing and other information about your service.
@@ -58,5 +56,3 @@ Only add secondary GOV.UK navigation if you’re creating a GOV.UK service, and 
 ### Footer with links and secondary navigation
 
 {{ example({group: "components", item: "footer", example: "full", html: true, nunjucks: true, open: false, size: "xl"}) }}
-
-<!-- [html-validate-enable no-dup-id] -->

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -104,8 +104,10 @@
               </thead>
               <tbody class="govuk-table__body">
                 {% for option in table.options -%}
+                  {# Option name only, without parent prefix -#}
+                  {% set optionName = option.name.split(" ") | last %}
                   <tr class="govuk-table__row">
-                    <th class="govuk-table__header" scope="row">{{ option.name | safe }}</th>
+                    <th class="govuk-table__header" scope="row">{{ optionName | safe }}</th>
                     <td class="govuk-table__cell">{{ option.type }}</td>
                     <td class="govuk-table__cell">
                       {% if (option.required === true) %}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -110,21 +110,16 @@
                     <th class="govuk-table__header" scope="row">{{ optionName | safe }}</th>
                     <td class="govuk-table__cell">{{ option.type }}</td>
                     <td class="govuk-table__cell">
-                      {% if (option.required === true) %}
-                        <strong>Required.</strong>
-                      {% endif %}
+                    {% if (option.required) %}
+                      <strong>Required.</strong>
+                    {% endif %}
                       {{ option.description | safe }}
-                      {% if (option.isComponent) -%}
-                        {# Create separate table data for components that are hidden in the Design System -#}
-                        {% if ["hint", "label"].includes(option.slug) %}
-                          See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name | safe }}</a>.
-                        {% else %}
-                          See <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ option.name | safe }}</a>.
-                        {% endif %}
-                      {% endif %}
-                      {% if (option.params) %}
-                        See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name | safe }}</a>.
-                      {% endif -%}
+                    {% if (option.params) or ["hint", "label"].includes(option.slug) %}
+                      See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name | safe }}</a>.
+                    {% elif (option.isComponent) %}
+                      {# Link to Design System component pages for nested components -#}
+                      See <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ option.name | safe }}</a>.
+                    {% endif %}
                     </td>
                   </tr>
                 {% endfor %}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -93,8 +93,8 @@
           If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must sanitise the HTML to protect against  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting exploits</a>.
           </p>
           {% for table in macroOptions %}
-            <table class="govuk-table app-options__table" id="options-{{ exampleId }}--{{ table.id }}">
-              <caption class="govuk-table__caption govuk-heading-m {% if table.id == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name | safe }}</caption>
+            <table class="govuk-table app-options__table" id="options-{{ exampleId }}--{{ table.slug }}">
+              <caption class="govuk-table__caption govuk-heading-m {% if table.slug == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name | safe }}</caption>
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                   <th class="govuk-table__header app-options__limit-table-cell" scope="col">Name</th>


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-design-system/issues/2260

Includes two main changes:

1. Ensure each nested option `slug` is suffixed with its parent to make it unique
2. Ensures each nested option table caption is suffixed with its parent to make it unique

## Fixed table captions
The following duplicate table captions have been renamed:

* Footer “items” → “meta items”
* Footer “items” → “navigation items”

But in GOV.UK Frontend v5 will also fix duplicate captions for:

* Summary list “actions” → “rows actions”
* Summary list “actions” for “card actions”
* Summary list "items" for “card actions items”
* Summary list “items” for “rows actions items”

## Fixed table slugs used for IDs
The following duplicate table ID slugs have been renamed:

* Footer meta `items` → `meta-items`
* Footer navigation `items` → `navigation-items`

But in GOV.UK Frontend v5 will also fix duplicate IDs for:

* Summary list `actions` → `rows-actions`
* Summary list `actions` → `card-actions`
* Summary list `items` → `card-actions-items`
* Summary list `items` → `rows-actions-items`