### PR TITLE
Add options `ignoreInPageNav` and `ignoreInSearch` to headings

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,7 +9,7 @@ coverage/
 
 # Build output
 deploy/public/
-fixtures/build/
+**/fixtures/build/
 
 # Files to ignore
 package-lock.json

--- a/config/navigation.js
+++ b/config/navigation.js
@@ -6,28 +6,23 @@
 module.exports = [
   {
     label: 'Get started',
-    url: 'get-started',
-    includeInSearch: true
+    url: 'get-started'
   },
   {
     label: 'Styles',
-    url: 'styles',
-    includeInSearch: true
+    url: 'styles'
   },
   {
     label: 'Components',
-    url: 'components',
-    includeInSearch: true
+    url: 'components'
   },
   {
     label: 'Patterns',
-    url: 'patterns',
-    includeInSearch: true
+    url: 'patterns'
   },
   {
     label: 'Community',
-    url: 'community',
-    includeInSearch: true
+    url: 'community'
   }
 ]
 
@@ -35,7 +30,7 @@ module.exports = [
  * @typedef {object} NavigationItem
  * @property {string} label - Navigation item text
  * @property {string} url - URL path without leading slash
- * @property {boolean} includeInSearch - Include in search index
+ * @property {boolean} [ignoreInSearch] - Ignore in search index
  * @property {NavigationSubItem[]} [items] - Navigation sub items
  */
 

--- a/lib/extract-page-headings/fixtures/src/example-with-aliases.md
+++ b/lib/extract-page-headings/fixtures/src/example-with-aliases.md
@@ -1,9 +1,12 @@
 ---
 title: Example with aliases
-headingAliases:
-  Heading level 1: one
-  Heading level 2: two
-  Heading level 3: three
+headings:
+  - text: Heading level 1
+    aliases: one
+  - text: Heading level 2
+    aliases: two
+  - text: Heading level 3
+    aliases: three
 ---
 
 Contents

--- a/lib/extract-page-headings/fixtures/src/example-with-page-nav.md
+++ b/lib/extract-page-headings/fixtures/src/example-with-page-nav.md
@@ -1,0 +1,18 @@
+---
+title: Example with page nav
+headings:
+  - text: Heading level 1
+    ignoreInPageNav: true
+---
+
+Contents
+
+# Heading level 1
+
+Paragraph
+
+## Heading level 2
+
+[Link](/)
+
+### Heading level 3

--- a/lib/extract-page-headings/fixtures/src/example-with-search.md
+++ b/lib/extract-page-headings/fixtures/src/example-with-search.md
@@ -1,0 +1,18 @@
+---
+title: Example with page nav
+headings:
+  - text: Heading level 3
+    ignoreInSearch: true
+---
+
+Contents
+
+# Heading level 1
+
+Paragraph
+
+## Heading level 2
+
+[Link](/)
+
+### Heading level 3

--- a/lib/extract-page-headings/index.js
+++ b/lib/extract-page-headings/index.js
@@ -1,44 +1,48 @@
-const { marked } = require('marked')
+const { Lexer } = require('marked')
 
-const plugin = () => {
-  return function (files, metalsmith, done) {
-    Object.keys(files).forEach(function (file) {
-      if (!file.endsWith('.njk') && !file.endsWith('.md')) {
+/**
+ * Metalsmith extract headings plugin
+ *
+ * @param {string[]} config.pattern - File match glob patterns
+ * @returns {import('metalsmith').Plugin} Metalsmith plugin
+ */
+const extractPageHeadings = () => (files, metalsmith, done) => {
+  Object.keys(files).forEach((file) => {
+    if (!file.endsWith('.njk') && !file.endsWith('.md')) {
+      return
+    }
+
+    const { contents, headingAliases = [] } = files[file]
+    const headings = []
+
+    const lexer = new Lexer()
+    const tokens = lexer.lex(contents.toString())
+
+    tokens.forEach((token) => {
+      if (token.type !== 'heading') {
         return
       }
-      const data = files[file]
-      const contents = data.contents.toString()
-      const lexer = new marked.Lexer()
-      const tokens = lexer.lex(contents)
-      const headingsArray = []
-      tokens.forEach((token) => {
-        if (token.type !== 'heading') {
-          return
-        }
 
-        let aliases = null
-        if (data.headingAliases) {
-          aliases = Object.entries(data.headingAliases)
-            .filter(([text]) => {
-              return text === token.text
-            })
-            .map(([text, alias]) => {
-              return alias
-            })
-            .join()
-        }
+      // Build search aliases for matching headings
+      const aliases = Object.entries(headingAliases)
+        .filter((alias) => alias[0] === token.text)
+        .map((alias) => alias[1])
+        .join()
 
-        const heading = {
-          depth: token.depth,
-          text: token.text,
-          url: token.text.toLowerCase().replace(/[^\w]+/g, '-'),
-          aliases
-        }
-        headingsArray.push(heading)
+      // Add extracted heading
+      headings.push({
+        depth: token.depth,
+        text: token.text,
+        url: token.text.toLowerCase().replace(/[^\w]+/g, '-'),
+        aliases: aliases || null
       })
-      data.headings = headingsArray
     })
-    done()
-  }
+
+    // Add extracted headings
+    files[file].headings = headings
+  })
+
+  done()
 }
-module.exports = plugin
+
+module.exports = extractPageHeadings

--- a/lib/extract-page-headings/index.js
+++ b/lib/extract-page-headings/index.js
@@ -1,5 +1,7 @@
 const { Lexer } = require('marked')
 
+const { slugify } = require('../nunjucks/filters')
+
 /**
  * Metalsmith extract headings plugin
  *
@@ -33,7 +35,7 @@ const extractPageHeadings = () => (files, metalsmith, done) => {
       headings.push({
         depth: token.depth,
         text: token.text,
-        url: token.text.toLowerCase().replace(/[^\w]+/g, '-'),
+        url: slugify(token.text),
         aliases: aliases || null
       })
     })

--- a/lib/extract-page-headings/index.js
+++ b/lib/extract-page-headings/index.js
@@ -39,7 +39,10 @@ const extractPageHeadings = () => (files, metalsmith, done) => {
         text: token.text,
         url: heading?.url ?? url,
         aliases: heading?.aliases,
-        ignoreInPageNav: !!heading?.ignoreInPageNav
+
+        // Flags to opt out of default behaviour
+        ignoreInPageNav: !!heading?.ignoreInPageNav,
+        ignoreInSearch: !!heading?.ignoreInSearch
       })
     })
 

--- a/lib/extract-page-headings/index.js
+++ b/lib/extract-page-headings/index.js
@@ -14,8 +14,13 @@ const extractPageHeadings = () => (files, metalsmith, done) => {
       return
     }
 
-    const { contents, headingAliases = [] } = files[file]
-    const headings = []
+    const { contents, headings = [] } = files[file]
+    const extracted = []
+
+    // Heading overrides from frontmatter (e.g. aliases)
+    const overrides = Object.fromEntries(
+      headings.map((heading) => [slugify(heading.text), heading])
+    )
 
     const lexer = new Lexer()
     const tokens = lexer.lex(contents.toString())
@@ -25,23 +30,20 @@ const extractPageHeadings = () => (files, metalsmith, done) => {
         return
       }
 
-      // Build search aliases for matching headings
-      const aliases = Object.entries(headingAliases)
-        .filter((alias) => alias[0] === token.text)
-        .map((alias) => alias[1])
-        .join()
+      const url = slugify(token.text)
+      const heading = overrides[url]
 
       // Add extracted heading
-      headings.push({
+      extracted.push({
         depth: token.depth,
         text: token.text,
-        url: slugify(token.text),
-        aliases: aliases || null
+        url: heading?.url ?? url,
+        aliases: heading?.aliases
       })
     })
 
     // Add extracted headings
-    files[file].headings = headings
+    files[file].headings = extracted
   })
 
   done()

--- a/lib/extract-page-headings/index.js
+++ b/lib/extract-page-headings/index.js
@@ -38,7 +38,8 @@ const extractPageHeadings = () => (files, metalsmith, done) => {
         depth: token.depth,
         text: token.text,
         url: heading?.url ?? url,
-        aliases: heading?.aliases
+        aliases: heading?.aliases,
+        ignoreInPageNav: !!heading?.ignoreInPageNav
       })
     })
 

--- a/lib/extract-page-headings/index.test.js
+++ b/lib/extract-page-headings/index.test.js
@@ -35,21 +35,24 @@ describe('extract-page-headings plugin', () => {
           depth: 1,
           text: 'Heading level 1',
           url: 'heading-level-1',
-          aliases: undefined
+          aliases: undefined,
+          ignoreInPageNav: false
         }),
 
         expect.objectContaining({
           depth: 2,
           text: 'Heading level 2',
           url: 'heading-level-2',
-          aliases: undefined
+          aliases: undefined,
+          ignoreInPageNav: false
         }),
 
         expect.objectContaining({
           depth: 3,
           text: 'Heading level 3',
           url: 'heading-level-3',
-          aliases: undefined
+          aliases: undefined,
+          ignoreInPageNav: false
         })
       ])
     )
@@ -71,6 +74,27 @@ describe('extract-page-headings plugin', () => {
         expect.objectContaining({
           text: 'Heading level 3',
           aliases: 'three'
+        })
+      ])
+    )
+  })
+
+  it('generates headings with `ignoreInPageNav', () => {
+    expect(output['example-with-page-nav.md'].headings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: 'Heading level 1',
+          ignoreInPageNav: true
+        }),
+
+        expect.objectContaining({
+          text: 'Heading level 2',
+          ignoreInPageNav: false
+        }),
+
+        expect.objectContaining({
+          text: 'Heading level 3',
+          ignoreInPageNav: false
         })
       ])
     )

--- a/lib/extract-page-headings/index.test.js
+++ b/lib/extract-page-headings/index.test.js
@@ -35,21 +35,21 @@ describe('extract-page-headings plugin', () => {
           depth: 1,
           text: 'Heading level 1',
           url: 'heading-level-1',
-          aliases: null
+          aliases: undefined
         }),
 
         expect.objectContaining({
           depth: 2,
           text: 'Heading level 2',
           url: 'heading-level-2',
-          aliases: null
+          aliases: undefined
         }),
 
         expect.objectContaining({
           depth: 3,
           text: 'Heading level 3',
           url: 'heading-level-3',
-          aliases: null
+          aliases: undefined
         })
       ])
     )

--- a/lib/extract-page-headings/index.test.js
+++ b/lib/extract-page-headings/index.test.js
@@ -36,7 +36,8 @@ describe('extract-page-headings plugin', () => {
           text: 'Heading level 1',
           url: 'heading-level-1',
           aliases: undefined,
-          ignoreInPageNav: false
+          ignoreInPageNav: false,
+          ignoreInSearch: false
         }),
 
         expect.objectContaining({
@@ -44,7 +45,8 @@ describe('extract-page-headings plugin', () => {
           text: 'Heading level 2',
           url: 'heading-level-2',
           aliases: undefined,
-          ignoreInPageNav: false
+          ignoreInPageNav: false,
+          ignoreInSearch: false
         }),
 
         expect.objectContaining({
@@ -52,7 +54,8 @@ describe('extract-page-headings plugin', () => {
           text: 'Heading level 3',
           url: 'heading-level-3',
           aliases: undefined,
-          ignoreInPageNav: false
+          ignoreInPageNav: false,
+          ignoreInSearch: false
         })
       ])
     )
@@ -95,6 +98,27 @@ describe('extract-page-headings plugin', () => {
         expect.objectContaining({
           text: 'Heading level 3',
           ignoreInPageNav: false
+        })
+      ])
+    )
+  })
+
+  it('generates headings with `ignoreInSearch', () => {
+    expect(output['example-with-search.md'].headings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: 'Heading level 1',
+          ignoreInSearch: false
+        }),
+
+        expect.objectContaining({
+          text: 'Heading level 2',
+          ignoreInSearch: false
+        }),
+
+        expect.objectContaining({
+          text: 'Heading level 3',
+          ignoreInSearch: true
         })
       ])
     )

--- a/lib/extract-page-headings/index.test.js
+++ b/lib/extract-page-headings/index.test.js
@@ -1,67 +1,78 @@
 const Metalsmith = require('metalsmith')
 
-const plugin = require('./index.js')
+const extractPageHeadings = require('./index.js')
 
 describe('extract-page-headings plugin', () => {
-  let pages
+  const source = './fixtures/src'
+  const destination = './fixtures/build'
+
+  let output
+
   beforeAll((done) => {
-    Metalsmith('lib/extract-page-headings/fixtures')
-      .use(plugin())
+    Metalsmith(__dirname)
+      // Use test fixtures
+      .source(source)
+      .destination(destination)
+
+      // Extract page headings
+      .use(extractPageHeadings())
+
+      // Build
       .build((err, files) => {
         if (err) {
           return done(err)
         }
-        pages = files
 
+        output = files
         done()
       })
   })
+
   it('generated heading metadata matches expected', () => {
-    const metadataHeadings = pages['example.md'].headings
-    const expectedHeadings = [
-      {
-        aliases: null,
-        depth: 1,
-        text: 'Heading level 1',
-        url: 'heading-level-1'
-      },
-      {
-        aliases: null,
-        depth: 2,
-        text: 'Heading level 2',
-        url: 'heading-level-2'
-      },
-      {
-        aliases: null,
-        depth: 3,
-        text: 'Heading level 3',
-        url: 'heading-level-3'
-      }
-    ]
-    expect(metadataHeadings).toEqual(expectedHeadings)
+    expect(output['example.md'].headings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          depth: 1,
+          text: 'Heading level 1',
+          url: 'heading-level-1',
+          aliases: null
+        }),
+
+        expect.objectContaining({
+          depth: 2,
+          text: 'Heading level 2',
+          url: 'heading-level-2',
+          aliases: null
+        }),
+
+        expect.objectContaining({
+          depth: 3,
+          text: 'Heading level 3',
+          url: 'heading-level-3',
+          aliases: null
+        })
+      ])
+    )
   })
-  it('generates headings with aliases', () => {
-    const metadataHeadings = pages['example-with-aliases.md'].headings
-    const expectedHeadings = [
-      {
-        aliases: 'one',
-        depth: 1,
-        text: 'Heading level 1',
-        url: 'heading-level-1'
-      },
-      {
-        aliases: 'two',
-        depth: 2,
-        text: 'Heading level 2',
-        url: 'heading-level-2'
-      },
-      {
-        aliases: 'three',
-        depth: 3,
-        text: 'Heading level 3',
-        url: 'heading-level-3'
-      }
-    ]
-    expect(metadataHeadings).toEqual(expectedHeadings)
+
+  it('generates headings with `aliases`', () => {
+    expect(output['example-with-aliases.md'].headings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: 'Heading level 1',
+          aliases: 'one'
+        }),
+
+        expect.objectContaining({
+          text: 'Heading level 2',
+          aliases: 'two'
+        }),
+
+        expect.objectContaining({
+          text: 'Heading level 3',
+          aliases: 'three'
+        })
+      ])
+    )
   })
 })

--- a/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md
+++ b/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md
@@ -7,6 +7,8 @@ headings:
     aliases: two
   - text: Heading excluded in page nav
     ignoreInPageNav: true
+  - text: Heading excluded in search
+    ignoreInSearch: true
 ---
 
 # Heading level 1
@@ -18,3 +20,7 @@ headings:
 ## Heading included in page nav
 
 ## Heading excluded in page nav
+
+## Heading included in search
+
+## Heading excluded in search

--- a/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md
+++ b/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md
@@ -5,6 +5,8 @@ showPageNav: true
 headings:
   - text: Heading level 2
     aliases: two
+  - text: Heading excluded in page nav
+    ignoreInPageNav: true
 ---
 
 # Heading level 1
@@ -12,3 +14,7 @@ headings:
 ## Heading level 2
 
 ### Heading level 3
+
+## Heading included in page nav
+
+## Heading excluded in page nav

--- a/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md
+++ b/lib/metalsmith-lunr-index/fixtures/src/with-page-headings.md
@@ -2,8 +2,9 @@
 title: Page with headings
 section: Components
 showPageNav: true
-headingAliases:
-  Heading level 2: two
+headings:
+  - text: Heading level 2
+    aliases: two
 ---
 
 # Heading level 1

--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -29,7 +29,7 @@ module.exports = function lunrPlugin() {
         permalink,
         title: file.title,
         section: file.section,
-        aliases: file.aliases ?? undefined
+        aliases: file.aliases
       }
     })
 
@@ -53,7 +53,7 @@ module.exports = function lunrPlugin() {
                 title: heading.text,
                 page: file.title,
                 section: file.section,
-                aliases: heading.aliases ?? undefined
+                aliases: heading.aliases
               }
             })
         )

--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -45,8 +45,10 @@ module.exports = function lunrPlugin() {
         const permalink = file.permalink || path
         return (
           file.headings
-            // only use <h2>s
-            .filter((heading) => heading.depth === 2)
+            // only use non-ignored <h2> headings
+            .filter(({ depth, ignoreInPageNav }) => {
+              return depth === 2 && !ignoreInPageNav
+            })
             .map((heading) => {
               return {
                 permalink: `${permalink}/#${heading.url}`,

--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -10,7 +10,7 @@ module.exports = function lunrPlugin() {
       '<span class="app-site-search__separator" aria-hidden="true">›</span>'
 
     const includedSections = navigationConfig
-      .filter((section) => section.includeInSearch)
+      .filter((section) => !section.ignoreInSearch)
       .map((section) => section.label)
 
     const documents = Object.keys(files)

--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -46,8 +46,8 @@ module.exports = function lunrPlugin() {
         return (
           file.headings
             // only use non-ignored <h2> headings
-            .filter(({ depth, ignoreInPageNav }) => {
-              return depth === 2 && !ignoreInPageNav
+            .filter(({ depth, ignoreInPageNav, ignoreInSearch }) => {
+              return depth === 2 && !ignoreInPageNav && !ignoreInSearch
             })
             .map((heading) => {
               return {

--- a/lib/metalsmith-lunr-index/index.test.js
+++ b/lib/metalsmith-lunr-index/index.test.js
@@ -132,15 +132,24 @@ describe('metalsmith-lunr-index plugin', () => {
       expect(documentStore[heading3]).toBeUndefined()
     })
 
-    it('does not store page headings with `ignoreInPageNav`', () => {
-      const headingIncluded =
-        'with-page-headings.html/#heading-included-in-page-nav'
+    it('does not store page headings with `ignoreInPageNav` or `ignoreInSearch`', () => {
+      const headingsIncluded = [
+        'with-page-headings.html/#heading-included-in-page-nav',
+        'with-page-headings.html/#heading-included-in-search'
+      ]
 
-      const headingExcluded =
-        'with-page-headings.html/#heading-excluded-in-page-nav'
+      const headingsExcluded = [
+        'with-page-headings.html/#heading-excluded-in-page-nav',
+        'with-page-headings.html/#heading-excluded-in-search'
+      ]
 
-      expect(documentStore[headingIncluded]).toEqual(expect.any(Object))
-      expect(documentStore[headingExcluded]).toBeUndefined()
+      headingsIncluded.forEach((heading) =>
+        expect(documentStore[heading]).toEqual(expect.any(Object))
+      )
+
+      headingsExcluded.forEach((heading) =>
+        expect(documentStore[heading]).toBeUndefined()
+      )
     })
 
     it('does not store page headings from pages in excluded sections', () => {

--- a/lib/metalsmith-lunr-index/index.test.js
+++ b/lib/metalsmith-lunr-index/index.test.js
@@ -122,6 +122,27 @@ describe('metalsmith-lunr-index plugin', () => {
       expect(documentStore[resultRef].title).toEqual('Heading level 2')
     })
 
+    it('stores only <h2> page headings in the index', () => {
+      const heading1 = 'with-page-headings.html/#heading-level-1'
+      const heading2 = 'with-page-headings.html/#heading-level-2'
+      const heading3 = 'with-page-headings.html/#heading-level-3'
+
+      expect(documentStore[heading1]).toBeUndefined()
+      expect(documentStore[heading2]).toEqual(expect.any(Object))
+      expect(documentStore[heading3]).toBeUndefined()
+    })
+
+    it('does not store page headings with `ignoreInPageNav`', () => {
+      const headingIncluded =
+        'with-page-headings.html/#heading-included-in-page-nav'
+
+      const headingExcluded =
+        'with-page-headings.html/#heading-excluded-in-page-nav'
+
+      expect(documentStore[headingIncluded]).toEqual(expect.any(Object))
+      expect(documentStore[headingExcluded]).toBeUndefined()
+    })
+
     it('does not store page headings from pages in excluded sections', () => {
       const searchResults = searchIndex.search('career')
 

--- a/src/styles/layout/index.md
+++ b/src/styles/layout/index.md
@@ -4,8 +4,9 @@ description: Organise the layout of the page into blocks
 section: Styles
 layout: layout-pane.njk
 showPageNav: true
-headingAliases:
-  Hide elements and keep them accessible to screen readers: visually hidden
+headings:
+  - text: Hide elements and keep them accessible to screen readers
+    aliases: visually hidden
 ---
 
 {% from "_example.njk" import example %}

--- a/src/styles/typography/index.md
+++ b/src/styles/typography/index.md
@@ -5,8 +5,9 @@ section: Styles
 backlogIssueId: 64
 layout: layout-pane.njk
 showPageNav: true
-headingAliases:
-  Section break: horizontal rule, hr
+headings:
+  - text: Section break
+    aliases: horizontal rule, hr
 ---
 
 {% from "_example.njk" import example %}

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -14,7 +14,7 @@
             {% if (subitem.headings) and (subitem.url == permalink) %}
               <ul class="app-subnav__section app-subnav__section--nested">
                 {% for link in subitem.headings %}
-                  {% if link.depth == 2 %}
+                  {% if link.depth == 2 and not link.ignoreInPageNav %}
                     <li class="app-subnav__section-item">
                       <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/#{{ link.url }}" >
                         {{ link.text }}


### PR DESCRIPTION
This is a quick supporting PR for:

* https://github.com/alphagov/govuk-design-system/pull/3106

I've extended page heading `aliases` to also include `url`, `ignoreInPageNav` and `ignoreInSearch`

### Before
Heading aliases were configurable

```yaml
headingAliases:
  Section break: horizontal rule, hr
```

### After
Headings can now be excluded from the side navigation, search, or given a custom URL fragment

```yaml
headings:
  - text: Section break
    aliases: horizontal rule, hr

  - text: Section example
    url: section-override

  - text: Section link not indexed or shown
    ignoreInPageNav: true

  - text: Section link not indexed only
    ignoreInSearch: true
```