### PR TITLE
Ensure inline `<code>` matches text font size

### DIFF
--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -133,7 +133,6 @@ $app-code-color: #d13118;
   pre,
   code {
     font-family: ui-monospace, monospace;
-    font-size: 1em;
   }
 }
 
@@ -267,9 +266,10 @@ $colour-list-breakpoint: 980px;
 li code,
 td code,
 p code {
-  padding: 0 govuk-spacing(1);
+  padding: 2px govuk-spacing(1);
   color: $app-code-color;
   background-color: govuk-colour("light-grey");
+  @include govuk-typography-responsive($size: 16);
 }
 
 // Add styling for block code
@@ -282,7 +282,7 @@ pre code {
   border: $govuk-focus-width solid transparent;
   outline: 1px solid $govuk-border-colour;
   background-color: $app-light-grey;
-  font-size: 16px;
+  @include govuk-typography-responsive($size: 19);
   @include govuk-responsive-margin(4, "bottom");
 
   &:focus {

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -101,23 +101,39 @@ $app-code-color: #d13118;
     @include govuk-responsive-margin(6, "bottom");
   }
 
-  // Fix monospace font size when used with relative typography
-  //
-  // Browsers automatically reduce monospace font size
-  //
-  // [1] restores the normal text size in Mozilla Firefox, Google Chrome,
-  // and Safari; this unusual style rule should also be used anywhere where
-  // you would otherwise set the font-family property to ‘monospace’.
-  // [2] restores the normal text size in Internet Explorer and Opera.
-  //
-  // source:
-  // http://code.iamkate.com/html-and-css/fixing-browsers-broken-monospace-font-handling/
+  /// System ui-monospace (regular) font family polyfill
+  /// @link https://www.w3.org/TR/css-fonts-4/#ui-monospace-def
+  @font-face {
+    font-family: ui-monospace;
+    src:
+      // Monospace macOS
+      local("Menlo-Regular"),
+      // Monospace Windows
+      local("CascadiaMono-Regular"),
+      local("Consolas"),
+      // Monospace Android
+      local("RobotoMono-Regular");
+  }
+
+  /// System ui-monospace (bold) font family polyfill
+  /// @link https://www.w3.org/TR/css-fonts-4/#ui-monospace-def
+  @font-face {
+    font-family: ui-monospace;
+    font-weight: 700;
+    src:
+      // Monospace macOS
+      local("Menlo-Bold"),
+      // Monospace Windows
+      local("CascadiaMono-Bold"),
+      local("Consolas"),
+      // Monospace Android
+      local("RobotoMono-Bold");
+  }
+
   pre,
   code {
-    // stylelint-disable font-family-no-duplicate-names
-    font-family: monospace, monospace; // [1]
-    // stylelint-enable font-family-no-duplicate-names
-    font-size: 1em; // [2]
+    font-family: ui-monospace, monospace;
+    font-size: 1em;
   }
 }
 


### PR DESCRIPTION
PR to ensure inline `<code>` blocks don't appear huge alongside body text

Will need a design review

## Before
<img width="348" alt="Inline code font size too big" src="https://github.com/alphagov/govuk-design-system/assets/415517/2af34362-dc02-4108-94a9-a118322e887d">

## After
<img width="357" alt="Inline code font size improved" src="https://github.com/alphagov/govuk-design-system/assets/415517/9deb4ea2-2241-4a93-a9c3-188314c022ce">