### PR TITLE
Remove parent prefix from nested component display names

### DIFF
--- a/lib/get-macro-options/index.js
+++ b/lib/get-macro-options/index.js
@@ -27,7 +27,7 @@ function addSlugs(option, parent) {
 
   // Prefix nested option slugs with parent slug to avoid duplicates
   // such as summary list row `items` versus card action `items`
-  if (!option.isComponent && parent?.slug) {
+  if ((!option.isComponent || option.params) && parent?.slug) {
     option.slug = `${parent.slug}-${option.slug}`
   }
 
@@ -41,7 +41,7 @@ function addSlugs(option, parent) {
 function addParentPrefix(option, parent) {
   // Prefix nested option names with parent name to avoid duplicates
   // such as summary list row "items" versus card action "items"
-  if (parent?.name) {
+  if ((!option.isComponent || option.params) && parent?.name) {
     option.name = `${parent.name} ${option.name}`
   }
 
@@ -101,7 +101,8 @@ function getAdditionalComponentOptions(options, parent) {
     .map((option) => {
       const output = []
 
-      if (option.isComponent && ['hint', 'label'].includes(option.slug)) {
+      const hasComponentPage = !['hint', 'label'].includes(option.slug)
+      if (option.isComponent && !option.params && !hasComponentPage) {
         output.push([option, parent])
       }
 


### PR DESCRIPTION
We didn't need to add parent prefixes in https://github.com/alphagov/govuk-design-system/pull/3107

Duplicate **Hints** and **Labels** are automatically removed from the page already

For these two components, this PR puts the original names back

<img width="757" alt="Unnecessary parent prefix" src="https://github.com/alphagov/govuk-design-system/assets/415517/e07ecdc8-4f41-4c2d-93b8-c4c2b77239b3">

You can see where this was already handled here:

https://github.com/alphagov/govuk-design-system/blob/6a3d9931ed141c8206d7bc1e3db89fa51d7c8a35/lib/get-macro-options/index.js#L119-L123