### PR TITLE
Various fixes for `html-validate` (nested forms etc)

### DIFF
--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -1,10 +1,6 @@
 module.exports = {
   extends: ['html-validate:recommended'],
   rules: {
-    // In some Nunjucks macro calls, we use single quotes for attributes since
-    // we wrap macro string properties in double quotes.
-    'attr-quotes': ['error', { style: 'any' }],
-
     // We don't use boolean attributes consistently – buttons currently
     // use disabled="disabled"
     'attribute-boolean-style': 'off',

--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -1,8 +1,8 @@
 module.exports = {
   extends: ['html-validate:recommended'],
   rules: {
-    // We don't use boolean attributes consistently – buttons currently
-    // use disabled="disabled"
+    // Allow components to set boolean attributes with empty values
+    // e.g. using `params.attributes` to set <fieldset hidden="">
     'attribute-boolean-style': 'off',
 
     // Allow for multiple buttons in the same form to have the same name

--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -12,9 +12,6 @@ module.exports = {
       { shared: ['radio', 'checkbox', 'submit', 'button'] }
     ],
 
-    // Allow pattern attribute on input type="number"
-    'input-attributes': 'off',
-
     // Flags most of our page titles because we append "- GOV.UK Design System"
     // to all of them.
     'long-title': 'off',
@@ -32,11 +29,6 @@ module.exports = {
 
     // More hassle than it's worth 👾
     'no-trailing-whitespace': 'off',
-
-    // We still support creating `input type=button` with the button
-    // component, but you have to explicitly choose to use them over
-    // buttons
-    'prefer-button': 'off',
 
     // Allow use of roles where there are native elements that would give
     // us that role automatically, e.g. <section> instead of
@@ -80,12 +72,6 @@ module.exports = {
         attributes: {
           type: { required: false }
         }
-      },
-      // Allow h1 to have children. This is because we have status tags within
-      // the <h1>. There's an issue to fix this:
-      // https://github.com/alphagov/govuk-design-system/issues/2606
-      h1: {
-        permittedContent: ['div', 'label', 'span']
       },
       // We added a summary to fix an accessibility issue, though we could
       // probably revisit.

--- a/.htmlvalidate.js
+++ b/.htmlvalidate.js
@@ -85,11 +85,6 @@ module.exports = {
           type: { required: false }
         }
       },
-      // Horrible hack to allow nested form elements for 3 current instances:
-      // https://github.com/alphagov/govuk-design-system/issues/2609
-      form: {
-        permittedDescendants: [{}]
-      },
       // Allow h1 to have children. This is because we have status tags within
       // the <h1>. There's an issue to fix this:
       // https://github.com/alphagov/govuk-design-system/issues/2606

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,7 @@ coverage/
 
 # Build output
 deploy/public/
+fixtures/build/
 
 # Files to ignore
 package-lock.json

--- a/src/community/contribution-criteria/index.md
+++ b/src/community/contribution-criteria/index.md
@@ -35,8 +35,8 @@ To be successful, proposals need to show that the component or pattern being sug
         text: "Useful"
       },
       {
-        html: "<p> There is evidence that this component or pattern would be useful for many teams or services.</p>
-        <p class='govuk-!-margin-bottom-0'>Evidence could be screenshots or links to versions of it being used in different services.</p>"
+        html: '<p> There is evidence that this component or pattern would be useful for many teams or services.</p>
+          <p class="govuk-!-margin-bottom-0">Evidence could be screenshots or links to versions of it being used in different services.</p>'
       }
     ],
     [
@@ -44,8 +44,8 @@ To be successful, proposals need to show that the component or pattern being sug
         text: "Unique"
       },
       {
-        html: "<p> It does not replicate something already in the Design System. </p>
-        <p class='govuk-!-margin-bottom-0'>If it’s intended to replace an existing component or pattern, there is evidence to show that it’s better than the existing version.</p>"
+        html: '<p> It does not replicate something already in the Design System. </p>
+          <p class="govuk-!-margin-bottom-0">If it’s intended to replace an existing component or pattern, there is evidence to show that it’s better than the existing version.</p>'
       }
     ]
   ]
@@ -76,8 +76,8 @@ Before a new component or pattern is published the working group reviews the imp
         text: "Usable"
       },
       {
-        html: "<p>It has been tested  in user research and shown to work with a representative sample of users, including those with disabilities.</p>
-        <p class='govuk-!-margin-bottom-0'>Components and patterns which are not proven usable can be published as experimental. But they must be clearly based on relevant user research from other organisations and best practice, and meet the other criteria.</p>"
+        html: '<p>It has been tested  in user research and shown to work with a representative sample of users, including those with disabilities.</p>
+          <p class="govuk-!-margin-bottom-0">Components and patterns which are not proven usable can be published as experimental. But they must be clearly based on relevant user research from other organisations and best practice, and meet the other criteria.</p>'
       }
     ],
     [
@@ -85,9 +85,9 @@ Before a new component or pattern is published the working group reviews the imp
         text: "Consistent"
       },
       {
-        html: "<p>It reuses existing styles and components in the Design System where relevant.</p>
-        <p>Both the guidance and any content included in examples must follow the <a href='https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style'>GOV.UK content style guide</a>.</p>
-        <p class='govuk-!-margin-bottom-0'>If there is code, it follows the <a href='https://github.com/alphagov/govuk-frontend/blob/main/CONTRIBUTING.md#conventions-to-follow'>GOV.UK Frontend coding standards</a> and is ready to merge in GOV.UK Frontend.</p>"
+        html: '<p>It reuses existing styles and components in the Design System where relevant.</p>
+          <p>Both the guidance and any content included in examples must follow the <a href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style">GOV.UK content style guide</a>.</p>
+          <p class="govuk-!-margin-bottom-0">If there is code, it follows the <a href="https://github.com/alphagov/govuk-frontend/blob/main/CONTRIBUTING.md#conventions-to-follow">GOV.UK Frontend coding standards</a> and is ready to merge in GOV.UK Frontend.</p>'
       }
     ],
     [
@@ -95,9 +95,9 @@ Before a new component or pattern is published the working group reviews the imp
         text: "Versatile"
       },
       {
-        html: "<p>The implementation is versatile enough that the component or pattern can be used in a range of different services that may need it.</p>
-        <p>For example, a versatile date input component could be set up to ask for a year only, a month and year only, a precise date, or any other combination you may need.</p>
-        <p class='govuk-!-margin-bottom-0'>The component or pattern must also have been tested and shown to work with a range of <a href='https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices'>browsers, assistive technologies and devices</a>.</p>"
+        html: '<p>The implementation is versatile enough that the component or pattern can be used in a range of different services that may need it.</p>
+          <p>For example, a versatile date input component could be set up to ask for a year only, a month and year only, a precise date, or any other combination you may need.</p>
+          <p class="govuk-!-margin-bottom-0">The component or pattern must also have been tested and shown to work with a range of <a href="https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices">browsers, assistive technologies and devices</a>.</p>'
       }
     ]
   ]

--- a/src/community/design-system-day/index.md
+++ b/src/community/design-system-day/index.md
@@ -10,9 +10,9 @@ order: 11
 <img src="/community/images/dsd23-announcement-banner.svg" alt="Design System Day 2023 logo" class="app-image--no-border govuk-!-margin-bottom-6" loading="lazy">
 
 Dates: 10 and 11 October 2023
-Location: Online and <a href='https://dynamicearth.org.uk/plan-your-visit/getting-here/'>Dynamic Earth</a>, Edinburgh
+Location: Online and <a href="https://dynamicearth.org.uk/plan-your-visit/getting-here/">Dynamic Earth</a>, Edinburgh
 
-We plan to release tickets at the start of September. <a href='https://mailchi.mp/707ce8dec373/get-updated-by-email-govuk-design-system'>Sign up to our mailing list</a> to get updates.
+We plan to release tickets at the start of September. <a href="https://mailchi.mp/707ce8dec373/get-updated-by-email-govuk-design-system">Sign up to our mailing list</a> to get updates.
 
 <!--
 
@@ -80,6 +80,6 @@ Joining instructions, etc.
 
 ## About the GOV.UK Design System community
 
-The GOV.UK Design System <a href='/community/'>relies on a strong cross-government community</a> to make sure it represents the latest research, design, and development work used in digital services.
+The GOV.UK Design System <a href="/community/">relies on a strong cross-government community</a> to make sure it represents the latest research, design, and development work used in digital services.
 
 To bring our community together, the GOV.UK Design System team regularly hosts events, workshops, and co-design sprints. Our team is always on the lookout for ways to engage users in different teams and departments to help strengthen the work we do, and to help to build better products.

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -55,7 +55,7 @@ Here’s a few places to join the discussions that help shape the Design System.
       alt: "Github propose a change illustration.",
       title: "Propose a change to pages"
     }) %}
-      <p>Anyone can suggest an improvement, report a bug or correct an error on our pages. Look for the ‘Help improve this page’ section at the end of each page to <a href='https://design-system.service.gov.uk/community/propose-a-content-change-using-github/'>propose a change using GitHub</a>.</p>
+      <p>Anyone can suggest an improvement, report a bug or correct an error on our pages. Look for the ‘Help improve this page’ section at the end of each page to <a href="https://design-system.service.gov.uk/community/propose-a-content-change-using-github/">propose a change using GitHub</a>.</p>
     {% endcall %}
   </div>
 </div>
@@ -97,8 +97,8 @@ Join one of our regular events where we share ideas and work together to solve c
       large: true
     }) %}
       <p>Every year, we host an online conference to collaborate and share knowledge about design systems with like-minded people, covering topics like accessibility, community and decision-making.</p>
-      <p>Design System Day 2023 will take place on 10 and 11 October. Find out about the <a href='/community/design-system-day/'>speakers and sessions at Design System Day 2023</a>.</p>
-      <p>View the videos, slides and notes for <a href='/community/design-system-day-2022/'>Design System Day 2022</a>.</p>
+      <p>Design System Day 2023 will take place on 10 and 11 October. Find out about the <a href="/community/design-system-day/">speakers and sessions at Design System Day 2023</a>.</p>
+      <p>View the videos, slides and notes for <a href="/community/design-system-day-2022/">Design System Day 2022</a>.</p>
     {% endcall %}
   </div>
 </div>

--- a/src/community/propose-a-content-change-using-github/index.md
+++ b/src/community/propose-a-content-change-using-github/index.md
@@ -7,13 +7,14 @@ layout: layout-pane.njk
 order: 5
 ---
 
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
 The GOV.UK Design System team uses a service called GitHub to manage content in the GOV.UK Design System.
 
 This guide explains how to propose a change to the Design System's content. You'll need a GitHub account to do this.
 
 If you do not have one already, you can [create a GitHub account for free](https://github.com/).
 
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {{ govukInsetText({
   text: "Rest assured that it's impossible for you to break the Design System by proposing changes. The GOV.UK Design System team reviews all changes before publishing."
 }) }}

--- a/src/community/upcoming-components-patterns/index.md
+++ b/src/community/upcoming-components-patterns/index.md
@@ -8,6 +8,8 @@ layout: layout-pane.njk
 order: 1
 ---
 
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
 These are the components and patterns we’re working on right now, and the ones we plan to work on next.
 
 We regularly ask our community to help us decide the things we need to work on the most. [Read a blog post about how we prioritise new additions to the Design System](https://designnotes.blog.gov.uk/2022/09/07/how-we-prioritise-additions-to-the-gov-uk-design-system/).
@@ -17,8 +19,6 @@ To get a wider look at our work and see what we released recently, see our [Road
 ## Working on now
 
 If you’d like to help us build these components and patterns, join the conversation to see what needs to be done to publish.
-
-{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {{ govukSummaryList({
   rows: [
@@ -62,8 +62,6 @@ If you’d like to help us build these components and patterns, join the convers
 ## Next priorities
 
 We particularly welcome input on the following themes. To contribute, you can add designs, code or research findings to the discussion on GitHub.
-
-{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {{ govukSummaryList({
   rows: [

--- a/src/components/accordion/index.md
+++ b/src/components/accordion/index.md
@@ -13,7 +13,7 @@ statusMessage: This component is currently experimental because <a class="govuk-
 
 The accordion component lets users show and hide sections of related content on a page.
 
-{{ example({group: "components", item: "accordion", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
+{{ example({ group: "components", item: "accordion", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -79,7 +79,7 @@ The heading button includes all of these areas:
 
 For users of screen readers, all the text in the button will be read as a single statement (separated by commas to allow for slight pauses). There’s also some visually hidden content in the heading text to help announce the call-to-action as 'show this section' or 'hide this section'.
 
-{{ example({group: "components", item: "accordion", example: "default", html: true, nunjucks: true, open: false, size: "xl", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "accordion", example: "default", html: true, nunjucks: true, open: false, size: "xl", titleSuffix: "second" }) }}
 
 #### Write clear button text
 
@@ -94,7 +94,7 @@ Only add a summary line if it’s actually needed, as it's likely to make the bu
 
 If you’ve decided that you need the summary line, you must make it as short as possible.
 
-{{ example({group: "components", item: "accordion", example: "with-summary-section", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "components", item: "accordion", example: "with-summary-section", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 #### Structure section headings with the rest of the page
 

--- a/src/components/back-link/default/index.njk
+++ b/src/components/back-link/default/index.njk
@@ -2,6 +2,7 @@
 title: Back link
 layout: layout-example.njk
 ---
+
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {{ govukBackLink({

--- a/src/components/back-link/index.md
+++ b/src/components/back-link/index.md
@@ -13,7 +13,7 @@ Use the back link component to help users go back to the previous page in a mult
 
 Although browsers have a back button, some sites break when you use it - so many users avoid it, instead of losing their progress in a service. Also, not all users are aware of the back button.
 
-{{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -35,7 +35,7 @@ If this is not possible, you should hide the back link when JavaScript is not av
 
 There are 2 ways to use the back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 Using the default link text ('Back') is ideal for services with a simple journey. For example, [applying for a National Insurance number](https://www.gov.uk/apply-national-insurance-number). Users will only ever go back to the previous page in the service.
 
@@ -47,4 +47,4 @@ Use the `govuk-back-link--inverse` modifier class to show a white link on a dark
 
 Make sure all users can see the back link — the background colour [must have a contrast ratio of at least 4.5:1](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) with white.
 
-{{ example({group: "components", item: "back-link", example: "inverse", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "back-link", example: "inverse", html: true, nunjucks: true, open: false }) }}

--- a/src/components/back-link/inverse/index.njk
+++ b/src/components/back-link/inverse/index.njk
@@ -4,6 +4,7 @@ layout: layout-example.njk
 stylesheets:
 - ../../../stylesheets/example-inverse.css
 ---
+
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {{ govukBackLink({
@@ -11,4 +12,3 @@ stylesheets:
   text: "Back",
   href: "#"
 }) }}
-

--- a/src/components/breadcrumbs/collapse-mobile/index.njk
+++ b/src/components/breadcrumbs/collapse-mobile/index.njk
@@ -2,6 +2,7 @@
 title: Breadcrumbs that collapse on mobile – Breadcrumbs
 layout: layout-example.njk
 ---
+
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
 {{ govukBreadcrumbs({

--- a/src/components/breadcrumbs/default/index.njk
+++ b/src/components/breadcrumbs/default/index.njk
@@ -2,6 +2,7 @@
 title: Breadcrumbs
 layout: layout-example.njk
 ---
+
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
 {{ govukBreadcrumbs({

--- a/src/components/breadcrumbs/index.md
+++ b/src/components/breadcrumbs/index.md
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 The breadcrumbs component helps users to understand where they are within a website’s structure and move between levels.
 
-{{ example({group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -31,7 +31,7 @@ The breadcrumb should start with your 'home' page and end with the parent sectio
 
 There are 2 ways to use the breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### Collapsing breadcrumbs on mobile devices
 
@@ -39,7 +39,7 @@ If you have long breadcrumbs you can configure the component to only show the fi
 
 To do this, add a `govuk-breadcrumbs--collapse-on-mobile` class to the outer `<div>` element of the component HTML. Or if you’re using Nunjucks, add `collapseOnMobile: true` to the Nunjucks macro as shown in this example.
 
-{{ example({group: "components", item: "breadcrumbs", example: "collapse-mobile", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "breadcrumbs", example: "collapse-mobile", html: true, nunjucks: true, open: false }) }}
 
 ### Breadcrumbs on dark backgrounds
 
@@ -47,4 +47,4 @@ Use the `govuk-breadcrumbs--inverse` modifier class to show white links and arro
 
 Make sure all users can see the breadcrumbs — the background colour [must have a contrast ratio of at least 4.5:1](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) with white.
 
-{{ example({group: "components", item: "breadcrumbs", example: "inverse", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "breadcrumbs", example: "inverse", html: true, nunjucks: true, open: false }) }}

--- a/src/components/breadcrumbs/inverse/index.njk
+++ b/src/components/breadcrumbs/inverse/index.njk
@@ -4,6 +4,7 @@ layout: layout-example.njk
 stylesheets:
 - ../../../stylesheets/example-inverse.css
 ---
+
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
 {{ govukBreadcrumbs({

--- a/src/components/button/button-group/index.njk
+++ b/src/components/button/button-group/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Button group – Button
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/components/button/button-group/index.njk
+++ b/src/components/button/button-group/index.njk
@@ -2,6 +2,7 @@
 title: Button group – Button
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 <div class="govuk-button-group">

--- a/src/components/button/default/index.njk
+++ b/src/components/button/default/index.njk
@@ -2,6 +2,7 @@
 title: Button
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {{ govukButton({

--- a/src/components/button/default/index.njk
+++ b/src/components/button/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Button
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/components/button/disabled/index.njk
+++ b/src/components/button/disabled/index.njk
@@ -2,6 +2,7 @@
 title: Disabled button – Button
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {{ govukButton({

--- a/src/components/button/disabled/index.njk
+++ b/src/components/button/disabled/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Disabled button – Button
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/components/button/index.md
+++ b/src/components/button/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -42,14 +42,14 @@ Use a default button for the main call to action on a page.
 
 Avoid using multiple default buttons on a single page. Having more than one main call to action reduces their impact, and makes it harder for users to know what to do next.
 
-{{ example({group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### Start buttons
 
 Use a start button for the main call to action on your service’s [start page](/patterns/start-using-a-service/).
 Start buttons do not usually submit form data, so use a link tag instead of a button tag.
 
-{{ example({group: "components", item: "button", example: "start", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "button", example: "start", html: true, nunjucks: true, open: false }) }}
 
 ### Secondary buttons
 
@@ -57,7 +57,7 @@ Use secondary buttons for secondary calls to action on a page.
 
 Pages with too many calls to action make it hard for users to know what to do next. Before adding lots of secondary buttons, try to simplify the page or break the content down across multiple pages.
 
-{{ example({group: "components", item: "button", example: "secondary", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "button", example: "secondary", html: true, nunjucks: true, open: false }) }}
 
 You can also [group default and secondary buttons together](#grouping-buttons).
 
@@ -65,7 +65,7 @@ You can also [group default and secondary buttons together](#grouping-buttons).
 
 Warning buttons are designed to make users think carefully before they use them. They only work if used very sparingly. Most services should not need one.
 
-{{ example({group: "components", item: "button", example: "warning", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "button", example: "warning", html: true, nunjucks: true, open: false }) }}
 
 Only use warning buttons for actions with serious destructive consequences that cannot be easily undone by a user. For example, permanently deleting an account.
 
@@ -81,7 +81,7 @@ Use the `govuk-button--inverse` modifier class to show white buttons on dark bac
 
 Make sure all users can see the button — the white button and background colour [must have a contrast ratio of at least 3:1](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html).
 
-{{ example({group: "components", item: "button", example: "inverse", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "button", example: "inverse", html: true, nunjucks: true, open: false }) }}
 
 ### Disabled buttons
 
@@ -89,17 +89,17 @@ Disabled buttons have poor contrast and can confuse some users, so avoid them if
 
 Only use disabled buttons if research shows it makes the user interface easier to&nbsp;understand.
 
-{{ example({group: "components", item: "button", example: "disabled", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "button", example: "disabled", html: true, nunjucks: true, open: false }) }}
 
 ### Grouping buttons
 
 Use a button group when two or more buttons are placed together.
 
-{{ example({group: "components", item: "button", example: "secondary-combo", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "button", example: "secondary-combo", html: true, nunjucks: true, open: false }) }}
 
 Any links within a button group will automatically align with the buttons.
 
-{{ example({group: "components", item: "button", example: "button-group", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "button", example: "button-group", html: true, nunjucks: true, open: false }) }}
 
 ### Stop users from accidentally sending information more than once
 
@@ -117,7 +117,7 @@ If you are working in production and research shows that users are frequently se
 
 To do this, set the `data-prevent-double-click` attribute to `true`. You can do this directly in the HTML or, if you’re using Nunjucks, you can use the Nunjucks macro as shown in this example.
 
-{{ example({group: "components", item: "button", example: "prevent-double-click", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "button", example: "prevent-double-click", html: true, nunjucks: true, open: false }) }}
 
 This feature will prevent double clicks for users that have JavaScript enabled, however you should also think about the issue server-side to protect against attacks.
 

--- a/src/components/button/inverse/index.njk
+++ b/src/components/button/inverse/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Inverse button – Button
-layout: layout-example.njk
+layout: layout-example-form.njk
 stylesheets:
 - ../../../stylesheets/example-inverse.css
 ---

--- a/src/components/button/inverse/index.njk
+++ b/src/components/button/inverse/index.njk
@@ -4,6 +4,7 @@ layout: layout-example-form.njk
 stylesheets:
 - ../../../stylesheets/example-inverse.css
 ---
+
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {{ govukButton({

--- a/src/components/button/prevent-double-click/index.njk
+++ b/src/components/button/prevent-double-click/index.njk
@@ -2,6 +2,7 @@
 title: Button with prevent double click – Button
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {{ govukButton({

--- a/src/components/button/prevent-double-click/index.njk
+++ b/src/components/button/prevent-double-click/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Button with prevent double click – Button
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/components/button/secondary-combo/index.njk
+++ b/src/components/button/secondary-combo/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Button group with mixed button types – Button
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/components/button/secondary-combo/index.njk
+++ b/src/components/button/secondary-combo/index.njk
@@ -2,6 +2,7 @@
 title: Button group with mixed button types – Button
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 <div class="govuk-button-group">

--- a/src/components/button/secondary/index.njk
+++ b/src/components/button/secondary/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Secondary button – Button
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/components/button/secondary/index.njk
+++ b/src/components/button/secondary/index.njk
@@ -2,6 +2,7 @@
 title: Secondary button – Button
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {{ govukButton({

--- a/src/components/button/start/index.njk
+++ b/src/components/button/start/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Start now button – Button
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/components/button/start/index.njk
+++ b/src/components/button/start/index.njk
@@ -2,6 +2,7 @@
 title: Start now button – Button
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {{ govukButton({

--- a/src/components/button/warning/index.njk
+++ b/src/components/button/warning/index.njk
@@ -2,6 +2,7 @@
 title: Warning button – Button
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {{ govukButton({

--- a/src/components/button/warning/index.njk
+++ b/src/components/button/warning/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Warning button – Button
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/components/character-count/default/index.njk
+++ b/src/components/character-count/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Character count
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 

--- a/src/components/character-count/default/index.njk
+++ b/src/components/character-count/default/index.njk
@@ -2,6 +2,7 @@
 title: Character count
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 
 {{ govukCharacterCount({

--- a/src/components/character-count/error/index.njk
+++ b/src/components/character-count/error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Error – Character count
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}

--- a/src/components/character-count/index.md
+++ b/src/components/character-count/index.md
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Help users know how much text they can enter when there is a limit on the number of characters.
 
-{{ example({group: "components", item: "character-count", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "character-count", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -46,13 +46,13 @@ This component uses JavaScript. If JavaScript is not available, users will see a
 
 There are 2 ways to use the character count component. You can use HTML or, if you’re using Nunjucks or the GOV.UK Prototype Kit, you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "character-count", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "character-count", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### If you’re asking more than one question on the page
 
 If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking multiple questions on question pages](/patterns/question-pages/#asking-multiple-questions-on-a-page).
 
-{{ example({group: "components", item: "character-count", example: "without-heading", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "character-count", example: "without-heading", html: true, nunjucks: true, open: false }) }}
 
 ### Consider if a word count is more helpful
 
@@ -60,8 +60,7 @@ In some cases it may be more helpful to show a word count. For example, if your 
 
 Do this by setting `data-maxwords` in the component markup. For example, `data-maxwords="150"` will set a word limit of 150.
 
-{% from "_example.njk" import example %}
-{{ example({group: "components", item: "character-count", example: "word-count", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "character-count", example: "word-count", html: true, nunjucks: true, open: false }) }}
 
 ### Avoid narrow limits
 
@@ -75,16 +74,13 @@ To do this, set the threshold in the component markup as a percentage. For examp
 
 Screen reader users will hear the character limit when they first interact with a textarea using the threshold option. Sighted users will not see anything until the count message is shown — though you might choose to include the character limit in the hint text.
 
-{% from "_example.njk" import example %}
-{{ example({group: "components", item: "character-count", example: "threshold", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "character-count", example: "threshold", html: true, nunjucks: true, open: false }) }}
 
 ### Error messages
 
 Error messages should be styled like this:
 
-{% from "_example.njk" import example %}
-
-{{ example({group: "components", item: "character-count", example: "error", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "character-count", example: "error", html: true, nunjucks: true, open: false }) }}
 
 If a user tries to send their response with too many characters, you must show an error message above the field as well as the count message below it.
 

--- a/src/components/character-count/threshold/index.njk
+++ b/src/components/character-count/threshold/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Threshold – Character count
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}

--- a/src/components/character-count/without-heading/index.njk
+++ b/src/components/character-count/without-heading/index.njk
@@ -2,7 +2,9 @@
 title: Character count without a heading – Character count
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+
 {{ govukCharacterCount({
   id: "label-as-page-heading",
   name: "labelAsPageHeading",

--- a/src/components/character-count/without-heading/index.njk
+++ b/src/components/character-count/without-heading/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Character count without a heading – Character count
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {{ govukCharacterCount({

--- a/src/components/character-count/word-count/index.njk
+++ b/src/components/character-count/word-count/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Word count – Character count
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}

--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Checkboxes with conditionally revealing content – Checkboxes
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/src/components/checkboxes/default/index.njk
+++ b/src/components/checkboxes/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Checkboxes
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/src/components/checkboxes/error/index.njk
+++ b/src/components/checkboxes/error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Checkbox items with error – Checkboxes
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/src/components/checkboxes/hint/index.njk
+++ b/src/components/checkboxes/hint/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Checkbox items with hint – Checkboxes
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/src/components/checkboxes/index.md
+++ b/src/components/checkboxes/index.md
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Let users select one or more options by using the checkboxes component.
 
-{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -51,19 +51,19 @@ Read more about [why and how to set legends as headings](/get-started/labels-leg
 
 There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
 
 ### If you’re asking more than one question on the page
 
 If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking multiple questions on question pages](/patterns/question-pages/#asking-multiple-questions-on-a-page).
 
-{{ example({group: "components", item: "checkboxes", example: "without-heading", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: "checkboxes", example: "without-heading", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ### Checkbox items with hints
 
 You can add hints to checkbox items to provide additional information about the options.
 
-{{ example({group: "components", item: "checkboxes", example: "hint", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "checkboxes", example: "hint", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Add an option for ‘none’
 
@@ -79,11 +79,11 @@ For example, for the question 'Will you be travelling to any of these countries?
 
 To enable some JavaScript that unchecks all other checkboxes when the user clicks 'None', add the `exclusive` behaviour to the 'none' checkbox.
 
-{{ example({group: "components", item: "checkboxes", example: "with-none-option", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "components", item: "checkboxes", example: "with-none-option", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 If JavaScript is unavailable, and a user selects both the ‘none’ checkbox and another checkbox, display an error message.
 
-{{ example({group: "components", item: "checkboxes", example: "with-none-option-in-error", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "components", item: "checkboxes", example: "with-none-option-in-error", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 ### Conditionally revealing a related question
 
@@ -91,7 +91,7 @@ You can ask the user a related question when they select a particular checkbox, 
 
 This might make 2 related questions easier to answer by grouping them on the same page. For example, you could reveal a phone number input when the user selects the 'Contact me by phone' option.
 
-{{ example({group: "components", item: "checkboxes", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "components", item: "checkboxes", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 Keep it simple. If the related question is complicated or has more than one part, show it on the next page in the process instead.
 
@@ -111,7 +111,7 @@ Use standard-sized checkboxes in most cases. However, smaller checkboxes work we
 
 For example, on a page of search results, the main user need is to see the results. Using smaller checkboxes lets users see and change search filters without distracting them from the main content.
 
-{{ example({group: "components", item: "checkboxes", example: "small", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "checkboxes", example: "small", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 Small checkboxes can work well on information dense screens in services designed for repeat use, like caseworking systems.
 
@@ -121,7 +121,7 @@ In services like these, the risk that they will not be noticed is lower because 
 
 Error messages should be styled like this:
 
-{{ example({group: "components", item: "checkboxes", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "checkboxes", example: "error", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/components/checkboxes/small/index.njk
+++ b/src/components/checkboxes/small/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Small checkboxes – Checkboxes
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/src/components/checkboxes/with-none-option-in-error/index.njk
+++ b/src/components/checkboxes/with-none-option-in-error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Checkboxes with 'none' option showing an error – Checkboxes
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/src/components/checkboxes/with-none-option/index.njk
+++ b/src/components/checkboxes/with-none-option/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Checkboxes with 'none' option – Checkboxes
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/src/components/checkboxes/without-heading/index.njk
+++ b/src/components/checkboxes/without-heading/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Checkboxes without a heading – Checkboxes
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/src/components/cookie-banner/index.md
+++ b/src/components/cookie-banner/index.md
@@ -13,7 +13,7 @@ statusMessage: This component is currently experimental because <a class="govuk-
 
 Allow users to accept or reject cookies which are not essential to making your service work.
 
-{{ example({group: "components", item: "cookie-banner", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "cookie-banner", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -81,13 +81,13 @@ All users will be able to see the banner as this approach does not rely on JavaS
 
 Here's an example of a cookie banner inside a form:
 
-{{ example({group: "components", item: "cookie-banner", example: "server-side", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "cookie-banner", example: "server-side", html: true, nunjucks: true, open: false }) }}
 
 Once the user has accepted or rejected cookies and set their cookie preferences, reload the page to show a confirmation message.
 
 Here's an example of a confirmation message inside a form:
 
-{{ example({group: "components", item: "cookie-banner", example: "server-side-confirmation", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "cookie-banner", example: "server-side-confirmation", html: true, nunjucks: true, open: false }) }}
 
 #### Show the same message to all users
 
@@ -103,11 +103,11 @@ Include all possible messages that the user could see in the cookie banner when 
 
 Here's an example of a progressively enhanced cookie banner that includes all possible messages which are hidden using HTML — the cookie banner message is shown using JavaScript to remove the `hidden` attribute:
 
-{{ example({group: "components", item: "cookie-banner", example: "server-side-multiple-messages-question-visible", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "cookie-banner", example: "server-side-multiple-messages-question-visible", html: true, nunjucks: true, open: false }) }}
 
 Here's the same example of a progressively enhanced cookie banner, with the confirmation message shown instead:
 
-{{ example({group: "components", item: "cookie-banner", example: "server-side-multiple-messages-confirmation-visible", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "cookie-banner", example: "server-side-multiple-messages-confirmation-visible", html: true, nunjucks: true, open: false }) }}
 
 ### Option 3: If you set non-essential cookies, but only on the client
 
@@ -128,17 +128,17 @@ Write your own JavaScript code so that when the user accepts or rejects cookies,
 
 Here’s an example:
 
-{{ example({group: "components", item: "cookie-banner", example: "client-side", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "cookie-banner", example: "client-side", html: true, nunjucks: true, open: false }) }}
 
 #### When the user has accepted cookies
 
 Show a confirmation message confirming that the user has either accepted or rejected cookies by removing the `hidden` attribute.
 
-{{ example({group: "components", item: "cookie-banner", example: "client-side-accepted", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "cookie-banner", example: "client-side-accepted", html: true, nunjucks: true, open: false }) }}
 
 #### When the user has rejected cookies
 
-{{ example({group: "components", item: "cookie-banner", example: "client-side-rejected", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "cookie-banner", example: "client-side-rejected", html: true, nunjucks: true, open: false }) }}
 
 ## What to cover in your cookie banner
 
@@ -157,7 +157,7 @@ Keep the text as short as possible while making sure it’s an accurate descript
 
 You can use this example text for a service which sets essential and analytics cookies. Analytics cookies are those set by your organisation to collect information about how people are using your digital service.
 
-{{ example({group: "components", item: "cookie-banner", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "cookie-banner", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### If you’re using more than one type of non-essential cookie
 
@@ -167,7 +167,7 @@ You can use this example text for a service that set:
 - analytics cookies
 - functional cookies to remember the user’s settings but are not essential
 
-{{ example({group: "components", item: "cookie-banner", example: "multiple-cookies", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "cookie-banner", example: "multiple-cookies", html: true, nunjucks: true, open: false }) }}
 
 ## Creating a cookies page
 

--- a/src/components/cookie-banner/server-side-confirmation/index.njk
+++ b/src/components/cookie-banner/server-side-confirmation/index.njk
@@ -9,20 +9,18 @@ layout: layout-example.njk
   <p class="govuk-body">You’ve accepted additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
-<form method="POST">
-  {{ govukCookieBanner({
-    ariaLabel: "Cookies on [name of service]",
-    messages: [
-      {
-        html: acceptHtml,
-        actions: [
+{{ govukCookieBanner({
+  ariaLabel: "Cookies on [name of service]",
+  messages: [
+    {
+      html: acceptHtml,
+      actions: [
         {
           text: "Hide cookie message",
           href: "#",
           type: "button"
         }
-        ]
-      }
-    ]
-  }) }}
-</form>
+      ]
+    }
+  ]
+}) }}

--- a/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
@@ -18,7 +18,6 @@ layout: layout-example.njk
   <p class="govuk-body">You’ve rejected additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
-<form method="POST">
 {{ govukCookieBanner({
   ariaLabel: "Cookies on [name of service]",
   messages: [
@@ -68,4 +67,3 @@ layout: layout-example.njk
     }
   ]
 }) }}
-</form>

--- a/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
@@ -18,7 +18,6 @@ layout: layout-example.njk
   <p class="govuk-body">You’ve rejected additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
 {% endset %}
 
-<form method="POST">
 {{ govukCookieBanner({
   ariaLabel: "Cookies on [name of service]",
   messages: [
@@ -68,4 +67,3 @@ layout: layout-example.njk
     }
   ]
 }) }}
-</form>

--- a/src/components/cookie-banner/server-side/index.njk
+++ b/src/components/cookie-banner/server-side/index.njk
@@ -10,7 +10,6 @@ layout: layout-example.njk
   <p class="govuk-body">We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
 {% endset %}
 
-<form method="POST">
 {{ govukCookieBanner({
   ariaLabel: "Cookies on [name of service]",
   messages: [
@@ -38,4 +37,3 @@ layout: layout-example.njk
     }
   ]
 }) }}
-</form>

--- a/src/components/date-input/date-of-birth/index.njk
+++ b/src/components/date-input/date-of-birth/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Date input to ask for date of birth – Date input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/components/date-input/default/index.njk
+++ b/src/components/date-input/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Date input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/components/date-input/error-single/index.njk
+++ b/src/components/date-input/error-single/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Dates with errors – Date input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/components/date-input/error/index.njk
+++ b/src/components/date-input/error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Date input with errors – Date input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/components/date-input/index.md
+++ b/src/components/date-input/index.md
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use the date input component to help users enter a memorable date or one they can easily look up.
 
-{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -39,7 +39,7 @@ Accept month names written out in full or abbreviated form (for example, ‘janu
 
 There are 2 ways to use the date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 Never automatically tab users between the fields of the date input because this can be confusing and may clash with normal keyboard controls.
 
@@ -47,7 +47,7 @@ Never automatically tab users between the fields of the date input because this 
 
 If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking multiple questions on question pages](/patterns/question-pages/#asking-multiple-questions-on-a-page).
 
-{{ example({group: "components", item: "date-input", example: "without-heading", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "date-input", example: "without-heading", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 ### Use the autocomplete attribute for a date of birth
 
@@ -55,7 +55,7 @@ Use the `autocomplete` attribute on the date input component when you're asking 
 
 To do this, set the `autocomplete` attribute on the 3 fields to `bday-day`, `bday-month` and `bday-year`. See how to do this in the HTML and Nunjucks tabs in the following example.
 
-{{ example({group: "components", item: "date-input", example: "date-of-birth", html: true, nunjucks: true, open: true, size: "s", id: "default-2"}) }}
+{{ example({ group: "components", item: "date-input", example: "date-of-birth", html: true, nunjucks: true, open: true, size: "s", id: "default-2" }) }}
 
 If you are working in production you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
 
@@ -65,11 +65,11 @@ You will not normally need to use the `autocomplete` attribute in prototypes, as
 
 If you’re highlighting the whole date, style all the fields like this:
 
-{{ example({group: "components", item: "date-input", example: "error", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "date-input", example: "error", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 If you’re highlighting just one field - either the day, month or year - only style the field that has an error. The error message must say which field has an error, like this:
 
-{{ example({group: "components", item: "date-input", example: "error-single", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "date-input", example: "error-single", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/components/date-input/without-heading/index.njk
+++ b/src/components/date-input/without-heading/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Date input without a heading – Date input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/components/details/default/index.njk
+++ b/src/components/details/default/index.njk
@@ -2,6 +2,7 @@
 title: Details
 layout: layout-example.njk
 ---
+
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {{ govukDetails({

--- a/src/components/details/index.md
+++ b/src/components/details/index.md
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Make a page easier to scan by letting users reveal more detailed information only if they need it.
 
-{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -35,7 +35,7 @@ The details component is a short link that shows more detailed help text when a 
 
 There are 2 ways to use the details component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 ### Write clear link text
 

--- a/src/components/error-message/custom-prefix/index.njk
+++ b/src/components/error-message/custom-prefix/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Error message with a custom visually hidden prefix – Error message
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}

--- a/src/components/error-message/default/index.njk
+++ b/src/components/error-message/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Error message
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/components/error-message/index.md
+++ b/src/components/error-message/index.md
@@ -13,7 +13,7 @@ This guidance is for government teams that build online services. [To find infor
 
 Follow the [validation pattern](/patterns/validation/) and show an error message when there is a validation error. In the error message explain what went wrong and how to fix it.
 
-{{ example({group: "components", item: "error-message", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: "error-message", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -45,7 +45,7 @@ To help screen reader users, the error message component includes a hidden 'Erro
 
 If your error message is written in another language, you can change the prefix as needed, as shown in this example.
 
-{{ example({group: "components", item: "error-message", example: "custom-prefix", html: true, nunjucks: true, open: true, displayExample: false, size: "s"}) }}
+{{ example({ group: "components", item: "error-message", example: "custom-prefix", html: true, nunjucks: true, open: true, displayExample: false, size: "s" }) }}
 
 Summarise all errors at the top of the page the user is on using an [error summary](/components/error-summary/).
 
@@ -53,11 +53,11 @@ There are 2 ways to use the error message component. You can use HTML or, if you
 
 ### Legend
 
-{{ example({group: "components", item: "error-message", example: "legend", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "error-message", example: "legend", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ### Label
 
-{{ example({group: "components", item: "error-message", example: "label", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "error-message", example: "label", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Be clear and concise
 

--- a/src/components/error-message/label/index.njk
+++ b/src/components/error-message/label/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Error message with label – Error message
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/error-message/legend/index.njk
+++ b/src/components/error-message/legend/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Error message with legend – Error message
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/src/components/error-summary/default/index.njk
+++ b/src/components/error-summary/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Error summary
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}

--- a/src/components/error-summary/index.md
+++ b/src/components/error-summary/index.md
@@ -13,7 +13,7 @@ Use this component at the top of a page to summarise any errors a user has made.
 
 When a user makes an error, you must show both an error summary and an [error message](/components/error-message/) next to each answer that contains an error.
 
-{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -34,7 +34,7 @@ And make your [error messages](/components/error-message/#be-clear-and-concise) 
 
 There are 2 ways to use the error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 ### Linking from the error summary to each answer
 
@@ -42,20 +42,20 @@ You must link the errors in the error summary to the answer they relate to.
 
 For questions that require a user to answer using a single field, like a file upload, select, textarea, text input or character count, link to the field.
 
-{{ example({group: "components", item: "error-summary", example: "linking", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "error-summary", example: "linking", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 When a user has to enter their answer into multiple fields, such as the day, month and year fields in the date input component, link to the first field that contains an error.
 
 If you do not know which field contains an error, link to the first field.
 
-{{ example({group: "components", item: "error-summary", example: "linking-multiple-fields", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "error-summary", example: "linking-multiple-fields", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 For questions that require a user to select one or more options from a list using radios or checkboxes, link to the first radio or checkbox.
 
-{{ example({group: "components", item: "error-summary", example: "linking-checkboxes-radios", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "error-summary", example: "linking-checkboxes-radios", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Where to put the error summary
 
 Put the error summary at the top of the `main` container. If your page includes breadcrumbs or a back link, place it below these, but above the `<h1>`.
 
-{{ example({group: "components", item: "error-summary", example: "full-page-example", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "error-summary", example: "full-page-example", html: true, nunjucks: true, open: false, size: "s" }) }}

--- a/src/components/error-summary/linking-checkboxes-radios/index.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Linking from the error summary to checkboxes – Error summary
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}

--- a/src/components/error-summary/linking-checkboxes-radios/index.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/index.njk
@@ -49,4 +49,3 @@ layout: layout-example-form.njk
     }
   ]
 }) }}
-

--- a/src/components/error-summary/linking-multiple-fields/index.njk
+++ b/src/components/error-summary/linking-multiple-fields/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Linking from the error summary to an answer that uses multiple fields – Error summary
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/components/error-summary/linking/index.njk
+++ b/src/components/error-summary/linking/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Linking from the error summary to an answer that uses a single field – Error summary
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}

--- a/src/components/exit-this-page/default/index.njk
+++ b/src/components/exit-this-page/default/index.njk
@@ -5,4 +5,4 @@ layout: layout-example.njk
 
 {% from "govuk/components/exit-this-page/macro.njk" import govukExitThisPage %}
 
-{{govukExitThisPage()}}
+{{ govukExitThisPage() }}

--- a/src/components/exit-this-page/index.md
+++ b/src/components/exit-this-page/index.md
@@ -15,7 +15,7 @@ Give users a way to quickly and safely exit a service, website or application.
 
 For service journeys, you must use this component with the pattern to help a user [Exit a page quickly](/patterns/exit-a-page-quickly/).
 
-{{ example({group: "components", item: "exit-this-page", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: "exit-this-page", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -61,7 +61,7 @@ Add the code for the 'secondary link' into the layout file of your service. The 
 
 When the user interacts with the 'secondary link', it will perform the same action as pressing the button to activate Exit this Page.
 
-{{ example({group: "components", item: "exit-this-page", example: "secondary-link", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "exit-this-page", example: "secondary-link", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 The `href` for the 'secondary link' should be the same as the URL used for the button.
 

--- a/src/components/fieldset/address-group/index.njk
+++ b/src/components/fieldset/address-group/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Address group – Fieldset
-layout: layout-example.njk
+layout: layout-example-form.njk
 stylesheets:
 - address-wrapper.css
 ---

--- a/src/components/fieldset/default/index.njk
+++ b/src/components/fieldset/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Fieldset
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}

--- a/src/components/fieldset/index.md
+++ b/src/components/fieldset/index.md
@@ -15,7 +15,7 @@ Use the fieldset component to group related form inputs.
 
 Use the fieldset component when you need to show a relationship between multiple form inputs. For example, you may need to group a set of text inputs into a single fieldset when [asking for an address](/patterns/addresses/).
 
-{{ example({group: "components", item: "fieldset", example: "address-group", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
+{{ example({ group: "components", item: "fieldset", example: "address-group", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
 
 If you’re using the examples or macros for [radios](/components/radios/), [checkboxes](/components/checkboxes/) or [date input](/components/date-input/), the fieldset will already be included.
 
@@ -27,7 +27,7 @@ If you’re asking just [one question per page](/patterns/question-pages/#start-
 
 Read more about [why and how to set legends as headings](/get-started/labels-legends-headings/).
 
-{{ example({group: "components", item: "fieldset", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "fieldset", example: "default", html: true, nunjucks: true, open: false }) }}
 
 On [question pages](/patterns/question-pages/) containing a group of inputs, including the question as the legend helps users of screen readers to understand that the inputs are all related to that&nbsp;question.
 

--- a/src/components/file-upload/default/index.njk
+++ b/src/components/file-upload/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: File upload
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}

--- a/src/components/file-upload/error/index.njk
+++ b/src/components/file-upload/error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Error – File upload
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}

--- a/src/components/file-upload/index.md
+++ b/src/components/file-upload/index.md
@@ -13,7 +13,7 @@ This guidance is for government teams that build online services. [To find infor
 
 Help users select and upload a file.
 
-{{ example({group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -23,13 +23,13 @@ You should only ask users to upload something if it’s critical to the delivery
 
 There are 2 ways to use the file upload component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### Error messages
 
 Error messages should be styled like this:
 
-{{ example({group: "components", item: "file-upload", example: "error", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "file-upload", example: "error", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 The footer provides copyright, licensing and other information about your service.
 
-{{ example({group: "components", item: "footer", example: "default", id: "default-1", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: "footer", example: "default", id: "default-1", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 If you use the page template, you'll also get the footer without having to add it, as it's included by default. However, if you want to customise the default footer, read the [page template guidance about customising components](/styles/page-template/#changing-template-content).
 
@@ -27,11 +27,11 @@ Make it clear whether content is available for re-use - and if it is, under what
 
 ### Footer without links
 
-{{ example({group: "components", item: "footer", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "footer", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
 
 ### Footer with links
 
-{{ example({group: "components", item: "footer", example: "with-meta", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "footer", example: "with-meta", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ## Adding links
 
@@ -51,8 +51,8 @@ Only add secondary GOV.UK navigation if you’re creating a GOV.UK service, and 
 
 ### Footer with secondary navigation
 
-{{ example({group: "components", item: "footer", example: "with-navigation", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "components", item: "footer", example: "with-navigation", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 ### Footer with links and secondary navigation
 
-{{ example({group: "components", item: "footer", example: "full", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "components", item: "footer", example: "full", html: true, nunjucks: true, open: false, size: "xl" }) }}

--- a/src/components/header/default/index.njk
+++ b/src/components/header/default/index.njk
@@ -2,6 +2,7 @@
 title: Header
 layout: layout-example.njk
 ---
+
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 
 {{ govukHeader({

--- a/src/components/header/index.md
+++ b/src/components/header/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 The GOV.UK header shows users that they are on GOV.UK and which service they are using.
 
-{{ example({group: "components", item: "header", example: "default", id: "default-1", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "header", example: "default", id: "default-1", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 If you use the page template, you'll also get the header without having to add it, as it's included by default. However, if you want to customise the default header, read the [page template guidance about customising components](/styles/page-template/#changing-template-content).
 
@@ -32,16 +32,16 @@ You must not use the GOV.UK header if your service is not being hosted on one of
 
 Use the default header if your service has 5 pages or fewer.
 
-{{ example({group: "components", item: "header", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "header", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### Header with service name
 
 Use the header with a service name if your service is more than 5 pages long - this can help users understand which service they are using.
 
-{{ example({group: "components", item: "header", example: "with-service-name", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "header", example: "with-service-name", html: true, nunjucks: true, open: false }) }}
 
 ### Header with service name and navigation
 
 Use the header with navigation if you need to include basic navigation, contact or account management links.
 
-{{ example({group: "components", item: "header", example: "with-service-name-and-navigation", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "header", example: "with-service-name-and-navigation", html: true, nunjucks: true, open: false, size: "s" }) }}

--- a/src/components/header/with-service-name-and-navigation/index.njk
+++ b/src/components/header/with-service-name-and-navigation/index.njk
@@ -2,6 +2,7 @@
 title: Header with service name and navigation – Header
 layout: layout-example.njk
 ---
+
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 
 {{ govukHeader({

--- a/src/components/header/with-service-name/index.njk
+++ b/src/components/header/with-service-name/index.njk
@@ -2,6 +2,7 @@
 title: Header with service name – Header
 layout: layout-example.njk
 ---
+
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 
 {{ govukHeader({

--- a/src/components/inset-text/index.md
+++ b/src/components/inset-text/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -31,4 +31,4 @@ Use inset text very sparingly - it’s less effective if it’s overused.
 
 There are 2 ways to use the inset text component. You can use HTML or, if you’re using Nunjucks or the GOV.UK Prototype Kit, you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}

--- a/src/components/notification-banner/index.md
+++ b/src/components/notification-banner/index.md
@@ -13,7 +13,7 @@ statusMessage: This component is currently experimental because <a class="govuk-
 
 Use a notification banner to tell the user about something they need to know about, but that’s not directly related to the page content.
 
-{{ example({group: "components", item: "notification-banner", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: "notification-banner", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -57,7 +57,7 @@ For example:
 - in a service that lets the user register or apply for something, they might need to know that it’s taking longer than usual to process applications because of an emergency
 - in an account-type service, the user might need to know that the service will be down for scheduled maintenance
 
-{{ example({group: "components", item: "notification-banner", example: "whole-service", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "notification-banner", example: "whole-service", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 If your service is on GOV.UK and it’s affected by an emergency, ask your department’s content team to [request a change to the service start page](https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#change-govuk-content).
 If your service is getting more demand than usual, check that you’ve set up [There is a problem with the service pages](/patterns/problem-with-the-service-pages/) and [Service unavailable pages](/patterns/service-unavailable-pages/), and the wording is up to date.
@@ -69,7 +69,7 @@ Use a ‘neutral’ notification banner if the user needs to know about somethin
 - in a case working system, the user might need to know that there are new cases waiting for their attention
 - in an account-type service, you might need to tell the user that there’s a deadline approaching or that a payment is overdue
 
-{{ example({group: "components", item: "notification-banner", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "notification-banner", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 ## Reacting to something the user has done
 
@@ -79,7 +79,7 @@ Using a notification banner is unlikely to be the right approach in a linear ser
 
 Use the green version of the notification banner to confirm that something they’re expecting to happen has happened.
 
-{{ example({group: "components", item: "notification-banner", example: "success", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "notification-banner", example: "success", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 Since you’re using the notification banner to tell the user about the outcome of something they’ve just done, add `role="alert"` so focus shifts to the notification banner on page load.
 

--- a/src/components/pagination/index.md
+++ b/src/components/pagination/index.md
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Help users navigate forwards and backwards through a series of pages. For example, search results or guidance that's divided into multiple website pages — like [the GOV.UK mainstream guide format](https://prototype-kit.service.gov.uk/docs/templates/mainstream-guide).
 
-{{ example({group: "components", item: "pagination", example: "default", html: true, nunjucks: true, loading: "eager" }) }}
+{{ example({ group: "components", item: "pagination", example: "default", html: true, nunjucks: true, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -44,13 +44,13 @@ Use the 'block' style of pagination to let users navigate through related conten
 
 You can use link labels to give context on what the neighbouring pages are about.
 
-{{ example({group: "components", item: "pagination", example: "for-content-pages", html: true, nunjucks: true }) }}
+{{ example({ group: "components", item: "pagination", example: "for-content-pages", html: true, nunjucks: true }) }}
 
 ## For navigating between pages of items
 
 Use a list-type layout if users need to navigate through pages of similar items. For example, a list of search results or a list of cases in a case working system.
 
-{{ example({group: "components", item: "pagination", example: "for-list-pages", html: true, nunjucks: true }) }}
+{{ example({ group: "components", item: "pagination", example: "for-list-pages", html: true, nunjucks: true }) }}
 
 Show the page number in the page `<title>` so that screen reader users know they’ve navigated to a different page. For example, 'Search results (page 1 of 4)'.
 
@@ -83,9 +83,9 @@ Use ellipses (…) to replace any skipped pages. For example:
 
 Do not show the previous page link on the first page — and do not show the next page link on the last page.
 
-{{ example({group: "components", item: "pagination", example: "first-page", html: true, nunjucks: true }) }}
+{{ example({ group: "components", item: "pagination", example: "first-page", html: true, nunjucks: true }) }}
 
-{{ example({group: "components", item: "pagination", example: "last-page", html: true, nunjucks: true }) }}
+{{ example({ group: "components", item: "pagination", example: "last-page", html: true, nunjucks: true }) }}
 
 ### Filtering and sorting
 

--- a/src/components/panel/index.md
+++ b/src/components/panel/index.md
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 The panel component is a visible container used on confirmation or results pages to highlight important content.
 
-{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -27,7 +27,7 @@ Never use the panel component to highlight important information within body con
 
 There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
 
 ### How to write heading text
 

--- a/src/components/phase-banner/beta/index.njk
+++ b/src/components/phase-banner/beta/index.njk
@@ -4,6 +4,7 @@ layout: layout-example.njk
 ---
 
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
 {{ govukPhaseBanner({
   tag: {
     text: "Beta"

--- a/src/components/phase-banner/default/index.njk
+++ b/src/components/phase-banner/default/index.njk
@@ -4,6 +4,7 @@ layout: layout-example.njk
 ---
 
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
 {{ govukPhaseBanner({
   tag: {
     text: "Alpha"

--- a/src/components/phase-banner/index.md
+++ b/src/components/phase-banner/index.md
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use the phase banner component to show users your service is still being worked on.
 
-{{ example({group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -25,9 +25,9 @@ Your banner must be directly under the black GOV.UK header and colour bar.
 
 There are 2 ways to use the phase banner component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
-{{ example({group: "components", item: "phase-banner", example: "beta", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "phase-banner", example: "beta", html: true, nunjucks: true, open: false }) }}
 
 ### Add a feedback link
 

--- a/src/components/radios/conditional-reveal-error/index.njk
+++ b/src/components/radios/conditional-reveal-error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Radios with conditionally revealing content showing an error – Radios
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Radios with conditionally revealing content – Radios
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/radios/default/index.njk
+++ b/src/components/radios/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Radios
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/radios/divider/index.njk
+++ b/src/components/radios/divider/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Radios with a text divider – Radios
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/radios/error/index.njk
+++ b/src/components/radios/error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Inline radios with error – Radios
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/radios/error/index.njk
+++ b/src/components/radios/error/index.njk
@@ -36,4 +36,3 @@ layout: layout-example-form.njk
     text: "Select the country where you live"
   }
 }) }}
-

--- a/src/components/radios/hint/index.njk
+++ b/src/components/radios/hint/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Radio items with hint – Radios
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/radios/index.md
+++ b/src/components/radios/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -50,13 +50,13 @@ Read more about [why and how to set legends as headings](/get-started/labels-leg
 
 There are 2 ways to use the radios component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 ### If you’re asking more than one question on the page
 
 If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking multiple questions on question pages](/patterns/question-pages/#asking-multiple-questions-on-a-page).
 
-{{ example({group: "components", item: "radios", example: "without-heading", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "radios", example: "without-heading", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Inline radios
 
@@ -69,19 +69,19 @@ Only use inline radios when:
 
 Remember that on small screens such as mobile devices, the radios will still be 'stacked' on top of one another (vertically).
 
-{{ example({group: "components", item: "radios", example: "inline", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "radios", example: "inline", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Radio items with hints
 
 You can add hints to radio items to provide additional information about the options.
 
-{{ example({group: "components", item: "radios", example: "hint", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "radios", example: "hint", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Radio items with a text divider
 
 If one or more of your radio options is different from the others, it can help users if you separate them using a text divider. The text is usually the word ‘or’.
 
-{{ example({group: "components", item: "radios", example: "divider", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "radios", example: "divider", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Conditionally revealing a related question
 
@@ -89,7 +89,7 @@ You can ask the user a related question when they select a particular radio opti
 
 This might make two related questions easier to answer by grouping them on the same page. For example, you could reveal a phone number input when the user selects the 'Contact me by phone' option.
 
-{{ example({group: "components", item: "radios", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "components", item: "radios", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 Keep it simple. If the related question is complicated or has more than one part, show it on the next page in the process instead.
 
@@ -111,7 +111,7 @@ Use standard-sized radios in nearly all cases. However, smaller versions work we
 
 For example, on a page of search results, the primary user need is to see the results. Using smaller radios lets users see and change search filters without distracting them from the main content.
 
-{{ example({group: "components", item: "radios", example: "small", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "radios", example: "small", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 Small radios can work well on information dense screens in services designed for repeat use, like caseworking systems.
 
@@ -126,7 +126,7 @@ Display an error message if the user has not:
 
 Error messages should be styled like this:
 
-{{ example({group: "components", item: "radios", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "radios", example: "error", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
@@ -146,7 +146,7 @@ Say ‘Select [whatever it is]’. For example, ‘Select the day of the week yo
 
 Include an [error message](/components/error-message/) that is clearly related to the initial question.
 
-{{ example({group: "components", item: "radios", example: "conditional-reveal-error", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "radios", example: "conditional-reveal-error", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ## Research on this component
 

--- a/src/components/radios/inline/index.njk
+++ b/src/components/radios/inline/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Inline radios – Radios
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/radios/small/index.njk
+++ b/src/components/radios/small/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Small radios – Radios
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/radios/without-heading/index.njk
+++ b/src/components/radios/without-heading/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Radios without a heading – Radios
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/components/radios/without-heading/index.njk
+++ b/src/components/radios/without-heading/index.njk
@@ -31,4 +31,3 @@ layout: layout-example-form.njk
     }
   ]
 }) }}
-

--- a/src/components/select/default/index.njk
+++ b/src/components/select/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Select
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/select/macro.njk" import govukSelect %}

--- a/src/components/select/error/index.njk
+++ b/src/components/select/error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Select with error – Select
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/select/macro.njk" import govukSelect %}

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -29,13 +29,13 @@ If you use the component for questions, you should not pre-select any of the opt
 
 There are 2 ways to use the select component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### Select with hint
 
 You can add hint text to help the user understand the options and choose one of them.
 
-{{ example({group: "components", item: "select", example: "with-hint", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "select", example: "with-hint", html: true, nunjucks: true, open: false }) }}
 
 ### Error messages
 
@@ -43,7 +43,7 @@ Display an error message if the user has not selected an option.
 
 Style error messages as shown in the example:
 
-{{ example({group: "components", item: "select", example: "error", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: "select", example: "error", html: true, nunjucks: true, open: false }) }}
 
 ## Research on this component
 

--- a/src/components/select/with-hint/index.njk
+++ b/src/components/select/with-hint/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Select with hint – Select
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/select/macro.njk" import govukSelect %}

--- a/src/components/skip-link/default/index.njk
+++ b/src/components/skip-link/default/index.njk
@@ -2,6 +2,7 @@
 title: Skip link
 layout: layout-example.njk
 ---
+
 <p class="govuk-body">To view the skip link component tab to this example, or click inside this example and press tab.</p>
 
 {% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}

--- a/src/components/skip-link/index.md
+++ b/src/components/skip-link/index.md
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use the skip link component to help keyboard-only users skip to the main content on a page.
 
-{{ example({group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 If you use the page template, you'll also get the skip link without having to add it, as it's included by default. However, if you want to customise the default skip link, read the [page template guidance about customising components](/styles/page-template/#changing-template-content).
 
@@ -31,4 +31,4 @@ The skip link component is visually hidden until a keyboard press activates it.
 
 There are 2 ways to use the skip link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}

--- a/src/components/summary-list/index.md
+++ b/src/components/summary-list/index.md
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use a summary list to summarise information, for example, a user’s responses at the end of a form.
 
-{{ example({group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -38,7 +38,7 @@ You can show a single or multiple summary lists on a page. If you’re showing m
 
 There are 2 ways to use the summary list component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "summary-list", example: "without-actions", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "summary-list", example: "without-actions", html: true, nunjucks: true, open: false }) }}
 
 ### Adding actions to each row
 
@@ -50,11 +50,11 @@ Assistive technology users, including those who use a screen reader, might hear 
 
 To give more context, add visually hidden text to the links. This means a screen reader user will hear the row action and the ‘key’ label for the information it will affect, like ‘Change name’ or ‘Change date of birth’.
 
-{{ example({group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 If you’re showing a mix of rows (where some rows include actions and some do not), add the `govuk-summary-list__row--no-actions` modifier class to the rows without actions. This is to ensure the bottom border is drawn correctly in some browsers.
 
-{{ example({group: "components", item: "summary-list", example: "mixed-actions", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "summary-list", example: "mixed-actions", html: true, nunjucks: true, open: false }) }}
 
 ### Removing the borders
 
@@ -64,21 +64,20 @@ Think carefully before you remove row borders. Borders help many users find and 
 
 If your summary list does not have any actions, you can choose to remove the separating borders with the `govuk-summary-list--no-border` class.
 
-{{ example({group: "components", item: "summary-list", example: "without-borders", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "summary-list", example: "without-borders", html: true, nunjucks: true, open: false }) }}
 
 To remove borders on a single row, use the `govuk-summary-list__row--no-border` class.
 
 ### Showing missing information
 
-In some contexts, you might need to show rows that have missing information. This can happen when: 
+In some contexts, you might need to show rows that have missing information. This can happen when:
 
 - a user returns to an incomplete journey
 - you've added or changed the questions in a service.
 
 Show a link to the appropriate question page in the `value` column so the user can enter the missing information, instead of showing a 'change' link on that row.
 
-{{ example({group: "components", item: "summary-list", example: "with-missing-information", html: true, nunjucks: true, open: false}) }}
-
+{{ example({ group: "components", item: "summary-list", example: "with-missing-information", html: true, nunjucks: true, open: false }) }}
 
 ## Summary cards
 
@@ -103,7 +102,7 @@ Each title must be unique and help identify what the summary list describes. For
 
 Try to keep titles short and relevant. You can use one or two important values in the summary list — such as the first and last name of a person.
 
-{{ example({group: "components", item: "summary-list", example: "card-with-title", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "summary-list", example: "card-with-title", html: true, nunjucks: true, open: false }) }}
 
 ### Adding card actions
 
@@ -127,7 +126,7 @@ Keep it short and do not add more than 2 to 3 actions in a header.
 
 If a card action cannot easily be undone or might have serious consequences, consider adding a warning or asking the user for confirmation.
 
-{{ example({group: "components", item: "summary-list", example: "card-with-actions", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "summary-list", example: "card-with-actions", html: true, nunjucks: true, open: false }) }}
 
 ## Research on this component
 

--- a/src/components/table/index.md
+++ b/src/components/table/index.md
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use the table component to make information easier to compare and scan for users.
 
-{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -29,7 +29,7 @@ Use the `<caption>` element to describe a table in the same way you would use a 
 
 There are other styling options for table captions. You can use `govuk-table__caption--s`, `govuk-table__caption--m`, `govuk-table__caption--l` and `govuk-table__caption--xl` classes to make them larger or smaller from the default.
 
-{{ example({group: "components", item: "table", example: "caption-l", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "table", example: "caption-l", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ### Table headers
 
@@ -37,22 +37,22 @@ Use table headers to tell users what the rows and columns represent. Use the `sc
 
 There are 2 ways to use the table component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
 
 ## Numbers in a table
 
 When comparing columns of numbers, align the numbers to the right in table cells.
 
-{{ example({group: "components", item: "table", example: "numbers", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "table", example: "numbers", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ## Custom column widths
 
 You can use the [width override classes](/styles/layout/#width-override-classes) to set the width of table columns.
 
-{{ example({group: "components", item: "table", example: "column-widths", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "table", example: "column-widths", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 If the [width override classes](/styles/layout/#width-override-classes) do not meet your needs you can create your own width classes and apply them to the cells in the table head. These can be added using the `classes` option in the Nunjucks macro or adding the class directly to the individual cells within `govuk-table__head` as below.
 
 To learn more about this, read guidance on [extending and modifying components in production](/get-started/extending-and-modifying-components/).
 
-{{ example({group: "components", item: "table", example: "column-widths-custom-classes", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "table", example: "column-widths-custom-classes", html: true, nunjucks: true, open: false, size: "m" }) }}

--- a/src/components/tabs/index.md
+++ b/src/components/tabs/index.md
@@ -13,7 +13,7 @@ statusMessage: This component is currently experimental because <a class="govuk-
 
 The tabs component lets users navigate between related sections of content, displaying one section at a time.
 
-{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
+{{ example({ group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -58,7 +58,7 @@ If you decide to use one of these components, consider if:
 
 There are 2 ways to use the tabs component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false, size: "xl", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false, size: "xl", titleSuffix: "second" }) }}
 
 The tabs component uses JavaScript. When JavaScript is not available, users will see the tabbed content on a single page, in order from first to last, with a table of contents that links to each of the sections.
 

--- a/src/components/tag/index.md
+++ b/src/components/tag/index.md
@@ -11,7 +11,7 @@ layout: layout-pane.njk
 
 Use the tag component to show users the status of something.
 
-{{ example({group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -31,13 +31,13 @@ The [task list pattern](/patterns/task-list-pages/) has an example of how to sho
 
 Or it can make sense to have two statuses. For example you may find that there’s a need to have one tag for ‘Active’ users and one for ‘Inactive’ users.
 
-{{ example({group: "components", item: "tag", example: "multiple-tags", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: "tag", example: "multiple-tags", html: true, nunjucks: true, open: false }) }}
 
 ## Showing multiple statuses
 
 Tags should be helpful to users. The more you add, the harder it is for users to remember them. So start with the smallest number of statuses you think might work, then add more if your user research shows there’s a need for them.
 
-{{ example({group: "components", item: "tag", example: "coloured-tags", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: "tag", example: "coloured-tags", html: true, nunjucks: true, open: false }) }}
 
 ## Using colour with tags
 
@@ -51,7 +51,7 @@ Because tags with solid colours tend to stand out more, it’s usually best to a
 
 If you need more tag colours, you can use the following tints.
 
-{{ example({group: "components", item: "tag", example: "all-colours", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: "tag", example: "all-colours", html: true, nunjucks: true, open: false }) }}
 
 ## Research on this component
 

--- a/src/components/text-input/code-sequence/index.njk
+++ b/src/components/text-input/code-sequence/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Example of a text input asking for a code or sequence – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/decimal-input/index.njk
+++ b/src/components/text-input/decimal-input/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Example of an input asking for numbers with decimal places – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/default/index.njk
+++ b/src/components/text-input/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/error/index.njk
+++ b/src/components/text-input/error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Text input with errors – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/index.md
+++ b/src/components/text-input/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -41,13 +41,13 @@ Read more about [why and how to set legends as headings](/get-started/labels-leg
 
 There are 2 ways to use the text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 ### If you’re asking more than one question on the page
 
 If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking multiple questions on question pages](/patterns/question-pages/#asking-multiple-questions-on-a-page).
 
-{{ example({group: "components", item: "text-input", example: "without-heading", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "text-input", example: "without-heading", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Use appropriately-sized text inputs
 
@@ -65,7 +65,7 @@ The widths are designed for specific character lengths and to be consistent acro
 
 On fixed width inputs, the width will remain fixed on all screens unless it is wider than the viewport, in which case it will shrink to fit.
 
-{{ example({group: "components", item: "text-input", example: "input-fixed-width", html: true, nunjucks: true, open: false, size: "l"}) }}
+{{ example({ group: "components", item: "text-input", example: "input-fixed-width", html: true, nunjucks: true, open: false, size: "l" }) }}
 
 #### Fluid width inputs
 
@@ -73,13 +73,13 @@ Use the width override classes to reduce the width of an input in relation to it
 
 Fluid width inputs will resize with the viewport.
 
-{{ example({group: "components", item: "text-input", example: "input-fluid-width", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "components", item: "text-input", example: "input-fluid-width", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 ### Hint text
 
 Use hint text for help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
-{{ example({group: "components", item: "text-input", example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "components", item: "text-input", example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 #### When not to use hint text
 
@@ -97,7 +97,7 @@ If you're asking the user to enter a whole number, set the `inputmode` attribute
 
 See how to do this by opening the HTML and Nunjucks tabs in this example:
 
-{{ example({group: "components", item: "text-input", example: "number-input", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "text-input", example: "number-input", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 There is specific guidance on how to ask for:
 
@@ -110,7 +110,7 @@ If you're asking the user to enter a number that might include decimal places, u
 
 Do not set the `inputmode` attribute to `decimal` as it causes some devices to bring up a keypad without a key for the decimal separator.
 
-{{ example({group: "components", item: "text-input", example: "decimal-input", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "text-input", example: "decimal-input", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 #### Avoid using inputs with a type of number
 
@@ -122,7 +122,7 @@ Help the user visually check the code they've typed is correct by styling the in
 
 You do not need to do this for memorable information, such as phone numbers and postcodes.
 
-{{ example({group: "components", item: "text-input", example: "code-sequence", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "components", item: "text-input", example: "code-sequence", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 There is specific guidance on how to:
 
@@ -134,7 +134,7 @@ There is specific guidance on how to:
 
 Use prefixes and suffixes to help users enter things like currencies and measurements.
 
-{{ example({group: "components", item: "text-input", example: "input-prefix-suffix", html: true, nunjucks: true, closed: true, size: "s"}) }}
+{{ example({ group: "components", item: "text-input", example: "input-prefix-suffix", html: true, nunjucks: true, closed: true, size: "s" }) }}
 
 Prefixes and suffixes are useful when there's a commonly understood symbol or abbreviation for the type of information you're asking for. Do not rely on prefixes or suffixes alone, because screen readers will not read them out.
 
@@ -146,11 +146,11 @@ Some users may miss that the input already has a suffix or prefix, and enter a p
 
 #### Text inputs with a prefix
 
-{{ example({group: "components", item: "text-input", example: "input-prefix", html: true, nunjucks: true, closed: true, size: "s"}) }}
+{{ example({ group: "components", item: "text-input", example: "input-prefix", html: true, nunjucks: true, closed: true, size: "s" }) }}
 
 #### Text inputs with a suffix
 
-{{ example({group: "components", item: "text-input", example: "input-suffix", html: true, nunjucks: true, closed: true, size: "s"}) }}
+{{ example({ group: "components", item: "text-input", example: "input-suffix", html: true, nunjucks: true, closed: true, size: "s" }) }}
 
 ### Use the autocomplete attribute
 
@@ -158,7 +158,7 @@ Use the `autocomplete` attribute on text inputs to help users complete forms mor
 
 For example, to enable autofill on a postcode field, set the `autocomplete` attribute to `postal-code`. See how to do this in the HTML and Nunjucks tabs in the following example.
 
-{{ example({group: "components", item: "text-input", example: "input-autocomplete-attribute", displayExample: false, html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({ group: "components", item: "text-input", example: "input-autocomplete-attribute", displayExample: false, html: true, nunjucks: true, open: true, size: "s" }) }}
 
 If you are working in production and there is a relevant [input purpose](https://www.w3.org/TR/WCAG21/#input-purposes), you'll need to use the `autocomplete` attribute to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
 
@@ -186,7 +186,7 @@ If you are asking users for information which is not appropriate to spellcheck, 
 
 To do this set the `spellcheck` attribute to `false` as shown in this example.
 
-{{ example({group: "components", item: "text-input", example: "input-spellcheck-disabled", html: true, nunjucks: true, displayExample: false, open: true, size: "s"}) }}
+{{ example({ group: "components", item: "text-input", example: "input-spellcheck-disabled", html: true, nunjucks: true, displayExample: false, open: true, size: "s" }) }}
 
 Browsers do not consistently spellcheck user’s input by default. If you are asking a question where spellcheck would be useful, set the `spellcheck` attribute to `true`.
 
@@ -194,11 +194,11 @@ Browsers do not consistently spellcheck user’s input by default. If you are as
 
 Error messages should be styled like this:
 
-{{ example({group: "components", item: "text-input", example: "error", html: true, nunjucks: true, closed: true, size: "s"}) }}
+{{ example({ group: "components", item: "text-input", example: "error", html: true, nunjucks: true, closed: true, size: "s" }) }}
 
 #### If the input has a prefix or a suffix
 
-{{ example({group: "components", item: "text-input", example: "input-prefix-suffix-error", html: true, nunjucks: true, closed: true, size: "s"}) }}
+{{ example({ group: "components", item: "text-input", example: "input-prefix-suffix-error", html: true, nunjucks: true, closed: true, size: "s" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/components/text-input/input-autocomplete-attribute/index.njk
+++ b/src/components/text-input/input-autocomplete-attribute/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Text input with autocomplete attribute – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-fixed-width/index.njk
+++ b/src/components/text-input/input-fixed-width/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Fixed width inputs – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-fluid-width/index.njk
+++ b/src/components/text-input/input-fluid-width/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Fluid width inputs – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-hint-text/index.njk
+++ b/src/components/text-input/input-hint-text/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Hint text – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-prefix-suffix-error/index.njk
+++ b/src/components/text-input/input-prefix-suffix-error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Text input with prefix and suffix with error – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-prefix-suffix/index.njk
+++ b/src/components/text-input/input-prefix-suffix/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Text input with prefix and suffix – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-prefix/index.njk
+++ b/src/components/text-input/input-prefix/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Text input with prefix – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-spellcheck-disabled/index.njk
+++ b/src/components/text-input/input-spellcheck-disabled/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Text input with spellcheck disabled – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/input-suffix/index.njk
+++ b/src/components/text-input/input-suffix/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Text input with suffix – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/number-input/index.njk
+++ b/src/components/text-input/number-input/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Number input – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/text-input/without-heading/index.njk
+++ b/src/components/text-input/without-heading/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Text input without a heading – Text input
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/components/textarea/default/index.njk
+++ b/src/components/textarea/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Textarea
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 

--- a/src/components/textarea/default/index.njk
+++ b/src/components/textarea/default/index.njk
@@ -2,6 +2,7 @@
 title: Textarea
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {{ govukTextarea({

--- a/src/components/textarea/error/index.njk
+++ b/src/components/textarea/error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Textarea with error – Textarea
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 

--- a/src/components/textarea/error/index.njk
+++ b/src/components/textarea/error/index.njk
@@ -2,6 +2,7 @@
 title: Textarea with error – Textarea
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {{ govukTextarea({

--- a/src/components/textarea/index.md
+++ b/src/components/textarea/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -31,13 +31,13 @@ Labels must be aligned above the textarea they refer to. They should be short, d
 
 There are 2 ways to use the textarea component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
 
 ### Use appropriately-sized textareas
 
 Make the height of a textarea proportional to the amount of text you expect users to enter. You can set the height of a textarea by by specifying the `rows` attribute.
 
-{{ example({group: "components", item: "textarea", example: "specifying-rows", html: true, nunjucks: true, open: false, size: "l"}) }}
+{{ example({ group: "components", item: "textarea", example: "specifying-rows", html: true, nunjucks: true, open: false, size: "l" }) }}
 
 ### Do not disable copy and paste
 
@@ -47,7 +47,7 @@ Users will often need to copy and paste information into a textarea, so do not s
 
 If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking multiple questions on question pages](/patterns/question-pages/#asking-multiple-questions-on-a-page).
 
-{{ example({group: "components", item: "textarea", example: "without-heading", html: true, nunjucks: true, open: false, size: "l"}) }}
+{{ example({ group: "components", item: "textarea", example: "without-heading", html: true, nunjucks: true, open: false, size: "l" }) }}
 
 ### Limiting the number of characters
 
@@ -57,7 +57,7 @@ If there’s a good reason to limit the number of characters users can enter, yo
 
 Error messages should be styled like this:
 
-{{ example({group: "components", item: "textarea", example: "error", html: true, nunjucks: true, open: false, size: "l"}) }}
+{{ example({ group: "components", item: "textarea", example: "error", html: true, nunjucks: true, open: false, size: "l" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/components/textarea/specifying-rows/index.njk
+++ b/src/components/textarea/specifying-rows/index.njk
@@ -2,6 +2,7 @@
 title: Textarea appropriately-sized with rows – Textarea
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {{ govukTextarea({

--- a/src/components/textarea/specifying-rows/index.njk
+++ b/src/components/textarea/specifying-rows/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Textarea appropriately-sized with rows – Textarea
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 

--- a/src/components/textarea/without-heading/index.njk
+++ b/src/components/textarea/without-heading/index.njk
@@ -2,6 +2,7 @@
 title: Textarea without a heading – Textarea
 layout: layout-example-form.njk
 ---
+
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {{ govukTextarea({

--- a/src/components/textarea/without-heading/index.njk
+++ b/src/components/textarea/without-heading/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Textarea without a heading – Textarea
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 

--- a/src/components/warning-text/index.md
+++ b/src/components/warning-text/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -19,6 +19,6 @@ Use the warning text component when you need to warn users about something impor
 
 There are 2 ways to use the warning text component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second"}) }}
+{{ example({ group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 You might need to rewrite the hidden text (‘Warning’ in the example) to make it appropriate for your context.

--- a/src/get-started/labels-legends-headings/index.md
+++ b/src/get-started/labels-legends-headings/index.md
@@ -33,7 +33,7 @@ To set the contents of a label as the page heading, you need to put the `<label>
 
 You then need to apply classes to the `<label>` to make it look like a heading.
 
-{{ example({group: "get-started", item: "labels-legends-headings", example: "label-h1", html: true, nunjucks: true, open: false, loading: "eager"}) }}
+{{ example({ group: "get-started", item: "labels-legends-headings", example: "label-h1", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## Legends as page headings
 
@@ -41,7 +41,7 @@ To set the contents of a legend as the page heading, you need to put the `<legen
 
 As with labels, you also need to apply classes to the `<legend>` to make it look like a heading.
 
-{{ example({group: "get-started", item: "labels-legends-headings", example: "legend-h1", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "get-started", item: "labels-legends-headings", example: "legend-h1", html: true, nunjucks: true, open: false }) }}
 
 ## Styling options for labels and legends
 
@@ -49,8 +49,8 @@ Instead of styling them as page headings, you can apply other classes to legends
 
 ### Styling labels
 
-{{ example({group: "get-started", item: "labels-legends-headings", example: "label-m-s", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "get-started", item: "labels-legends-headings", example: "label-m-s", html: true, nunjucks: true, open: false }) }}
 
 ### Styling legends
 
-{{ example({group: "get-started", item: "labels-legends-headings", example: "legend-m-s", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "get-started", item: "labels-legends-headings", example: "legend-m-s", html: true, nunjucks: true, open: false }) }}

--- a/src/get-started/labels-legends-headings/label-h1/index.njk
+++ b/src/get-started/labels-legends-headings/label-h1/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Labels as page headings – Making labels and legends headings
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/get-started/labels-legends-headings/label-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/label-m-s/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Styling labels – Making labels and legends headings
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 

--- a/src/get-started/labels-legends-headings/label-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/label-m-s/index.njk
@@ -3,7 +3,6 @@ title: Styling labels – Making labels and legends headings
 layout: layout-example-form.njk
 ---
 
-
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {{ govukInput({

--- a/src/get-started/labels-legends-headings/legend-h1/index.njk
+++ b/src/get-started/labels-legends-headings/legend-h1/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Legends as page headings – Making labels and legends headings
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/src/get-started/labels-legends-headings/legend-h1/index.njk
+++ b/src/get-started/labels-legends-headings/legend-h1/index.njk
@@ -32,4 +32,3 @@ layout: layout-example-form.njk
     }
   ]
 }) }}
-

--- a/src/get-started/labels-legends-headings/legend-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/legend-m-s/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Styling legends – Making labels and legends headings
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/src/get-started/production/index.md
+++ b/src/get-started/production/index.md
@@ -70,4 +70,4 @@ You can use them in your live application as either:
 
 You can get the code from the HTML or Nunjucks tabs below any examples:
 
-{{ example({group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false }) }}

--- a/src/get-started/production/index.md
+++ b/src/get-started/production/index.md
@@ -14,7 +14,7 @@ This guide explains how to set up your project so you can start using the styles
 
 {{ govukInsetText({
   classes: "app-table--constrained",
-  html: "If you’ve used GOV.UK Elements, GOV.UK Template or the GOV.UK Frontend Toolkit before, you might also find it useful to read the guide on <a href=\"/get-started/updating-your-code/\">updating your code</a>."
+  html: 'If you’ve used GOV.UK Elements, GOV.UK Template or the GOV.UK Frontend Toolkit before, you might also find it useful to read the guide on <a href="/get-started/updating-your-code/">updating your code</a>.'
 }) }}
 
 ## Include GOV.UK Frontend in your project

--- a/src/get-started/prototyping/index.md
+++ b/src/get-started/prototyping/index.md
@@ -33,7 +33,7 @@ There are 2 ways to use components in the Design System. You can either use HTML
 
 You can copy the code from the HTML or Nunjucks tabs below any examples:
 
-{{ example({group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false, loading: "eager"}) }}
+{{ example({ group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## Using Nunjucks macros
 

--- a/src/patterns/addresses/error-messages/index.njk
+++ b/src/patterns/addresses/error-messages/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Pattern error – Addresses
-layout: layout-example.njk
+layout: layout-example-form.njk
 stylesheets:
 - address-wrapper.css
 ---

--- a/src/patterns/addresses/error-postcode/index.njk
+++ b/src/patterns/addresses/error-postcode/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Postcode error – Addresses
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -8,9 +8,9 @@ backlogIssueId: 31
 layout: layout-pane.njk
 ---
 
-This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
-
 {% from "_example.njk" import example %}
+
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 Help users provide an address using one of the following:
 
@@ -20,7 +20,7 @@ Help users provide an address using one of the following:
 
 ## Multiple text inputs
 
-{{ example({group: "patterns", item: "addresses", example: "multiple", html: true, nunjucks: true, open: true, size: "xl", loading: "eager"}) }}
+{{ example({ group: "patterns", item: "addresses", example: "multiple", html: true, nunjucks: true, open: true, size: "xl", loading: "eager" }) }}
 
 ### When to use multiple text inputs
 
@@ -65,11 +65,11 @@ In production, you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.
 
 Error messages should be styled like this:
 
-{{ example({group: "patterns", item: "addresses", example: "error-messages", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "patterns", item: "addresses", example: "error-messages", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
-If a postcode entered is not a real postcode, use a message like this: 
+If a postcode entered is not a real postcode, use a message like this:
 
-{{ example({group: "patterns", item: "addresses", example: "error-postcode", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "patterns", item: "addresses", example: "error-postcode", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
@@ -108,7 +108,7 @@ You should let users enter postcodes that contain:
 
 ## Textarea
 
-{{ example({group: "patterns", item: "addresses", example: "textarea", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({ group: "patterns", item: "addresses", example: "textarea", html: true, nunjucks: true, open: true, size: "s" }) }}
 
 ### When to use textarea
 

--- a/src/patterns/addresses/multiple/index.njk
+++ b/src/patterns/addresses/multiple/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Multiple text inputs – Addresses
-layout: layout-example.njk
+layout: layout-example-form.njk
 stylesheets:
 - address-wrapper.css
 ---

--- a/src/patterns/addresses/textarea/index.njk
+++ b/src/patterns/addresses/textarea/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Textarea – Addresses
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 

--- a/src/patterns/addresses/textarea/index.njk
+++ b/src/patterns/addresses/textarea/index.njk
@@ -3,7 +3,6 @@ title: Textarea – Addresses
 layout: layout-example-form.njk
 ---
 
-
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {{ govukTextarea({

--- a/src/patterns/bank-details/branch/index.njk
+++ b/src/patterns/bank-details/branch/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Branch question – Bank details
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/bank-details/default/index.njk
+++ b/src/patterns/bank-details/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Bank details
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/bank-details/error/index.njk
+++ b/src/patterns/bank-details/error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Errors – Bank details
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/bank-details/index.md
+++ b/src/patterns/bank-details/index.md
@@ -10,11 +10,11 @@ status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#next-steps">more research</a> is needed to validate it.
 ---
 
-This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
-
 {% from "_example.njk" import example %}
 
-{{ example({group: "patterns", item: "bank-details", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager"}) }}
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
+
+{{ example({ group: "patterns", item: "bank-details", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
 
 ## When to use this pattern
 
@@ -56,7 +56,7 @@ Let users choose to get paid by an alternative method.
 
 Adapt this question depending on what payment options your users need and what your service can support.
 
-{{ example({group: "patterns", item: "bank-details", example: "branch", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "patterns", item: "bank-details", example: "branch", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 ### International bank account details
 
@@ -76,13 +76,13 @@ Only show the fields that relate to that country.
 
 Most countries need the IBAN and BIC, sometimes known as the SWIFT code.
 
-{{ example({group: "patterns", item: "bank-details", example: "international", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "patterns", item: "bank-details", example: "international", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 ### Error messages
 
 Error messages should be styled like this:
 
-{{ example({group: "patterns", item: "bank-details", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "patterns", item: "bank-details", example: "error", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/patterns/bank-details/international/index.njk
+++ b/src/patterns/bank-details/international/index.njk
@@ -1,6 +1,6 @@
 ---
 title: International bank account details – Bank details
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/check-answers/default/index.njk
+++ b/src/patterns/check-answers/default/index.njk
@@ -115,7 +115,6 @@ layout: layout-example-full-page.njk
         ]
       }) }}
 
-
       <h2 class="govuk-heading-m">Application details</h2>
 
       {{ govukSummaryList({

--- a/src/patterns/check-answers/index.md
+++ b/src/patterns/check-answers/index.md
@@ -12,7 +12,7 @@ layout: layout-pane.njk
 
 Let users check their answers before submitting information to a service.
 
-{{ example({group: "patterns", item: "check-answers", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager"}) }}
+{{ example({ group: "patterns", item: "check-answers", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
 
 ## When to use this pattern
 

--- a/src/patterns/confirm-a-phone-number/default/index.njk
+++ b/src/patterns/confirm-a-phone-number/default/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout-example.njk
+layout: layout-example-form.njk
 title: Confirm a phone number
 ---
 

--- a/src/patterns/confirm-a-phone-number/error-expired/index.njk
+++ b/src/patterns/confirm-a-phone-number/error-expired/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout-example.njk
+layout: layout-example-form.njk
 title: Error, security code expired – Confirm a phone number
 ---
 

--- a/src/patterns/confirm-a-phone-number/error-incorrect/index.njk
+++ b/src/patterns/confirm-a-phone-number/error-incorrect/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout-example.njk
+layout: layout-example-form.njk
 title: Error, incorrect security code – Confirm a phone number
 ---
 

--- a/src/patterns/confirm-a-phone-number/index.md
+++ b/src/patterns/confirm-a-phone-number/index.md
@@ -8,11 +8,12 @@ backlogIssueId: 25
 layout: layout-pane.njk
 ---
 
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "_example.njk" import example %}
 
 Check that a user has access to a specific mobile phone number using a security code sent by text message.
 
-{{ example({group: "patterns", item: "confirm-a-phone-number", example: "default", html: true, nunjucks: true, open: false, loading: "eager"}) }}
+{{ example({ group: "patterns", item: "confirm-a-phone-number", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this pattern
 
@@ -35,14 +36,13 @@ When the user creates an account, ask for their password and mobile phone number
 
 After saving the user’s password and mobile phone number, verify their mobile phone number by sending them a text message with a 5 digit code in this format:
 
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {{ govukInsetText({
   text: "12345 is your [service name] security code"
 }) }}
 
 Then ask the user to enter this code:
 
-{{ example({group: "patterns", item: "confirm-a-phone-number", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "confirm-a-phone-number", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false }) }}
 
 Let the user enter the code in whatever format is familiar to them. Allow additional spaces, hyphens and dashes.
 
@@ -55,7 +55,7 @@ If the user enters an expired code that was sent more than:
 
 If the user follows the ‘Not received a text message?’ link, allow them to check which mobile number they entered, and to change it if necessary. This prevents the user becoming stuck if they entered a mobile number incorrectly. Do not allow the user to change the number when they're signing in.
 
-{{ example({group: "patterns", item: "confirm-a-phone-number", example: "resend-first-time", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "confirm-a-phone-number", example: "resend-first-time", html: true, nunjucks: true, open: false }) }}
 
 When the user requests a new code, send them a new one. The new code should have its 15 minute time limit. The previous code should remain valid within its original time limit.
 
@@ -63,7 +63,6 @@ When the user requests a new code, send them a new one. The new code should have
 
 When the user returns to your service, verify their password first. Once they have entered this correctly, send a text message to their mobile phone with a 5 digit code in this format:
 
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {{ govukInsetText({
   text: "12345 is your [service name] security code"
 }) }}
@@ -72,7 +71,7 @@ Ask the user to enter this code. Use the same pattern and time limit as when cre
 
 If they follow the ‘Not received a text message?’ link, show them a page allowing them to request a new code. Do not reveal the mobile number you sent it to.
 
-{{ example({group: "patterns", item: "confirm-a-phone-number", example: "resend", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "confirm-a-phone-number", example: "resend", html: true, nunjucks: true, open: false }) }}
 
 You should tell the user what to do if they no longer have access to the phone used to sign up.
 
@@ -85,14 +84,14 @@ You can also follow the [domain-bound codes](https://developer.apple.com/news/?i
 Include the domain of the service on a new line, prefixed with an `@`, followed by a `#` symbol and the code, like this:
 
 {{ govukInsetText({
-html: "12345 is your [service name] security code<br><br>@www.example.service.gov.uk #12345"
+  html: "12345 is your [service name] security code<br><br>@www.example.service.gov.uk #12345"
 }) }}
 
 ### Error messages
 
 Style error messages like this:
 
-{{ example({group: "patterns", item: "confirm-a-phone-number", example: "error-incorrect", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "confirm-a-phone-number", example: "error-incorrect", html: true, nunjucks: true, open: false }) }}
 
 If the user does not enter enough digits:
 <br>Say ‘You've not entered enough numbers, the code must be 5 numbers’.
@@ -105,7 +104,7 @@ If the user enters non-numeric characters, other than spaces:
 
 If the code has expired, show this message:
 
-{{ example({group: "patterns", item: "confirm-a-phone-number", example: "error-expired", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "confirm-a-phone-number", example: "error-expired", html: true, nunjucks: true, open: false }) }}
 
 If the code was sent more than 2 hours ago, show the 'incorrect security code' message.
 

--- a/src/patterns/confirm-a-phone-number/resend-first-time/index.njk
+++ b/src/patterns/confirm-a-phone-number/resend-first-time/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout-example.njk
+layout: layout-example-form.njk
 title: Request a new security code (first time) – Confirm a phone number
 ---
 

--- a/src/patterns/confirm-a-phone-number/resend-first-time/index.njk
+++ b/src/patterns/confirm-a-phone-number/resend-first-time/index.njk
@@ -8,7 +8,6 @@ title: Request a new security code (first time) – Confirm a phone number
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
-
 {{ govukBackLink({
   text: "Back",
   href: "#"
@@ -37,5 +36,6 @@ title: Request a new security code (first time) – Confirm a phone number
   html: mobileNumberHtml
 }) }}
 
-
-{{ govukButton({text: "Request a new code"}) }}
+{{ govukButton({
+  text: "Request a new code"
+}) }}

--- a/src/patterns/confirm-a-phone-number/resend/index.njk
+++ b/src/patterns/confirm-a-phone-number/resend/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout-example.njk
+layout: layout-example-form.njk
 title: Request a new security code – Confirm a phone number
 ---
 

--- a/src/patterns/confirm-a-phone-number/resend/index.njk
+++ b/src/patterns/confirm-a-phone-number/resend/index.njk
@@ -7,7 +7,6 @@ title: Request a new security code – Confirm a phone number
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
-
 {{ govukBackLink({
   text: "Back",
   href: "#"
@@ -17,13 +16,11 @@ title: Request a new security code – Confirm a phone number
 
 <p class="govuk-body">Text messages sometimes take a few minutes to arrive. If you do not receive the text message, you can request a new one.</p>
 
-
 {{ govukDetails({
   summaryText: "I do not have access to the phone",
   html: '<p class="govuk-body">If you cannot access the phone number for this account, <a href="#" class="govuk-link">contact the Tax Credits Helpline</a> to get help signing in.</p>'
 }) }}
 
-{{ govukButton({text: "Request a new code"}) }}
-
-
-
+{{ govukButton({
+  text: "Request a new code"
+}) }}

--- a/src/patterns/confirmation-pages/index.md
+++ b/src/patterns/confirmation-pages/index.md
@@ -14,7 +14,7 @@ Use this pattern to let users know they’ve completed a transaction.
 
 Include a link to the [GOV.UK feedback page](https://www.gov.uk/service-manual/service-assessments/get-feedback-page) to allow users to tell you what they think of your transaction.
 
-{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager"}) }}
+{{ example({ group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
 
 ## When to use this pattern
 
@@ -33,7 +33,7 @@ Your confirmation page must include:
 - a link to your [feedback page](https://www.gov.uk/service-manual/service-assessments/get-feedback-page)
 - a way for users to save a record of the transaction, for example, as a PDF
 
-{{ example({group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second", size: "xl"}) }}
+{{ example({ group: "patterns", item: "confirmation-pages", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second", size: "xl" }) }}
 
 ### Help users who bookmark the page
 

--- a/src/patterns/contact-a-department-or-service-team/index.md
+++ b/src/patterns/contact-a-department-or-service-team/index.md
@@ -14,7 +14,7 @@ statusMessage: This pattern is currently experimental because <a class="govuk-li
 
 Give users contact information within your service.
 
-{{ example({group: "patterns", item: "contact-a-department-or-service-team", example: "default", html: true, open: false, size: "s"}) }}
+{{ example({ group: "patterns", item: "contact-a-department-or-service-team", example: "default", html: true, open: false, size: "s" }) }}
 
 ## When to use this pattern
 
@@ -24,7 +24,7 @@ Read about how and why to [set up user support](https://www.gov.uk/service-manua
 
 ## How it works
 
-{{ example({group: "patterns", item: "contact-a-department-or-service-team", example: "all-contact-information", html: true, open: false, size: "xl"}) }}
+{{ example({ group: "patterns", item: "contact-a-department-or-service-team", example: "all-contact-information", html: true, open: false, size: "xl" }) }}
 
 ### Order contact channels consistently
 
@@ -50,7 +50,7 @@ Tell users if they might have to pay to use any of your contact channels.
 
 For telephone call charges, link to the GOV.UK page on [call charges](https://www.gov.uk/call-charges). Include the link after the contact channels list and opening hours.
 
-{{ example({group: "patterns", item: "contact-a-department-or-service-team", example: "default", html: true, open: false, size: "s", titleSuffix: "second"}) }}
+{{ example({ group: "patterns", item: "contact-a-department-or-service-team", example: "default", html: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 ### Give opening hours
 
@@ -73,7 +73,7 @@ For example, tell users how long it'll usually take to:
 
 Use [inset text](/components/inset-text/) to display contact information when you want to differentiate it from the content that surrounds it.
 
-{{ example({group: "patterns", item: "contact-a-department-or-service-team", example: "inset-contact-information", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "patterns", item: "contact-a-department-or-service-team", example: "inset-contact-information", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ### Expanding contact information
 
@@ -83,7 +83,7 @@ For example, if you need to provide contact information at the bottom of a form 
 
 Only do this when there’s a lot of contact information to display. When there are only 1 or 2 lines, include the contact information within the body of the page.
 
-{{ example({group: "patterns", item: "contact-a-department-or-service-team", example: "expanding-contact-information", html: true, nunjucks: true, open: false, size: "m"}) }}
+{{ example({ group: "patterns", item: "contact-a-department-or-service-team", example: "expanding-contact-information", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ## Research on this pattern
 

--- a/src/patterns/cookies-page/index.md
+++ b/src/patterns/cookies-page/index.md
@@ -95,11 +95,11 @@ Use [radios](/components/radios/) and a [button](/components/button/) to let use
 
 Load the page with the radios set to ‘no’ on the user’s first visit. If they’ve previously used the service and set their preferences, load the page with those preferences selected.
 
-{{ example({group: "patterns", item: "cookies-page", example: "cookies-form", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "cookies-page", example: "cookies-form", html: true, nunjucks: true, open: false }) }}
 
 When the user sets or changes their cookie preferences, use a green [notification banner](/components/notification-banner/) to confirm that the service has updated the user’s cookie settings. This is so they can get back to the page they were looking at.
 
-{{ example({group: "patterns", item: "cookies-page", example: "cookies-updated", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "cookies-page", example: "cookies-updated", html: true, nunjucks: true, open: false }) }}
 
 ## If you depend on JavaScript to ask users to accept or reject cookies
 
@@ -107,7 +107,7 @@ If you depend on JavaScript to ask about cookie preferences and the user’s dev
 
 Replace the radios with a section of text explaining what the user needs to do in order to change their cookie settings.
 
-{{ example({group: "patterns", item: "cookies-page", example: "no-js", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "cookies-page", example: "no-js", html: true, nunjucks: true, open: false }) }}
 
 ## Keeping your cookies page up to date and asking for new consent
 

--- a/src/patterns/dates/default/index.njk
+++ b/src/patterns/dates/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Dates
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/patterns/dates/index.md
+++ b/src/patterns/dates/index.md
@@ -33,7 +33,7 @@ In some cases you might need users to pick a date from a given selection.
 
 Ask for memorable dates, like dates of birth, using the [date input](/components/date-input/) component.
 
-{{ example({group: "patterns", item: "dates", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager"}) }}
+{{ example({ group: "patterns", item: "dates", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ### Asking for dates from documents and cards
 

--- a/src/patterns/dates/memorable-date/index.njk
+++ b/src/patterns/dates/memorable-date/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Asking for memorable dates – Dates
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/patterns/email-addresses/default/index.njk
+++ b/src/patterns/email-addresses/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Email addresses
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/email-addresses/error/index.njk
+++ b/src/patterns/email-addresses/error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Email input with errors – Email addresses
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/email-addresses/index.md
+++ b/src/patterns/email-addresses/index.md
@@ -8,11 +8,11 @@ backlogIssueId: 45
 layout: layout-pane.njk
 ---
 
-This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
-
 {% from "_example.njk" import example %}
 
-{{ example({group: "patterns", item: "email-addresses", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager"}) }}
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
+
+{{ example({ group: "patterns", item: "email-addresses", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this pattern
 
@@ -28,7 +28,7 @@ When asking users for their email address, you must:
 
 You may also need to check that users have access to the email account they give you.
 
-{{ example({group: "patterns", item: "email-addresses", example: "default", html: true, nunjucks: true, open: true, size: "s", titleSuffix: "second"}) }}
+{{ example({ group: "patterns", item: "email-addresses", example: "default", html: true, nunjucks: true, open: true, size: "s", titleSuffix: "second" }) }}
 
 ### Tell users why you want the email address
 
@@ -73,7 +73,7 @@ However, these are disruptive and should be avoided as far as possible.
 
 Error messages should be styled like this:
 
-{{ example({group: "patterns", item: "email-addresses", example: "error", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "patterns", item: "email-addresses", example: "error", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/patterns/equality-information/asian/index.njk
+++ b/src/patterns/equality-information/asian/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Asian ethnicity equality question – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/equality-information/black/index.njk
+++ b/src/patterns/equality-information/black/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Black ethnicity equality question – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/equality-information/date-of-birth/index.njk
+++ b/src/patterns/equality-information/date-of-birth/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Date of birth equality question – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/patterns/equality-information/disability-impact/index.njk
+++ b/src/patterns/equality-information/disability-impact/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Disability impact equality question – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/equality-information/disability/index.njk
+++ b/src/patterns/equality-information/disability/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Disability equality question – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/equality-information/error-date-of-birth/index.njk
+++ b/src/patterns/equality-information/error-date-of-birth/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Date of birth equality question with error – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/src/patterns/equality-information/error-ethnicity/index.njk
+++ b/src/patterns/equality-information/error-ethnicity/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Ethnicity question with error – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/patterns/equality-information/ethnic-group/index.njk
+++ b/src/patterns/equality-information/ethnic-group/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Ethnic group equality question – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/equality-information/explainer-screen/index.njk
+++ b/src/patterns/equality-information/explainer-screen/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Explainer screen for equality information questions – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/patterns/equality-information/index.md
+++ b/src/patterns/equality-information/index.md
@@ -37,7 +37,7 @@ For a service that people are likely to use on a one-off basis:
 - place equality questions between the [‘check your answers’ page](/patterns/check-answers/) and the [confirmation page](/patterns/confirmation-pages/)
 - show the user a screen explaining why you’re asking the questions and what you’ll do with the information they provide, like the one below
 
-{{ example({group: "patterns", item: "equality-information", example: "explainer-screen", html: true, nunjucks: true, open: false, loading: "eager"}) }}
+{{ example({ group: "patterns", item: "equality-information", example: "explainer-screen", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 #### Longer term services
 
@@ -79,17 +79,17 @@ See the [full list of Government Statistical Service harmonised standards](https
 
 Use this approach to ask for the user’s date of birth.
 
-{{ example({group: "patterns", item: "equality-information", example: "date-of-birth", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "equality-information", example: "date-of-birth", html: true, nunjucks: true, open: false }) }}
 
 ### Asking about disability
 
 Use this approach to ask about disability.
 
-{{ example({group: "patterns", item: "equality-information", example: "disability", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "equality-information", example: "disability", html: true, nunjucks: true, open: false }) }}
 
 If the user answers ‘yes’, ask about the impact of their condition or illness.
 
-{{ example({group: "patterns", item: "equality-information", example: "disability-impact", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "equality-information", example: "disability-impact", html: true, nunjucks: true, open: false }) }}
 
 ### Asking about ethnic group
 
@@ -99,21 +99,21 @@ If your service covers more than one of England, Wales, Scotland or Northern Ire
 
 First ask about the user’s broad ethnic group.
 
-{{ example({group: "patterns", item: "equality-information", example: "ethnic-group", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "equality-information", example: "ethnic-group", html: true, nunjucks: true, open: false }) }}
 
 Then ask for a more detailed category, depending on which broad ethnic group the user selects. Always give the user the option to enter their own description of their background.
 
-{{ example({group: "patterns", item: "equality-information", example: "white", html: true, nunjucks: true, open: false}) }}
-{{ example({group: "patterns", item: "equality-information", example: "multiple", html: true, nunjucks: true, open: false}) }}
-{{ example({group: "patterns", item: "equality-information", example: "asian", html: true, nunjucks: true, open: false}) }}
-{{ example({group: "patterns", item: "equality-information", example: "black", html: true, nunjucks: true, open: false}) }}
-{{ example({group: "patterns", item: "equality-information", example: "other", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "equality-information", example: "white", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "patterns", item: "equality-information", example: "multiple", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "patterns", item: "equality-information", example: "asian", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "patterns", item: "equality-information", example: "black", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "patterns", item: "equality-information", example: "other", html: true, nunjucks: true, open: false }) }}
 
 ### Asking about marriage or civil partnership status
 
 Use this approach to ask about marriage or civil partnership status.
 
-{{ example({group: "patterns", item: "equality-information", example: "marriage-status", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "equality-information", example: "marriage-status", html: true, nunjucks: true, open: false }) }}
 
 ### Asking about religion
 
@@ -121,19 +121,19 @@ The categories used here are for England. The Government Statistical Service har
 
 If your service covers more than one of England, Wales, Scotland or Northern Ireland, you should accommodate these differences in your design. For example, by changing the categories shown depending on where the user is based. Where this is not possible, use the English categories.
 
-{{ example({group: "patterns", item: "equality-information", example: "religion", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "equality-information", example: "religion", html: true, nunjucks: true, open: false }) }}
 
 ### Asking about sex and gender identity
 
 Use this approach to ask about sex and gender identity.
 
-{{ example({group: "patterns", item: "equality-information", example: "sex-gender", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "equality-information", example: "sex-gender", html: true, nunjucks: true, open: false }) }}
 
 ### Asking about sexual orientation
 
 Use this approach to ask about sexual orientation.
 
-{{ example({group: "patterns", item: "equality-information", example: "sexual-orientation", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "equality-information", example: "sexual-orientation", html: true, nunjucks: true, open: false }) }}
 
 ### Validation and error messages
 
@@ -141,9 +141,9 @@ If a user enters information that’s valid but incomplete, accept it. For examp
 
 Error messages should be styled like this -
 
-{{ example({group: "patterns", item: "equality-information", example: "error-ethnicity", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "equality-information", example: "error-ethnicity", html: true, nunjucks: true, open: false }) }}
 
-{{ example({group: "patterns", item: "equality-information", example: "error-date-of-birth", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "equality-information", example: "error-date-of-birth", html: true, nunjucks: true, open: false }) }}
 
 ## Research on this pattern
 

--- a/src/patterns/equality-information/marriage-status/index.njk
+++ b/src/patterns/equality-information/marriage-status/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Marriage or civil partnership status equality question – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/equality-information/multiple/index.njk
+++ b/src/patterns/equality-information/multiple/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Multiple ethnicity equality question – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/equality-information/other/index.njk
+++ b/src/patterns/equality-information/other/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Other ethnicity equality question – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/equality-information/religion/index.njk
+++ b/src/patterns/equality-information/religion/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Religion equality question – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/equality-information/sex-gender/index.njk
+++ b/src/patterns/equality-information/sex-gender/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Sex and gender equality question – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/equality-information/sexual-orientation/index.njk
+++ b/src/patterns/equality-information/sexual-orientation/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Sexual orientation equality question – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/equality-information/white/index.njk
+++ b/src/patterns/equality-information/white/index.njk
@@ -1,6 +1,6 @@
 ---
 title: White ethnicity equality question – Equality information
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/patterns/exit-a-page-quickly/index.md
+++ b/src/patterns/exit-a-page-quickly/index.md
@@ -90,7 +90,7 @@ What you include will depend on your service and who uses it. But wherever pract
 
 ### Example of a safety content page
 
-{{ example({group: "patterns", item: "exit-a-page-quickly", example: "safety-content-example", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "patterns", item: "exit-a-page-quickly", example: "safety-content-example", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 Useful resources to help write this safety advice include:
 

--- a/src/patterns/names/default/index.njk
+++ b/src/patterns/names/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Names
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/names/error/index.njk
+++ b/src/patterns/names/error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Name input with errors – Names
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/names/index.md
+++ b/src/patterns/names/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({group: "patterns", item: "names", example: "default", html: true, nunjucks: true, open: false, loading: "eager"}) }}
+{{ example({ group: "patterns", item: "names", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this pattern
 
@@ -21,7 +21,7 @@ Only ask for people’s names if you need that information to deliver a service.
 
 Make it as easy as possible for a user to enter their name.
 
-{{ example({group: "patterns", item: "names", example: "default", html: true, nunjucks: true, open: true, titleSuffix: "second"}) }}
+{{ example({ group: "patterns", item: "names", example: "default", html: true, nunjucks: true, open: true, titleSuffix: "second" }) }}
 
 ### Make sure the fields work for most of your users
 
@@ -84,7 +84,7 @@ You will not normally need to use the `autocomplete` attribute in prototypes, as
 
 Sometimes, browsers will spellcheck the information a user enters into a text input. To make sure user's names will not be spellchecked, set the `spellcheck` attribute to `false` as shown in this example.
 
-{{ example({group: "patterns", item: "names", example: "default", html: true, nunjucks: true, open: true, displayExample: false, titleSuffix: "third"}) }}
+{{ example({ group: "patterns", item: "names", example: "default", html: true, nunjucks: true, open: true, displayExample: false, titleSuffix: "third" }) }}
 
 ### Avoid asking for a person’s title
 
@@ -110,7 +110,7 @@ Avoid making it hard for users to change their name. As well as causing them dis
 
 Error messages should be styled like this:
 
-{{ example({group: "patterns", item: "names", example: "error", html: true, nunjucks: true, open: true}) }}
+{{ example({ group: "patterns", item: "names", example: "error", html: true, nunjucks: true, open: true }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/patterns/national-insurance-numbers/default/index.njk
+++ b/src/patterns/national-insurance-numbers/default/index.njk
@@ -1,6 +1,6 @@
 ---
 title: National Insurance numbers
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/national-insurance-numbers/error/index.njk
+++ b/src/patterns/national-insurance-numbers/error/index.njk
@@ -1,6 +1,6 @@
 ---
 title: National insurance number input with errors – National Insurance numbers
-layout: layout-example.njk
+layout: layout-example-form.njk
 ---
 
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/src/patterns/national-insurance-numbers/index.md
+++ b/src/patterns/national-insurance-numbers/index.md
@@ -8,13 +8,13 @@ backlogIssueId: 54
 layout: layout-pane.njk
 ---
 
-This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
-
 {% from "_example.njk" import example %}
+
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 Ask users to provide their National Insurance number.
 
-{{ example({group: "patterns", item: "national-insurance-numbers", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager"}) }}
+{{ example({ group: "patterns", item: "national-insurance-numbers", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this pattern
 
@@ -40,13 +40,13 @@ When asking for a National Insurance number:
 - avoid using ‘AB 12 34 56 C’ as an example because it belongs to a real person and use ‘QQ 12 34 56 C’ instead
 - set the `spellcheck` attribute to `false` so that browsers do not spellcheck the National Insurance number
 
-{{ example({group: "patterns", item: "national-insurance-numbers", example: "default", html: true, nunjucks: true, open: true, size: "s", titleSuffix: "second"}) }}
+{{ example({ group: "patterns", item: "national-insurance-numbers", example: "default", html: true, nunjucks: true, open: true, size: "s", titleSuffix: "second" }) }}
 
 ### Error messages
 
 Error messages should be styled like this:
 
-{{ example({group: "patterns", item: "national-insurance-numbers", example: "error", html: true, nunjucks: true, open: true, size: "s"}) }}
+{{ example({ group: "patterns", item: "national-insurance-numbers", example: "error", html: true, nunjucks: true, open: true, size: "s" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/patterns/page-not-found-pages/index.md
+++ b/src/patterns/page-not-found-pages/index.md
@@ -14,7 +14,7 @@ statusMessage: This pattern is currently experimental because <a class="govuk-li
 
 A page not found tells someone we cannot find the page they were trying to view. They are also known as 404 pages.
 
-{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true, nunjucks: true, size: "xl", loading: "eager"}) }}
+{{ example({ group: "patterns", item: "page-not-found-pages", example: "default", html: true, nunjucks: true, size: "xl", loading: "eager" }) }}
 
 ## When to use this pattern
 
@@ -50,7 +50,7 @@ Do not use:
 - informal or humorous words like oops
 - red text to warn people
 
-{{ example({group: "patterns", item: "page-not-found-pages", example: "default", html: true, nunjucks: true, titleSuffix: "second", size: "xl"}) }}
+{{ example({ group: "patterns", item: "page-not-found-pages", example: "default", html: true, nunjucks: true, titleSuffix: "second", size: "xl" }) }}
 
 ## Research on this pattern
 

--- a/src/patterns/problem-with-the-service-pages/index.md
+++ b/src/patterns/problem-with-the-service-pages/index.md
@@ -10,13 +10,13 @@ status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
 ---
 
-This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
-
 {% from "_example.njk" import example %}
+
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 Tell the user there is something wrong with the service. These are also known as 500 and internal server error pages.
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "offline-support-link", html: true, nunjucks: true, open: false, size: "xl", loading: "eager"}) }}
+{{ example({ group: "patterns", item: "problem-with-the-service-pages", example: "offline-support-link", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
 
 ## When to use this pattern
 
@@ -51,15 +51,15 @@ Have clear and concise content and do not use:
 
 ### Service has a specific page that includes numbers and opening times
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "offline-support-link", html: true, nunjucks: true, open: false, titleSuffix: "second", size: "xl"}) }}
+{{ example({ group: "patterns", item: "problem-with-the-service-pages", example: "offline-support-link", html: true, nunjucks: true, open: false, titleSuffix: "second", size: "xl" }) }}
 
 ### Service has offline support but no specific page that includes numbers and opening times
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "offline-support", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "patterns", item: "problem-with-the-service-pages", example: "offline-support", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 ### A link to another service
 
-{{ example({group: "patterns", item: "problem-with-the-service-pages", example: "link-to-another-service", html: true, nunjucks: true, open: false, size: "xl"}) }}
+{{ example({ group: "patterns", item: "problem-with-the-service-pages", example: "link-to-another-service", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 ## Research on this pattern
 

--- a/src/patterns/question-pages/index.md
+++ b/src/patterns/question-pages/index.md
@@ -12,7 +12,7 @@ layout: layout-pane.njk
 
 This pattern explains when to use question pages and what elements they need to include.
 
-{{ example({group: "patterns", item: "question-pages", example: "default", html: true, nunjucks: true, open: false, loading: "eager"}) }}
+{{ example({ group: "patterns", item: "question-pages", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this pattern
 
@@ -70,11 +70,11 @@ Read more about why and [how to set labels and legends as headings](/get-started
 
 A question page with a legend as the page heading:
 
-{{ example({group: "patterns", item: "question-pages", example: "date-of-birth", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "question-pages", example: "date-of-birth", html: true, nunjucks: true, open: false }) }}
 
 A question page with a label as the page heading:
 
-{{ example({group: "patterns", item: "question-pages", example: "postcode", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "question-pages", example: "postcode", html: true, nunjucks: true, open: false }) }}
 
 Do not use the same page heading across multiple pages.
 
@@ -84,7 +84,7 @@ If you need to show the high-level section, you can use the `govuk-caption` styl
 
 For example, ‘About you’
 
-{{ example({group: "patterns", item: "question-pages", example: "section-headings", html: true, open: true, hideTab:true}) }}
+{{ example({ group: "patterns", item: "question-pages", example: "section-headings", html: true, open: true, hideTab:true }) }}
 
 You can also learn more about how starting with [one thing per page](https://www.gov.uk/service-manual/design/form-structure#start-with-one-thing-per-page) helps users in the GOV.UK Service Manual.
 
@@ -100,7 +100,7 @@ If you're asking a question that needs a detailed explanation, use:
 - whatever mix of text, paragraphs, lists and examples best explains your question to users
 - a label, above the form input, that asks users a specific question – for example, 'Do you have any interview needs?'
 
-{{ example({group: "patterns", item: "question-pages", example: "explanatory-text", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "question-pages", example: "explanatory-text", html: true, nunjucks: true, open: false }) }}
 
 #### Asking multiple questions on a page
 
@@ -112,7 +112,7 @@ If you need to ask for multiple related things on a page, use a statement as the
 
 You can style each `<label>` or `<legend>` to make the questions easier to scan. Read more about why and [how to style labels and legends](/get-started/labels-legends-headings/#styling-options-for-labels-and-legends).
 
-{{ example({group: "patterns", item: "question-pages", example: "passport", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "question-pages", example: "passport", html: true, nunjucks: true, open: false }) }}
 
 ### Continue button
 
@@ -127,7 +127,7 @@ Start by testing your form without a progress indicator to see if it’s simple 
 
 Try improving the order, type or number of questions before adding a progress indicator. If people still have difficulty, try adding a simple step or question indicator like this one.
 
-{{ example({group: "patterns", item: "question-pages", example: "progress", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "question-pages", example: "progress", html: true, nunjucks: true, open: false }) }}
 
 Only include the total number of questions if you can do so reliably. As the user moves through the form, make sure the indicator updates to tell them which question they are on and the total number remaining.
 

--- a/src/patterns/service-unavailable-pages/index.md
+++ b/src/patterns/service-unavailable-pages/index.md
@@ -10,13 +10,13 @@ status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
 ---
 
-This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
-
 {% from "_example.njk" import example %}
+
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
 Tell the user a service is unavailable on purpose. These are also known as 503 and shutter pages.
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "default", html: true, nunjucks: true, open: false, loading: "eager"}) }}
+{{ example({ group: "patterns", item: "service-unavailable-pages", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this pattern
 
@@ -50,15 +50,15 @@ Have clear and concise content and do not use:
 
 ### General page
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "general", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "service-unavailable-pages", example: "general", html: true, nunjucks: true, open: false }) }}
 
 ### When you know when a service will be available
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "available-at-known-date", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "service-unavailable-pages", example: "available-at-known-date", html: true, nunjucks: true, open: false }) }}
 
 ### A link to another service
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "link-to-another-service", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "service-unavailable-pages", example: "link-to-another-service", html: true, nunjucks: true, open: false }) }}
 
 ### Service is closed for part of the year
 
@@ -66,23 +66,23 @@ This is for a service like tax credit renewals.
 
 #### After a service closes
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "after-service-closes", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "service-unavailable-pages", example: "after-service-closes", html: true, nunjucks: true, open: false }) }}
 
 #### Before a service opens
 
 Do not include any contact information.
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "before-service-opens", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "service-unavailable-pages", example: "before-service-opens", html: true, nunjucks: true, open: false }) }}
 
 ### Service is closed forever
 
 #### Nothing has replaced the service
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "no-replacement-service", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "service-unavailable-pages", example: "no-replacement-service", html: true, nunjucks: true, open: false }) }}
 
 #### Something has replaced the service
 
-{{ example({group: "patterns", item: "service-unavailable-pages", example: "service-replaced", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "service-unavailable-pages", example: "service-replaced", html: true, nunjucks: true, open: false }) }}
 
 ## Research on this pattern
 

--- a/src/patterns/task-list-pages/have-you-completed-this-section-error/index.njk
+++ b/src/patterns/task-list-pages/have-you-completed-this-section-error/index.njk
@@ -1,39 +1,35 @@
 ---
-layout: layout-example.njk
+layout: layout-example-form.njk
 title: Have you completed this section error – Task list pages
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
-<form action="/form-handler" method="post" novalidate>
-
-  {{ govukRadios({
-    name: "haveYouCompletedThisSectionError",
-    fieldset: {
-      legend: {
-        text: "Have you completed this section?",
-        isPageHeading: false,
-        classes: "govuk-fieldset__legend--m"
-      }
+{{ govukRadios({
+  name: "haveYouCompletedThisSectionError",
+  fieldset: {
+    legend: {
+      text: "Have you completed this section?",
+      isPageHeading: false,
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  errorMessage: {
+  text: "Select whether you've completed this section"
+  },
+  items: [
+    {
+      value: "yes",
+      text: "Yes, I’ve completed this section"
     },
-    errorMessage: {
-    text: "Select whether you've completed this section"
-    },
-    items: [
-      {
-        value: "yes",
-        text: "Yes, I’ve completed this section"
-      },
-      {
-        value: "no",
-        text: "No, I’ll come back to it later"
-      }
-    ]
-  }) }}
+    {
+      value: "no",
+      text: "No, I’ll come back to it later"
+    }
+  ]
+}) }}
 
-  {{ govukButton({
-    text: "Continue"
-  }) }}
-
-</form>
+{{ govukButton({
+  text: "Continue"
+}) }}

--- a/src/patterns/task-list-pages/have-you-completed-this-section/index.njk
+++ b/src/patterns/task-list-pages/have-you-completed-this-section/index.njk
@@ -1,36 +1,32 @@
 ---
-layout: layout-example.njk
+layout: layout-example-form.njk
 title: Have you completed this section – Task list pages
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
-<form action="/form-handler" method="post" novalidate>
-
-  {{ govukRadios({
-    name: "haveYouCompletedThisSection",
-    fieldset: {
-      legend: {
-        text: "Have you completed this section?",
-        isPageHeading: false,
-        classes: "govuk-fieldset__legend--m"
-      }
+{{ govukRadios({
+  name: "haveYouCompletedThisSection",
+  fieldset: {
+    legend: {
+      text: "Have you completed this section?",
+      isPageHeading: false,
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  items: [
+    {
+      value: "yes",
+      text: "Yes, I’ve completed this section"
     },
-    items: [
-      {
-        value: "yes",
-        text: "Yes, I’ve completed this section"
-      },
-      {
-        value: "no",
-        text: "No, I’ll come back to it later"
-      }
-    ]
-  }) }}
+    {
+      value: "no",
+      text: "No, I’ll come back to it later"
+    }
+  ]
+}) }}
 
-  {{ govukButton({
-    text: "Continue"
-  }) }}
-
-</form>
+{{ govukButton({
+  text: "Continue"
+}) }}

--- a/src/patterns/task-list-pages/index.md
+++ b/src/patterns/task-list-pages/index.md
@@ -100,7 +100,7 @@ If the user selects ‘No, I’ll come back to it later,’ mark the task as 'In
 
 If the user selects ‘Yes, I’ve completed this section,’ mark the task as 'Completed'.
 
-{{ example({group: "patterns", item: "task-list-pages", example: "have-you-completed-this-section", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "task-list-pages", example: "have-you-completed-this-section", html: true, nunjucks: true, open: false }) }}
 
 Always allow users to go back into a task to change their answer.
 
@@ -108,7 +108,7 @@ Always allow users to go back into a task to change their answer.
 
 If the user does not select an option, show an [error message](/components/error-message/) to say: 'Select whether you’ve completed this section'.
 
-{{ example({group: "patterns", item: "task-list-pages", example: "have-you-completed-this-section-error", html: true, nunjucks: true, open: false}) }}
+{{ example({ group: "patterns", item: "task-list-pages", example: "have-you-completed-this-section-error", html: true, nunjucks: true, open: false }) }}
 
 ## Research on this pattern
 

--- a/src/patterns/telephone-numbers/default/index.njk
+++ b/src/patterns/telephone-numbers/default/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout-example.njk
+layout: layout-example-form.njk
 title: Telephone numbers
 ---
 

--- a/src/patterns/telephone-numbers/error-empty-field/index.njk
+++ b/src/patterns/telephone-numbers/error-empty-field/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout-example.njk
+layout: layout-example-form.njk
 title: Error, empty field – Telephone numbers
 ---
 

--- a/src/patterns/telephone-numbers/index.md
+++ b/src/patterns/telephone-numbers/index.md
@@ -10,11 +10,11 @@ status: Experimental
 statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
 ---
 
-This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
-
 {% from "_example.njk" import example %}
 
-{{ example({group: "patterns", item: "telephone-numbers", example: "default", html: true, nunjucks: true, open: false, loading: "eager"}) }}
+This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
+
+{{ example({ group: "patterns", item: "telephone-numbers", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this pattern
 
@@ -44,7 +44,7 @@ You will not normally need to use the `autocomplete` attribute in prototypes, as
 
 Error messages should be styled like this:
 
-{{ example({group: "patterns", item: "telephone-numbers", example: "error-empty-field", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "patterns", item: "telephone-numbers", example: "error-empty-field", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
@@ -60,7 +60,7 @@ Say ‘Enter a telephone number in the correct format’.
 
 Use the form label or hint text to tell users if you specifically need a UK, international or mobile telephone number.
 
-{{ example({group: "patterns", item: "telephone-numbers", example: "international", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({ group: "patterns", item: "telephone-numbers", example: "international", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Using example telephone numbers
 

--- a/src/patterns/telephone-numbers/international/index.njk
+++ b/src/patterns/telephone-numbers/international/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout-example.njk
+layout: layout-example-form.njk
 title: International – Telephone numbers
 ---
 

--- a/src/styles/images/default/index.njk
+++ b/src/styles/images/default/index.njk
@@ -5,5 +5,4 @@ stylesheets:
 - ../images.css
 ---
 
-
 <img src="3by2.jpg" alt="Three Olympic cyclists overlayed with a 3 by 2 grid to show the 3 by 2 ratio.">

--- a/src/styles/images/index.md
+++ b/src/styles/images/index.md
@@ -212,7 +212,7 @@ Do not write alt text that:
 - repeats information from the page
 - includes extra information not in the image
 
-{{ example({group: "styles", item: "images", example: "alt-text", html: true, open: true, size: "l"}) }}
+{{ example({ group: "styles", item: "images", example: "alt-text", html: true, open: true, size: "l" }) }}
 
 ## Research on images
 

--- a/src/styles/layout/index.md
+++ b/src/styles/layout/index.md
@@ -24,15 +24,15 @@ The default maximum page width is 1020px, but you can make it wider if your cont
 
 ### Two-thirds
 
-{{ example({group: "styles", item: "layout", example: "common-two-thirds", html: true, open: true, size: "m", loading: "eager"}) }}
+{{ example({ group: "styles", item: "layout", example: "common-two-thirds", html: true, open: true, size: "m", loading: "eager" }) }}
 
 ### Two-thirds and one-third
 
-{{ example({group: "styles", item: "layout", example: "common-two-thirds-one-third", html: true, open: true, size: "m"}) }}
+{{ example({ group: "styles", item: "layout", example: "common-two-thirds-one-third", html: true, open: true, size: "m" }) }}
 
 ### Row 1: Two-thirds <br>Row 2: Two-thirds and one-third
 
-{{ example({group: "styles", item: "layout", example: "common-two-thirds-two-thirds-one-third", html: true, open: true, size: "l"}) }}
+{{ example({ group: "styles", item: "layout", example: "common-two-thirds-two-thirds-one-third", html: true, open: true, size: "l" }) }}
 
 ## Setting up page wrappers
 
@@ -55,11 +55,11 @@ If you’re not using the [breadcrumbs](/components/breadcrumbs/), [back link](/
 
 ### Exploded view of page wrappers
 
-{{ example({group: "styles", item: "layout", example: "layout-wrappers", html: true, open: true, size: "l"}) }}
+{{ example({ group: "styles", item: "layout", example: "layout-wrappers", html: true, open: true, size: "l" }) }}
 
 ### Exploded view of page wrappers without a back link, breadcrumbs or phase banner
 
-{{ example({group: "styles", item: "layout", example: "layout-wrappers-l", html: true, open: true, size: "l"}) }}
+{{ example({ group: "styles", item: "layout", example: "layout-wrappers-l", html: true, open: true, size: "l" }) }}
 
 ## Using the grid system
 
@@ -79,45 +79,45 @@ The available widths are:
 
 ### Full width
 
-{{ example({group: "styles", item: "layout", example: "full-width", html: true, open: true, size: "s"}) }}
+{{ example({ group: "styles", item: "layout", example: "full-width", html: true, open: true, size: "s" }) }}
 
 ### One-half
 
-{{ example({group: "styles", item: "layout", example: "one-half", html: true, open: true, size: "s"}) }}
+{{ example({ group: "styles", item: "layout", example: "one-half", html: true, open: true, size: "s" }) }}
 
 ### One-third
 
-{{ example({group: "styles", item: "layout", example: "one-third", html: true, open: true, size: "s"}) }}
+{{ example({ group: "styles", item: "layout", example: "one-third", html: true, open: true, size: "s" }) }}
 
 ### Two-thirds
 
-{{ example({group: "styles", item: "layout", example: "two-thirds", html: true, open: true, size: "s"}) }}
+{{ example({ group: "styles", item: "layout", example: "two-thirds", html: true, open: true, size: "s" }) }}
 
 ### One-quarter
 
-{{ example({group: "styles", item: "layout", example: "one-quarter", html: true, open: true, size: "s"}) }}
+{{ example({ group: "styles", item: "layout", example: "one-quarter", html: true, open: true, size: "s" }) }}
 
 ### Three-quarters
 
-{{ example({group: "styles", item: "layout", example: "three-quarters", html: true, open: true, size: "s"}) }}
+{{ example({ group: "styles", item: "layout", example: "three-quarters", html: true, open: true, size: "s" }) }}
 
 ### Example combinations
 
-{{ example({group: "styles", item: "layout", example: "combinations", html: true, open: true, size: "xl"}) }}
+{{ example({ group: "styles", item: "layout", example: "combinations", html: true, open: true, size: "xl" }) }}
 
 ### Desktop specific grid classes
 
 To specify a width at the desktop breakpoint you can use the desktop specific grid classes. For example `govuk-grid-column-two-thirds-from-desktop` will set your column width to be two-thirds width at the desktop breakpoint only.
 
-{{ example({group: "styles", item: "layout", example: "desktop", html: true, open: true, size: "m"}) }}
+{{ example({ group: "styles", item: "layout", example: "desktop", html: true, open: true, size: "m" }) }}
 
 The desktop specific classes also allow you to set the width of the tablet breakpoint by using them in combination with the standard grid classes. For example using `govuk-grid-column-one-half` and `govuk-grid-column-two-thirds-from-desktop` together will mean the column will be one-half at the tablet breakpoint and two-thirds width at desktop.
 
-{{ example({group: "styles", item: "layout", example: "tablet-desktop", html: true, open: true, size: "m"}) }}
+{{ example({ group: "styles", item: "layout", example: "tablet-desktop", html: true, open: true, size: "m" }) }}
 
 ### Nested grids
 
-{{ example({group: "styles", item: "layout", example: "nested", html: true, open: true, size: "m"}) }}
+{{ example({ group: "styles", item: "layout", example: "nested", html: true, open: true, size: "m" }) }}
 
 ## Width override classes
 
@@ -127,7 +127,7 @@ The width override classes start with `govuk-!-width-`, followed by the width on
 
 These examples are for the generic width override classes - read specific [guidance on setting text input width](/components/text-input/#use-appropriately-sized-text-inputs).
 
-{{ example({group: "styles", item: "layout", example: "width-overrides", html: true, open: true, size: "xl"}) }}
+{{ example({ group: "styles", item: "layout", example: "width-overrides", html: true, open: true, size: "xl" }) }}
 
 ## Override how elements display
 

--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -42,8 +42,8 @@ ignoreInSitemap: true
     messages: [
       {
         headingText: "Cookies on [name of service]",
-        html: "<p class=\"govuk-body\">We use some essential cookies to make this service work.</p>
-          <p class=\"govuk-body\">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>",
+        html: '<p class="govuk-body">We use some essential cookies to make this service work.</p>
+          <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>',
         actions: [
           {
             text: "Accept analytics cookies",

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -43,8 +43,8 @@ ignoreInSitemap: true
     messages: [
       {
         headingText: "Cookies on [name of service]",
-        html: "<p class=\"govuk-body\">We use some essential cookies to make this service work.</p>
-          <p class=\"govuk-body\">We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>",
+        html: '<p class="govuk-body">We use some essential cookies to make this service work.</p>
+          <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>',
         actions: [
           {
             text: "Accept analytics cookies",

--- a/src/styles/page-template/default/code.njk
+++ b/src/styles/page-template/default/code.njk
@@ -3,6 +3,7 @@ title: Default – Page template
 layout: false
 ignoreInSitemap: true
 ---
+
 {% extends "govuk/template.njk" %}
 
 {% block head %}

--- a/src/styles/page-template/default/index.njk
+++ b/src/styles/page-template/default/index.njk
@@ -2,6 +2,7 @@
 title: Default – Page template
 layout: false
 ---
+
 {% extends "govuk/template.njk" %}
 
 {% block pageTitle %}{{ title }} – Example - GOV.UK Design System{% endblock %}

--- a/src/styles/page-template/index.md
+++ b/src/styles/page-template/index.md
@@ -27,7 +27,7 @@ You’ll get updates to the page template when we update GOV.UK Frontend.
 
 This example shows the minimum required for a GOV.UK page.
 
-{{ example({group: "styles", item: "page-template", example: "default", customCode: true, html: true, nunjucks: true, open: false, size: "l", loading: "eager"}) }}
+{{ example({ group: "styles", item: "page-template", example: "default", customCode: true, html: true, nunjucks: true, open: false, size: "l", loading: "eager" }) }}
 
 ## Customised page template
 
@@ -36,7 +36,7 @@ You can customise the page template, for example, by:
 - adding a service name and navigation
 - including a [back link](/components/back-link/) or [phase banner](/components/phase-banner/)
 
-{{ example({group: "styles", item: "page-template", example: "custom", customCode: true, html: true, nunjucks: true, open: false, size: "xl" }) }}
+{{ example({ group: "styles", item: "page-template", example: "custom", customCode: true, html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 ## Changing template content
 
@@ -256,4 +256,4 @@ To change the components that are included in the page template by default, set 
 
 #### Exploded view of the page template block areas
 
-{{ example({group: "styles", item: "page-template", example: "block-areas", html: false, open: false }) }}
+{{ example({ group: "styles", item: "page-template", example: "block-areas", html: false, open: false }) }}

--- a/src/styles/spacing/index.md
+++ b/src/styles/spacing/index.md
@@ -204,6 +204,6 @@ For example, use:
 
 ### Examples
 
-{{ example({group: "styles", item: "spacing", example: "spacing-scale-padding", html: true, open: false, size: "l"}) }}
+{{ example({ group: "styles", item: "spacing", example: "spacing-scale-padding", html: true, open: false, size: "l" }) }}
 
-{{ example({group: "styles", item: "spacing", example: "spacing-scale-margin", html: true, open: false, size: "xl"}) }}
+{{ example({ group: "styles", item: "spacing", example: "spacing-scale-margin", html: true, open: false, size: "xl" }) }}

--- a/src/styles/typography/index.md
+++ b/src/styles/typography/index.md
@@ -32,21 +32,21 @@ Use heading tags, such as `<h1>`, `<h2>` and so on, to tag the headings on a pag
 
 For a [question page](/patterns/question-pages/), or pages with long headings, start with `govuk-heading-l` for an `<h1>`, `govuk-heading-m` for an `<h2>` and so on. But change it if your pages feel unbalanced – the heading class you use does not always need to correspond to the heading level.
 
-{{ example({group: "styles", item: "typography", example: "headings", html: true, open: true, size: "m", loading: "eager"}) }}
+{{ example({ group: "styles", item: "typography", example: "headings", html: true, open: true, size: "m", loading: "eager" }) }}
 
 If your page has lots of long form content, start with `govuk-heading-xl` for an `<h1>`, `govuk-heading-l` for an `<h2>`, and so on.
 
-{{ example({group: "styles", item: "typography", example: "headings-xl", html: true, open: true, size: "m"}) }}
+{{ example({ group: "styles", item: "typography", example: "headings-xl", html: true, open: true, size: "m" }) }}
 
 ### Headings with captions
 
 Sometimes you may need to make it clear that a page is part of a larger section or group. To do this, you can use a heading with a caption above it.
 
-{{ example({group: "styles", item: "typography", example: "captions", html: true, open: true, size: "l"}) }}
+{{ example({ group: "styles", item: "typography", example: "captions", html: true, open: true, size: "l" }) }}
 
 If the caption should be considered part of the page heading, you can also nest the caption within the `<h1>`.
 
-{{ example({group: "styles", item: "typography", example: "captions-inside", html: true, open: true, size: "l"}) }}
+{{ example({ group: "styles", item: "typography", example: "captions-inside", html: true, open: true, size: "l" }) }}
 
 ## Paragraphs
 
@@ -54,7 +54,7 @@ If the caption should be considered part of the page heading, you can also nest 
 
 The default paragraph font size is 19px on large screens and 16px on small screens.
 
-{{ example({group: "styles", item: "typography", example: "body", html: true, open: true}) }}
+{{ example({ group: "styles", item: "typography", example: "body", html: true, open: true }) }}
 
 You can also add classes to create a lead paragraph or smaller body copy to convey hierarchy in your page.
 
@@ -62,7 +62,7 @@ You can also add classes to create a lead paragraph or smaller body copy to conv
 
 A lead paragraph is an introductory paragraph that you can use at the top of a page to summarise the content. Lead paragraphs use 24px type on desktop and should only be used once per page if needed.
 
-{{ example({group: "styles", item: "typography", example: "lead", html: true, open: true}) }}
+{{ example({ group: "styles", item: "typography", example: "lead", html: true, open: true }) }}
 
 ### Body small
 
@@ -70,7 +70,7 @@ You can use the `govuk-body-s` class sparingly to make your paragraph font size 
 
 The majority of your body copy should use the standard 19px paragraph size.
 
-{{ example({group: "styles", item: "typography", example: "small", html: true, open: true}) }}
+{{ example({ group: "styles", item: "typography", example: "small", html: true, open: true }) }}
 
 ## Text alignment override classes
 
@@ -94,13 +94,13 @@ You might need to set the font size or font weight of an element outside of the 
 
 The full GOV.UK typography scale goes from 14px up to 80px on large screens. You can add these font size override classes to any other typographic class or element and they will change the font size.
 
-{{ example({group: "styles", item: "typography", example: "font-size", html: true, open: true, size: "xl"}) }}
+{{ example({ group: "styles", item: "typography", example: "font-size", html: true, open: true, size: "xl" }) }}
 
 ### Font weight
 
 As with the font size, you can add a font weight override class to any other typographic class or element to change the font weight to regular or bold weight.
 
-{{ example({group: "styles", item: "typography", example: "font-weight", html: true, open: true}) }}
+{{ example({ group: "styles", item: "typography", example: "font-weight", html: true, open: true }) }}
 
 #### Bold text
 
@@ -114,11 +114,11 @@ Use bold sparingly. Overuse will make it difficult for users to know which parts
 
 Links are blue and underlined by default. If your link is at the end of a sentence or paragraph, make sure that the linked text does not include the full stop.
 
-{{ example({group: "styles", item: "typography", example: "link", html: true, open: true}) }}
+{{ example({ group: "styles", item: "typography", example: "link", html: true, open: true }) }}
 
 Use the `govuk-link--no-visited-state` modifier class where it is not helpful to distinguish between visited and unvisited states, for example when linking to pages with frequently-changing content such as the dashboard for an admin interface.
 
-{{ example({group: "styles", item: "typography", example: "link-no-visited-state", html: true, open: true}) }}
+{{ example({ group: "styles", item: "typography", example: "link-no-visited-state", html: true, open: true }) }}
 
 ### External links
 
@@ -132,7 +132,7 @@ If you need a link to open in a new tab - for example, to stop the user losing i
 
 Include `rel="noreferrer noopener"` along with `target="_blank"` to reduce the risk of [reverse tabnabbing](https://owasp.org/www-community/attacks/Reverse_Tabnabbing). The following example shows how to do this in HTML.
 
-{{ example({group: "styles", item: "typography", example: "link-opening-in-new-tab", html: true, open: true}) }}
+{{ example({ group: "styles", item: "typography", example: "link-opening-in-new-tab", html: true, open: true }) }}
 
 If you're displaying lots of links together and want to save space and avoid repetition, consider doing both of the following:
 
@@ -145,7 +145,7 @@ Use the `govuk-link--inverse` modifier class to show white links on dark backgro
 
 Make sure all users can see the links — the white links and background colour [must have a contrast ratio of at least 4.5:1](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).
 
-{{ example({group: "styles", item: "typography", example: "link-on-dark-background", html: true, open: true}) }}
+{{ example({ group: "styles", item: "typography", example: "link-on-dark-background", html: true, open: true }) }}
 
 ### Links without underlines
 
@@ -155,7 +155,7 @@ Only do this if the context tells the user that the text is a link, even without
 
 For example, links in a header or side navigation might not need underlines. Users will understand that they’re links because of where they are, at the same place, across different pages.
 
-{{ example({group: "styles", item: "typography", example: "link-no-underline", html: true, open: true}) }}
+{{ example({ group: "styles", item: "typography", example: "link-no-underline", html: true, open: true }) }}
 
 ### Links to change a language
 
@@ -173,13 +173,13 @@ For example, your link text could be 'use [Service name] in [language]'.
 
 Use lists to make blocks of text easier to read, and to break information into manageable chunks.
 
-{{ example({group: "styles", item: "typography", example: "list", html: true, open: true, size: "s"}) }}
+{{ example({ group: "styles", item: "typography", example: "list", html: true, open: true, size: "s" }) }}
 
 ### Bulleted lists
 
 Introduce bulleted lists with a lead-in line ending in a colon. Start each item with a lowercase letter, and do not use a full stop at the end.
 
-{{ example({group: "styles", item: "typography", example: "list-bullet", html: true, open: true, size: "s"}) }}
+{{ example({ group: "styles", item: "typography", example: "list-bullet", html: true, open: true, size: "s" }) }}
 
 ### Numbered lists
 
@@ -187,13 +187,13 @@ Use numbered lists instead of bulleted lists when the order of the items is rele
 
 You do not need to use a lead-in line for numbered lists. Items in a numbered list should end in a full stop because each should be a complete sentence.
 
-{{ example({group: "styles", item: "typography", example: "list-number", html: true, open: true, size: "s"}) }}
+{{ example({ group: "styles", item: "typography", example: "list-number", html: true, open: true, size: "s" }) }}
 
 ### Adding extra spacing between list items
 
 If a list is hard to read because the items run across multiple lines you can add extra spacing.
 
-{{ example({group: "styles", item: "typography", example: "list-spaced", html: true, open: true, size: "s"}) }}
+{{ example({ group: "styles", item: "typography", example: "list-spaced", html: true, open: true, size: "s" }) }}
 
 ## Section break
 
@@ -201,7 +201,7 @@ You can use the `govuk-section-break` classes on an `<hr>` element to create a t
 
 By default `govuk-section-break` is only visible by its margin. You can add the `govuk-section-break--visible` class to make it visible with a separator line.
 
-{{ example({group: "styles", item: "typography", example: "section-break", html: true, open: true, size: "m"}) }}
+{{ example({ group: "styles", item: "typography", example: "section-break", html: true, open: true, size: "m" }) }}
 
 ## Our plans to improve this style
 

--- a/views/layouts/layout-example-form.njk
+++ b/views/layouts/layout-example-form.njk
@@ -1,0 +1,10 @@
+{% extends "layout-example.njk" %}
+
+{% block main %}
+  <!-- Disable browser validation for any examples that include form elements -->
+  <form action="/form-handler" method="post" novalidate>
+    {% block body %}
+      {{ contents | safe }}
+    {% endblock %}
+  </form>
+{% endblock %}

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -26,12 +26,9 @@
 {% set bodyClasses = "app-example-page" %}
 
 {% block main %}
-  <!-- Disable browser validation for any examples that include form elements -->
-  <form action="/form-handler" method="post" novalidate>
-    {% block body %}
-      {{ contents | safe }}
-    {% endblock %}
-  </form>
+  {% block body %}
+    {{ contents | safe }}
+  {% endblock %}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -132,7 +132,7 @@
         {%- from "govuk/components/details/macro.njk" import govukDetails %}
 
         {{- govukDetails({
-          summaryHtml: "<span data-components='github-component-arguments'>Nunjucks macro options</span>",
+          summaryHtml: '<span data-components="github-component-arguments">Nunjucks macro options</span>',
           html: macroOptionsHTML,
           classes: "app-options",
           attributes:{

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -42,7 +42,7 @@
       <label class="govuk-visually-hidden" for="app-site-search__input">Search Design system</label>
       <a class="app-site-search__link govuk-link" href="/sitemap/">Sitemap</a>
     </div>
-    <button hidden class="govuk-header__menu-button app-navigation__menu-button js-app-navigation__toggler" aria-controls="app-navigation">
+    <button type="button" class="govuk-header__menu-button app-navigation__menu-button js-app-navigation__toggler" aria-controls="app-navigation" hidden>
       Menu
     </button>
   </div>

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -8,7 +8,7 @@
         </a>
 
         {% if item.items %}
-          <button hidden class="app-navigation__button js-app-navigation__button">
+          <button type="button" class="app-navigation__button js-app-navigation__button" hidden>
             {{ item.label }}
           </button>
           <!-- [html-validate-disable-next aria-label-misuse --- inline fix for html-validate rule, rather than disable it entirely] -->


### PR DESCRIPTION
PR to fix various issues flagged by `html-validate` which we've temporarily ignored

## Issues now fixed

* https://github.com/alphagov/govuk-design-system/issues/2609
* Navigation toggle buttons had implicit `type="submit"`
* Some HTML attributes used single quotes

To fix "forms within forms" I've split our example layout in two:

1. Use **layout-example.njk** for examples without forms
2. Use **layout-example-form.njk** for examples with forms

## Issues already fixed

Plus some issues had already been fixed so we can remove their rules:

* https://github.com/alphagov/govuk-design-system/issues/2606
* https://github.com/alphagov/govuk-frontend/pull/2830

I'll open a separate PR for cookie banner specific things