### PR TITLE
Various fixes for `html-validate` (cookie banner buttons)

### DIFF
--- a/__tests__/cookies-page.test.js
+++ b/__tests__/cookies-page.test.js
@@ -10,8 +10,8 @@ describe('Cookies page', () => {
 
   async function setup(page) {
     $module = await page.$('[data-module="app-cookies-page"]')
-    $radioYes = await $module.$('input[name="analytics"][value="yes"]')
-    $radioNo = await $module.$('input[name="analytics"][value="no"]')
+    $radioYes = await $module.$('input[name="cookies[analytics]"][value="yes"]')
+    $radioNo = await $module.$('input[name="cookies[analytics]"][value="no"]')
     $buttonSave = await $module.$('button')
   }
 

--- a/src/components/cookie-banner/client-side-accepted/index.njk
+++ b/src/components/cookie-banner/client-side-accepted/index.njk
@@ -45,7 +45,8 @@ layout: layout-example.njk
       role: "alert",
       actions: [
         {
-          text: "Hide cookie message"
+          text: "Hide cookie message",
+          type: "button"
         }
       ]
     },
@@ -55,7 +56,8 @@ layout: layout-example.njk
       hidden: true,
       actions: [
         {
-          text: "Hide cookie message"
+          text: "Hide cookie message",
+          type: "button"
         }
       ]
     }

--- a/src/components/cookie-banner/client-side-rejected/index.njk
+++ b/src/components/cookie-banner/client-side-rejected/index.njk
@@ -46,7 +46,8 @@ layout: layout-example.njk
       hidden: true,
       actions: [
         {
-          text: "Hide cookie message"
+          text: "Hide cookie message",
+          type: "button"
         }
       ]
     },
@@ -55,7 +56,8 @@ layout: layout-example.njk
       role: "alert",
       actions: [
         {
-          text: "Hide cookie message"
+          text: "Hide cookie message",
+          type: "button"
         }
       ]
     }

--- a/src/components/cookie-banner/client-side/index.njk
+++ b/src/components/cookie-banner/client-side/index.njk
@@ -45,7 +45,8 @@ layout: layout-example.njk
       hidden: true,
       actions: [
         {
-          text: "Hide cookie message"
+          text: "Hide cookie message",
+          type: "button"
         }
       ]
     },
@@ -55,7 +56,8 @@ layout: layout-example.njk
       hidden: true,
       actions: [
         {
-          text: "Hide cookie message"
+          text: "Hide cookie message",
+          type: "button"
         }
       ]
     }

--- a/src/components/cookie-banner/default/index.njk
+++ b/src/components/cookie-banner/default/index.njk
@@ -19,15 +19,11 @@ layout: layout-example.njk
       actions: [
         {
           text: "Accept analytics cookies",
-          type: "button",
-          name: "cookies",
-          value: "accept"
+          type: "button"
         },
         {
           text: "Reject analytics cookies",
-          type: "button",
-          name: "cookies",
-          value: "reject"
+          type: "button"
         },
         {
           text: "View cookies",

--- a/src/components/cookie-banner/multiple-cookies/index.njk
+++ b/src/components/cookie-banner/multiple-cookies/index.njk
@@ -19,15 +19,11 @@ layout: layout-example.njk
       actions: [
         {
           text: "Accept additional cookies",
-          type: "button",
-          name: "cookies",
-          value: "accept"
+          type: "button"
         },
         {
           text: "Reject additional cookies",
-          type: "button",
-          name: "cookies",
-          value: "reject"
+          type: "button"
         },
         {
           text: "View cookies",

--- a/src/components/cookie-banner/server-side-confirmation/index.njk
+++ b/src/components/cookie-banner/server-side-confirmation/index.njk
@@ -17,7 +17,7 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          type: "button"
+          type: "submit"
         }
       ]
     }

--- a/src/components/cookie-banner/server-side-confirmation/index.njk
+++ b/src/components/cookie-banner/server-side-confirmation/index.njk
@@ -17,7 +17,9 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          type: "submit"
+          type: "submit",
+          name: "cookies[hide]",
+          value: "yes"
         }
       ]
     }

--- a/src/components/cookie-banner/server-side-confirmation/index.njk
+++ b/src/components/cookie-banner/server-side-confirmation/index.njk
@@ -17,7 +17,6 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          href: "#",
           type: "button"
         }
       ]

--- a/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
@@ -29,14 +29,14 @@ layout: layout-example.njk
         {
           text: "Accept additional cookies",
           type: "submit",
-          name: "cookies",
-          value: "accept"
+          name: "cookies[additional]",
+          value: "yes"
         },
         {
           text: "Reject additional cookies",
           type: "submit",
-          name: "cookies",
-          value: "reject"
+          name: "cookies[additional]",
+          value: "no"
         },
         {
           text: "View cookies",
@@ -49,7 +49,9 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          type: "submit"
+          type: "submit",
+          name: "cookies[hide]",
+          value: "yes"
         }
       ]
     },
@@ -58,7 +60,9 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          type: "submit"
+          type: "submit",
+          name: "cookies[hide]",
+          value: "yes"
         }
       ],
       hidden: true

--- a/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
@@ -49,7 +49,7 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          type: "button"
+          type: "submit"
         }
       ]
     },
@@ -58,7 +58,7 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          type: "button"
+          type: "submit"
         }
       ],
       hidden: true

--- a/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-confirmation-visible/index.njk
@@ -49,7 +49,6 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          href: "#",
           type: "button"
         }
       ]
@@ -59,7 +58,6 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          href: "#",
           type: "button"
         }
       ],

--- a/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
@@ -48,7 +48,6 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          href: "#",
           type: "button"
         }
       ],
@@ -59,7 +58,6 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          href: "#",
           type: "button"
         }
       ],

--- a/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
@@ -28,14 +28,14 @@ layout: layout-example.njk
         {
           text: "Accept additional cookies",
           type: "submit",
-          name: "cookies",
-          value: "accept"
+          name: "cookies[additional]",
+          value: "yes"
         },
         {
           text: "Reject additional cookies",
           type: "submit",
-          name: "cookies",
-          value: "reject"
+          name: "cookies[additional]",
+          value: "no"
         },
         {
           text: "View cookies",
@@ -48,7 +48,9 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          type: "submit"
+          type: "submit",
+          name: "cookies[hide]",
+          value: "yes"
         }
       ],
       hidden: true
@@ -58,7 +60,9 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          type: "submit"
+          type: "submit",
+          name: "cookies[hide]",
+          value: "yes"
         }
       ],
       hidden: true

--- a/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
+++ b/src/components/cookie-banner/server-side-multiple-messages-question-visible/index.njk
@@ -48,7 +48,7 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          type: "button"
+          type: "submit"
         }
       ],
       hidden: true
@@ -58,7 +58,7 @@ layout: layout-example.njk
       actions: [
         {
           text: "Hide cookie message",
-          type: "button"
+          type: "submit"
         }
       ],
       hidden: true

--- a/src/components/cookie-banner/server-side/index.njk
+++ b/src/components/cookie-banner/server-side/index.njk
@@ -20,14 +20,14 @@ layout: layout-example.njk
         {
           text: "Accept additional cookies",
           type: "submit",
-          name: "cookies",
-          value: "accept"
+          name: "cookies[additional]",
+          value: "yes"
         },
         {
           text: "Reject additional cookies",
           type: "submit",
-          name: "cookies",
-          value: "reject"
+          name: "cookies[additional]",
+          value: "no"
         },
         {
           text: "View cookies",

--- a/src/cookies.njk
+++ b/src/cookies.njk
@@ -104,8 +104,8 @@ layout: layout-single-page.njk
         }) }}
 
         {{ govukRadios({
-          name: "analytics",
-          idPrefix: "radio-analytics",
+          name: "cookies[analytics]",
+          idPrefix: "cookies-analytics",
           fieldset: {
             legend: {
               text: "Do you want to accept analytics cookies?",
@@ -113,7 +113,7 @@ layout: layout-single-page.njk
             },
             classes: "js-cookies-page-form-fieldset",
             attributes: {
-              id: "analytics",
+              "data-cookie-type": "analytics",
               hidden: ""
             }
           },

--- a/src/javascripts/components/cookies-page.mjs
+++ b/src/javascripts/components/cookies-page.mjs
@@ -47,7 +47,7 @@ CookiesPage.prototype.savePreferences = function (event) {
     function ($cookieFormFieldset) {
       var cookieType = this.getCookieType($cookieFormFieldset)
       var selectedItem = $cookieFormFieldset.querySelector(
-        'input[name=' + cookieType + ']:checked'
+        'input[name="cookies[' + cookieType + ']"]:checked'
       ).value
 
       preferences[cookieType] = selectedItem === 'yes'
@@ -72,7 +72,7 @@ CookiesPage.prototype.showUserPreference = function (
 
   var radioValue = preference ? 'yes' : 'no'
   var radio = $cookieFormFieldset.querySelector(
-    'input[name=' + cookieType + '][value=' + radioValue + ']'
+    'input[name="cookies[' + cookieType + ']"][value=' + radioValue + ']'
   )
   radio.checked = true
 }
@@ -94,7 +94,7 @@ CookiesPage.prototype.showSuccessNotification = function () {
 }
 
 CookiesPage.prototype.getCookieType = function ($cookieFormFieldset) {
-  return $cookieFormFieldset.id
+  return $cookieFormFieldset.getAttribute('data-cookie-type')
 }
 
 export default CookiesPage

--- a/src/patterns/cookies-page/cookies-form/index.njk
+++ b/src/patterns/cookies-page/cookies-form/index.njk
@@ -11,7 +11,8 @@ layout: layout-example.njk
     <h2 class="govuk-heading-l">Change your cookie settings</h2>
     <form action="/form-handler" method="post" novalidate>
       {{ govukRadios({
-          name: "functionalCookies",
+          name: "cookies[functional]",
+          idPrefix: "cookies-functional",
           fieldset: {
             legend: {
               text: "Do you want to accept functional cookies?",
@@ -32,7 +33,8 @@ layout: layout-example.njk
         }) }}
 
         {{ govukRadios({
-          name: "analyticsCookies",
+          name: "cookies[analytics]",
+          idPrefix: "cookies-analytics",
           fieldset: {
             legend: {
               text: "Do you want to accept analytics cookies?",

--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -37,34 +37,36 @@ ignoreInSitemap: true
 {% endblock %}
 
 {% block bodyStart %}
-  {{ govukCookieBanner({
-    ariaLabel: "Cookies on [name of service]",
-    messages: [
-      {
-        headingText: "Cookies on [name of service]",
-        html: '<p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>',
-        actions: [
-          {
-            text: "Accept analytics cookies",
-            type: "button",
-            name: "cookies",
-            value: "accept"
-          },
-          {
-            text: "Reject analytics cookies",
-            type: "button",
-            name: "cookies",
-            value: "reject"
-          },
-          {
-            text: "View cookies",
-            href: "#"
-          }
-        ]
-      }
-    ]
-  }) }}
+  <form action="/form-handler" method="post" novalidate>
+    {{ govukCookieBanner({
+      ariaLabel: "Cookies on [name of service]",
+      messages: [
+        {
+          headingText: "Cookies on [name of service]",
+          html: '<p class="govuk-body">We use some essential cookies to make this service work.</p>
+            <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>',
+          actions: [
+            {
+              text: "Accept analytics cookies",
+              type: "submit",
+              name: "cookies",
+              value: "accept"
+            },
+            {
+              text: "Reject analytics cookies",
+              type: "submit",
+              name: "cookies",
+              value: "reject"
+            },
+            {
+              text: "View cookies",
+              href: "#"
+            }
+          ]
+        }
+      ]
+    }) }}
+  </form>
 {% endblock %}
 
 {% block skipLink %}

--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -49,14 +49,14 @@ ignoreInSitemap: true
             {
               text: "Accept analytics cookies",
               type: "submit",
-              name: "cookies",
-              value: "accept"
+              name: "cookies[analytics]",
+              value: "yes"
             },
             {
               text: "Reject analytics cookies",
               type: "submit",
-              name: "cookies",
-              value: "reject"
+              name: "cookies[analytics]",
+              value: "no"
             },
             {
               text: "View cookies",

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -50,14 +50,14 @@ ignoreInSitemap: true
             {
               text: "Accept analytics cookies",
               type: "submit",
-              name: "cookies",
-              value: "accept"
+              name: "cookies[analytics]",
+              value: "yes"
             },
             {
               text: "Reject analytics cookies",
               type: "submit",
-              name: "cookies",
-              value: "reject"
+              name: "cookies[analytics]",
+              value: "no"
             },
             {
               text: "View cookies",

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -38,34 +38,36 @@ ignoreInSitemap: true
 {% endblock %}
 
 {% block bodyStart %}
-  {{ govukCookieBanner({
-    ariaLabel: "Cookies on [name of service]",
-    messages: [
-      {
-        headingText: "Cookies on [name of service]",
-        html: '<p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>',
-        actions: [
-          {
-            text: "Accept analytics cookies",
-            type: "button",
-            name: "cookies",
-            value: "accept"
-          },
-          {
-            text: "Reject analytics cookies",
-            type: "button",
-            name: "cookies",
-            value: "reject"
-          },
-          {
-            text: "View cookies",
-            href: "#"
-          }
-        ]
-      }
-    ]
-  }) }}
+  <form action="/form-handler" method="post" novalidate>
+    {{ govukCookieBanner({
+      ariaLabel: "Cookies on [name of service]",
+      messages: [
+        {
+          headingText: "Cookies on [name of service]",
+          html: '<p class="govuk-body">We use some essential cookies to make this service work.</p>
+            <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>',
+          actions: [
+            {
+              text: "Accept analytics cookies",
+              type: "submit",
+              name: "cookies",
+              value: "accept"
+            },
+            {
+              text: "Reject analytics cookies",
+              type: "submit",
+              name: "cookies",
+              value: "reject"
+            },
+            {
+              text: "View cookies",
+              href: "#"
+            }
+          ]
+        }
+      ]
+    }) }}
+  </form>
 {% endblock %}
 
 {% block skipLink %}
@@ -150,5 +152,6 @@ ignoreInSitemap: true
 
 {% block bodyEnd %}
   <script src="{{ getFingerprint('javascripts/govuk-frontend.js') }}"></script>
+  <script src="{{ getFingerprint('javascripts/example.js') }}"></script>
   <script src="{{ getFingerprint('javascripts/vendor/iframeResizer.contentWindow.min.js') }}"></script>
 {% endblock %}

--- a/views/partials/_cookie-banner.njk
+++ b/views/partials/_cookie-banner.njk
@@ -48,6 +48,7 @@
       actions: [
         {
           text: "Hide cookie message",
+          type: "button",
           classes: "js-cookie-banner-hide js-cookie-banner-hide--accept"
         }
       ],
@@ -60,6 +61,7 @@
       actions: [
         {
           text: "Hide cookie message",
+          type: "button",
           classes: "js-cookie-banner-hide js-cookie-banner-hide--reject"
         }
       ],


### PR DESCRIPTION
Follows on from https://github.com/alphagov/govuk-design-system/pull/3115 to fix a few things spotted by `html-validate`

1. Add button `type="button"` to **Hide cookie message** client-side buttons
1. Add button `type="submit"` to **Hide cookie message** server-side buttons
1. Remove button `href="#"` from **Hide cookie message** server-side buttons
1. Remove button `name` and `value` from various client-side examples

To solve a gotcha I've hit in the past too, the [Cookie banner](https://design-system.service.gov.uk/components/cookie-banner) and [Cookies page](https://design-system.service.gov.uk/patterns/cookies-page/) form fields now match

E.g. The same server-side middleware could respond to form submissions from either the banner or page

## Customised page template

I've updated the [**Customised page template** cookie banner](https://design-system.service.gov.uk/styles/page-template/#customised-page-template) example to show server-side usage

Some client-side features from [the guidance](https://design-system.service.gov.uk/components/cookie-banner/#option-3-if-you-set-non-essential-cookies-but-only-on-the-client) were missing such as:

1. Message hidden by default users without JavaScript
1. Additional confirmation messages for accept/reject
1. Usage of `role="alert"` for confirmation messages

But we can add those missing features if we'd prefer it to show client-side usage instead