### PR TITLE
Add Kam to the team

### DIFF
--- a/src/design-system-team.md
+++ b/src/design-system-team.md
@@ -13,6 +13,7 @@ The GOV.UK Design System at the [Government Digital Service](https://www.gov.uk/
 If you want to contact the team you can [get in touch via email or Slack](/get-in-touch/).
 
 - Izabela Podralska – Delivery Manager
+- Kam Nijjar – Associate Delivery Manager
 - Kelly Lee – Delivery Manager
 - Oliver Byford – Lead Frontend Developer
 - Steve Messer – Senior Product Manager


### PR DESCRIPTION
We add people to the team page when they join, so let's get Kam listed.