### PR TITLE
[WIP] Add code of conduct

### DIFF
--- a/src/code-of-conduct.md
+++ b/src/code-of-conduct.md
@@ -1,0 +1,63 @@
+---
+title: Design System Day code of conduct
+description: In order to establish and maintain an inclusive environment we ask attendees, volunteers, speakers, facilitators and organisers to agree to the following code of conduct.
+layout: layout-single-page-prose.njk
+---
+
+<span class="govuk-caption-xl">Design System Day 2023</span>
+<h1 class="govuk-heading-xl">Code of Conduct</h1>
+
+In order to establish and maintain an inclusive environment we ask attendees, volunteers, speakers, facilitators and organisers to agree to the following code of conduct.
+
+* Have respect for all fellow participants. We should all create a harassment-free event for everyone regardless of gender, age, sexual identity, disability, physical appearance, body size, race, ethnicity, religion or belief. Harassment will not be tolerated in any form.
+
+* Expect people to prefer different ways of communicating on a video conference, such as turning off their video or using chat instead of speaking.
+* Help create a safe and welcoming environment. We can do this by being open to diverse points of view, by inviting other people to join and by keeping things people share confidential if they specify it.
+* Do not assume everyone has the same context. Encourage questions.
+* Listen to others, and ensure that all activities are respectful, participatory, and productive.
+* Consider your environment and minimise loud noises. Have empathy for others in different situations who may not be able to control their environment. Please mute your microphone when entering a session unless you want to contribute.
+* Provide constructive, helpful feedback rather than criticising. There are some great tips here (you can download the file): [https://github.com/alphagov/govdesign/blob/master/Poster_GivingAskingReceivingFeedback.pdf](https://github.com/alphagov/govdesign/blob/master/Poster_GivingAskingReceivingFeedback.pdf)
+* Stay on topic as we only have a limited amount of time. If a conversation goes off topic we may ask you to hold off on the conversation until a more suitable time.
+* Be present – please try to make the most of the event. Engage with discussions and workshops as much as you feel comfortable. We want everyone to learn from others and meet people working on similar challenges. If you’re unable to attend, please cancel your ticket as soon as possible so people on the waitlist can attend. 
+* Attendees should not record video or take photographs of sessions run unless specified by session runners. You can take screenshots of presentation slides for personal use or shared within a government context unless stated otherwise by the session runners. 
+* Be considerate of what you share on social media. Do not share any content, insights or links from sessions without the explicit permission of the session runners.
+
+The event organisers reserve the right to ask anyone in violation of these policies to not participate in further activities. 
+
+Organisers will reinforce this code throughout event engagements. If you have any concerns, contact any of our organisers immediately. Organisers can be contacted: 
+
+* in person on day 1; they will be wearing a Design System Day t-shirt
+* by direct message in Hopin on day 2; they will have Organiser or Moderator next to their name
+
+Alternatively you can [email the Design System Day inbox](mailto:design-system-day-enquiries@digital.cabinet-office.gov.uk) and a member of the team will get back to you. 
+
+List of organisers: 
+
+* Antoni Devlin
+* Bee Butler
+* Brett Kyle
+* Calvin Lau
+* Charlotte Downs
+* Chris Ballantine-Thomas
+* Ciandelle Hughes
+* Claire Ashworth
+* David Cox
+* Dinesh Gnanachchelvam
+* Imran Hussain
+* Izabela Podralska
+* Katrina Birch
+* Kelly Lee
+* Kim 'beeps' Grey
+* Nora Brodian
+* Oliver Byford
+* Owen Jones
+* Romaric Pascal
+* Steve Messer
+* Tallulah Jackson-Marriott 
+
+(These guidelines are adapted from the [Practical Service Design](http://www.practicalservicedesign.com/getting-started-on-slack/) community guidelines, [Afrotech Fest](https://www.afrotechfest.co.uk/coc/), [Code for America](http://www.cvent.com/events/code-for-america-summit-2018/custom-40-e12d85b157b94d69b80d8911cc641d36.aspx), [UKGovcamp](https://www.ukgovcamp.com/code-of-conduct/), and [Services Week 2021](https://docs.google.com/document/d/1vQchJh-s6Fu6F4bN8UFM4lvRChe8ERgsE5whf9pUfjA/edit?usp=sharing) codes of conduct.)
+
+
+---
+
+Last updated: 21 September 2023 


### PR DESCRIPTION
We want a code of conduct with a shorter URL, to appear on lanyards and booklets, hence why we didn't add this to the community section. But we can link to it from other pages (hence the [WIP] tag).