### PR TITLE
Fix flaky broken link checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 deploy/public
 node_modules/
-npm-debug.log
+*.log
 .DS_Store
 .sass-cache
 .cache

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:js": "eslint --cache --cache-location .cache/eslint --cache-strategy content --color --ignore-path .gitignore \"**/*.{cjs,js,md,mjs}\"",
     "lint:prettier": "prettier --cache --cache-location .cache/prettier --cache-strategy content --check \"**/*.{cjs,js,json,md,mjs,scss,yaml,yml}\"",
     "lint:scss": "stylelint \"**/*.{md,scss}\"",
-    "check-links": "hyperlink --canonicalroot https://design-system.service.gov.uk/ --internal --recursive --source-maps deploy/public/sitemap.xml | tap-mocha-reporter min"
+    "check-links": "hyperlink --canonicalroot https://design-system.service.gov.uk/ --internal --recursive deploy/public/sitemap.xml | tap-mocha-reporter min"
   },
   "dependencies": {
     "accessible-autocomplete": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:js": "eslint --cache --cache-location .cache/eslint --cache-strategy content --color --ignore-path .gitignore \"**/*.{cjs,js,md,mjs}\"",
     "lint:prettier": "prettier --cache --cache-location .cache/prettier --cache-strategy content --check \"**/*.{cjs,js,json,md,mjs,scss,yaml,yml}\"",
     "lint:scss": "stylelint \"**/*.{md,scss}\"",
-    "check-links": "hyperlink --canonicalroot https://design-system.service.gov.uk/ --internal --recursive deploy/public/sitemap.xml | tap-mocha-reporter min"
+    "check-links": "hyperlink --canonicalroot https://design-system.service.gov.uk/ --internal --recursive deploy/public/sitemap.xml | tee check-links.log | tap-mocha-reporter min"
   },
   "dependencies": {
     "accessible-autocomplete": "^2.0.4",


### PR DESCRIPTION
We have a very flaky `npm run check-links` script at the moment

This PR partially fixes https://github.com/alphagov/govuk-design-system/issues/3113 and https://github.com/alphagov/govuk-frontend/issues/4223 makes the link checker stable by:

~1. Avoiding **sitemap.xml** parsing~
2. Remove flag `--source-maps`
~3. Remove flag `--recursive` (uses glob instead)~
~4. Replace reporter [`tap-mocha-reporter`](https://www.npmjs.com/package/tap-mocha-reporter) with [`tap-min`](https://www.npmjs.com/package/tap-min)~
5. Saving output to disk before piping to reporter

### Task output
In the past we've [switched reporter](https://github.com/alphagov/govuk-frontend-docs/commit/3e3adb6e2f28aa14e7706fecce81b34b11f5d967) to increase stability but see https://github.com/Munter/hyperlink/issues/179#issuecomment-619537282. The best fix was to pipe to disk first, using the [**README** suggestion](https://github.com/Munter/hyperlink#reporters) in https://github.com/alphagov/govuk-design-system/pull/3173#issuecomment-1740893471

Initially this PR bypassed the reporter entirely but output was too noisy:

```console
> check-links
> hyperlink --canonicalroot https://design-system.service.gov.uk/ --internal --root deploy/public --skip "govuk/all.css" --skip "govuk-frontend/all.css" --skip "govuk-frontend/all.js" --skip "<YOUR-DOMAIN>" $(glob "deploy/public/**/*.html")

TAP version 13
# Crawling internal assets
ok 1 load deploy/public/index.html
ok 2 load deploy/public/google921002f57f264802.html
ok 3 load deploy/public/styles/index.html
ok 4 load deploy/public/sitemap/index.html
ok 5 load deploy/public/privacy-policy/index.html
ok 6 load deploy/public/patterns/index.html
ok 7 load deploy/public/get-started/index.html
ok 8 load deploy/public/get-in-touch/index.html
ok 9 load deploy/public/design-system-team/index.html
ok 10 load deploy/public/cookies/index.html
```