### PR TITLE
Add a link to GOV.UK Frontend ASP.NET Core library

### DIFF
--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -61,6 +61,9 @@ A walkthrough for how to import the GOV.UK Design System into a MVC project and 
 [GOV.UK Design System for ASP.NET MVC and Umbraco](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions) -
 GOV.UK Frontend ASP.NET tag helpers, and Umbraco CMS support.
 
+[ASP.NET Core integration for GOV.UK Design System](https://github.com/gunndabad/govuk-frontend-aspnetcore) - 
+GOV.UK Frontend asset integration and component library for ASP.NET Core.
+
 ### Node.js
 
 Guidance on [building a hapi service using GOV.UK Frontend](https://github.com/DEFRA/hapi-govuk-examples).

--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -53,16 +53,16 @@ Sketch wireframes based on the GOV.UK Design System.
 
 ## Build front ends
 
-### ASP.NET MVC
+### ASP.NET
 
 Guidance on [bringing the GOV.UK Design System into a .NET MVC Project](https://github.com/nouriach/compile-gds-runtime-dotnet) -
 A walkthrough for how to import the GOV.UK Design System into a MVC project and compile the sass at runtime using gulp.
 
-[GOV.UK Design System for ASP.NET MVC and Umbraco](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions) -
-GOV.UK Frontend ASP.NET tag helpers, and Umbraco CMS support.
+[GOV.UK Design System for ASP.NET Core](https://github.com/gunndabad/govuk-frontend-aspnetcore) - 
+GOV.UK Frontend component library and assets integration for ASP.NET Core
 
-[ASP.NET Core integration for GOV.UK Design System](https://github.com/gunndabad/govuk-frontend-aspnetcore) - 
-GOV.UK Frontend asset integration and component library for ASP.NET Core.
+[GOV.UK Design System for Umbraco CMS](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions) -
+Additional extensions with Umbraco CMS support, based on the ASP.NET Core integration
 
 ### Node.js
 


### PR DESCRIPTION
This open source library is used within DfE and is built upon by https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions.