### PR TITLE
Fix local `search-index.json` test (no hash fingerprint)

### DIFF
--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -1,7 +1,7 @@
 const { goTo, getProperty } = require('../lib/puppeteer-helpers.js')
 
 // Regex that can be used to match on fingerprinted search index files
-const isSearchIndex = /.*\/search-index-[0-9a-f]{32}.json$/
+const isSearchIndex = /.*\/search-index(-[0-9a-f]{32})?.json$/
 
 describe('Site search', () => {
   let $module


### PR DESCRIPTION
This PR fixes a bug that only affects local development builds

Consider the following:

* When running locally using `npm test` we **do** add hash fingerprints to generated assets
* When running locally using `npm start` we **do not** add hash fingerprints to generated assets

Since `npm test` overwrites a development build with a production build, we must run `npx jest` directly as shown

### Steps to reproduce

1. In Terminal 1, run `npm start`
1. In Terminal 2, run `npx jest --watch __tests__/search.test.js`

### Test output

You'll see two failures because requests to `search-index.json` (without a hash fingerprint) are not mocked:

```console
  ● Site search › shows user a message that the index has failed to download

    expect(received).resolves.toBe(expected) // Object.is equality

    Expected: "Failed to load the search index"
    Received: "No results found"
```

The fix? We can update the mock to [match `search-index.json` without or without a hash fingerprint](https://github.com/alphagov/govuk-design-system/pull/3180#pullrequestreview-1650594272)