### PR TITLE
Ensure `git clone` uses LF line endings for EditorConfig

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This PR prevents [**EditorConfig** check failures](https://github.com/alphagov/govuk-frontend/pull/2863/commits/dfe47a5fe0e95f4196a600fdfd4fc7142e5f11e9) on Windows

The change adds `* text=auto eol=lf` to **.gitattributes** copied from https://github.com/alphagov/govuk-frontend/pull/2863/commits/dfe47a5fe0e95f4196a600fdfd4fc7142e5f11e9

This was simpler than configuring [`core.autocrlf`](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf) for every Windows developer