### PR TITLE
Design system day speakers

### DIFF
--- a/src/community/design-system-day/index.md
+++ b/src/community/design-system-day/index.md
@@ -66,93 +66,19 @@ Our speakers come from organisations across the UK and international public sect
 
 ### Day 1
 
-The first day will be at Dynamic Earth, Edinburgh.
+The first day will be on Tuesday 10 October, in-person at Dynamic Earth, Holyrood Road, Edinburgh, EH8 8AS.
 
 The event is open from 9am and starts at 9:45am. There will be breaks throughout the day and an hour for lunch. Talks will close at 4:15pm and a social hour will run until 5:15pm.
 
 Dynamic Earth is an accessible venue, and we'll have a room set aside as a quiet space and prayer room. There will be live captions of all sessions.
 
-- Reflections on creating the Scottish Government Digital Design System
-  Samantha Ernstzen and Jennifer I'Anson (Scottish Government)
-- The impact of research operations when conducting user research at scale
-  Rachel Male (Scottish Government)
-- What we've been up to, where we're headed
-  Ciandelle Hughes, Calvin Lau and Steve Messer (GOV.UK Design System)
-- How design systems manage contributions
-  Caroline Jarrett (Effortmark), Frankie Roberto (Department for Education), Vicky Teinaki (Student Loans Company), and Ellis Capon (Just Eat)
-- Trauma-informed research and design
-  Janice Hannaway (ResearchU), Kate Every (Mastek), and Helen Baron (The Emily Davison Centre)
-- Design systems don’t solve problems, people do
-  Tash Willcocks (TPXimpact)
+You can find out more about what each session will be about by looking up the [session information](/community/design-system-day/session-information/#day-1-sessions).
+
+You can read our [speaker and panelist biographies](/community/design-system-day/speaker-information/#day-1-speakers) for those talking and presenting at the event. 
 
 You'll be able to speak with others in the community and chat with panellists too. Towards the end of the day, we'll have an optional social for more conversation.
 
-### Day 2
-
-The second day will be hosted online.
-
-The event starts at 9:30am and runs until 5pm, and we'll break for lunch at 12:30pm. There will be breaks throughout the day and you're free to drop in and out as you like.
-
-Most sessions are talks or show and tells where speakers may take questions at the end. We've highlighted workshops that will ask the audience to participate.
-
-#### In the morning
-
-- We’re feeling ’appy
-  Oliver Binns, Chris Choy and Helena Trippe (GOV.UK One Login)
-- The contributor perspective on design systems
-  Frankie Roberto (Department for Education)
-- Trauma-informed design – passing trend, or new aspect of accessibility?
-  Katharine Beer (Department for Education)
-- How brand design systems offer the power of confidence
-  Abigail Baldwin (Buttercrumble)
-- How GOV.UK Pay is making recurring payments easy for the public sector
-  Sacha Zarb (GOV.UK Pay)
-- From pixels to paradigm shifts – tailoring a dedicated design system to catalyse innovation in the Italian Ministry of Economy and Finance
-  Simone di Fresco (DOS Design)
-- The challenges of scaling up a truly user-centred service
-  Laura Smith (Unboxed)
-
-#### After lunch
-
-- A service designer's approach to human-centered life transitions
-  Sylvie Abookhire (Independent)
-- Leading the system
-  Daniel Fontaneda (Bumble)
-- Imposter syndrome in government and why it's not always a bad thing
-  Ciandelle Hughes (GOV.UK Design System)
-- Web components – a year in the field
-  Ashley Watson-Nolan (Just Eat)
-- From code to content-first – scaling content production at PayPal
-  Kate Thomas (PayPal)
-- Design pattern histories
-  Vicky Teinaki (Student Loans Company)
-- How a design API empowers product teams to ensure brand consistency at scale
-  Louis Chenais (Specify)
-- Responsive design, design systems and 'hyperobjects'
-  Ethan Marcotte (Autogram) and Steve Messer (GOV.UK Design System)
-
-#### In the afternoon
-
-- Doing good discovery
-  Debra Churchill (Ontario Public Service)
-- Workshop: Using task lists in your services
-  Frankie Roberto (Department for Education)
-- The iPhone state – simplicity through complexity
-  Gordon Guthrie (Scottish Government)
-- Workshop: How participatory research can help us co-design more ethically
-  Jane Martin and Betty Mwema (Government Digital Service)
-- Designing for underserved audiences
-  Valentine Makhouleen (Prelude Security/New Media Studio)
-- From chaos to clarity – unlocking the potential of design systems
-  Hassan Nawaz (FanDuel)
-- Fostering Collaboration in Design Systems.
-  James Carleton (PayPal)
-
-## Getting there
-
-Day 1 will be on Tuesday 10 October, in-person at Dynamic Earth, Holyrood Road, Edinburgh, EH8 8AS.
-
-The venue is accessible by foot and public transport.
+#### Getting there
 
 {{ govukSummaryList({
   classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-8",
@@ -192,11 +118,20 @@ The venue is accessible by foot and public transport.
   ]
 }) }}
 
-## Joining online
+### Day 2
 
 Day 2 will take place online using the Hopin platform. You can use another device if it's blocked on your work computer.
 
 A link to join will be sent to all attendees before the event. If you email us as the event is starting, it might take us a while to reply to you as we'll be busy running the event.
+
+We have a variety of speakers from public and private sector organisations. You can find our more about them by looking at their [speaker biographies](/community/design-system-day/speaker-information/#day-1-speakers).
+
+The event starts at 9:30am and runs until 5pm, and we'll break for lunch at 12:30pm. There will be breaks throughout the day and you're free to drop in and out as you like.
+
+Most sessions are talks or show and tells where speakers may take questions at the end. We've highlighted workshops that will ask the audience to participate.
+
+You can find out more information about each session by looking up the [session information](/community/design-system-day/session-information/#day-2-sessions). 
+
 
 ## About the GOV.UK Design System community
 

--- a/src/community/design-system-day/index.md
+++ b/src/community/design-system-day/index.md
@@ -98,7 +98,7 @@ Most sessions are talks or show and tells where speakers may take questions at t
 #### In the morning
 
 - We’re feeling ’appy
-  Oliver Binns and Chris Choy (GOV.UK One Login)
+  Oliver Binns, Chris Choy and Helena Trippe (GOV.UK One Login)
 - The contributor perspective on design systems
   Frankie Roberto (Department for Education)
 - Trauma-informed design – passing trend, or new aspect of accessibility?
@@ -115,7 +115,7 @@ Most sessions are talks or show and tells where speakers may take questions at t
 #### After lunch
 
 - A service designer's approach to human-centered life transitions
-  Sylvie Abookhire (DC.gov)
+  Sylvie Abookhire (Independent)
 - Leading the system
   Daniel Fontaneda (Bumble)
 - Imposter syndrome in government and why it's not always a bad thing
@@ -145,7 +145,7 @@ Most sessions are talks or show and tells where speakers may take questions at t
   Valentine Makhouleen (Prelude Security/New Media Studio)
 - From chaos to clarity – unlocking the potential of design systems
   Hassan Nawaz (FanDuel)
-- Collaborative design systems at scale
+- Fostering Collaboration in Design Systems.
   James Carleton (PayPal)
 
 ## Getting there

--- a/src/community/design-system-day/session-information.md
+++ b/src/community/design-system-day/session-information.md
@@ -1,0 +1,229 @@
+---
+title: Session information for Design System Day 2023
+description: Session information for talks, show and tells, workshops and keynotes.
+section: Community
+theme: Events and workshops
+layout: layout-pane.njk
+order: 14
+---
+
+<img src="/community/images/dsd23-announcement-banner.svg" alt="Design System Day 2023 logo" class="app-image--no-border" loading="lazy">
+
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{{ govukSummaryList({
+  classes: "govuk-!-margin-top-3 govuk-!-margin-bottom-9",
+  rows: [
+    {
+      key: {
+        text: "Dates"
+      },
+      value: {
+        text: "10 and 11 October 2023"
+      }
+    },
+    {
+      key: {
+        text: "Location"
+      },
+      value: {
+        html: '<a href="https://dynamicearth.org.uk/plan-your-visit/getting-here/">Dynamic Earth</a>, Edinburgh, and online'
+      }
+    }
+  ]
+}) }}
+
+<!--
+
+Setting the following convention:
+    /community/design-system-day/ always describes the upcoming event or the event in general
+    /community/design-system-day-[year]/ is the archive page for an event which collects the videos, slides and notes for a particular conference
+
+This means that hyperlinks to /community/design-system-day/ can always encourage ticket sales or mailing list subscriptions.
+
+-->
+
+## Day 1 sessions
+
+### The impact of research operations when conducting user research at scale
+Rachel Male
+10:00 - 10:30
+
+Rachel will cover the user research context in the Scottish Government’s Social Security Directorate, and how she created a research operations unit that refined processes and added critical value when the team suddenly scaled. She will focus on the lessons she learnt during the process and share some tips on how to create impact.
+
+### Reflections on creating the Scottish Government Digital Design System
+Samantha Ernstzen and Jennifer I'Anson
+10:30 - 11:00
+
+Join the Scottish Government's Head of Design, Samantha Ernstzen, and Product Owner of Design System, Jennifer I'Anson, as they reflect candidly on creating the Scottish Government Digital Design System. They’ll discuss the challenges of launching during the Covid-19 pandemic, how the design system is being used, and the future plans for the product.
+
+### What we've been up to, where we're headed
+Ciandelle Hughes, Calvin Lau and Steve Messer
+11:00 - 11.30
+
+
+
+### How design systems manage contributions
+Caroline Jarrett, Frankie Roberto, Vicky Teinaki and Ellis Capon
+11:45 - 12:30
+
+Hear how designers and developers across the private and public sector prioritise contributions and work with their communities to make the process effective and rewarding for contributors and system curators.
+
+### Trauma-informed research and design
+Janice Hannaway, Kate Every and Helen Baron
+13:45 - 14:45
+
+Whether you consider yourself well informed about trauma informed approaches to research and design or are curious and want to learn more, this is your opportunity to engage with a multidisciplinary panel and colleagues across the public and private sector who are working towards more compassionate and aware design.
+
+### Design systems don’t solve problems, people do
+Tash Willcocks
+15:00 - 16:00
+
+The Design Lead at TPX Impact, Tash will discuss the intricate relationship between people and design systems. She will explore how individuals shape design systems just as profoundly as these systems influence them. From user feedback, ownership, to the organisation's context, she will delve into the dynamic interplay that defines modern design practices.
+
+## Day 2
+
+### We’re feeling ’appy
+Oliver Binns, Chris Choy and Helena Trippe
+10:00 - 11:30
+
+We’ll talk about the design system we created for GDS’s first mobile app ‘GOV.UK ID Check’. We’ll cover our work to adapt the GOV.UK Design System for web into a native mobile world, taking guidance from Apple’s Human Interface Guidelines, Google’s Material Design Guidelines and the Web Consortium Accessibility Guidelines.
+
+### The contributor perspective on design systems
+Frankie Roberto
+10:00 - 11:30
+
+The process of contributing to a design system, especially when your main job is designing a service, can be daunting and time-consuming. With input from a number of past contributors, this talk looks at a number of successful contributions, and offers a perspective on how contribution models might continue to scale and evolve.
+
+### Trauma-informed design – passing trend, or new aspect of accessibility?
+Katharine Beer
+10:00 - 11:30
+
+Is trauma-informed design a passing trend or a new facet of accessibility? In this session, we aim for participants to deepen their understanding of trauma and its complexities. While we believe that this approach can enhance design practices and results, we welcome diverse perspectives and encourage open discussion. We also welcome anyone who prefers to stay quiet and listen during sessions.
+
+### How brand design systems offer the power of confidence
+Abigail and Chloe Baldwin
+10:00 - 11:30
+
+Amid challenges, two young twin designers from humble backgrounds share a relatable tale of creative business beginnings. Design systems alleviate the burden of risk, functioning as a guide, and empowering the creative practice. This talk will provide practical guidance to fledgling designers and business owners to forge their branding systems.
+
+### How GOV.UK Pay is making recurring payments easy for the public sector
+Sacha Zarb
+10:00 - 11:30
+
+The talk will look at how GOV.UK Pay, has brought functionality to the platform, that allows services to quickly and easily add recurring payments. We will talk about the design challenges, how services are using this, and how we've designed this for the future. 
+
+### From pixels to paradigm shifts – tailoring a dedicated design system to catalyse innovation in the Italian Ministry of Economy and Finance
+Simone di Fresco
+10:00 - 11:30
+
+Unlock the power of dedicated Design Systems with our case study on the Italian Ministry of Economy and Finance. Discover how user insights and innovative tools are supporting the accounting operations of hundreds of thousands of users in the major Italian Public administrations, fostering a culture of meaningful change.
+
+### The challenges of scaling up a truly user-centred service
+Laura Smith
+10:00 - 11:30
+
+Using two case studies from public healthcare, we'll consider the challenges of maintaining a focus on users when scaling beyond minimum viable product (MVP) into growth and diversification.
+
+### A service designer's approach to human-centered life transitions
+Sylvie Abookire 
+10:00 - 11:30
+
+How might we… design our design practice for optimal success and wellbeing? The methods we use every day as designers can help us creatively navigate our own professional journeys. Through reflective, hands-on activities, participants will learn how they can apply human-centered design to navigate personal decisions surrounding life and work.
+
+### Leading the system
+Daniel Fontaneda
+13:45 - 14:45
+
+In this talk I will explain what are the key pillars that are helping me and my team to lead the design system in a complex environment, working with multiple products at the same time and being a small team and dealing with many different stakeholders.
+
+### Imposter syndrome in government and why it's not always a bad thing
+Ciandelle Hughes
+13:45 - 14:45
+
+Imposter syndrome is something that is often talked about but rarely understood well. This session is designed to talk about the basics of imposter syndrome, including the way in which it can manifest itself. 
+
+We will explore some of the ways imposter syndrome can impact your personal and professional lives. This will be both on a short and longer term basis. We will ask ourselves two key questions:
+- Can I overcome imposter syndrome?
+- If I can't, can I learn to live with it?
+
+### Web components – a year in the field
+Ashley Watson-Nolan
+13:45 - 14:45
+
+Over the last year, Ashley has been delving into the world of Web Components, exploring the promise of native component development to help build a global design system. In this talk, he'll share his learnings, revealing why he's so excited by their potential to shape the future of web development.
+
+### From code to content-first – scaling content production at PayPal
+Kate Thomas 
+13:45 - 14:45
+
+After 20+ years of managing experiences in code, a new design system + headless CMS changed everything about PayPal.com. Kate Thomas, at the forefront of this transformation, will share the highs, lows, and deep dive into how they reduced publishing time from weeks to hours while increasing global reach. 
+
+### Design pattern histories
+Vicky Teinaki
+13:45 - 14:45
+
+### How a design API empowers product teams to ensure brand consistency at scale
+Louis Chenais
+13:45 - 14:45
+
+How to manage design decisions at scale? How to adopt a shared design language across team and ensure brand consistency across any product and platform? This presentation introduces how a design API can help designers collect, store, and distribute their design tokens at scale.
+
+### Responsive design, design systems and 'hyperobjects'
+Ethan Marcotte and Steve Messer 
+13:45 - 14:45
+
+### Doing good discovery
+Debra Churchill 
+15:00 - 16:30
+
+Employment Ontario services have a mix of old and current user platforms. 8 months of Discovery and User research was completed to delve into the problem statement. This session presents the findings from the research but also looks to tackle the problem of user research with vulnerable and marginalized populations.
+
+### Workshop: Using task lists in your services
+Frankie Roberto
+15:00 - 16:30
+
+This session takes a detailed look at the new Task List component, and will show you how to implement the wider task list pattern within your service through a live demo.
+
+This will include how to:
+
+- use the new Task List component
+- split up a complex application into smaller tasks
+- give the user control over when tasks are marked as completed
+- allow users to review all their tasks before submitting
+
+You'll also have the opportunity to share screenshots from your service, and get feedback from others on whether and how a task list pattern might work for it.
+
+### The iPhone state – simplicity through complexity
+Gordon Guthrie 
+15:00 - 16:30
+
+iPhones work but no one individual knows how. They are technically, legally and linguistically sophisticated but just work globally.  The modern digital state must embrace simplicity through management of complexity - taking systems view of state capability from manifesto and think tank, through parliamentary oversight to design, delivery and in-service.
+
+### Workshop: How participatory research can help us co-design more ethically
+Jane Martin and Betty Mwema 
+15:00 - 16:30
+
+In this session, we will be looking at how the field of participation has lived a long time and how it has much to offer to co-design, ethics, equity and justice.
+
+We'll look at how we can develop co-design practice with an ethics-based approach that's safe and informed. 
+
+### Designing for underserved audiences
+Valentine Makhouleen 
+15:00 - 16:30
+
+What do gender-affirming care providers, childhood mental health experts, reindeer herders and life science researchers have in common? Aside from being underserved, they are leading the charge in changing the world. Their budgets are small, requirements large and needs endless. How do we design meaningful tools for those changing the world? 
+
+### From chaos to clarity – unlocking the potential of design systems
+Hassan Nawaz 
+15:00 - 16:30
+
+Experience the evolution from chaos to clarity within design systems. See their potential unlocked, creating a united future for experiences that yield impact.
+
+As we embark on this immersive session, prepare to gain actionable insights that empower you to harness the untapped potential of design systems. Together, let's unlock a united future where the synergy of creativity and clarity gives rise to impactful experiences that resonate and endure.
+
+### Fostering Collaboration in Design Systems.
+James Carleton 
+15:00 - 16:30
+
+Design systems work best when they are collaborative and flexible instead of a strict set of fixed rules. I would like to share my experience in building a community that encourages collaboration and contribution to our DS.

--- a/src/community/design-system-day/session-information.md
+++ b/src/community/design-system-day/session-information.md
@@ -51,7 +51,7 @@ Join the Scottish Government's Head of Design, Samantha Ernstzen, and Product Ow
 Ciandelle Hughes, Calvin Lau and Steve Messer
 11:00 - 11.30
 
-
+In this show and tell you will hear about the work the GOV.UK Design System team have been up to over the last 12 months. You'll hear about the work we have done with amazing contributors and where we are planning to head over next. 
 
 ### How design systems manage contributions
 Caroline Jarrett, Frankie Roberto, Vicky Teinaki and Ellis Capon
@@ -71,7 +71,7 @@ Tash Willcocks
 
 The Design Lead at TPX Impact, Tash will discuss the intricate relationship between people and design systems. She will explore how individuals shape design systems just as profoundly as these systems influence them. From user feedback, ownership, to the organisation's context, she will delve into the dynamic interplay that defines modern design practices.
 
-## Day 2
+## Day 2 sessions
 
 ### We’re feeling ’appy
 Oliver Binns, Chris Choy and Helena Trippe

--- a/src/community/design-system-day/session-information.md
+++ b/src/community/design-system-day/session-information.md
@@ -33,16 +33,6 @@ order: 14
   ]
 }) }}
 
-<!--
-
-Setting the following convention:
-    /community/design-system-day/ always describes the upcoming event or the event in general
-    /community/design-system-day-[year]/ is the archive page for an event which collects the videos, slides and notes for a particular conference
-
-This means that hyperlinks to /community/design-system-day/ can always encourage ticket sales or mailing list subscriptions.
-
--->
-
 ## Day 1 sessions
 
 ### The impact of research operations when conducting user research at scale
@@ -172,6 +162,8 @@ How to manage design decisions at scale? How to adopt a shared design language a
 ### Responsive design, design systems and 'hyperobjects'
 Ethan Marcotte and Steve Messer 
 13:45 - 14:45
+
+A fireside talk with Ethan Marcotte, a web designer, speaker and author who's best known for creating responsive web design. Over his career, Ethan has helped people create beautiful, accessible web experiences and design systems, and Steve will be picking Ethan's brain on what makes design system work different.
 
 ### Doing good discovery
 Debra Churchill 

--- a/src/community/design-system-day/speaker-information.md
+++ b/src/community/design-system-day/speaker-information.md
@@ -41,24 +41,32 @@ Our speakers come from organisations across the UK and international public sect
 
 ## Day 1 speakers
 
+### Kelly Lee (GOV.UK Design System team)
+
+Kelly Lee is a delivery manager on the GOV.UK Design System team. Before joining the Government Digital Service, she worked at Jobcentre Plus in a variety of roles including business coach, performance team leader and financial assessor.
+
+### Imran Hussain (GOV.UK Design System team)
+Imran is a community consultant with over 10 years experience building communities across different sectors. He believes communities can be a force for good in society and loves working with communities that have a positive impact on public life.
+
+He is currently a Community Designer at Government Digital Service, a department in the UK Government. He works on creating the right conditions for a community to thrive around the ever-popular GOV.UK Design System.
+
 ### Rachel Male (Scottish Governement)
 Rachel is User Researcher and works in the Social Security Directorate for the Scottish Government. Rachel helps design disability and low income benefits for the people of Scotland and currently leads research operations focusing on operationalising their user research. Rachel has a passion for ensuring user research is effective, efficient and informative.
 
 ### Samantha Ernstzen (Scottish Governement)
-TBC
+To be confirmed
 
 ### Jennifer I'Anson (Scottish Governement)
-TBC
+To be confirmed
+
+### GOV.UK Design System team 
+The <a href="/design-system-team/" class="govuk-link">GOV.UK Design System team</a> is responsible for the implementation and maintenance of styles, components and patterns on the GOV.UK Design System. 
 
 ### Deborah Dada (Storelab)
 Deborah is a Product Designer with a strong focus on crafting meaningful user experiences and simplifying complex business solutions. Deborah brings a wealth of hands-on experience in UX principles and creating Design Systems with expertise that spans research, design systems and success metrics, underpinned by a design thinking approach. Deborah is currently a Product Designer at StoreLab and contributes to enhancing user satisfaction.
 
 ### Caroline Jarrett (Effortmark)
-Caroline Jarrett is the forms specialist. She advises organisations on how to make forms easier, improve websites and business processes. Her work spans all the types of design that will improve forms. This includes interaction, content and service design. 
-
-Caroline is a sought-after speaker, trainer, and author. Her latest book is Surveys that work: a practical guide for designing and running better surveys.
-
-Caroline has an MA in Mathematics from Oxford University, an MBA and a Diploma in Statistics from the Open University, and is a Chartered Engineer.
+Caroline is the forms specialist. She advises organisations on how to make forms easier, improve websites and business processes. Her work spans all the types of design that will improve forms. Caroline is a sought-after speaker, trainer and author. Her latest book is Surveys that work: a practical guide for designing and running better surveys.
 
 ### Frankie Roberto (Department for Education)
 Frankie Roberto is a lead interaction designer who has worked on several services across different government departments, including 'Apply for teacher training' and 'Ethnicity facts and figures'. 
@@ -66,12 +74,11 @@ Frankie Roberto is a lead interaction designer who has worked on several service
 He's also an experienced contributor to the design community and the GOV.UK Design System. 
 
 ### Vicky Teinaki (Student Loans Company)
-I am a designer currently working as a UX Lead at Student Loans Company. I have worked at Government Digital Service, Department of Work and Pensions and HM Revenue and Customs. I have worked as a user researcher and  more recently as an interaction designer. Since January 2017 I have been a design assessor.
+Vicky is a designer and UX Lead at Student Loans Company. She’s worked at the Government Digital Service, Department of Work and Pensions, and HM Revenue & Customs. Vicky has worked as a user researcher and interaction designer. Vicky has a background as a developer, having done Drupal and WordPress theming and module/plugin development. 
 
-I have several years of experience as a writer and blogger. I began writing  Johnny Holland in 2008, and was one of the chief editors from 2010 to late 2012. 
 
 ### Ellis Capon (Just Eat)
-TBC
+To be confirmed
 
 ### Janice Hannaway (ResearchU)
 Janice is an empathic leader, a trauma-informed user researcher, therapist, and coach with experience working with people who have experienced the effects of trauma. She champions the psychological safety of user-centered design teams and highlights the potential harm from research and design on users. A co-founder of ResearchU Training Academy, she delivers specialist trauma-informed training
@@ -83,13 +90,12 @@ Kate is a Lead Service Designer at Mastek, specialising in inclusive and ethical
 Helen leads the Move-On team and is centre manager at the Emily Davison Centre supporting domestic abuse survivors to access work, education, volunteering and training. Adopting a trauma informed approach within the service has enabled the team to see great leaps in confidence and self-esteem of the women they work with. 
 
 ### Tash Willcocks (TPXimpact)
-Tash has spent over 25 years shaping future change-makers. First as Programme Leader of BA & MA Graphics at Salford University; then as Director of Masters at Hyper Island, working with international students and organisations such as the BBC, UN, NHS, Unilever & Adidas. 
+Tash has spent over 25 years shaping future change-makers. First as Programme Leader of BA and MA Graphics at Salford University, then as Director of Masters at Hyper Island, working with the BBC, UN, NHS, Unilever and Adidas. After joining Snook, Tash created the learning design hub and launched the Snook Design Academy. Her most recent venture is joining TPXImpact to design and build their Design Academy.
 
-Tash later joined Snook, where she created the learning design hub and launched the Snook 
-Design Academy. Her most recent venture is joining TPXImpact to design and build their Design Academy.
+### David Cox (GOV.UK Design System team)
+To be confirmed
 
-
-## Day 2
+## Day 2 speakers
 
 ### Oliver Binns (GOV.UK One Login)
 Oliver is a software engineer from Yorkshire with a master’s degree in Computer Science. He has worked on mobile apps for airlines, healthcare, and government, with a focus on iOS development. 
@@ -98,7 +104,7 @@ Oliver is a software engineer from Yorkshire with a master’s degree in Compute
 Chris is a UX design lead with a Computer Science degree. He worked as an SAP consultant before designing and delivering digital platforms and mobile apps, with a focus on experience design.
  
 ### Helena Trippe (GOV.UK One Login)
-TBC 
+To be confirmed 
 
 ### Frankie Roberto (Department for Education)
 Frankie Roberto is a lead interaction designer who has worked on several services across different government departments, including 'Apply for teacher training' and 'Ethnicity facts and figures'. 
@@ -136,9 +142,7 @@ Ashley is a Principal Engineer at Just Eat Takeaway with over 15 years experienc
 Kate has been unravelling knotty content puzzles for more than 20 years. She's worked in agencies and large institutions and organisations in Australia, the US and the UK, and is currently Content Architect for PayPal. 
 
 ### Vicky Teinaki (Student Loans Company)
-I am a designer currently working as a UX Lead at Student Loans Company. I have worked at Government Digital Service, Department of Work and Pensions and HM Revenue and Customs. I have worked as a user researcher and  more recently as an interaction designer. Since January 2017 I have been a design assessor.
-
-I have several years of experience as a writer and blogger. I began writing  Johnny Holland in 2008, and was one of the chief editors from 2010 to late 2012.  
+Vicky is a designer and UX Lead at Student Loans Company. She’s worked at the Government Digital Service, Department of Work and Pensions, and HM Revenue & Customs. Vicky has worked as a user researcher and interaction designer. Vicky has a background as a developer, having done Drupal and WordPress theming and module/plugin development. 
 
 ### Louis Chenais (Specify)
 Louis is the co-founder and Chief Evangelist at Specify, a DesignOps startup that helps organisations manage their brand identity at scale. Louis is also a contributor of the Design Tokens W3C Community Group (DTCG) whose objective is to create a standard format for design tokens and promote best practices. 

--- a/src/community/design-system-day/speaker-information.md
+++ b/src/community/design-system-day/speaker-information.md
@@ -35,16 +35,6 @@ order: 13
   ]
 }) }}
 
-<!--
-
-Setting the following convention:
-    /community/design-system-day/ always describes the upcoming event or the event in general
-    /community/design-system-day-[year]/ is the archive page for an event which collects the videos, slides and notes for a particular conference
-
-This means that hyperlinks to /community/design-system-day/ can always encourage ticket sales or mailing list subscriptions.
-
--->
-
 ## Speakers 
 
 Our speakers come from organisations across the UK and international public sector. We're joined by folks working on design systems from notable companies too.
@@ -154,10 +144,10 @@ I have several years of experience as a writer and blogger. I began writing  Joh
 Louis is the co-founder and Chief Evangelist at Specify, a DesignOps startup that helps organisations manage their brand identity at scale. Louis is also a contributor of the Design Tokens W3C Community Group (DTCG) whose objective is to create a standard format for design tokens and promote best practices. 
 
 ### Ethan Marcotte (Autogram)
-TBC 
+Ethan is a web designer, speaker, and author who's best known for creating responsive web design. Over the last two decades, his design practice has focused on designing and building beautiful, accessible web experiences, and on helping organisations create more effective design systems. He is a partner and cofounder at Autogram, a strategic consultancy that works at the intersection of design systems and content management.
 
 ### Steve Messer (GOV.UK Design System)
-TBC 
+Steve is a freelance product person, working on the GOV.UK Design System currently. He's passionate about innovation for the public good and open, ethical product design. He's worked at startups, Government Digital Service and NHS Digital, and has taught product management to people from numerous companies through General Assembly. 
 
 ### Debra Churchill (Ontario Public Service)
 Debra’s career has focused on human services. Before leaving New Zealand for Toronto, Canada, Debra worked in operational and policy roles. Since 2015 Debra has used service design methodology to co-create and re-design programs and services. Debra has been part of transformation projects including digital transformation, developmental services transformation, and transfer payment modernisation. 

--- a/src/community/design-system-day/speaker-information.md
+++ b/src/community/design-system-day/speaker-information.md
@@ -1,0 +1,181 @@
+---
+title: Speaker and panelist information for Design System Day 2023
+description: Speaker and panelist biographies and photographs 
+section: Community
+theme: Events and workshops
+layout: layout-pane.njk
+order: 13
+---
+
+<img src="/community/images/dsd23-announcement-banner.svg" alt="Design System Day 2023 logo" class="app-image--no-border" loading="lazy">
+
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "_image-card.njk" import imageCard %}
+
+
+{{ govukSummaryList({
+  classes: "govuk-!-margin-top-3 govuk-!-margin-bottom-9",
+  rows: [
+    {
+      key: {
+        text: "Dates"
+      },
+      value: {
+        text: "10 and 11 October 2023"
+      }
+    },
+    {
+      key: {
+        text: "Location"
+      },
+      value: {
+        html: '<a href="https://dynamicearth.org.uk/plan-your-visit/getting-here/">Dynamic Earth</a>, Edinburgh, and online'
+      }
+    }
+  ]
+}) }}
+
+<!--
+
+Setting the following convention:
+    /community/design-system-day/ always describes the upcoming event or the event in general
+    /community/design-system-day-[year]/ is the archive page for an event which collects the videos, slides and notes for a particular conference
+
+This means that hyperlinks to /community/design-system-day/ can always encourage ticket sales or mailing list subscriptions.
+
+-->
+
+## Speakers 
+
+Our speakers come from organisations across the UK and international public sector. We're joined by folks working on design systems from notable companies too.
+
+## Day 1 speakers
+
+### Rachel Male (Scottish Governement)
+Rachel is User Researcher and works in the Social Security Directorate for the Scottish Government. Rachel helps design disability and low income benefits for the people of Scotland and currently leads research operations focusing on operationalising their user research. Rachel has a passion for ensuring user research is effective, efficient and informative.
+
+### Samantha Ernstzen (Scottish Governement)
+TBC
+
+### Jennifer I'Anson (Scottish Governement)
+TBC
+
+### Deborah Dada (Storelab)
+Deborah is a Product Designer with a strong focus on crafting meaningful user experiences and simplifying complex business solutions. Deborah brings a wealth of hands-on experience in UX principles and creating Design Systems with expertise that spans research, design systems and success metrics, underpinned by a design thinking approach. Deborah is currently a Product Designer at StoreLab and contributes to enhancing user satisfaction.
+
+### Caroline Jarrett (Effortmark)
+Caroline Jarrett is the forms specialist. She advises organisations on how to make forms easier, improve websites and business processes. Her work spans all the types of design that will improve forms. This includes interaction, content and service design. 
+
+Caroline is a sought-after speaker, trainer, and author. Her latest book is Surveys that work: a practical guide for designing and running better surveys.
+
+Caroline has an MA in Mathematics from Oxford University, an MBA and a Diploma in Statistics from the Open University, and is a Chartered Engineer.
+
+### Frankie Roberto (Department for Education)
+Frankie Roberto is a lead interaction designer who has worked on several services across different government departments, including 'Apply for teacher training' and 'Ethnicity facts and figures'. 
+      
+He's also an experienced contributor to the design community and the GOV.UK Design System. 
+
+### Vicky Teinaki (Student Loans Company)
+I am a designer currently working as a UX Lead at Student Loans Company. I have worked at Government Digital Service, Department of Work and Pensions and HM Revenue and Customs. I have worked as a user researcher and  more recently as an interaction designer. Since January 2017 I have been a design assessor.
+
+I have several years of experience as a writer and blogger. I began writing  Johnny Holland in 2008, and was one of the chief editors from 2010 to late 2012. 
+
+### Ellis Capon (Just Eat)
+TBC
+
+### Janice Hannaway (ResearchU)
+Janice is an empathic leader, a trauma-informed user researcher, therapist, and coach with experience working with people who have experienced the effects of trauma. She champions the psychological safety of user-centered design teams and highlights the potential harm from research and design on users. A co-founder of ResearchU Training Academy, she delivers specialist trauma-informed training
+
+### Kate Every (Mastek)
+Kate is a Lead Service Designer at Mastek, specialising in inclusive and ethical design and delivery. She led on accessibility, inclusive and equitable design for the UK's COVID-19 testing roll-out at NHS Digital. Heading up Mastek’s Service Design practice, she champions inclusive, trauma-informed approaches to research and design.  
+
+### Helen Baron (The Emily Davison Centre)
+Helen leads the Move-On team and is centre manager at the Emily Davison Centre supporting domestic abuse survivors to access work, education, volunteering and training. Adopting a trauma informed approach within the service has enabled the team to see great leaps in confidence and self-esteem of the women they work with. 
+
+### Tash Willcocks (TPXimpact)
+Tash has spent over 25 years shaping future change-makers. First as Programme Leader of BA & MA Graphics at Salford University; then as Director of Masters at Hyper Island, working with international students and organisations such as the BBC, UN, NHS, Unilever & Adidas. 
+
+Tash later joined Snook, where she created the learning design hub and launched the Snook 
+Design Academy. Her most recent venture is joining TPXImpact to design and build their Design Academy.
+
+
+## Day 2
+
+### Oliver Binns (GOV.UK One Login)
+Oliver is a software engineer from Yorkshire with a master’s degree in Computer Science. He has worked on mobile apps for airlines, healthcare, and government, with a focus on iOS development. 
+
+### Chris Choy (GOV.UK One Login)
+Chris is a UX design lead with a Computer Science degree. He worked as an SAP consultant before designing and delivering digital platforms and mobile apps, with a focus on experience design.
+ 
+### Helena Trippe (GOV.UK One Login)
+TBC 
+
+### Frankie Roberto (Department for Education)
+Frankie Roberto is a lead interaction designer who has worked on several services across different government departments, including 'Apply for teacher training' and 'Ethnicity facts and figures'. 
+      
+He's also an experienced contributor to the design community and the GOV.UK Design System. 
+
+### Katharine Beer (Department of Education)
+Katharine Beer from the Department for Education is dedicated to crafting accessible and compassionate user experiences. 
+
+### Abigail and Chloe Baldwin (Buttercrumble)
+Twin sisters, Abigail and Chloe Baldwin founded the award-winning creative studio, Buttercrumble. Their specialist blend of design and strategy helps community-sensitive brands become the go-to choice for their audience, and authority in their industry. This is something they've helped to achieve for clients such as John Lewis and Mamas & Papas.  
+
+### Sacha Zarb (GOV.UK Pay)
+Sacha is a Product Manager on GOV.UK Pay, working on improving the experience for the 700 services that use Pay. GOV.UK Pay is currently building new features like recurring card payments, mobile wallets and soon Open Banking to make it the default for payments in government. 
+
+### Simone di Fresco (DOS Design)
+Simone is a Design System specialist and facilitator at DOS Design which is working collaboratively in design with Italy’s Ministry of Economy and Finance. Beyond UX design, Simone is a facilitator in design and research workshops, emphasising co-creation and user-centricity.  
+
+### Laura Smith (Unboxed)
+Laura is a lead designer at Unboxed, specialising in content. With particular experience in digital health, Laura has a keen interest in the importance of language and words in helping people access healthcare services. 
+
+### Sylvie Abookire (Independent)
+Sylvie is a Service Designer specialising in public health, and a Coach in transitions and life design. Sylvie was formerly a Civic Designer at The Lab @ DC, an applied research team in the Washington DC Government. Some of her previous projects focused on housing stability and emergency responses to mental health crises.
+
+### Daniel Fontaneda (Bumble)
+After working as a product designer at Vodafone Group and Amazon, Daniel now leads the Design System at Bumble Inc. within a complex environment where the Design System supports 3 products: Bumble Date, Badoo and BFF (Bumble for Friends). Daniel’s role is to lead the definition and implementation of the product. 
+
+### Ciandelle Hughes (GOV.UK Design System)
+Ciandelle is an Interaction Designer on the GOV.UK Design System. She is an advocate for accessible design as well as a strong believer in human-based design. 
+
+### Ashley Watson-Nolan (Just Eat)
+Ashley is a Principal Engineer at Just Eat Takeaway with over 15 years experience in web development and is a fan of all things visual. He specialises in component-driven development and front-end architecture and is passionate about emerging front-end technologies. He hacks about with CSS and JavaScript, blogs at ashleynolan.co.uk and is @WelshAsh_ on X. 
+
+### Kate Thomas (PayPal)
+Kate has been unravelling knotty content puzzles for more than 20 years. She's worked in agencies and large institutions and organisations in Australia, the US and the UK, and is currently Content Architect for PayPal. 
+
+### Vicky Teinaki (Student Loans Company)
+I am a designer currently working as a UX Lead at Student Loans Company. I have worked at Government Digital Service, Department of Work and Pensions and HM Revenue and Customs. I have worked as a user researcher and  more recently as an interaction designer. Since January 2017 I have been a design assessor.
+
+I have several years of experience as a writer and blogger. I began writing  Johnny Holland in 2008, and was one of the chief editors from 2010 to late 2012.  
+
+### Louis Chenais (Specify)
+Louis is the co-founder and Chief Evangelist at Specify, a DesignOps startup that helps organisations manage their brand identity at scale. Louis is also a contributor of the Design Tokens W3C Community Group (DTCG) whose objective is to create a standard format for design tokens and promote best practices. 
+
+### Ethan Marcotte (Autogram)
+TBC 
+
+### Steve Messer (GOV.UK Design System)
+TBC 
+
+### Debra Churchill (Ontario Public Service)
+Debra’s career has focused on human services. Before leaving New Zealand for Toronto, Canada, Debra worked in operational and policy roles. Since 2015 Debra has used service design methodology to co-create and re-design programs and services. Debra has been part of transformation projects including digital transformation, developmental services transformation, and transfer payment modernisation. 
+
+### Gordon Guthrie (Scottish Government)
+Gordon is a Research Fellow at the Scottish Government on the First Ministers Digital Fellowship Programme. His professional life started as a code monkey in the private sector and has ranged from Chief Technical Architect at if.com, scalability guru at bet365 and ending up as a Silicon Valley VP Engineering. He has worked in public policy in London, Belfast and Scotland.
+ 
+### Jane Martin (Government Digital Service)
+Jane is a senior service designer at the Government Digital Service. Before this she worked for 20 years as a theatre producer and specialist in arts-based methods in international development. She's worked in over 20 countries including 10 years in Cambodia, working with some of the most marginalised groups in the country. 
+
+### Betty Mwema (Government Digital Service)
+Betty Mwema is a senior service designer in the GOV.UK Forms team at the Government Digital Service. She has worked in the social and private sectors for 7 years, with a strong emphasis on inclusivity and ethics. Betty enjoys creating and improving design methods, to ensure that we equitably and inclusively meet the needs of users.
+ 
+### Valentine Makhouleen (Prelude Security/New Media Studio)
+Valentine is a Canadian designer specialising in interaction design, and application of design to solving complex problems. Over the years he has dedicated his time to projects and people that attempt to make the world a better place.
+ 
+### Hassan Nawaz (FanDuel)
+Hassan is curious about people, technology, and behaviour, currently working in senior design leadership at FanDuel, MIT. Passionate about design thinking and humanising technology, Hassan has a track record of creating cohesive, data-driven experiences that drive business results. 
+
+### James Carleton (PayPal)
+James is Senior UX Designer on the Design System (DS) team at PayPal where he’s built and evolved the DS, its team, and community of internal users. James also enjoys contributing to improved accessibility of PayPal products and exploring design tools. James loves following design system industry events and learning from other systems designers.


### PR DESCRIPTION
This change will add speaker and session information to Design System Day, update information for some of the out of date session and remove duplicate information. 