### PR TITLE
Remove experimental status tag and references to experimental status on website

### DIFF
--- a/src/community/contribution-criteria/index.md
+++ b/src/community/contribution-criteria/index.md
@@ -77,7 +77,7 @@ Before a new component or pattern is published the working group reviews the imp
       },
       {
         html: '<p>It has been tested  in user research and shown to work with a representative sample of users, including those with disabilities.</p>
-          <p class="govuk-!-margin-bottom-0">Components and patterns published in a limited number of services can still be published, as long as it meets other contribution criteria. We'll be clear about the specific contexts the component or pattern has been tested in and encourage feedback about its performance in a wide range of services.</p>'        
+          <p class="govuk-!-margin-bottom-0">Components and patterns published in a limited number of services can still be published, as long as it meets other contribution criteria. We\'ll be clear about the specific contexts the component or pattern has been tested in and encourage feedback about its performance in a wide range of services.</p>'
       }
     ],
     [

--- a/src/community/contribution-criteria/index.md
+++ b/src/community/contribution-criteria/index.md
@@ -77,7 +77,7 @@ Before a new component or pattern is published the working group reviews the imp
       },
       {
         html: '<p>It has been tested  in user research and shown to work with a representative sample of users, including those with disabilities.</p>
-          <p class="govuk-!-margin-bottom-0">Components and patterns published in a limited number of services can still be published, as long as it meets other contribution criteria. We\'ll be clear about the specific contexts the component or pattern has been tested in and encourage feedback about its performance in a wide range of services.</p>'
+          <p class="govuk-!-margin-bottom-0">Components and patterns published in a limited number of services can still be contributed, as long as it meets other contribution criteria. We\'ll be clear about the specific contexts the component or pattern has been tested in and encourage feedback about its performance in a wide range of services.</p>'
       }
     ],
     [

--- a/src/community/contribution-criteria/index.md
+++ b/src/community/contribution-criteria/index.md
@@ -77,7 +77,7 @@ Before a new component or pattern is published the working group reviews the imp
       },
       {
         html: '<p>It has been tested  in user research and shown to work with a representative sample of users, including those with disabilities.</p>
-          <p class="govuk-!-margin-bottom-0">Components and patterns which are not proven usable can be published as experimental. But they must be clearly based on relevant user research from other organisations and best practice, and meet the other criteria.</p>'
+          <p class="govuk-!-margin-bottom-0">If there isn\'t evidence of usability outside of one or a small number of services, the component or pattern can still be published if it meets other contribution criteria. We will be clear about what contexts the component or pattern has been tested in upon publishing and invite feedback about its performance in a wide range of services.</p>'
       }
     ],
     [

--- a/src/community/contribution-criteria/index.md
+++ b/src/community/contribution-criteria/index.md
@@ -77,7 +77,7 @@ Before a new component or pattern is published the working group reviews the imp
       },
       {
         html: '<p>It has been tested  in user research and shown to work with a representative sample of users, including those with disabilities.</p>
-          <p class="govuk-!-margin-bottom-0">If there isn\'t evidence of usability outside of one or a small number of services, the component or pattern can still be published if it meets other contribution criteria. We will be clear about what contexts the component or pattern has been tested in upon publishing and invite feedback about its performance in a wide range of services.</p>'
+          <p class="govuk-!-margin-bottom-0">Components and patterns published in a limited number of services can still be published, as long as it meets other contribution criteria. We'll be clear about the specific contexts the component or pattern has been tested in and encourage feedback about its performance in a wide range of services.</p>'        
       }
     ],
     [

--- a/src/community/develop-a-component-or-pattern/index.md
+++ b/src/community/develop-a-component-or-pattern/index.md
@@ -75,5 +75,3 @@ During the meeting, you’ll be able to ask questions, hear recommendations and 
 If the working group recommended some changes to make before publishing, the Design System team will help you work on them.
 
 If the working group agree your contribution meets the criteria, the Design System team will help you get ready to publish. This includes organising any final checks or updates to the design, content, code and guidance.
-
-Most new components and patterns will be published as experimental at first. The Design System team will remove the experimental status once research proves the component or pattern meets user needs. The research must be from different services and with different types of users.

--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -5,7 +5,6 @@ section: Community
 theme: Resources
 layout: layout-pane.njk
 order: 9
-status: Experimental
 ---
 
 You can use these community resources and tools to help you use the GOV.UK Design System in your design tool or development environment.

--- a/src/components/accordion/index.md
+++ b/src/components/accordion/index.md
@@ -5,8 +5,6 @@ section: Components
 aliases:
 backlogIssueId: 1
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This component is currently experimental because <a class="govuk-link" href="#known-issues-and-gaps">more research</a> is needed to validate it.
 ---
 
 {% from "_example.njk" import example %}

--- a/src/components/cookie-banner/index.md
+++ b/src/components/cookie-banner/index.md
@@ -5,8 +5,6 @@ section: Components
 aliases: Cookies banner, consent banner, GDPR banner, tracking banner, analytics banner
 backlogIssueId: 12
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This component is currently experimental because <a class="govuk-link" href="#research-on-this-component">more research</a> is needed to validate it.
 ---
 
 {% from "_example.njk" import example %}

--- a/src/components/exit-this-page/index.md
+++ b/src/components/exit-this-page/index.md
@@ -5,8 +5,6 @@ section: Components
 aliases:
 backlogIssueId: 213
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This component is currently experimental. <a class="govuk-link" href="#known-issues-and-gaps">You'll need to do your own research</a> to decide whether to add this component to your service.
 ---
 
 {% from "_example.njk" import example %}

--- a/src/components/notification-banner/index.md
+++ b/src/components/notification-banner/index.md
@@ -5,8 +5,6 @@ section: Components
 aliases: alert, warning, success message, important message, flash message
 backlogIssueId: 2
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This component is currently experimental because <a class="govuk-link" href="#research-on-this-component">more research</a> is needed to validate it.
 ---
 
 {% from "_example.njk" import example %}

--- a/src/components/tabs/index.md
+++ b/src/components/tabs/index.md
@@ -5,8 +5,6 @@ section: Components
 aliases:
 backlogIssueId: 100
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This component is currently experimental because <a class="govuk-link" href="#next-steps">more research</a> is needed to validate it.
 ---
 
 {% from "_example.njk" import example %}
@@ -96,7 +94,7 @@ Include a heading at the beginning of each tab that duplicates the information i
 
 ## Research and testing
 
-This component is experimental because it has not yet been tried in research with users.
+This component has not yet been tried in research with users.
 
 The design, code and guidance here are based on recommendations from [Inclusive Components](https://inclusive-components.design/tabbed-interfaces/) and the [Nielsen Norman Group](https://www.nngroup.com/articles/tabs-used-right/) as well as user research findings and examples of tabs in the following services:
 

--- a/src/patterns/bank-details/index.md
+++ b/src/patterns/bank-details/index.md
@@ -6,8 +6,6 @@ theme: Ask users for…
 aliases:
 backlogIssueId: 149
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#next-steps">more research</a> is needed to validate it.
 ---
 
 {% from "_example.njk" import example %}

--- a/src/patterns/contact-a-department-or-service-team/index.md
+++ b/src/patterns/contact-a-department-or-service-team/index.md
@@ -6,8 +6,6 @@ theme: Help users to…
 aliases:
 backlogIssueId: 10
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#next-steps">more research</a> is needed to validate it.
 ---
 
 {%- from "_example.njk" import example -%}

--- a/src/patterns/cookies-page/index.md
+++ b/src/patterns/cookies-page/index.md
@@ -6,8 +6,6 @@ theme: Pages
 aliases: Privacy settings, Cookie settings, tracking settings
 backlogIssueId: 13
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This pattern is currently experimental because more research is needed to validate it.
 ---
 
 {% from "_example.njk" import example %}

--- a/src/patterns/exit-a-page-quickly/index.md
+++ b/src/patterns/exit-a-page-quickly/index.md
@@ -6,8 +6,6 @@ theme: Help users to…
 aliases:
 backlogIssueId: 213
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This component is currently experimental. You'll need to do your own research to decide whether to use this pattern and add the <a class="govuk-link" href="/components/exit-this-page/">Exit this page</a> component to your service.
 ---
 
 {% from "_example.njk" import example %}

--- a/src/patterns/page-not-found-pages/index.md
+++ b/src/patterns/page-not-found-pages/index.md
@@ -6,8 +6,6 @@ theme: Pages
 aliases: "404"
 backlogIssueId: 130
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
 ---
 
 {% from "_example.njk" import example %}

--- a/src/patterns/problem-with-the-service-pages/index.md
+++ b/src/patterns/problem-with-the-service-pages/index.md
@@ -6,8 +6,6 @@ theme: Pages
 aliases: "500"
 backlogIssueId: 129
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
 ---
 
 {% from "_example.njk" import example %}

--- a/src/patterns/service-unavailable-pages/index.md
+++ b/src/patterns/service-unavailable-pages/index.md
@@ -6,8 +6,6 @@ theme: Pages
 aliases: "503"
 backlogIssueId: 124
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
 ---
 
 {% from "_example.njk" import example %}

--- a/src/patterns/telephone-numbers/index.md
+++ b/src/patterns/telephone-numbers/index.md
@@ -6,8 +6,6 @@ theme: Ask users for…
 aliases: phone numbers
 backlogIssueId: 101
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This pattern is currently experimental because <a class="govuk-link" href="#research-on-this-pattern">more research</a> is needed to validate it.
 ---
 
 {% from "_example.njk" import example %}

--- a/src/styles/images/index.md
+++ b/src/styles/images/index.md
@@ -4,8 +4,6 @@ description: Only use images if there’s a real user need
 section: Styles
 backlogIssueId: 70
 layout: layout-pane.njk
-status: Experimental
-statusMessage: This guidance is currently experimental because <a class="govuk-link" href="#research-on-images">we want to get feedback</a> to validate how useful it is for service teams.
 showPageNav: true
 ---
 


### PR DESCRIPTION
Removes the experimental status tag from all docs that use it, it's associated content and references to the experimental status in the tag component and the [develop a component or pattern guidance page](https://design-system.service.gov.uk/community/develop-a-component-or-pattern/).

Closes https://github.com/alphagov/govuk-design-system/issues/3194. More details in issue.

## Extra thoughts
There's a reference to stuff being marked as experimental on the [contribution criteria page](https://design-system.service.gov.uk/community/contribution-criteria/):

>Components and patterns which are not proven usable can be published as experimental. But they must be clearly based on relevant user research from other organisations and best practice, and meet the other criteria.

Should we remove it?

Is removing the reference to the Tag being experimental the right move?