### PR TITLE
less is more or in this case should be 'fewer'

### DIFF
--- a/src/components/character-count/error/index.njk
+++ b/src/components/character-count/error/index.njk
@@ -16,6 +16,6 @@ layout: layout-example-form.njk
     isPageHeading: true
   },
   errorMessage: {
-    text: "Job description must be 350 characters or less"
+    text: "Job description must be 350 characters or fewer"
   }
 }) }}


### PR DESCRIPTION
The current error text reads: "Job description must be 350 characters or less."
The updated error text reads: "Job description must be 350 characters or fewer."

"Fewer" is the correct term to use when referring to countable items, such as characters in this context. This change aligns with proper grammar usage.