### PR TITLE
Fix opening line on task list pattern page

### DIFF
--- a/src/patterns/complete-multiple-tasks/index.md
+++ b/src/patterns/complete-multiple-tasks/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-Complete multiple tasks pages help users understand:
+Help users understand:
 
 - the tasks involved in completing a transaction
 - the order they should complete tasks in


### PR DESCRIPTION
We forgot to update this line when renaming the page... 🤦 