### PR TITLE
Add line about qual or quant study on sharing insights

### DIFF
--- a/src/community/share-research-findings/index.md
+++ b/src/community/share-research-findings/index.md
@@ -67,7 +67,8 @@ Give us some context and briefly explain how you gathered the findings.
 Try to include:
 - which service you used the pattern or component in
 - when you did your user research or test
-- whether you tested with users with access needs, noting any assistive technologies they - used
+- whether it was a qualitative or quantitative study
+- whether you tested with users with access needs, noting any assistive technologies they used
 
 ## More information
 


### PR DESCRIPTION
This feels like an important topic to discuss but if raising a PR to do it isn't right, if we should instead start a community discussion (on GitHub, in a community call, or elsewhere), let me know what you think.

It can be hard to establish the importance of fixing a problem or making a design change based on some of the evidence we receive. It's not clear how confident in the evidence the team is, and therefore we can be hamstrung on whether to act on the reported problem or request. But better data and more context could lead to more robust decisions, and therefore better support for services.

A few times I've seen insights shared from research or testing where the evidence wasn't robust (in my opinion). The research had 6 participants and 1 person mentioned needing something, and this is presented as an established user need. It's not clear how often the team is running research and how confident they are in this datapoint. So we can't use this insight, from 1 person, to represent thousands or millions of people across the country. 

So I'm wondering whether asking for a few more details about the study – or maybe the team's confidence in the results – would make it easier to act on evidence presented?

Leisa Reichelt used to say [more than 3, less than 10](https://userresearch.blog.gov.uk/2014/09/16/sample-size-and-confidence/) participants in a study, unless it's quantitative research. Nielsen Norman Group have some good pointers on [qualitative and quantitative research studies](https://www.nngroup.com/articles/5-test-users-qual-quant/) too. 

Note: I think there are occasions when evidence isn't required, for example, when we can already see that majority proportions are behaving in a certain way or interacting with interfaces in a certain way. We don't always need concrete evidence to be confident about something, but we do receive a lot of evidence it's hard to be confident about.