### PR TITLE
Change wording of share research findings template

### DIFF
--- a/src/community/share-research-findings/index.md
+++ b/src/community/share-research-findings/index.md
@@ -51,9 +51,9 @@ Remember that all the information on GitHub is open to the public. Do not share 
 Use this template to give the community useful context about your findings. Copy and paste it into the GitHub comments box and add your findings.
 
 ```markdown
-## Key insights
+## Insights
 
-What are your key insights about how people use the style, pattern or component?
+What are your insights about how people use the style, pattern or component?
 
 Try to include:
 - how it helped or hindered users’ journeys, using specific observations


### PR DESCRIPTION
## What
Change the wording of our template for sharing research findings with us to remove the word "key" from "key insights".

## Why
["Key" is a word to avoid as per the govuk styleguide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#words-to-avoid)

Based on feedback from [this support ticket](https://govuk.zendesk.com/agent/tickets/5526787) (internal to DS team only)