### PR TITLE
Reorganise border cadence of example partials

### DIFF
--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -2,11 +2,13 @@
 .app-example-wrapper {
   @include govuk-responsive-margin(6, "top");
   @include govuk-responsive-margin(6, "bottom");
+  border: 1px solid $govuk-border-colour;
+  border-top: 0;
 }
 
 .app-example {
   position: relative;
-  border: 1px solid $govuk-border-colour;
+  border-top: 1px solid $govuk-border-colour;
   // Add a 'checkerboard' background
   background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQoU2P88ePHfwY0wMHBwYguxjgUFKI7GsTH5m4M3w1ChQAZTSeO0/AZpgAAAABJRU5ErkJggg==")
     repeat;
@@ -14,10 +16,6 @@
 
 .app-example--tabs {
   @include govuk-responsive-margin(0, "bottom");
-
-  @include govuk-media-query($from: desktop) {
-    margin-bottom: -1px;
-  }
 }
 
 .app-example__toolbar {

--- a/src/stylesheets/components/_tabs.scss
+++ b/src/stylesheets/components/_tabs.scss
@@ -7,7 +7,7 @@
   padding: 0;
   overflow: visible;
   list-style-type: none;
-  border: 1px solid $govuk-border-colour;
+  border-top: 1px solid $govuk-border-colour;
 
   @include govuk-media-query($until: desktop) {
     display: none;
@@ -91,8 +91,7 @@
   display: none;
   position: relative;
   padding: govuk-spacing(3);
-  border: 1px solid $govuk-border-colour;
-  border-top: 0;
+  border-top: 1px solid $govuk-border-colour;
 
   @include govuk-media-query($until: desktop) {
     display: block;
@@ -145,12 +144,12 @@
 
 .app-tabs__container {
   padding: 20px;
-  border: 1px solid $govuk-border-colour;
+  border-top: 1px solid $govuk-border-colour;
   background-color: govuk-colour("white");
 
   // When used for tabs, position to underlap tabs
   @include govuk-media-query($from: desktop) {
-    margin-top: -2px;
+    margin-top: -1px;
   }
 }
 


### PR DESCRIPTION
## What
Reorganises border styling of the code example partial so that the outside border is now handled by `app-example-wrapper` and all blocks within an example ie: iframe, code block, tabs etc have a top border only.

## Why
Spotted during website testing work on https://github.com/alphagov/govuk-design-system/issues/2862

On mobile, instances of the code example where we only display the tabs and not the iframe, the top border of the example partial is missing. This is because we remove the top border from `app-tabs__heading` on the assumption that it'll be placed under an `app-example`, which has a full border.

## Visual changes
### Before
<img width="426" alt="Screenshot 2023-10-19 at 15 33 56" src="https://github.com/alphagov/govuk-design-system/assets/64783893/12791e63-aa10-4c76-84b2-fb8d91f292ca">

### After
<img width="418" alt="Screenshot 2023-10-19 at 15 34 22" src="https://github.com/alphagov/govuk-design-system/assets/64783893/114166c0-fef2-4062-85fb-18e398c34c9e">
