### PR TITLE
Increase font size of example new tab link to 16

### DIFF
--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -25,7 +25,7 @@
 }
 
 .app-example__new-window {
-  @include govuk-font(14);
+  @include govuk-font($size: 16);
 }
 
 .app-example__frame {


### PR DESCRIPTION
## What/Why
Increase the font size of the "Open this example in a new tab" link as part of our example partials from 14 on the font scale 16. As we're removing 14 as an option in out font scale as part of https://github.com/alphagov/govuk-design-system/issues/2289, we should aim to not use it ourselves.

## Visual changes
### Before
![Screenshot 2023-10-20 at 09 44 13](https://github.com/alphagov/govuk-design-system/assets/64783893/3242603c-16c3-4eb4-8482-f0d5104d804b)

### After
![Screenshot 2023-10-20 at 09 44 36](https://github.com/alphagov/govuk-design-system/assets/64783893/4d368dfa-145c-4885-a1fd-1647e32024a3)
