### PR TITLE
Update links to share findings page

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -46,8 +46,7 @@ Here’s a few places to join the discussions that help shape the Design System.
       alt: "Share your examples and research section illustration.",
       title: "Share your examples and research"
     }) %}
-      <p>We want to hear how existing styles, components and patterns perform in your service, not just <a href="https://design-system.service.gov.uk/community/upcoming-components-patterns/">what we’re working on.</a></p>
-      <p>See where to add findings and follow our research template to <a href="https://design-system.service.gov.uk/community/share-research-findings/">share findings about your users.</a></p>
+      <p>We want to hear how existing styles, components and patterns perform in your service, not just <a href="https://design-system.service.gov.uk/community/upcoming-components-patterns/">what we’re working on</a>. Follow our research template to <a href="https://design-system.service.gov.uk/community/share-research-findings/">share findings about your users.</a></p>
     {% endcall %}
   </div>
   <div class="govuk-grid-column-full govuk-grid-column-one-half-from-desktop">

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -46,7 +46,8 @@ Here’s a few places to join the discussions that help shape the Design System.
       alt: "Share your examples and research section illustration.",
       title: "Share your examples and research"
     }) %}
-      <p>‘<a href="https://design-system.service.gov.uk/community/upcoming-components-patterns/">Upcoming components and patterns</a>’ shows what we're working on, and how you can help us develop and publish them. Any examples, use cases and research you can share would be very valuable to us.</p>
+      <p>We want to hear how existing styles, components and patterns perform in your service, not just <a href="https://design-system.service.gov.uk/community/upcoming-components-patterns/">what we’re working on.</a></p>
+      <p>See where to add findings and follow our research template to <a href="https://design-system.service.gov.uk/community/share-research-findings/">share findings about your users.</a></p>
     {% endcall %}
   </div>
   <div class="govuk-grid-column-full govuk-grid-column-one-half-from-desktop">

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -46,7 +46,7 @@ Here’s a few places to join the discussions that help shape the Design System.
       alt: "Share your examples and research section illustration.",
       title: "Share your examples and research"
     }) %}
-      <p>We want to hear how existing styles, components and patterns perform in your service, not just <a href="https://design-system.service.gov.uk/community/upcoming-components-patterns/">what we’re working on</a>. Follow our research template to <a href="https://design-system.service.gov.uk/community/share-research-findings/">share findings about your users.</a></p>
+      <p>We want to hear how existing components and patterns perform in your service, not just <a href="https://design-system.service.gov.uk/community/upcoming-components-patterns/">what we’re working on</a>. Follow our research template to <a href="https://design-system.service.gov.uk/community/share-research-findings/">share findings about your users.</a></p>
     {% endcall %}
   </div>
   <div class="govuk-grid-column-full govuk-grid-column-one-half-from-desktop">

--- a/src/community/share-research-findings/index.md
+++ b/src/community/share-research-findings/index.md
@@ -1,13 +1,13 @@
 ---
 title: Share findings about your users
-description: Find out how to share information on how styles, components and patterns are performing
+description: Find out how to share information on how users experience styles, components and patterns in your service
 section: Community
 theme: Ways to get involved
 layout: layout-pane.njk
 order: 2
 ---
 
-We want to hear how styles, components and patterns perform in your service – it helps us improve the Design System. You can do this by taking part in discussions on GitHub.
+We want to hear how users experience styles, components and patterns in your service – it helps us improve the Design System. You can do this by taking part in discussions on GitHub.
 
 Useful findings to share might be things like:
 


### PR DESCRIPTION
**From @Katrina-Birch:**

Can we change a link on the Community page? - so users go straight to here:
https://design-system.service.gov.uk/community/share-research-findings/

Under "Share your examples and research". The section will then do what it says on the tin. We want research findings on existing components, not just what we're working on. It will need a content tweak for the paragraph and a way to link to the what we're working on.

Also tweak the language to users rather than performance.
