### PR TITLE
New guidance on matching error message text to input label

### DIFF
--- a/src/components/error-message/index.md
+++ b/src/components/error-message/index.md
@@ -66,10 +66,12 @@ Error messages should directly include language from the question or fieldset la
 Here are some examples of label and error message pairs.
 
 Example 1:
+
 - Label: ‘How many hours do you work a week?’
 - Error message: ‘Enter how many hours you work a week’
 
 Example 2:
+
 - Label: ‘Address line 1’
 - Error message: ‘Enter address line 1, typically the building and street’
 

--- a/src/components/error-message/index.md
+++ b/src/components/error-message/index.md
@@ -61,7 +61,7 @@ There are 2 ways to use the error message component. You can use HTML or, if you
 
 ### Match up error messages to labels
 
-Error messages should directly include language from the question or fieldset label. This helps match up the error message with the form field for which it applies.
+Error messages should directly include language from the question or fieldset label. This helps match up the error message with the relevant form field.
 
 Here are some examples of label and error message pairs.
 

--- a/src/components/error-message/index.md
+++ b/src/components/error-message/index.md
@@ -59,6 +59,20 @@ There are 2 ways to use the error message component. You can use HTML or, if you
 
 {{ example({ group: "components", item: "error-message", example: "label", html: true, nunjucks: true, open: false, size: "s" }) }}
 
+### Match up error messages to labels
+
+Error messages should directly include language from the question or fieldset label. This helps match up the error message with the form field for which it applies.
+
+Here are some examples of label and error message pairs.
+
+Example 1:
+- Label: ‘How many hours do you work a week?’
+- Error message: ‘Enter how many hours you work a week’
+
+Example 2:
+- Label: ‘Address line 1’
+- Error message: ‘Enter address line 1, typically the building and street’
+
 ### Be clear and concise
 
 Describe what has happened and tell them how to fix it. The message must be in plain English, use positive language and get to the point.
@@ -85,8 +99,6 @@ Use the same message next to the field and in the [error summary](/components/er
 - look, sound and mean the same
 - make sense out of context
 - reduce the cognitive effort needed to understand what has happened
-
-Use the question or form label in the error to provide context. For example, ‘Enter how many hours you work a week’ for ‘How many hours do you work a week?’
 
 ### Be specific
 

--- a/src/patterns/addresses/error-messages/index.njk
+++ b/src/patterns/addresses/error-messages/index.njk
@@ -23,7 +23,7 @@ stylesheets:
     id: "address-line-1",
     name: "addressLine1",
     errorMessage: {
-    text: "Enter address line 1"
+    text: "Enter address line 1, typically the building and street"
     },
     autocomplete: "address-line1"
   }) }}


### PR DESCRIPTION
In a recent DAC audit they noted a usability issue with our error summary link text not matching the labels for inputs.

[This issue contains further detail on why we are making this change](https://github.com/alphagov/govuk-design-system/issues/3097).