### PR TITLE
Prevent search engine indexing for Netlify branch deployments

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -61,7 +61,8 @@ module.exports = metalsmith
     // Node.js build environment
     NODE_ENV: process.env.NODE_ENV ?? 'production',
 
-    // Netlify deployment context
+    // Netlify deploy context
+    // https://docs.netlify.com/site-deploys/overview/#deploy-contexts
     CONTEXT: process.env.CONTEXT ?? 'production',
 
     // Netlify variables for preview banner

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -5,8 +5,8 @@
 {% block pageTitle %}{{ title | smartypants }} – GOV.UK Design System{% endblock %}
 
 {% block head %}
-  {#- Prevent search engine indexing for preview and development builds -#}
-  {% if ["deploy-preview", "dev"].includes(env("CONTEXT")) or env("NODE_ENV") != 'production' %}
+  {#- Prevent search engine indexing for archive, preview and development builds -#}
+  {% if env("CONTEXT") !== "production" %}
     <meta name="robots" content="noindex, nofollow">
   {% endif %}
   <meta name="og:title" content="{{ title | smartypants }}">


### PR DESCRIPTION
This PR fixes a bug where only [Netlify `deploy-preview` and `dev` deploy contexts](https://docs.netlify.com/site-deploys/overview/#deploy-contexts) deny search engine indexing:

```html
<meta name="robots" content="noindex, nofollow">
```

We don't currently deny `branch-deploy` deploy context such as:
https://release-5-0--govuk-design-system-preview.netlify.app

This was spotted whilst catching up with https://github.com/alphagov/govuk-design-system/issues/3289