### PR TITLE
Set up Netlify custom `404.html` page

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -137,22 +137,22 @@ http {
 
       # Configure error pages
 
-      error_page 404 /errors/404/index.html;
-      error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 500 501 502 503 504 505 506 507 508 509 510 511 /errors/generic/index.html;
+      error_page 404 /404.html;
+      error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 500 501 502 503 504 505 506 507 508 509 510 511 /errors/generic.html;
 
       # Configure basic authentication - this is disabled on the service domain.
       # See above definition of $auth_enabled using the map directive.
 
       auth_basic $auth_enabled;
       auth_basic_user_file nginx/.htpasswd;
-      
+
       # Redirect to the Cabinet Office's responsible disclosure policy
       # https://github.com/alphagov/security.txt
-      
+
       location = /security.txt {
         return 302 https://vdp.cabinetoffice.gov.uk/.well-known/security.txt;
       }
-      
+
       location = /.well-known/security.txt {
         return 302 https://vdp.cabinetoffice.gov.uk/.well-known/security.txt;
       }

--- a/src/404.njk
+++ b/src/404.njk
@@ -2,6 +2,7 @@
 title: Page not found
 layout: layout-single-page.njk
 ignoreInSitemap: true
+permalink: false
 ---
 
 <div class="govuk-grid-row">

--- a/src/errors/generic.njk
+++ b/src/errors/generic.njk
@@ -2,6 +2,7 @@
 title: Sorry, there is a problem with the service
 layout: layout-single-page.njk
 ignoreInSitemap: true
+permalink: false
 ---
 
 <div class="govuk-grid-row">

--- a/views/partials/_category-nav.njk
+++ b/views/partials/_category-nav.njk
@@ -6,7 +6,7 @@ navigation doesn't expand and so the user can only access the top level category
 pages. #}
 <nav class="category-nav">
   {% for item in navigation %}
-    {% if permalink.startsWith(item.url) %}
+    {% if permalink and permalink.startsWith(item.url) %}
     {% if item.items %}
       {% for theme, items in item.items | groupby("theme") %}
         {% if theme != 'undefined' %}

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -2,7 +2,7 @@
   <h2 class="govuk-visually-hidden" id="app-navigation-heading">Menu</h2>
   <ul class="app-navigation__list app-width-container">
     {% for item in navigation %}
-      <li class="app-navigation__list-item {% if permalink == item.url or item.url and permalink.startsWith(item.url) %} app-navigation__list-item--current{% endif %}">
+      <li class="app-navigation__list-item {% if permalink and (permalink == item.url or item.url and permalink.startsWith(item.url)) %} app-navigation__list-item--current{% endif %}">
         <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link js-app-navigation__link" href="/{{ item.url }}/">
           {{ item.label }}
         </a>
@@ -12,7 +12,7 @@
             {{ item.label }}
           </button>
           <!-- [html-validate-disable-next aria-label-misuse --- inline fix for html-validate rule, rather than disable it entirely] -->
-          <ul class="app-navigation__subnav js-app-navigation__subnav {% if permalink.startsWith(item.url) %}app-navigation__subnav--active{% endif %}"
+          <ul class="app-navigation__subnav js-app-navigation__subnav {% if permalink and permalink.startsWith(item.url) %}app-navigation__subnav--active{% endif %}"
             aria-label="{{ item.label }}"
             hidden
           >

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -1,7 +1,7 @@
 <nav class="app-subnav" aria-labelledby="app-subnav-heading">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   {% for item in navigation %}
-    {% if permalink.startsWith(item.url) %}
+    {% if permalink and permalink.startsWith(item.url) %}
     {% if item.items %}
       {% for theme, items in item.items | groupby("theme") %}
         {% if theme != 'undefined' %}


### PR DESCRIPTION
Another super quick one for Netlify support

Moves Nginx `/errors/404/index.html` to `/404.html` which also closes https://github.com/alphagov/govuk-design-system/issues/3281

Give it a try: https://deploy-preview-3309--govuk-design-system-preview.netlify.app/foo