### PR TITLE
Fix minor issues with select examples

### DIFF
--- a/src/components/select/error/index.njk
+++ b/src/components/select/error/index.njk
@@ -6,8 +6,8 @@ layout: layout-example-form.njk
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 
 {{ govukSelect({
-  id: "subject",
-  name: "subject",
+  id: "location",
+  name: "location",
   label: {
     text: "Choose location"
   },

--- a/src/components/select/with-hint/index.njk
+++ b/src/components/select/with-hint/index.njk
@@ -6,12 +6,12 @@ layout: layout-example-form.njk
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 
 {{ govukSelect({
-  id: "subject",
-  name: "subject",
+  id: "location",
+  name: "location",
   label: {
     text: "Choose location"
   },
-    hint: {
+  hint: {
     text: "This can be different to where you went before"
   },
   items: [


### PR DESCRIPTION
Fix incorrect indentation and `id` and `name` not relating to the examples being used.