### PR TITLE
Remove outdated resources and tools

### DIFF
--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -38,9 +38,6 @@ SVG images for creating flow diagrams of GOV.UK services.
 
 ## Create prototypes and wireframes
 
-[Adobe XD wireframes](https://github.com/SulimanK/gds-adobexd-wireframing-kit) -
-Adobe XD wireframes based on the GOV.UK Design System.
-
 [Balsamiq wireframes](https://github.com/enoranidi/govuk-design-system-balsamiq) -
 Balsamiq wireframes based on the GOV.UK Design System.
 

--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -82,11 +82,6 @@ GOV.UK Frontend WTForms Widgets.
 [GOV.UK Laravel](https://github.com/AnthonyEdmonds/govuk-laravel) -
 A collection of GOV.UK Frontend Laravel Blade components, validation rules, page building templates, and PHP helpers.
 
-### R
-
-[Govdown](https://github.com/ukgovdatascience/govdown) -
-A GOV.UK Design System theme for R Markdown.
-
 ### Ruby on Rails
 
 [GOV.UK Design System Formbuilder](https://github.com/DFE-Digital/govuk_design_system_formbuilder) -

--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -105,7 +105,6 @@ A complete Rails application template using GOV.UK Frontend.
 
 You can download GOV.UK Frontend Nunjucks macro snippets for:
 
-- [Atom](https://atom.io/packages/govuk-design-system-snippets)
 - [Nova](https://extensions.panic.com/extensions/ca/ca.GOVUKDesignSystemSnippets/)
 - [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=simonwhatley.govuk-design-system-snippets)
 

--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -90,9 +90,6 @@ A Rails form builder using GOV.UK Frontend.
 [GOV.UK Components](https://github.com/DFE-Digital/govuk-components) -
 A set of non-form Rails components using GOV.UK Frontend. You can use these together with the Design System Formbuilder.
 
-[GOV.UK Frontend Rails](https://github.com/dxw/dxw_govuk_frontend_rails) -
-A Ruby gem that adds the GOV.UK Frontend to Rails applications.
-
 [GOV.UK Rails Template](https://github.com/DFE-Digital/rails-template) -
 A complete Rails application template using GOV.UK Frontend.
 


### PR DESCRIPTION
## What
Removes ~3~ 4 dead resources from our [resources and tools](https://design-system.service.gov.uk/community/resources-and-tools/) page:

- Govdown for R Markdown; the repo was archived April 2022
- GOV.UK Frontend Rails; the repo was archived in April 2023
- Atom snippets; github have discontinued Atom and the link now redirects to a github blog on their sunsetting plan (it was turned off December 2022)
- Adobe XD Wireframes; the repo hasn't been updated in 3 years and [Adobe have discontinued XD since purchasing figma](https://mondo.com/insights/adobe-xd-discontinued-implications-for-creatives-employers/)

## Extra thoughts
There are several stale resources on that page but it's not clear if they should be removed. The inception for this PR was a user on support pointing out that the [Adobe XD resource](https://github.com/SulimanK/gds-adobexd-wireframing-kit) we link to hasn't been updated in 3 years and the twitter account linked on the readme no longer exists. Should we also remove these?