### PR TITLE
Redirect form submissions somewhere sensible

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,27 @@
+# A number of the examples in the Design System include <form> elements so that
+# users copying the examples have something that requires relatively little
+# tweaking to work out the box (in particular Prototype Kit users, for example)
+#
+# We have some JavaScript to prevent those forms actually being submitted but
+# for users who don’t have JavaScript enabled (or who manage to interact with
+# the form before the JS has run) it’s still possible to submit the form.
+#
+# Handle that gracefully by redirecting to a page that explains what has
+# happened and what the user needs to do next.
+#
+# POST requests work just fine. Requires examples to be set up with an action of
+# `/form-handler`.
+
+[[redirects]]
+  from = "/form-handler"
+  to = "/form-success"
+  status = 301
+
+# Proxy requests for security.txt to the centralised Cabinet Office
+# vulnerability disclosure policy (VDP)
+#
+# https://github.com/alphagov/security.txt
+
 [[redirects]]
   from = "/.well-known/security.txt"
   to = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"

--- a/src/form-success.html
+++ b/src/form-success.html
@@ -1,0 +1,10 @@
+---
+title: Form submitted
+layout: layout-example.njk
+---
+
+<h1 class="govuk-heading-m">Form submitted</h1>
+
+<p class="govuk-body">You're seeing this page because you submitted a form in an example.</p>
+
+<p class="govuk-body">You can return to the previous page by using your browser's back button.</p>


### PR DESCRIPTION
A number of the examples in the Design System include `<form>` elements so that users copying the examples have something that requires relatively little tweaking to work out the box (in particular for Prototype Kit users, for example)

We have [some JavaScript to prevent those forms actually being submitted][1] but for users who don’t have JavaScript enabled (or who manage to interact with the form before the JS has run) it’s still possible to submit the form.

This adds the required Netlify config to handle that gracefully by redirecting to a page that explains what has happened and what the user needs to do next.


https://github.com/alphagov/govuk-design-system/assets/121939/ae293f18-fc10-47ae-bf95-104d7bcbb630



We’ve [previously tried to handle this by redirecting back to the referrer][2] but that doesn’t actually work because [CloudFront doesn’t forward the `Referer` header][3].

Given how rarely this should come up, we’ve decided to do this instead as it’s simpler.

[1]: https://github.com/alphagov/govuk-design-system/blob/141e4b556a48ac6c8299ae804b3c2ede95f5779b/src/javascripts/components/example-page.mjs#L16-L24
[2]: https://github.com/alphagov/govuk-design-system/blob/e2ec59808e88a8514821f272b7678e1a2e288e06/deploy/nginx.conf#L160-L176
[3]: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html