### PR TITLE
Add guidance for password input component

### DIFF
--- a/src/components/password-input/default/index.njk
+++ b/src/components/password-input/default/index.njk
@@ -1,0 +1,14 @@
+---
+title: Password input
+layout: layout-example.njk
+---
+
+{% from "govuk/components/password-input/macro.njk" import govukPasswordInput %}
+
+{{ govukPasswordInput({
+  label: {
+    text: "Password"
+  },
+  id: "password-input",
+  name: "password"
+}) }}

--- a/src/components/password-input/error/index.njk
+++ b/src/components/password-input/error/index.njk
@@ -1,0 +1,17 @@
+---
+title: Password input with errors – Password input
+layout: layout-example-form.njk
+---
+
+{% from "govuk/components/password-input/macro.njk" import govukPasswordInput %}
+
+{{ govukPasswordInput({
+  label: {
+    text: "Password"
+  },
+  id: "password-input-with-error-message",
+  name: "password-input-with-error-message",
+  errorMessage: {
+    text: "Enter a password"
+  }
+}) }}

--- a/src/components/password-input/index.md
+++ b/src/components/password-input/index.md
@@ -1,0 +1,188 @@
+---
+title: Password input
+description: Help users accessibly enter passwords
+section: Components
+aliases: pass word, pass phrase
+backlogIssueId: 240
+layout: layout-pane.njk
+---
+
+{% from "_example.njk" import example %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+Help users to create and enter passwords.
+
+{% set wcagCallout %}
+
+{{ govukTag({
+  text: "WCAG 2.2",
+  classes: "app-tag"
+}) }}
+
+### New WCAG 2.2 criteria affects this component
+
+To use the ‘Password input’ and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
+
+- [interact with any 'show password' button](/components/password-input/#wcag-interact-show-password)
+- [use `autocomplete` to securely create and enter passwords](/components/password-input/#wcag-autocomplete-attribute)
+- [copy and paste into a password input](/components/password-input/#wcag-copy-paste-password)
+
+See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
+{% endset %}
+
+{{ govukInsetText({
+  html: wcagCallout,
+  classes: "app-inset-text"
+}) }}
+
+{{ example({ group: "components", item: "password-input", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+
+## When to use this component
+
+Use this component whenever you need users to create or enter a password.
+
+Before using this component, you should also read the guidance on [asking users for passwords](/patterns/passwords/) and [creating user accounts](/patterns/create-accounts/).
+
+## When not to use this component
+
+Do not use this component to ask for any information other than a password.
+
+Use [Text input](/components/text-input/) to ask for other security information, such as:
+
+- multi-factor authentication codes
+- answers to security questions
+- other personally identifiable information
+
+Also see the [Confirm a phone number](/patterns/confirm-a-phone-number/) pattern.
+
+## How it works
+
+This component allows users to enter a password, with an option to show what they’ve entered as plain text.
+
+This allows users to visually check their password before they submit it, which helps them reduce errors and choose passwords that are more unique and secure.
+
+### Error messages
+
+{{ example({ group: "components", item: "password-input", example: "error", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+
+If the user enters their account details incorrectly, do not reveal whether they got the username or password wrong. Clear any information entered into the password input.
+
+Revealing the source of the error can help fraudsters break into people’s accounts.
+
+See how to handle incorrect login attempts and help users who forget their password in the [Ask users for passwords](/patterns/passwords/) pattern.
+
+### Showing and hiding passwords
+
+Hide passwords by default until the user chooses to show it using the ‘show’ button. Users might not be in a private space when entering or creating a password, so you should hide passwords by default.
+
+<div class="app-wcag-22" id="wcag-interact-show-password" role="note">
+  {{ govukTag({
+    text: "WCAG 2.2",
+    classes: "app-tag"
+  }) }}
+  <p>Make sure any ‘show password’ button is at least 24px by 24px in size, or has adequate spacing. This is to make sure users can easily interact with the button. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target Size (minimum)</a>.</p>
+</div>
+
+If you do choose to include two or more password inputs on a page, the ‘show’ and ‘hide’ toggles and labels for each password input must be different.
+
+For example, you can label the input “Password” as “show password” and label the second input “Re-enter password” as “show re-entered password”.
+
+### Avoid adding a ‘confirm password’ field
+
+It’s not necessary to add a second password field, also known as a ‘confirm password’ field, particularly as this component allows users to show and hide passwords.
+
+See [Research on this component](#research-on-this-component) and why we decided having a second field is not helpful for users.
+
+### Define the input’s type as ‘password’
+
+When the form is submitted, the password input should automatically change its `type` to `password`, if it has not already done so.
+
+This is to prevent browsers from remembering it as a previously-provided value and potentially displaying it as an autofill option on non-password inputs.
+
+### Use the autocomplete attribute
+
+Use the `autocomplete` attribute on password inputs to help users complete forms faster.
+
+`Autocomplete` indicates to browsers and password managers what kind of password is needed so it can be entered for the user.
+
+Set the `autocomplete` attribute to `new-password` if the user is creating a password. Otherwise, use `current-password`.
+
+<div class="app-wcag-22" id="wcag-autocomplete-attribute" role="note">
+  {{ govukTag({
+    text: "WCAG 2.2",
+    classes: "app-tag"
+  }) }}
+<p>Providing an `autocomplete` attribute is one way to avoid making the user memorise or transcribe a password from somewhere else in order to use your service. This is to help comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum">3.3.8 Accessible Authentication (Minimum)</a>.</p>
+</div>
+
+Many browsers will autofill password inputs, even when the `autocomplete` attribute is missing or set to `off`.
+
+### Allow copy and paste
+
+Always allow users to copy and paste in password fields. People may have very good reasons why they want to do this, for example if they’re using a password manager.
+
+<div class="app-wcag-22" id="wcag-copy-paste-password" role="note">
+  {{ govukTag({
+    text: "WCAG 2.2",
+    classes: "app-tag"
+  }) }}
+  <p>You must allow users to paste in or use autofill to enter their password. Avoid making the user memorise or transcribe a password from somewhere else in order to use your service. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum">3.3.8 Accessible Authentication (Minimum)</a>.</p>
+</div>
+
+#### Copying text from password fields
+
+Users can copy any text from a password field when it’s set on ‘show’ – this is a feature of browser behaviour and cannot be overridden.
+
+This can be useful for users, such as to save a password that the browser has suggested into a separate password manager.
+
+### Avoid restricting the user's input
+
+See the [Ask users for Passwords](/patterns/passwords/) pattern to see how to help users choose strong passwords.
+
+Support all the characters users may need to enter a password, including numbers and symbols.
+
+If you must place password restrictions on users, such as for technical or security reasons, be clear and consistent.
+
+Any restrictions must be identical wherever the user creates or enters a password. If you change the restrictions over time, you must continue to support existing user passwords or ask them to set a new one.
+
+#### Do not use maxlength to restrict password length
+
+Users will not get any feedback when they’ve reached the `maxlength` and their text input has been truncated. This happens when a user has pasted text from elsewhere or it’s been autofilled by a password manager.
+
+If you must restrict the length of a password, show an error message instead using the [validation](/patterns/validation/) pattern.
+
+### Do not spellcheck or autocapitalise the user's input
+
+Some browsers might automatically change what the user is typing when the input’s text is visible, such as correcting spelling or automatically turning on upper case letters at the start of sentences.
+
+You can tell browsers not to correct spellings by setting the `spellcheck` attribute to `false`.
+
+Doing this can also prevent ['spell-jacking'](https://www.otto-js.com/news/article/chrome-and-edge-enhanced-spellcheck-features-expose-pii-even-your-passwords), where security researchers have found some spell checking tools gathering personal identifiable information, even user’s passwords, from password input fields to send to third party services.
+
+You can tell browsers not to autocapitalise values by setting the `autocapitalize` attribute to `off`.
+
+### Known issues
+
+Some apps and tools will add their own native functionality to show and hide passwords.
+
+These tools include:
+
+- browsers (particularly when suggesting new passwords)
+- password managers
+- screen readers
+
+We’ve tried to minimise duplicate functionality by hiding other types of ‘show password’ buttons where possible.
+
+There’s also other instances where a password could be ‘shown’ or ‘hidden’ without the use of a button – causing a mismatch with the button label (in other words, the user would see a button to ‘show’ a password that’s already visible).
+
+We found [this happens in some browsers](https://github.com/alphagov/govuk-design-system/issues/3552#issuecomment-1976660248) when:
+
+- a keyboard shortcut is pressed
+- a suggested password is created
+
+## Research on this component
+
+We [decided that having a second field is not helpful for users](https://github.com/alphagov/govuk-design-system-backlog/issues/240), particularly on password inputs with show and hide buttons.
+
+However, we’d like to better support our rationale with real life examples from service teams and get your feedback.

--- a/src/patterns/passwords/index.md
+++ b/src/patterns/passwords/index.md
@@ -24,8 +24,6 @@ Help users to create and enter secure and memorable passwords.
 
 To ask users for 'Passwords' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
 
-- [interact with any 'show password' button](/patterns/passwords/#wcag-interact-show-password)
-- [copy and paste into a password input](/patterns/passwords/#wcag-copy-paste-password)
 - [find 'reset password' links in a consistent place on each page](/patterns/passwords/#wcag-consistent-reset)
 
 See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
@@ -40,34 +38,40 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
 
 You should follow this pattern whenever you need users to create or enter a password. Before using this pattern, you should also read the guidance on [user accounts](/patterns/create-accounts/).
 
+For technical considerations, you may also want to read the guidance for the [Password input](/components/password-input/) component.
+
 ## How it works
 
 When using passwords in your service, you should:
 
-- help users make them memorable and strong
+- help users make strong, unique passwords
 - let users paste their password
 - keep them secure, particularly when helping users reset a password
 
 ### Helping users choose strong passwords
 
-Overly strict or confusing constraints can make it harder for people to create memorable passwords. This could mean they:
+Overly strict or confusing constraints can make it harder for people to create strong and memorable passwords. This could mean they:
 
 - stop using your service
 - forget their password and have to reset it
 - store their password in a non-secure place
 
-Choose constraints that meet the security needs of your service. If you need additional security, add a second authentication factor rather than extra password constraints.
+Choose restrictions that meet the security needs of your service, and be clear and consistent about them.
+
+Any restrictions must be identical wherever the user creates or enters a password. If you change the restrictions over time, you must continue to support existing user passwords or ask them to set a new one.
+
+If you need additional security, consider adding a second authentication factor rather than extra password restrictions.
 
 Make sure you:
 
 - set a minimum length of at least 8 characters
 - do not set a maximum length
-- explain the constraints to users
+- explain any restrictions to users
 - do not allow commonly used passwords
 
 ### Do not make users keep changing their passwords
 
-Some services force users to change their passwords periodically, for example every&nbsp;month.
+Some services force users to change their passwords regularly, for example every month.
 
 You should not do this because it means users:
 
@@ -75,7 +79,7 @@ You should not do this because it means users:
 - will tend to pick simple variations on their previous password
 - are more likely to store their password in a non-secure place
 
-You should only force a password change if you suspect an account may be&nbsp;compromised.
+Usually, you should only force a password change if you suspect an account might be compromised.
 
 ### Handling incorrect login attempts
 
@@ -83,47 +87,9 @@ If a user enters their account details incorrectly, do not reveal whether they g
 
 Revealing the source of the error can help fraudsters break into people’s accounts.
 
+Do not keep any entered password inputs from an incorrect login attempt.
+
 Give users between 5 and 10 attempts to enter their password correctly before you lock their account or do any further security checks.
-
-### Hide passwords by default
-
-Users might be in a public space when entering or creating a password, so you should hide passwords by default.
-
-To help users meet your password constraints and prevent mistyped passwords, you can:
-
-- let them see their password if they want to
-- show the last typed character of their password
-- make them enter their password twice and automatically compare them
-
-#### Showing and hiding passwords
-
-It's common for services to provide a '[show password](https://github.com/alphagov/govuk-design-system-backlog/issues/240)' button which helps users to accurately add their password by letting them see what they're typing
-
-When there are two or more password fields on a page, the 'show' and 'hide' labels for each password input must be unique.
-
-For example, you can label the input "Password" as "show password" and label the second input "Re-enter password" as "show re-entered password".
-
-<div class="app-wcag-22" id="wcag-interact-show-password" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure any ‘show password’ button is at least 24px by 24px in size, or have adequate spacing. This is to make sure users can easily interact with the button. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target Size (minimum)</a>.</p>
-</div>
-
-### Allow users to paste or autofill their password
-
-Do not disable paste on password fields. People might have good reasons why they want to paste their password, for example if they’re using a password manager.
-
-Allow password managers to populate password inputs by adding the autocomplete attribute values for `current-password` and `new-password`.
-
-<div class="app-wcag-22" id="wcag-copy-paste-password" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>You must allow users to copy and paste or autofill their password. Avoid making the user memorise or transcribe a password from somewhere else in order to use your service. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum">3.3.8 Accessible Authentication (Minimum)</a>.</p>
-</div>
 
 ### Help users who forget their password
 
@@ -140,8 +106,10 @@ When helping users who’ve forgotten their password, you should:
     text: "WCAG 2.2",
     classes: "app-tag"
   }) }}
-  <p>If you include instructions or a link to help users reset their password, make sure to place them consistently on the page. Also make sure any password reset links always perform the same action across each page. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent Help</a>.</p>
+  <p>If you include instructions or a link to help users reset their password, make sure to place them consistently on the page. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent Help</a>.</p>
 </div>
+
+Also make sure any password reset links always perform the same action across each page.
 
 ### Send a link to trigger password resets
 
@@ -153,6 +121,8 @@ Always email the user when a password reset has happened, in case it was trigger
 
 ### Avoid password reset questions
 
+Some services ask users to provide a ‘password reminder’ when they create a password, and give users the option to show this reminder when they’ve forgotten their password.
+
 You should not use password reset questions because they often ask for information that’s:
 
 - too obscure and therefore just as hard to remember as a password
@@ -160,6 +130,8 @@ You should not use password reset questions because they often ask for informati
 - subject to change, for example ‘favourite colour’
 
 ### Avoid password reminders
+
+Some services ask users to provide a ‘password reminder’ when they create a password, and give users the option to show this reminder when they’ve forgotten their password.
 
 You should not use password reminders because they:
 


### PR DESCRIPTION
WIP of some guidance for the password input component, transposing content from the "ask users for passwords" pattern guidance where it seems relevant.

Related to: 
- #3352
- #3353

Still needs examples.