### PR TITLE
Add links to nested components with subset of options

### DIFF
--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -115,11 +115,16 @@
                     {% endif %}
                       {{ option.description | safe }}
                     {% if (option.params) or ["hint", "label"].includes(option.slug) %}
-                      {# Link to Nunjucks macro options table only -#}
-                      See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name | safe }}</a>.
-                    {% elif (option.isComponent) %}
+                      {% if option.isComponent and not ["hint", "label"].includes(option.slug) %}
+                        {# Link to subset of Nunjucks macro options table and Design System component page -#}
+                        See supported <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name | safe }}</a> options for <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ optionName | safe }}</a>.
+                      {% else %}
+                        {# Link to Nunjucks macro options table only -#}
+                        See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name | safe }}</a>.
+                      {% endif %}
+                    {% elif option.isComponent %}
                       {# Link to Design System component page for nested components -#}
-                      See <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ option.name | safe }}</a>.
+                      See <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ optionName | safe }}</a>.
                     {% endif %}
                     </td>
                   </tr>

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -115,9 +115,10 @@
                     {% endif %}
                       {{ option.description | safe }}
                     {% if (option.params) or ["hint", "label"].includes(option.slug) %}
+                      {# Link to Nunjucks macro options table only -#}
                       See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name | safe }}</a>.
                     {% elif (option.isComponent) %}
-                      {# Link to Design System component pages for nested components -#}
+                      {# Link to Design System component page for nested components -#}
                       See <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ option.name | safe }}</a>.
                     {% endif %}
                     </td>


### PR DESCRIPTION
This PR takes adds a third flavour of nested component option:

1. Nested option
2. Nested option as `option.isComponent` with link to all component options
3. Nested option as `option.isComponent` with subset of options via `option.params`

For example **Checkboxes** and **Radios** `label` option only supports a subset of options:

* https://github.com/alphagov/govuk-frontend/issues/1779

This is also logged on our [Trello board (internal)](https://trello.com/c/RxuFrKQS/19-radio-and-checkbox-item-nested-label-components-list-options-that-cant-be-used)

## Before

Nested components can only link to their separate Design System guidance pages

<img width="638" alt="Nested label with only component link" src="https://github.com/alphagov/govuk-design-system/assets/415517/6b07be6e-13d8-46c8-89ae-5c589f0ef2bf">

## After

Nested components with a subset of `option.params` get their own options table too

<img width="638" alt="Nested label with separate table link" src="https://github.com/alphagov/govuk-design-system/assets/415517/61af07a0-3ec8-46ee-b6ef-4a8ad60c40ad">

Now **Checkboxes** and **Radios** `label` option shows it supports only `classes` and `attributes` 🙌

<img width="636" alt="Nunjucks macro options table" src="https://github.com/alphagov/govuk-design-system/assets/415517/2ec074b1-3924-4aab-a59e-ea52b8ee856e">

But see the supporting change https://github.com/alphagov/govuk-frontend/pull/4563 for the subset of options