### PR TITLE
[DO NOT MERGE] Add warning

### DIFF
--- a/src/get-started/index.md
+++ b/src/get-started/index.md
@@ -5,6 +5,19 @@ description: The following introductory guides will help you to get set up
 showSubNav: true
 ---
 
+The GOV.UK Design System is for everyone that works on government services for GOV.UK. It helps digital teams in government make services look like GOV.UK with guides for applying layout, typography, colour and images.
+
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% set callout %}
+  Using the GOV.UK Design System for websites that spoof GOV.UK services and information may result in legal action.
+{% endset %}
+
+{{ govukWarningText({
+  html: callout,
+  iconFallbackText: "Warning"
+}) }}
+
 The examples in the GOV.UK Design System come with code to make it easy for you to use them in your project.
 
 There are guides to getting started:

--- a/src/get-started/index.md
+++ b/src/get-started/index.md
@@ -10,7 +10,7 @@ The GOV.UK Design System is for everyone that works on government services for G
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set callout %}
-  Using the GOV.UK Design System for websites that spoof GOV.UK services and information may result in legal action.
+  Using the GOV.UK Design System to imitate government websites and services may result in legal action.
 {% endset %}
 
 {{ govukWarningText({


### PR DESCRIPTION
People may use the GOV.‌UK Design System to build websites that spoof GOV.‌UK information and services. However, it's possible to do that without using the design system because of the web's open nature. HTML, CSS and JavaScript is available openly to all web browsers and anyone using a web browser, meaning you can take the code that makes GOV.‌UK look the way it does and make a spoof website.

Despite this, it seems prudent to make it clear that any websites that look like GOV.‌UK and are not part of [the GOV.‌UK proposition](https://www.gov.uk/government/publications/govuk-proposition/govuk-proposition) may face legal action. 

This is a draft pull request to demonstrate potential messaging we could add to the GOV.‌UK Design System website to make that clear. 