### PR TITLE
Add further Design System Day 2023 content

### DIFF
--- a/src/community/design-system-day-2023/session-information.md
+++ b/src/community/design-system-day-2023/session-information.md
@@ -252,3 +252,7 @@ James Carleton
 3pm to 4:30pm
 
 Design systems work best when they are collaborative and flexible instead of a strict set of fixed rules. James shared his experience in building a community that encourages collaboration and contribution to their design system.
+
+## Further information
+If you would like to read the slide decks for any of the sessions delivered on day 2, please email the GOV.UK Design System team <a class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">govuk-design-system-support@digital.cabinet-office.gov.uk</a>.
+

--- a/src/community/design-system-day-2023/session-information.md
+++ b/src/community/design-system-day-2023/session-information.md
@@ -254,5 +254,5 @@ James Carleton
 Design systems work best when they are collaborative and flexible instead of a strict set of fixed rules. James shared his experience in building a community that encourages collaboration and contribution to their design system.
 
 ## Further information
-If you would like to read the slide decks for any of the sessions delivered on day 2, please email the GOV.UK Design System team <a class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">govuk-design-system-support@digital.cabinet-office.gov.uk</a>.
 
+If you would like to read the slide decks for any of the sessions delivered on day 2, please email the GOV.UK Design System team <a class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">govuk-design-system-support@digital.cabinet-office.gov.uk</a>.

--- a/src/community/design-system-day-2023/session-information.md
+++ b/src/community/design-system-day-2023/session-information.md
@@ -52,6 +52,8 @@ Whether you consider yourself well informed about trauma-informed approaches to 
 
 [Trauma-informed research and design (video)](https://www.youtube.com/watch?v=Ch0FPJNdaHg)
 
+You can access the resources mentioned during the panel discussion in [this document](https://docs.google.com/document/d/e/2PACX-1vTEmIFxxU0ncEcnCmgBV184xBEC_hioE7Yk194NfcJXP2l7ufhWsEchuNK7xL8XtZTWSmKkn4CHJ_C3/pub).
+
 ### Design systems don’t solve problems, people do
 
 Tash Willcocks


### PR DESCRIPTION
Add
- a link to the resources mentioned during the trauma informed panel discussion
- content advising users to contact the team if they want access to slide decks from day 2