### PR TITLE
Re-route archived link on "Getting started: production" page

### DIFF
--- a/src/get-started/production/index.md
+++ b/src/get-started/production/index.md
@@ -14,7 +14,7 @@ This guide explains how to set up your project so you can start using the styles
 
 {{ govukInsetText({
   classes: "app-table--constrained",
-  html: 'If you’ve used GOV.UK Elements, GOV.UK Template or the GOV.UK Frontend Toolkit before, you might also find it useful to read the guide on <a href="/get-started/updating-your-code/">updating your code</a>.'
+  html: 'If you’ve used GOV.UK Elements, GOV.UK Template or the GOV.UK Frontend Toolkit before, you might also find it useful to read the guide on <a href="https://frontend.design-system.service.gov.uk/staying-up-to-date/">staying up to date with changes</a>.'
 }) }}
 
 ## Include GOV.UK Frontend in your project


### PR DESCRIPTION
It looks like the old link here was archived in November / December, as part of the 5.0 release. I feel like routing people to the Frontend docs page on making sure to keep up to date with the latest version is a pretty valuable alternative piece of guidance for teams still stuck on GOV.UK Elements, Templates, etc.