### PR TITLE
[WIP] Replace archives with redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -59,6 +59,11 @@
   status = 302 # We will bring this page back in future so it is not a permanent redirect
 
 [[redirects]]
+  from = "/community/design-system-day/speaker-information/"
+  to = "/community/design-system-day/"
+  status = 302 # We will bring this page back in future so it is not a permanent redirect
+
+[[redirects]]
   from = "/patterns/ethnic-group/"
   to = "/patterns/equality-information/"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -37,3 +37,43 @@
   from = "/security.txt"
   to = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
   status = 200 # Proxy rather than redirect
+
+[[redirects]]
+  from = "/community/backlog/"
+  to = "/community/upcoming-components-patterns/"
+  status = 301
+
+[[redirects]]
+  from = "/community/how-you-can-contribute/"
+  to = "/community/"
+  status = 301
+
+[[redirects]]
+  from = "/community/call-for-speakers-2023/"
+  to = "/community/design-system-day/"
+  status = 301
+
+[[redirects]]
+  from = "/community/design-system-day/session-information/"
+  to = "/community/design-system-day/"
+  status = 302 # We will bring this page back in future so it is not a permanent redirect
+
+[[redirects]]
+  from = "/patterns/ethnic-group/"
+  to = "/patterns/equality-information/"
+  status = 301
+
+[[redirects]]
+  from = "/patterns/start-pages/"
+  to = "/patterns/start-using-a-service/"
+  status = 301
+
+[[redirects]]
+  from = "/patterns/task-list-pages/"
+  to = "/patterns/complete-multiple-tasks/"
+  status = 301
+
+[[redirects]]
+  from = "/patterns/understand-the-impact-of-an-emergency/"
+  to = "/components/notification-banner/"
+  status = 301

--- a/src/community/backlog.md
+++ b/src/community/backlog.md
@@ -1,7 +1,0 @@
----
-title: This page has been archived
-layout: layout-archived.njk
-ignoreInSitemap: true
----
-
-To find out what we’re working on right now, and what we plan to work on next, see the [Upcoming components and patterns](/community/upcoming-components-patterns/) page.

--- a/src/community/call-for-speakers-2023/index.md
+++ b/src/community/call-for-speakers-2023/index.md
@@ -1,7 +1,0 @@
----
-title: This page has been archived
-layout: layout-archived.njk
-ignoreInSitemap: true
----
-
-To find out more about Design System Day, see the [Design System Day](/community/design-system-day/) page.

--- a/src/community/design-system-day/session-information.md
+++ b/src/community/design-system-day/session-information.md
@@ -1,7 +1,0 @@
----
-title: This page has been archived
-layout: layout-archived.njk
-ignoreInSitemap: true
----
-
-See the [Design System Day](/community/design-system-day/) page to find out more.

--- a/src/community/design-system-day/speaker-information.md
+++ b/src/community/design-system-day/speaker-information.md
@@ -1,7 +1,0 @@
----
-title: This page has been archived
-layout: layout-archived.njk
-ignoreInSitemap: true
----
-
-See the [Design System Day](/community/design-system-day/) page to find out more.

--- a/src/community/how-you-can-contribute.md
+++ b/src/community/how-you-can-contribute.md
@@ -1,7 +1,0 @@
----
-title: How you can contribute
-layout: layout-archived.njk
-ignoreInSitemap: true
----
-
-For up to date information, see [the community section](/community/).

--- a/src/get-started/updating-your-code/index.md
+++ b/src/get-started/updating-your-code/index.md
@@ -1,7 +1,0 @@
----
-title: Replace variables, functions and mixins from our old frameworks
-layout: layout-archived.njk
-ignoreInSitemap: true
----
-
-In December 2023, we archived this page as GOV.UK Frontend v5.x no longer supports our legacy frameworks.

--- a/src/patterns/ethnic-group/index.md
+++ b/src/patterns/ethnic-group/index.md
@@ -1,9 +1,0 @@
----
-title: Ethnic groups
-layout: layout-archived.njk
-ignoreInSitemap: true
----
-
-In March 2021, we published a new pattern to [ask users for equality information](/patterns/equality-information/), based on data standards set by the Government Statistical Service (GSS).
-
-To meet these standards, we’ve retired the ethnic groups pattern, which has been replaced by parts of the new pattern.

--- a/src/patterns/start-pages/index.md
+++ b/src/patterns/start-pages/index.md
@@ -1,7 +1,0 @@
----
-title: Start pages
-layout: layout-archived.njk
-ignoreInSitemap: true
----
-
-In March 2022, we replaced the 'Start pages' pattern with a new, expanded pattern to help users [Start using a service](/patterns/start-using-a-service/).

--- a/src/patterns/task-list-pages/index.md
+++ b/src/patterns/task-list-pages/index.md
@@ -1,7 +1,0 @@
----
-title: Task list pages
-layout: layout-archived.njk
-ignoreInSitemap: true
----
-
-The task list pattern has been renamed [complete multiple tasks](/patterns/complete-multiple-tasks/) and a new [task list component](/components/task-list/) published with updated guidance.

--- a/src/patterns/understand-the-impact-of-an-emergency/index.md
+++ b/src/patterns/understand-the-impact-of-an-emergency/index.md
@@ -1,7 +1,0 @@
----
-title: Understand the impact of an emergency on your service
-layout: layout-archived.njk
-ignoreInSitemap: true
----
-
-For up to date information, see [the notification banner component](/components/notification-banner/).


### PR DESCRIPTION
Have added archived pages to a redirects file along with details of the page to redirect to. Have also deleted the archive pages. However, I haven't updated the information about archiving a page because there might be instances when we want to archive a page rather than redirect.

If we are obviously changing the location of some content or guidance, a redirect is applicable. However there may be instances when archiving a page is appropriate, for example, when we deprecate a component/pattern and do not replace it.

Raising this draft PR to use as the basis for a conversation.