### PR TITLE
Configure Netlify `Cache-Control` headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -37,3 +37,38 @@
   from = "/security.txt"
   to = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
   status = 200 # Proxy rather than redirect
+
+# Send different cache-control headers depending on the file path
+#
+# Asset filenames with fingerprint hashes (fonts, stylesheets, javascripts) are
+# given an 'infinite' max-age since the content never changes.
+#
+# Historically, an 'infinite' max-age is the 32-bit maximum 2,147,483,648.
+# https://datatracker.ietf.org/doc/html/rfc9111#section-1.2.2
+
+[[headers]]
+  for = "*.css"
+  [headers.values]
+    Cache-Control = "public,max-age=2147483648,immutable"
+
+[[headers]]
+  for = "*.js"
+  [headers.values]
+    Cache-Control = "public,max-age=2147483648,immutable"
+
+[[headers]]
+  for = "*.map"
+  [headers.values]
+    Cache-Control = "public,max-age=2147483648,immutable"
+
+# Search index JSON with unique fingerprint
+[[headers]]
+  for = "/search-index-*.json"
+  [headers.values]
+    Cache-Control = "public,max-age=2147483648,immutable"
+
+# Fonts from GOV.UK Frontend with unique fingerprints
+[[headers]]
+  for = "/assets/fonts/*"
+  [headers.values]
+    Cache-Control = "public,max-age=2147483648,immutable"


### PR DESCRIPTION
Closes #3323 with `Cache-Control` headers only for known files with fingerprint hashes

We've chosen not to restore the [30 minute expiry times for images and videos](https://github.com/alphagov/govuk-design-system/pull/3402/commits/6a9681d83abe2ad96078ddebc120e74b343af50c#diff-402dd7ffa98c26c1269efd4ffd9a5048e88e20c306cb0df8e05306711e9fe781L92-L113) such as:

* [/images/homepage-illustration.svg](https://deploy-preview-3417--govuk-design-system-preview.netlify.app/images/homepage-illustration.svg)
* [/patterns/payment-card-details/enter-card-details.jpg](https://deploy-preview-3417--govuk-design-system-preview.netlify.app/patterns/payment-card-details/enter-card-details.jpg)
* [/patterns/payment-card-details/card-number.mp4](https://deploy-preview-3417--govuk-design-system-preview.netlify.app/patterns/payment-card-details/card-number.mp4)

Browsers will still cache these assets but with `If-None-Match: XXXXX` cache validation HTTP requests

```
Cache-Control: public,max-age=0,must-revalidate
Date: Tue, 09 Jan 2024 17:11:42 GMT
ETag: "XXXXX"
```

Testing in Safari shows that `must-revalidate` delays cached image rendering until `304 Not Modified` is returned. Perhaps we should add a maximum `stale-while-revalidate` time to avoid the cache checking latency?