### PR TITLE
Add Mural template to 'Create prototypes and wireframes'

### DIFF
--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -44,7 +44,7 @@ Balsamiq wireframes based on the GOV.UK Design System.
 [Figma resources](https://www.figma.com/file/NWuFffKvPQhl3aJ9nKU0p3/GOV.UK-Design-System) -
 Figma library of styles and components based on the GOV.UK Design System.
 
-[Mural resources](https://github.com/vickytnz/govuk-elements-mural) - 
+[Mural resources](https://github.com/vickytnz/govuk-elements-mural) -
 Mural template based on the GOV.UK Design System.
 
 [Sketch Wireframing Kit](https://github.com/dwp/sketch_wireframing_kit) -

--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -44,6 +44,9 @@ Balsamiq wireframes based on the GOV.UK Design System.
 [Figma resources](https://www.figma.com/file/NWuFffKvPQhl3aJ9nKU0p3/GOV.UK-Design-System) -
 Figma library of styles and components based on the GOV.UK Design System.
 
+[Mural resources](https://github.com/vickytnz/govuk-elements-mural) - 
+Mural template based on the GOV.UK Design System.
+
 [Sketch Wireframing Kit](https://github.com/dwp/sketch_wireframing_kit) -
 Sketch wireframes based on the GOV.UK Design System.
 


### PR DESCRIPTION
This was mentioned as being an additional link in the GitHub discussion [Add GOV.UK Mural template to community resources #250](https://github.com/alphagov/govuk-design-system-backlog/issues/250).