### PR TITLE
WCAG 2.2 what's new and roadmap changes

### DIFF
--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -30,6 +30,8 @@ You can read more about this breaking release in the guide [‘Changes to GOV.UK
 
 We've also:
 
+- updated the components, patterns and styles to be compliant with WCAG 2.2
+- made it easier for teams to understand [what's changed in WCAG 2.2 and what they need to do](/accessibility/wcag-2.2)
 - made it easier for teams to [share their findings from user research](/community/share-research-findings/)
 - run [Design System Day 2023](/community/design-system-day/)
 
@@ -37,19 +39,15 @@ We've also:
 
 We're:
 
-- updating the components, patterns and styles to be compliant with WCAG 2.2
-- making it easier for teams to understand what's changed in WCAG 2.2 and what they need to do
-- running more workshops on accessibility
 - [updating the typographic scale](https://github.com/alphagov/govuk-design-system/issues/2289), including increasing the minimum text size on mobile
+- adding the [Password input](https://github.com/alphagov/govuk-design-system-backlog/issues/240) component to the Design System (thanks to Andy Sellick)
 
 ## Coming up next
 
 We're getting ready to:
 
-- add the [Show password](https://github.com/alphagov/govuk-design-system-backlog/issues/240) component to the Design System (thanks to Andy Sellick)
 - improve the way we organise technical documentation on the website
 - start working on the next pattern, [Navigation](https://github.com/alphagov/govuk-design-system-backlog/issues/76)
-- run a discovery to understand how the Design System might better support teams on what they’re building today and in the future
 
 ## Future plans
 

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -7,11 +7,10 @@
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
         <p class="govuk-body">
-          8 December 2023: We’ve released GOV.UK Frontend v5.0.0. This is a breaking release, so you will need to assess which changes are relevant to your service and make the required updates. There are also some new features such as the <a href="/components/task-list" class="govuk-link">Task List</a> component.
+          11 January 2024: We’ve released <a href="/accessibility/wcag-2.2/" class="govuk-link">guidance on how to update your service to meet the latest Web Content Accessibility Guidelines (WCAG 2.2)</a>.
         </p>
         <p class="govuk-body">
-          You can read more about this breaking release in the guide <a href="https://frontend.design-system.service.gov.uk/changes-to-govuk-frontend-v5/" class="govuk-link">‘Changes to GOV.UK Frontend v5.0.0’</a> and the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0" class="govuk-link">release notes</a>.
-        </p>
+          WCAG 2.2 changes to GOV.UK Frontend were released in v5.0.0. You can read more about this breaking release in the guide <a href="https://frontend.design-system.service.gov.uk/changes-to-govuk-frontend-v5/#changes-to-gov-uk-frontend-v5-0-0" class="govuk-link">‘Changes to GOV.UK Frontend v5.0.0’</a> and the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0" class="govuk-link">release notes</a>.</p>
         <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design System</a>.</p>
       </div>
     </div>


### PR DESCRIPTION
This PR is to add comms changes to our website after publication of pull request [WCAG 2.2 guidance updates #3090](https://github.com/alphagov/govuk-design-system/pull/3090)

N.B. This will have broken links until the above PR is changed and merged.