### PR TITLE
WCAG 2.2 content follow-up

### DIFF
--- a/src/accessibility/wcag-2.2/index.md
+++ b/src/accessibility/wcag-2.2/index.md
@@ -355,7 +355,7 @@ We've made changes to these components and patterns to comply with WCAG 2.2 leve
         html: '<a href="/patterns/problem-with-the-service-pages/">There is a problem with the service pages</a>'
       },
       {
-        html: 'Consistent help'
+        html: 'Consistent help<br>Redundant entry'
       }
     ]
   ]

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -22,7 +22,7 @@ layout: layout-pane.njk
 
 To use the ‘Select' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
 
-- <a href="/components/select/#wcag-avoid-dragging-multiple-options">use the select without relying on 'click and drag' movements (if you choose to add functionality to select multiple options)</a>
+- [use the select without relying on 'click and drag' movements \(if you choose to add functionality to select multiple options\)](/components/select/#wcag-avoid-dragging-multiple-options)
 
 See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
 {% endset %}

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -22,7 +22,7 @@ layout: layout-pane.njk
 
 To use the ‘Select' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
 
-- [use the select without relying on 'click and drag' movements \(if you choose to add functionality to select multiple options\)](/components/select/#wcag-avoid-dragging-multiple-options)
+- [use the select without relying on 'click and drag' movements (if you choose to add functionality to select multiple options)](/components/select/#wcag-avoid-dragging-multiple-options)
 
 See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
 {% endset %}

--- a/src/components/tag/index.md
+++ b/src/components/tag/index.md
@@ -24,7 +24,7 @@ Use the tag component to show users the status of something.
 
 To use the ‘Tag' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
 
-- [interact with tags without relying on 'click and drag' movements /(if you choose to add functionality to reorder tags/)](/components/tag/#wcag-tag-no-dragging-reorder)
+- [interact with tags without relying on 'click and drag' movements (if you choose to add functionality to reorder tags)](/components/tag/#wcag-tag-no-dragging-reorder)
 
 See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
 {% endset %}

--- a/src/components/tag/index.md
+++ b/src/components/tag/index.md
@@ -24,7 +24,7 @@ Use the tag component to show users the status of something.
 
 To use the ‘Tag' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
 
-- <a href="/components/tag/#wcag-tag-no-dragging-reorder">interact with tags without relying on 'click and drag' movements (if you choose to add functionality to reorder tags)</a>
+- [interact with tags without relying on 'click and drag' movements /(if you choose to add functionality to reorder tags/)](/components/tag/#wcag-tag-no-dragging-reorder)
 
 See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
 {% endset %}

--- a/src/patterns/confirm-an-email-address/index.md
+++ b/src/patterns/confirm-an-email-address/index.md
@@ -25,7 +25,7 @@ This guidance is for government teams that build online services. [To find infor
 
 To help users to 'Confirm an email address' and meet the new WCAG 2.2 criteria, make sure that users can successfully:
 
-- <a href="/patterns/confirm-an-email-address/#wcag-copy-paste-security-codes">copy and paste a security code (if you're asking the user to enter a security code you've sent them)</a>
+- [copy and paste a security code \(if you're asking the user to enter a security code you've sent them\)](/patterns/confirm-an-email-address/#wcag-copy-paste-security-codes)
 
 See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
 {% endset %}

--- a/src/patterns/confirm-an-email-address/index.md
+++ b/src/patterns/confirm-an-email-address/index.md
@@ -25,7 +25,7 @@ This guidance is for government teams that build online services. [To find infor
 
 To help users to 'Confirm an email address' and meet the new WCAG 2.2 criteria, make sure that users can successfully:
 
-- [copy and paste a security code \(if you're asking the user to enter a security code you've sent them\)](/patterns/confirm-an-email-address/#wcag-copy-paste-security-codes)
+- [copy and paste a security code (if you're asking the user to enter a security code you've sent them)](/patterns/confirm-an-email-address/#wcag-copy-paste-security-codes)
 
 See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
 {% endset %}


### PR DESCRIPTION
Follows-up on few outstanding comments from #3090 
- changing links to Markdown (fixing a previous issue with brackets in link text, fixed by using `/` escape)
- add a missing overview criteria for 'Problem with a service' pages