### PR TITLE
Fix navigation `$from: tablet` gutter offset

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -1,3 +1,5 @@
+$navigation-height: 50px;
+
 .app-navigation {
   border-bottom: 1px solid $govuk-border-colour;
   background-color: $app-light-grey;
@@ -10,7 +12,11 @@
 
   @include govuk-media-query($from: tablet) {
     position: relative;
-    left: govuk-spacing(-3);
+
+    // Offset gutter by tablet list-item padding
+    left: $govuk-gutter-half * -1;
+    width: calc(100% - $govuk-gutter);
+    min-height: $navigation-height;
   }
 }
 
@@ -18,8 +24,6 @@
   position: relative;
 
   @include govuk-media-query($from: tablet) {
-    $navigation-height: 50px;
-
     @include govuk-font(19, $weight: bold, $line-height: $navigation-height);
     box-sizing: border-box;
     height: $navigation-height;


### PR DESCRIPTION
This PR fixes the `$from: tablet` navigation menu width to occupy an extra 30px space

The extra available width is due to our `left: -15px` gutter offset, but we didn't use it

## Before

Menu item “Accessibility” doesn't fit at 768px width

<img width="830" alt="Screenshot showing the menu item wrapping to a new line" src="https://github.com/alphagov/govuk-design-system/assets/415517/4de0ac5a-900d-48ec-a76d-e3d6deb37094">

## After

Menu item “Accessibility” now fits at 768px width

<img width="834" alt="Screenshot showing the menu item no longer wraps" src="https://github.com/alphagov/govuk-design-system/assets/415517/077d34d6-cefe-4740-b99a-59811074b827">