### PR TITLE
Update WCAG 2.2 guidance on summary action links minimum size and spacing

### DIFF
--- a/src/components/summary-list/index.md
+++ b/src/components/summary-list/index.md
@@ -77,7 +77,7 @@ There's a few things to keep in mind to ensure that users can successfully use r
     text: "WCAG 2.2",
     classes: "app-tag"
   }) }}
-  <p>Make sure any 'action links' are at least 24px by 24px in size, with adequate spacing. This is to make sure users can easily interact with the links. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target Size (minimum)</a>.</p>
+  <p>Make sure any 'action links' are at least 24px by 24px in size, or have adequate spacing. This is to make sure users can easily interact with the links. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target Size (minimum)</a>.</p>
 </div>
 
 <div class="app-wcag-22" id="wcag-change-answers" role="note">

--- a/src/patterns/passwords/index.md
+++ b/src/patterns/passwords/index.md
@@ -108,7 +108,7 @@ For example, you can label the input "Password" as "show password" and label the
     text: "WCAG 2.2",
     classes: "app-tag"
   }) }}
-  <p>Make sure any ‘show password’ button is at least 24px by 24px in size, with adequate spacing. This is to make sure users can easily interact with the button. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target Size (minimum)</a>.</p>
+  <p>Make sure any ‘show password’ button is at least 24px by 24px in size, or have adequate spacing. This is to make sure users can easily interact with the button. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target Size (minimum)</a>.</p>
 </div>
 
 ### Allow users to paste or autofill their password


### PR DESCRIPTION
This change adds 'or' to the statement to clarify the exception to the 'Target Size (Minimum) (Level AA)' guideline which states targets can be undersized if: "...are positioned so that if a 24 CSS pixel diameter circle is centered on the bounding box of each, the circles do not intersect another target or the circle for another undersized target;"

See comment: https://github.com/alphagov/govuk-design-system-backlog/issues/182#issuecomment-1887303500