### PR TITLE
Correct date of 'focus not obscured' workshop

### DIFF
--- a/src/community/blogs-talks-podcasts/index.md
+++ b/src/community/blogs-talks-podcasts/index.md
@@ -71,7 +71,7 @@ Get some practical advice on how to use the Design System and Prototype Kit.
 
 [Testing a component's accessibility](https://www.youtube.com/watch?v=C770bSvGr_E) (video) – 26 July 2023
 
-[Inspecting WCAG 2.2: Focus Not Obscured](https://www.youtube.com/watch?v=_fi7SsSkBtM) (video) – 18 July 2023
+[Inspecting WCAG 2.2: Focus Not Obscured](https://www.youtube.com/watch?v=_fi7SsSkBtM) (video) – 5 July 2023
 
 [Going beyond the GOV.UK Design System for MoJ Forms professional users](https://designnotes.blog.gov.uk/2022/03/21/going-beyond-the-gov-uk-design-system-for-moj-forms-professional-users/) (blog post) – 21 March 2022
 


### PR DESCRIPTION
Changed the 'Focus not obscured' workshop date from 18 July to 5 July.  Evidence of the correct date was found via the archived Eventbrite workshop page: https://www.eventbrite.co.uk/e/wcag-22-criteria-workshop-focus-not-obscured-tickets-665281102687