### PR TITLE
Change 'also known as' to' includes' on the sitemap for aliases

### DIFF
--- a/views/layouts/layout-sitemap.njk
+++ b/views/layouts/layout-sitemap.njk
@@ -14,7 +14,7 @@
           <li class="govuk-!-margin-bottom-2">
             <a class="govuk-link" href="/{{ subitem.url }}/">{{ subitem.label }}</a>
             {% if subitem.aliases %}
-              &mdash; also known as {% for alias in subitem.aliases %}{{ ", " if not (loop.first or loop.last) }}{{ " or " if loop.last and loop.length > 1 }}{{ alias | lower }}{% endfor %}
+              &mdash; includes {% for alias in subitem.aliases %}{{ ", " if not (loop.first or loop.last) }}{{ " or " if loop.last and loop.length > 1 }}{{ alias | lower }}{% endfor %}
             {% endif %}
           </li>
         {% endfor %}


### PR DESCRIPTION
## What 

This changes the pattern to prefix 'also know as' to 'includes' to a list of aliases of design system pages that have them.

## Why

This should enable us to include more on the page content in search results. 

For example, information on hint text is given across multiple component and pattern pages. Our site search analytics data shows that it is third most likely result to return 'no result' over the past year (18 Jan 2023 - 18 Jan 2024).
<img width="605" alt="List of the top ten search terms that give no results, 1. [Redacted number], 2. Search, 3. Hint" src="https://github.com/alphagov/govuk-design-system/assets/56260216/f5a1096f-61bd-4b06-98d0-91e12c7b4f72">
Most reference to hint text is given within context so writing separate guidance for it might be equally hard to understand and/or find. 

This suggestion means that across the website we could alias included content to the pages we think are the most suitable.
 
