### PR TITLE
Add guidance for tables with lots of data

### DIFF
--- a/src/components/table/index.md
+++ b/src/components/table/index.md
@@ -56,3 +56,13 @@ If the [width override classes](/styles/layout/#width-override-classes) do not m
 To learn more about this, read guidance on [extending and modifying components in production](/get-started/extending-and-modifying-components/).
 
 {{ example({ group: "components", item: "table", example: "column-widths-custom-classes", html: true, nunjucks: true, open: false, size: "m" }) }}
+
+## Tables with a lot of data
+
+If possible, you should aim to have less data in your tables. If you have a lot of data, try to organise it into multiple tables or multiple pages.
+
+If you cannot split your data, you can use the CSS class `govuk-table--small-text-until-tablet`. This class reduces the size of the text on small screens so large amounts of data has more empty space around it. This makes it easier to visually differentiate between each piece of data when read on small screens.
+
+You should not use this class on tables unless your table has a lot of data, because a smaller amount of data is easier to read if the text is larger.
+
+{{ example({ group: "components", item: "table", example: "lots-of-data", html: true, nunjucks: true, open: false, size: "m" }) }}

--- a/src/components/table/lots-of-data/index.njk
+++ b/src/components/table/lots-of-data/index.njk
@@ -1,0 +1,81 @@
+---
+title: Lots of data – Table
+layout: layout-example.njk
+---
+
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{{ govukTable({
+  caption: "Dates and amounts",
+  captionClasses: "govuk-table__caption--m",
+  firstCellIsHeader: true,
+  classes: "govuk-table--small-text-until-tablet",
+  head: [
+    {
+      text: "Date"
+    },
+    {
+      text: "First amount"
+    },
+    {
+      text: "Second amount"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "First 3 weeks"
+      },
+      {
+        text: "£27.45 per week"
+      },
+      {
+        text: "£33.90 per week"
+      }
+    ],
+    [
+      {
+        text: "Next 6 weeks"
+      },
+      {
+        text: "£27.45 per week"
+      },
+      {
+        text: "£33.90 per week"
+      }
+    ],
+    [
+      {
+        text: "Next 24 weeks"
+      },
+      {
+        text: "£27.45 per week"
+      },
+      {
+        text: "£33.90 per week"
+      }
+    ],
+    [
+      {
+        text: "Next 33 weeks"
+      },
+      {
+        text: "£27.45 per week"
+      },
+      {
+        text: "£33.90 per week"
+      }
+    ],
+    [
+      {
+        text: "Total estimated pay"
+      },
+      {
+        text: "£4,282.20"
+      },
+      {
+        text: "£5,288.40"
+      }
+    ]
+  ]
+}) }}


### PR DESCRIPTION
## What
Add a section to the bottom of the tables page with instructions on how and when to use the small text from tablet modifier introduced in https://github.com/alphagov/govuk-frontend/pull/4630.

Closes https://github.com/alphagov/govuk-frontend/issues/3922

> [!IMPORTANT]
> This change can only be merged after the new typography scale is launched as part of https://github.com/alphagov/govuk-design-system/issues/3456

## Why
So that we are advertising that this feature exists to users as well as adding some light guidance on minimising data in a table where possible.

## Notes
I need to make it clear that this is currently only tied to 5.2 if you turn the feature flag on. This could link to the new scale guide that now lives in https://github.com/alphagov/govuk-design-system/pull/3343.