### PR TITLE
Add more links that explain each WCAG 2.2 criteria

### DIFF
--- a/src/accessibility/wcag-2.2/index.md
+++ b/src/accessibility/wcag-2.2/index.md
@@ -35,7 +35,7 @@ Make sure there's expertise within your organisation by advocating for people to
 
 We've made changes to these components and patterns to comply with WCAG 2.2 level AA. You must check if your service needs amending to align with these changes.
 
-See an [explanation about each WCAG 2.2 criteria](https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/) on the W3C website.
+See an [explanation of every success criteria in WCAG 2.2](https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/) on the W3C website.
 
 [Images](/styles/images/) also includes guidance to help ensure icons and images in your service meet Target Size (minimum).
 

--- a/src/accessibility/wcag-2.2/index.md
+++ b/src/accessibility/wcag-2.2/index.md
@@ -35,7 +35,7 @@ Make sure there's expertise within your organisation by advocating for people to
 
 We've made changes to these components and patterns to comply with WCAG 2.2 level AA. You must check if your service needs amending to align with these changes.
 
-See [What's New in WCAG 2.2](https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/) on the W3C website for more about each WCAG 2.2 criteria.
+See an [explanation about each WCAG 2.2 criteria](https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/) on the W3C website.
 
 [Images](/styles/images/) also includes guidance to help ensure icons and images in your service meet Target Size (minimum).
 

--- a/src/accessibility/wcag-2.2/index.md
+++ b/src/accessibility/wcag-2.2/index.md
@@ -35,6 +35,8 @@ Make sure there's expertise within your organisation by advocating for people to
 
 We've made changes to these components and patterns to comply with WCAG 2.2 level AA. You must check if your service needs amending to align with these changes.
 
+See [What's New in WCAG 2.2](https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/) on the W3C website for more about each WCAG 2.2 criteria.
+
 [Images](/styles/images/) also includes guidance to help ensure icons and images in your service meet Target Size (minimum).
 
 {{ govukTable({


### PR DESCRIPTION
On the 'Changes to meet WCAG 2.2' page, [we received feedback from a user](https://ukgovernmentdigital.slack.com/archives/C6DMEH5R6/p1706258637961479) that they did not understand what the data in the 'Relevant WCAG 2.2 criteria' column of the table went. It's also possible they did not have context on WCAG and its criteria and how they related to accessibility, and the page does not explain this.

Alongside a hypothesis that it's common for users to overlook table headers (and therefore miss needed context to understand table data), there could be more context on this page of what WCAG success criteria are and how they work.

Still to decide, whether to:
- add a single link on the page
- add before each instance of the table
- add link in the table header "Relevant WCAG 2.2 criteria" (but might be overdoing it)