### PR TITLE
Remove $govuk-new-link-styles

### DIFF
--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -1,5 +1,3 @@
-$govuk-new-link-styles: true;
-
 @import "govuk/all";
 
 // App-specific variables


### PR DESCRIPTION
We got rid of this var and turned new link styles on by default in 5.0, so we don't need this variable anymore!