### PR TITLE
Add `aria-current="page"` to subnav links

### DIFF
--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -11,7 +11,9 @@
         <ul class="app-subnav__section">
         {% for subitem in items %}
           <li class="app-subnav__section-item{% if subitem.url == permalink %} app-subnav__section-item--current{% endif %}">
-            <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/">{{ subitem.label }}</a>
+            <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/"{% if subitem.url == permalink %} aria-current="page"{% endif %}>
+              {{ subitem.label }}
+            </a>
             {% if (subitem.headings) and (subitem.url == permalink) %}
               <ul class="app-subnav__section app-subnav__section--nested">
                 {% for link in subitem.headings %}


### PR DESCRIPTION
Does what it says on the tin. A minor enhancement to our subnav to make it easier for screen reader users to know where they are.

Only applied to the subnav as opposed to the top-level nav as it's harder from [the spec](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) to denote sections of a website.