### PR TITLE
Update last updated date on roadmap

### DIFF
--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -13,7 +13,7 @@ Some things on the roadmap might change – the purpose is to tell you what’s 
 
 See our [GitHub team board](https://github.com/orgs/alphagov/projects/53) for more details on our plans and day-to-day activities.
 
-Last updated 8 December 2023.
+Last updated 5 February 2024.
 
 ## Recently shipped
 


### PR DESCRIPTION
The [latest commit](https://github.com/alphagov/govuk-design-system/commit/f95278c9ab5dffa62f9259102cddd76462867bcf) didn’t change the reviewed date, so this does that.