### PR TITLE
Update the What's new section and roadmap for 5.2.0

### DIFF
--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -17,18 +17,7 @@ Last updated 8 December 2023.
 
 ## Recently shipped
 
-We’ve released GOV.UK Frontend [v5.1.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.1.0), [v4.8.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.8.0) and [v3.15.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.15.0) which include the update of the crown logo.
-
-We also recently shipped GOV.UK Frontend v5.0 which includes:
-
-- a new [Task List](/components/task-list) component
-- updates to the [Tag](/components/tag) component
-- [updates to browser support](https://github.com/alphagov/govuk-frontend/issues/2621), including the removal of support for Internet Explorer 8 to 10 and reduced support for Internet Explorer 11
-- [a clear JavaScript API for our components](https://github.com/alphagov/govuk-frontend/issues/1389)
-- [removal of support for compatibility mode](https://github.com/alphagov/govuk-frontend/issues/2769)
-- [new link styles enabled by default](https://github.com/alphagov/govuk-frontend/issues/2350)
-
-You can read more about this breaking release in the guide [‘Changes to GOV.UK Frontend v5.0.0’](https://frontend.design-system.service.gov.uk/changes-to-govuk-frontend-v5/) and the [release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0).
+We’ve released [GOV.UK Frontend v5.2.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.2.0) which includes the deprecation of the `useTudorCrown` parameter and an adjustment to our responsive type scale.
 
 We've also:
 

--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -30,15 +30,14 @@ We've also:
 
 We're:
 
-- [updating the typographic scale](https://github.com/alphagov/govuk-design-system/issues/2289), including increasing the minimum text size on mobile
 - adding the [Password input](https://github.com/alphagov/govuk-design-system-backlog/issues/240) component to the Design System (thanks to Andy Sellick)
+- investigating the [Navigation pattern](https://github.com/alphagov/govuk-design-system-backlog/issues/76)
 
 ## Coming up next
 
 We're getting ready to:
 
 - improve the way we organise technical documentation on the website
-- start working on the next pattern, [Navigation](https://github.com/alphagov/govuk-design-system-backlog/issues/76)
 
 ## Future plans
 

--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -13,7 +13,7 @@ Some things on the roadmap might change – the purpose is to tell you what’s 
 
 See our [GitHub team board](https://github.com/orgs/alphagov/projects/53) for more details on our plans and day-to-day activities.
 
-Last updated 8 December 2023.
+Last updated 21 February 2024.
 
 ## Recently shipped
 

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -6,17 +6,9 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
-        <p class="govuk-body">
-          5 February 2024: We’ve released GOV.UK Frontend v5.1.0, v4.8.0 and v3.15.0.
-        </p>
-        <p class="govuk-body">
-These feature releases include the update of the crown logo. Government services and channels must update the crown logo between 19 February and 1 March 2024. Release v5.1.0 also includes some new features and deprecations.</p>
-<p class="govuk-body">Read the full release notes to see what’s changed:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.1.0" class="govuk-link">GOV.UK Frontend v5.1.0</a></li>
-        <li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v4.8.0" class="govuk-link">GOV.UK Frontend v4.8.0</a></li>
-        <li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v3.15.0" class="govuk-link">GOV.UK Frontend v3.15.0</a></li>
-      </ul>
+        <p class="govuk-body">21 February 2024: We’ve released GOV.UK Frontend v5.2.0</p>
+        <p class="govuk-body">This release adjusts our responsive type scale, which is available behind a feature flag. The type scale change is to make text easier to read on smaller screens. We’ve also deprecated the <code>useTudorCrown</code> parameter.</p>
+        <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.2.0" class="govuk-link">full release notes</a> to see what’s changed.</p>
         <br>
         <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design System</a>.</p>
 </div>


### PR DESCRIPTION
Updates the what's new section on the homepage and the roadmap page with 5.2.0 comms.

Also removes references to 5.0 and the crown releases from the roadmap and moves navigation work into the list of things we're doing now.

Closes https://github.com/alphagov/govuk-design-system/issues/3489