### PR TITLE
Move navigation to 'Working on now' section

### DIFF
--- a/src/community/upcoming-components-patterns/index.md
+++ b/src/community/upcoming-components-patterns/index.md
@@ -38,6 +38,23 @@ If you’d like to help us build these components and patterns, join the convers
           }
         ]
       }
+    },
+    {
+      key: {
+        text: "Navigation"
+      },
+      value: {
+        text: "Exploration into different kinds of navigation, for example sub-navigation and side navigation."
+      },
+      actions: {
+        classes: "govuk-!-text-align-left",
+        items: [
+          {
+            href: "https://github.com/alphagov/govuk-design-system/discussions/2376",
+            text: "Discuss Navigation"
+          }
+        ]
+      }
     }
   ]
 }) }}
@@ -78,23 +95,6 @@ We particularly welcome input on the following themes. To contribute, you can ad
           {
             href: "https://github.com/alphagov/govuk-design-system/discussions/2375",
             text: "Discuss Choosing a date"
-          }
-        ]
-      }
-    },
-    {
-      key: {
-        text: "Navigation"
-      },
-      value: {
-        text: "Exploration into different kinds of navigation, for example sub-navigation and side navigation."
-      },
-      actions: {
-        classes: "govuk-!-text-align-left",
-        items: [
-          {
-            href: "https://github.com/alphagov/govuk-design-system/discussions/2376",
-            text: "Discuss Navigation"
           }
         ]
       }


### PR DESCRIPTION
We've updated on [the 'Roadmap' page](https://design-system.service.gov.uk/community/roadmap/) but @joelanman noticed that Navigation is still under ['Next priorities' on the 'Upcoming components and patterns'](https://design-system.service.gov.uk/community/upcoming-components-patterns/#next-priorities). 

This PR moves it into [the 'Working on now' section](https://deploy-preview-3593--govuk-design-system-preview.netlify.app/community/upcoming-components-patterns/#working-on-now).