### PR TITLE
Remove date from prioritisation list

### DIFF
--- a/src/community/upcoming-components-patterns/index.md
+++ b/src/community/upcoming-components-patterns/index.md
@@ -102,7 +102,7 @@ We particularly welcome input on the following themes. To contribute, you can ad
   ]
 }) }}
 
-When we start new work, we'll choose from this list of priorities first.
+When we start new work, we’ll choose from this list of priorities first.
 
 ## Other components and patterns
 

--- a/src/community/upcoming-components-patterns/index.md
+++ b/src/community/upcoming-components-patterns/index.md
@@ -102,7 +102,7 @@ We particularly welcome input on the following themes. To contribute, you can ad
   ]
 }) }}
 
-We’ll next review the list of priorities in summer 2023. We’re not committing to publishing all the things on the list before then, but we’ll choose them first when starting new work.
+When we start new work, we'll choose from this list of priorities first.
 
 ## Other components and patterns
 


### PR DESCRIPTION
Removes date from prioritisation list, as it's currently outdated for summer 2023.

We're also not sure whether we'll undergo the same process to review the list next time, so we're removing the date until we've decided the process for next time.