### PR TITLE
Remove redundant `govukButton` import from whats-new partial

### DIFF
--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -1,5 +1,3 @@
-{% from "govuk/components/button/macro.njk" import govukButton %}
-
 <div class="app-whats-new">
   <div class="app-width-container">
     <div class="govuk-main-wrapper govuk-main-wrapper--l">


### PR DESCRIPTION
What it says on the tin.

From [skimming the history](https://github.com/alphagov/govuk-design-system/commits/main/views/partials/_whats-new.njk) I suspect this was added as part of the prototyping of the What's New section and we just forgot to scoop it out. We may want to reintroduce it as part of exploration into https://github.com/alphagov/govuk-design-system/issues/1974 but for now let's keep the partial nice and lean.