### PR TITLE
Add issue template for writing cycle briefs

### DIFF
--- a/.github/ISSUE_TEMPLATE/cycle-brief.md
+++ b/.github/ISSUE_TEMPLATE/cycle-brief.md
@@ -1,0 +1,23 @@
+---
+name: "Cycle brief template"
+about: For internal use only – issue template for writing briefs at the beginning of each cycle
+title: ""
+labels: "epic"
+assignees: ""
+---
+
+## Brief
+
+<!-- Use this format if it helps: [Action + Outcome/Output + For User Type + To Solve User Problem] e.g. reinstate the Friday call for contributors to provide an opportunity to engage with the team -->
+
+## Epic lead
+
+## Driving role(s)
+
+## Supporting roles
+
+## Needs awareness
+
+## Further detail
+
+<!-- Any extra context that might help – can include things that are out of scope, things to consider, related work, references -->

--- a/.github/ISSUE_TEMPLATE/cycle-brief.md
+++ b/.github/ISSUE_TEMPLATE/cycle-brief.md
@@ -21,3 +21,8 @@ assignees: ""
 ## Further detail
 
 <!-- Any extra context that might help – can include things that are out of scope, things to consider, related work, references -->
+
+```[tasklist]
+### Tasks
+- [ ] Add a draft title or issue reference here
+```


### PR DESCRIPTION
Adds a new template to the 'new issue' page in the Design System repo on Github.

It uses the format we've been using so far, but let me know if there are any tweaks that would make it clearer.