### PR TITLE
Link to MDN instead of w3schools on links page

### DIFF
--- a/src/styles/links/index.md
+++ b/src/styles/links/index.md
@@ -66,6 +66,6 @@ When offering links to content in other languages, make sure:
 
 - the link's text includes the name of the alternative language in both English and the source language
 - the link's purpose is always clear, even when taken out of context
-- the link element includes an [`hreflang` attribute](https://www.w3schools.com/tags/att_a_hreflang.asp) that identifies the language of the linked page.
+- the link element includes an [`hreflang` attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLinkElement/hreflang) that identifies the language of the linked page.
 
 For example, your link text could be 'use [Service name] in [language]'.


### PR DESCRIPTION
## What
Where we reference `hreflang` when talking about links to pages in other languages, use [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLinkElement/hreflang) as a source instead of [w3schools](https://www.w3schools.com/tags/att_a_hreflang.asp).

## Why
Prompted by https://github.com/alphagov/govuk-design-system-backlog/issues/64#issuecomment-2031964308

In my opinion, w3schools isn't an untrustworthy resource but MDN is typically more reliable, a little less digestible than w3s but still better than directly linking to specs and more common across our guidance when referencing browser tech.