### PR TITLE
Fix duplicate line in Start page pattern

### DIFF
--- a/src/patterns/start-using-a-service/index.md
+++ b/src/patterns/start-using-a-service/index.md
@@ -18,7 +18,7 @@ Use this pattern to help you prototype a start point for your service, so you ca
 
 Public-facing UK government services need to start on a GOV.UK content page. The GDS content team creates these start points using GOV.UK publishing apps, separate from GOV.UK Frontend.
 
-Service teams will usually need to agree content for this GOV.UK content page with the GDS content team. Read guidance on how to get your service on GOV.UK. Read [guidance on how to get your service on GOV.UK](https://www.gov.uk/service-manual/service-assessments/get-your-service-on-govuk).
+Service teams will need to agree content for this GOV.UK content page with the GDS content team. Read [guidance on how to get your service on GOV.UK](https://www.gov.uk/service-manual/service-assessments/get-your-service-on-govuk).
 
 ## How it works
 


### PR DESCRIPTION
Fixes a duplicate line in the Start page pattern, also strengthens the language a bit re: approval process.