### PR TITLE
Only use scss that the website is using

### DIFF
--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -1,6 +1,44 @@
 $govuk-new-typography-scale: true;
 
-@import "govuk/all";
+@import "govuk/settings/all";
+@import "govuk/helpers/all";
+@import "govuk/tools/all";
+@import "govuk/core/all";
+@import "govuk/objects/all";
+
+@import "govuk/components/back-link";
+@import "govuk/components/breadcrumbs";
+@import "govuk/components/button";
+@import "govuk/components/cookie-banner";
+@import "govuk/components/date-input";
+@import "govuk/components/details";
+@import "govuk/components/error-message";
+@import "govuk/components/error-summary";
+@import "govuk/components/fieldset";
+@import "govuk/components/footer";
+@import "govuk/components/header";
+@import "govuk/components/hint";
+@import "govuk/components/input";
+@import "govuk/components/inset-text";
+@import "govuk/components/label";
+@import "govuk/components/notification-banner";
+@import "govuk/components/pagination";
+@import "govuk/components/panel";
+@import "govuk/components/phase-banner";
+@import "govuk/components/radios";
+@import "govuk/components/skip-link";
+@import "govuk/components/summary-list";
+@import "govuk/components/table";
+@import "govuk/components/tag";
+@import "govuk/components/task-list";
+@import "govuk/components/warning-text";
+
+@import "govuk/utilities/all";
+
+@import "govuk/overrides/spacing";
+@import "govuk/overrides/text-align";
+@import "govuk/overrides/typography";
+@import "govuk/overrides/width";
 
 // App-specific variables
 $app-light-grey: #f8f8f8;


### PR DESCRIPTION
## Change
Change `main.scss` to only import what the website is using so that we are serving less css to users. Part of https://github.com/alphagov/govuk-design-system/issues/3732.

## Notes
This change reduces the built `main.css` by approximately 22kb.

There are a few things in here that are only relevant to full page examples because we are using the same asset set for full page examples and the website. We can investigate this later via https://github.com/alphagov/govuk-design-system/issues/3757 but for now we think this is still a useful gain.

What the website uses was discovered via post-processing analysis using rehype. You can see what we did in https://github.com/alphagov/govuk-design-system/tree/optimise-website-imports