### PR TITLE
Add type scale feature flag to example scss

### DIFF
--- a/src/stylesheets/_example-init.scss
+++ b/src/stylesheets/_example-init.scss
@@ -1,3 +1,5 @@
+$govuk-new-typography-scale: true;
+
 @import "govuk/settings/all";
 @import "govuk/helpers/all";
 @import "govuk/tools/all";


### PR DESCRIPTION
Prompted by a report that the warning text examples on the website aren't using the new type scale despite us setting `govuk-new-typography-scale` to true in `main.scss`.

Because we use a different stylesheet for examples, the examples themselves weren't using the new type scale. This is set on `example-init` which is being used by the 2 example stylesheets: `example` and `example-inverse`.