### PR TITLE
Remove non-verbose override classes from index

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -30,7 +30,7 @@ masthead: true
         <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl govuk-!-margin-top-0">
       </div>
 
-      <div class="govuk-grid-column-two-thirds govuk-!-mb-r4">
+      <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-l">Principles we follow</h2>
         <p class="govuk-body">
 The GOV.UK Design System helps teams that work on government services follow the <a class="govuk-link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a> and <a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a>. This website also follows the <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide">style guide</a> and <a class="govuk-link" href="https://www.gov.uk/guidance/content-design">content design guidance</a> used by GOV.UK.
@@ -78,7 +78,7 @@ Also see <a href="/community/upcoming-components-patterns/" class="govuk-link" d
         <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
       </div>
 
-      <div class="govuk-grid-column-two-thirds govuk-!-mb-r4">
+      <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-l">Roadmap</h2>
         <p class="govuk-body">
           See what the Design System team at GDS is planning to work on over the next 12 months in the


### PR DESCRIPTION
These are old, non-verbose versions of the override classes that were removed in [0.0.32](https://github.com/alphagov/govuk-frontend/releases/tag/v0.0.32) and just hid in plain sight for 6 years!

They're intended to add extra margin bottom to these elements however they're unnecessary as the grid classes are handling spacing between the homepage section so I don't think these need replacing with the correct override classes.