### PR TITLE
Only import the js from GOV.UK Frontend that the website is using

### DIFF
--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -1,6 +1,12 @@
 /* eslint-disable no-new */
 
-import { initAll } from 'govuk-frontend'
+// Import directly from the modules in govuk-frontend because our treeshaking
+// currently doesn't work when importing directly from govuk-frontend
+//
+// See https://github.com/alphagov/govuk-frontend/issues/4957
+import { Button } from 'govuk-frontend/dist/govuk/components/button/button.mjs'
+import { NotificationBanner } from 'govuk-frontend/dist/govuk/components/notification-banner/notification-banner.mjs'
+import { SkipLink } from 'govuk-frontend/dist/govuk/components/skip-link/skip-link.mjs'
 
 import Analytics from './components/analytics.mjs'
 import BackToTop from './components/back-to-top.mjs'
@@ -18,7 +24,28 @@ import Search from './components/search.mjs'
 import AppTabs from './components/tabs.mjs'
 
 // Initialise GOV.UK Frontend
-initAll()
+// Button
+const $buttons = document.querySelectorAll('[data-module="govuk-button"]')
+
+$buttons.forEach(($button) => {
+  new Button($button)
+})
+
+// Notification Banner
+const $notificationBanner = document.querySelector(
+  '[data-module="govuk-notification-banner"]'
+)
+
+if ($notificationBanner) {
+  new NotificationBanner($notificationBanner)
+}
+
+// Skip link
+const $skipLink = document.querySelector('[data-module="govuk-skip-link"]')
+
+// No checking if it exists because we can safely assume there will always be
+// a skip link on a page
+new SkipLink($skipLink)
 
 // Initialise cookie banner
 const $cookieBanner = document.querySelector(

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -1,4 +1,4 @@
-<header class="govuk-header app-header" role="banner" data-module="govuk-header">
+<header class="govuk-header app-header" role="banner">
   <div class="govuk-header__container app-width-container app-header__container">
     <div class="govuk-header__logo app-header__logo">
       <a href="/" class="govuk-header__link govuk-header__link--homepage">


### PR DESCRIPTION
## Change
Updates `application.js` to only initialise the components that the website is using to optimise website performance. Part of https://github.com/alphagov/govuk-design-system/issues/3732.

## Notes
This change reduces `application.js` by approximately 36kb.

This change imports the component js directly from the mjs in the component folders instead of importing directly from `govuk-frontend` via combined curly brackets as we'd expect our users to do. This is because we've noticed as part of this work that our tree shaking doesn't work when importing the "expected" way and only works when importing the components directly. See https://github.com/alphagov/govuk-frontend/issues/4957.

This was made possible by Romaric's work to figure out what `data-module`'s the website is using in https://github.com/alphagov/govuk-design-system/pull/3760.

There are a couple of components that we're using that have js associated with them that I haven't included in the import:

### Header
The header js is only used to manage the mobile menu view toggle. We're using custom navigation that doesn't rely on or interact with this js so importing it is unnecessary. I've additionally removed `data-module="govuk-header"` as this isn't being used by anything.

### Radios
We're using radios on the cookie banner page but the radios js is only used to manage conditional reveals, which we aren't using.