### PR TITLE
Fix hard breaks on Colours and Accordion pages

### DIFF
--- a/src/components/accordion/index.md
+++ b/src/components/accordion/index.md
@@ -82,6 +82,7 @@ For users of screen readers, all the text in the button will be read as a single
 #### Write clear button text
 
 Write the heading and summary line like any other button text. Use sentence case, describe the content that will show, and keep it short.
+
 Users of screen readers might find it difficult to navigate the accordion if the button text is too long.
 
 If you struggle to come up with clear button text, it might be because the way you’ve separated the content is not clear. Organise sections in a way that makes sense to users, based on their needs.

--- a/src/styles/colour/index.md
+++ b/src/styles/colour/index.md
@@ -15,9 +15,7 @@ Always use the GOV.UK colour palette.
 
 ## Colour contrast
 
-You must make sure that the contrast ratio of text and interactive elements in
-your service meets [level AA of the Web Content Accessibility Guidelines
-(WCAG 2.2)](https://www.w3.org/TR/WCAG22/#contrast-minimum).
+You must make sure that the contrast ratio of text and interactive elements in your service meets [level AA of the Web Content Accessibility Guidelines (WCAG 2.2)](https://www.w3.org/TR/WCAG22/#contrast-minimum).
 
 {{ govukInsetText({
   text: "The WCAG 2.2 criteria for Contrast (Minimum) is the same as WCAG 2.1."
@@ -25,17 +23,9 @@ your service meets [level AA of the Web Content Accessibility Guidelines
 
 ## Main colours
 
-If you are using GOV.UK Frontend or the GOV.UK Prototype Kit, use the [Sass
-variables](https://frontend.design-system.service.gov.uk/sass-api-reference/#colours) provided rather than copying the
-hexadecimal (hex) colour values. For example, use `$govuk-brand-colour` rather
-than `{{ colours.applied['Brand colour'][0]['colour'] | trim }}`.
-This means that your service will always use the most recent colour palette
-whenever you update.
+If you are using GOV.UK Frontend or the GOV.UK Prototype Kit, use the [Sass variables](https://frontend.design-system.service.gov.uk/sass-api-reference/#colours) provided rather than copying the hexadecimal (hex) colour values. For example, use `$govuk-brand-colour` rather than `{{ colours.applied['Brand colour'][0]['colour'] | trim }}`. This means that your service will always use the most recent colour palette whenever you update.
 
-Only use the variables in the context they're designed for. In all other cases,
-you should reference the [colour palette](#colour-palette) directly. For
-example, if you wanted to use red, you should
-use `govuk-colour("red")` rather than `$govuk-error-colour`.
+Only use the variables in the context they're designed for. In all other cases, you should reference the [colour palette](#colour-palette) directly. For example, if you wanted to use red, you should use `govuk-colour("red")` rather than `$govuk-error-colour`.
 
 <table class="govuk-body app-colour-list" summary="Table of main colours">
   <tbody>
@@ -75,13 +65,9 @@ use `govuk-colour("red")` rather than `$govuk-error-colour`.
 
 Use these colours for supporting materials like illustrations, or in custom components where appropriate.
 
-To reference colours from the palette directly you should use the `govuk-colour`
-function. For example, `color: govuk-colour("blue")`.
+To reference colours from the palette directly you should use the `govuk-colour` function. For example, `color: govuk-colour("blue")`.
 
-Avoid using the palette colours if there is a Sass variable that is designed for
-your context. For example, if you are styling the error state of a component you
-should use the `$govuk-error-colour` Sass variable rather than
-`govuk-colour("red")`.
+Avoid using the palette colours if there is a Sass variable that is designed for your context. For example, if you are styling the error state of a component you should use the `$govuk-error-colour` Sass variable rather than `govuk-colour("red")`.
 
 If you need to use tints of this palette, use either 25% or 50%.
 

--- a/src/styles/colour/index.md
+++ b/src/styles/colour/index.md
@@ -23,7 +23,9 @@ You must make sure that the contrast ratio of text and interactive elements in y
 
 ## Main colours
 
-If you are using GOV.UK Frontend or the GOV.UK Prototype Kit, use the [Sass variables](https://frontend.design-system.service.gov.uk/sass-api-reference/#colours) provided rather than copying the hexadecimal (hex) colour values. For example, use `$govuk-brand-colour` rather than `{{ colours.applied['Brand colour'][0]['colour'] | trim }}`. This means that your service will always use the most recent colour palette whenever you update.
+If you are using GOV.UK Frontend or the GOV.UK Prototype Kit, use the [Sass variables](https://frontend.design-system.service.gov.uk/sass-api-reference/#colours) provided rather than copying the hexadecimal (hex) colour values. For example, use `$govuk-brand-colour` rather than `{{ colours.applied['Brand colour'][0]['colour'] | trim }}`.
+
+This means that your service will always use the most recent colour palette whenever you update.
 
 Only use the variables in the context they're designed for. In all other cases, you should reference the [colour palette](#colour-palette) directly. For example, if you wanted to use red, you should use `govuk-colour("red")` rather than `$govuk-error-colour`.
 


### PR DESCRIPTION
Hello 👋

I've been on the [**Colour** styles page](https://design-system.service.gov.uk/styles/colour/) a bit recently and spotted a few hard line breaks affecting the layout

Most have been fixed already (e.g. https://github.com/alphagov/govuk-design-system/pull/2709/commits/41a5f1065a84d87f5f857ca737938b78ab00f91f, https://github.com/alphagov/govuk-design-system/pull/2991/commits/099bfd4fcfb7e3fa2d0a8149d57a14f2a6c2227a) but I found a few more

---

### [Accordion component page](https://design-system.service.gov.uk/components/accordion/)

<img width="706" alt="Hard line breaks on Colours page" src="https://github.com/alphagov/govuk-design-system/assets/415517/0909f145-623d-4d7a-9188-825877000d84">

---

### [Colour styles page](https://design-system.service.gov.uk/styles/colour/)

<img width="775" alt="Missing new paragraph on Accordion page" src="https://github.com/alphagov/govuk-design-system/assets/415517/557bcf59-3623-40b2-b715-c365a75f2954">
