### PR TITLE
Update links to importing assets docs

### DIFF
--- a/src/get-started/production/index.md
+++ b/src/get-started/production/index.md
@@ -29,7 +29,8 @@ We recommend [installing GOV.UK Frontend using npm](https://frontend.design-syst
 
 Using this option, you will be able to:
 
-- selectively [include the CSS or JavaScript](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/) for individual components
+- selectively [include the CSS](https://frontend.design-system.service.gov.uk/import-css/) for individual components
+- selectively [include the JavaScript](https://frontend.design-system.service.gov.uk/import-javascript/) for individual components
 - build your own styles or components based on the palette or typography and spacing mixins
 - customise the build (for example, overriding colours or enabling global styles)
 - use the [Nunjucks template and macros](https://frontend.design-system.service.gov.uk/use-nunjucks/) if your environment supports them
@@ -42,7 +43,8 @@ Using this option, you will be able to include all the CSS and JavaScript of GOV
 
 You will not be able to:
 
-- selectively [include the CSS or JavaScript](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/) for individual components
+- selectively [include the CSS](https://frontend.design-system.service.gov.uk/import-css/) for individual components
+- selectively [include the JavaScript](https://frontend.design-system.service.gov.uk/import-javascript/) for individual components
 - build your own styles or components based on the palette or typography and spacing mixins
 - customise the build, for example, overriding colours or enabling global styles
 - use the component Nunjucks templates

--- a/src/styles/page-template/index.md
+++ b/src/styles/page-template/index.md
@@ -97,7 +97,7 @@ To change the components that are included in the page template by default, set 
       <td class="govuk-table__cell">assetPath</td>
       <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">
-        Specify a path to the <a href="https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#font-and-image-assets">GOV.UK Frontend assets</a> (icons, images, font files).
+        Specify a path to the <a href="https://frontend.design-system.service.gov.uk/import-font-and-images-assets/">GOV.UK Frontend assets</a> (icons, images, font files).
       </td>
     </tr>
     <tr class="govuk-table__row">
@@ -157,7 +157,7 @@ To change the components that are included in the page template by default, set 
       <td class="govuk-table__cell">cspNonce</td>
       <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">
-        Add a <code>nonce</code> attribute to the script for your Content Security Policy (CSP). Provide a nonce that hostile actors cannot guess, as otherwise they can easily find a way around your CSP. However, you should use this attribute only if you’re not able to <a class="govuk-link" href="https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-is-not-working-properly">include the hash for the inline scripts in your service’s CSP</a>.
+        Add a <code>nonce</code> attribute to the script for your Content Security Policy (CSP). Provide a nonce that hostile actors cannot guess, as otherwise they can easily find a way around your CSP. However, you should use this attribute only if you’re not able to <a class="govuk-link" href="https://frontend.design-system.service.gov.uk/import-javascript/#if-our-inline-javascript-snippet-is-blocked-by-a-content-security-policy">include the hash for the inline scripts in your service’s CSP</a>.
       </td>
     </tr>
     <tr class="govuk-table__row">


### PR DESCRIPTION
## Change
Updates links to what was the [combined importing assets page](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/) which used to cover CSS, JS and other assets and has now been split out into 3 separate pages via https://github.com/alphagov/govuk-frontend-docs/pull/438.

Resolves https://github.com/alphagov/govuk-frontend-docs/issues/435

## Notes
On the production page, I've split what was a single bullet point referencing both the CSS and JS into 2 near identical bullet points that reference their respective pages. I did this because it felt like links called just 'the CSS' and 'the JavaScript' didn't feel right from an accessibility perspective. However it's unclear to me if this is good from a content design perspective. Interested in review to verify.