### PR TITLE
Update the website roadmap

### DIFF
--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -32,7 +32,7 @@ We've also:
 
 We're:
 
-- investigating the [Navigation pattern](https://github.com/alphagov/govuk-design-system-backlog/issues/76)
+- developing components and patterns for [Navigation](https://github.com/alphagov/govuk-design-system-backlog/issues/76)
 - planning Design System Day 2024 events
 - making it easier for teams using GOV.UK Frontend to only include the components a service is using
 

--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -27,6 +27,7 @@ We've also:
 - updated the components, patterns and styles to be compliant with WCAG 2.2
 - made it easier for teams to understand [what's changed in WCAG 2.2 and what they need to do](/accessibility/wcag-2.2)
 - made it easier for teams to [share their findings from user research](/community/share-research-findings/)
+- made it easier for teams using GOV.UK Frontend to only include the components a service is using
 
 ## Working on now
 
@@ -34,7 +35,6 @@ We're:
 
 - developing components and patterns for [Navigation](https://github.com/alphagov/govuk-design-system-backlog/issues/76)
 - planning Design System Day 2024 events
-- making it easier for teams using GOV.UK Frontend to only include the components a service is using
 
 ## Coming up next
 

--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -33,18 +33,21 @@ We've also:
 We're:
 
 - investigating the [Navigation pattern](https://github.com/alphagov/govuk-design-system-backlog/issues/76)
-- making the guidance around form design and validation easier to find
-- working out how the Design System might need to change when used for pages embedded in apps using web views
-- starting to plan Design System Day 2024
+- planning Design System Day 2024 events
+- making it easier for teams using GOV.UK Frontend to only include the components a service is using
 
 ## Coming up next
 
 We're getting ready to:
 
-- improve the way we organise technical documentation on the website
+- understand how we can better help users find what they need on the GOV.UK Design System website
+- ensure the GOV.UK Design System website is compliant with WCAG 2.2
+- improve the JavaScript of the Chararcter count, Tabs and Accordion components
 
 ## Future plans
 
 We plan to:
 
 - [drop support for Ruby Sass and LibSass](https://github.com/alphagov/govuk-frontend/issues/2637) and [migrate to the Sass module system](https://github.com/alphagov/govuk-frontend/issues/1791)
+- explore how the [accessibile autocomplete component](https://github.com/alphagov/accessible-autocomplete) could be added to the GOV.UK Design System
+- provide conventions, configs, tools and code to help users build build things on top of GOV.UK Frontend

--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -50,4 +50,4 @@ We plan to:
 
 - [drop support for Ruby Sass and LibSass](https://github.com/alphagov/govuk-frontend/issues/2637) and [migrate to the Sass module system](https://github.com/alphagov/govuk-frontend/issues/1791)
 - explore how the [accessibile autocomplete component](https://github.com/alphagov/accessible-autocomplete) could be added to the GOV.UK Design System
-- provide conventions, configs, tools and code to help users build build things on top of GOV.UK Frontend
+- provide conventions, configs, tools and code to help users build things on top of GOV.UK Frontend

--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -42,7 +42,7 @@ We're getting ready to:
 
 - understand how we can better help users find what they need on the GOV.UK Design System website
 - ensure the GOV.UK Design System website is compliant with WCAG 2.2
-- improve the JavaScript of the Chararcter count, Tabs and Accordion components
+- improve the JavaScript of the Character count, Tabs and Accordion components
 
 ## Future plans
 

--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -49,5 +49,5 @@ We're getting ready to:
 We plan to:
 
 - [drop support for Ruby Sass and LibSass](https://github.com/alphagov/govuk-frontend/issues/2637) and [migrate to the Sass module system](https://github.com/alphagov/govuk-frontend/issues/1791)
-- explore how the [accessibile autocomplete component](https://github.com/alphagov/accessible-autocomplete) could be added to the GOV.UK Design System
+- explore how the [accessible autocomplete component](https://github.com/alphagov/accessible-autocomplete) could be added to the GOV.UK Design System
 - provide conventions, configs, tools and code to help users build things on top of GOV.UK Frontend


### PR DESCRIPTION
Following Trang's preso at mid cycle demo, here's a proposed update to the roadmap on the website. It doesn't include any of the TBC items discussed where we're dependent on other teams.