### PR TITLE
Add documentation for 'id' to accordion component

### DIFF
--- a/src/components/accordion/index.md
+++ b/src/components/accordion/index.md
@@ -65,6 +65,8 @@ There are 2 ways to use the accordion component. You can use HTML or, if you’r
 
 The accordion component uses JavaScript. When JavaScript is not available, users will see all the content displayed with the section labels as headings.
 
+If you are using HTML, you must add an 'id' attribute to to the `<div>` tag with the `accordion` class. It must be unique across the service's domain to maintain the persistent expanded state of the accordion.
+
 ### Section heading buttons
 
 An accordion will usually start with all sections hidden. To show a section, the user can interact anywhere in the heading button.


### PR DESCRIPTION
## What

Add extra documentation for the 'id' attribute to the 'How It Works' section of the accordion component.

## Why

if a user is just using the HTML of the accordion component, then they might not encounter the additional documentation provided for the 'id' attribute. This addresses issue #1073.
