### PR TITLE
Update to GOV.UK Frontend v5.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "accessible-autocomplete": "^2.0.4",
         "clipboard": "^2.0.11",
-        "govuk-frontend": "^5.3.1",
+        "govuk-frontend": "^5.4.0",
         "iframe-resizer": "^4.3.9",
         "lunr": "^2.3.9"
       },
@@ -8906,9 +8906,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.3.1.tgz",
-      "integrity": "sha512-EzegdVdmZVwXUGTQTsBgK4TkMpMyPdOIa2g1kvwX7EeyP9Kah+amXSo97gbiI8N49L6E0J6/2H6qLW4QN3KhMQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
+      "integrity": "sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "accessible-autocomplete": "^2.0.4",
     "clipboard": "^2.0.11",
-    "govuk-frontend": "^5.3.1",
+    "govuk-frontend": "^5.4.0",
     "iframe-resizer": "^4.3.9",
     "lunr": "^2.3.9"
   },

--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -13,16 +13,15 @@ Some things on the roadmap might change – the purpose is to tell you what’s 
 
 See our [GitHub team board](https://github.com/orgs/alphagov/projects/53) for more details on our plans and day-to-day activities.
 
-Last updated 19 April 2024.
+Last updated 17 May 2024.
 
 ## Recently shipped
 
-We've released [GOV.UK Frontend v5.3.1](https://github.com/alphagov/govuk-frontend/releases/tag/v5.3.1) with minor bug fixes.
-
-Previously, we’ve released [GOV.UK Frontend v5.3.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.3.0) which includes a new [Password input](/components/password-input/) component and an update to the [Character count](/components/character-count/) component’s HTML.
+We’ve released [GOV.UK Frontend v5.4.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.4.0) which includes new features to help you include only the components your service uses.
 
 We've also:
 
+- introduced a new [‘Password input’ component](https://design-system.service.gov.uk/components/password-input/)
 - updated the crown in the header, favicon and social share images
 - updated the components, patterns and styles to be compliant with WCAG 2.2
 - made it easier for teams to understand [what's changed in WCAG 2.2 and what they need to do](/accessibility/wcag-2.2)

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -4,9 +4,8 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
           <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
-          <p class="govuk-body">12 April 2024: We’ve released GOV.UK Frontend v5.3.1 with minor bug fixes.</p>
-          <p class="govuk-body">Previously, on 26 March 2024, we released GOV.UK Frontend v5.3.0, which included a new <a href="/components/password-input/" class="govuk-link">‘Password input’ component</a> and an update to the ‘Character count’ component’s HTML code.</p>
-          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.3.1" class="govuk-link">full release notes</a> to see what’s changed.</p>
+          <p class="govuk-body">17 May 2024: We’ve released GOV.UK Frontend v5.4.0. It has new features to help you include only the components your service uses, which reduces the weight of the JavaScript and CSS files sent to users.</p>
+          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.4.0" class="govuk-link">full release notes</a> to see what’s changed.</p>
           <br>
           <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design System</a>.</p>
         </div>


### PR DESCRIPTION
- Updates the package version
- Update the "What's new" section on the homepage
- Update the 'Recently shipped' section on the 'Roadmap' page