### PR TITLE
Tidy up how our sass and js is imported

### DIFF
--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -1,12 +1,6 @@
 /* eslint-disable no-new */
 
-// Import directly from the modules in govuk-frontend because our treeshaking
-// currently doesn't work when importing directly from govuk-frontend
-//
-// See https://github.com/alphagov/govuk-frontend/issues/4957
-import { Button } from 'govuk-frontend/dist/govuk/components/button/button.mjs'
-import { NotificationBanner } from 'govuk-frontend/dist/govuk/components/notification-banner/notification-banner.mjs'
-import { SkipLink } from 'govuk-frontend/dist/govuk/components/skip-link/skip-link.mjs'
+import { createAll, Button, NotificationBanner, SkipLink } from 'govuk-frontend'
 
 import Analytics from './components/analytics.mjs'
 import BackToTop from './components/back-to-top.mjs'
@@ -24,28 +18,9 @@ import Search from './components/search.mjs'
 import AppTabs from './components/tabs.mjs'
 
 // Initialise GOV.UK Frontend
-// Button
-const $buttons = document.querySelectorAll('[data-module="govuk-button"]')
-
-$buttons.forEach(($button) => {
-  new Button($button)
-})
-
-// Notification Banner
-const $notificationBanner = document.querySelector(
-  '[data-module="govuk-notification-banner"]'
-)
-
-if ($notificationBanner) {
-  new NotificationBanner($notificationBanner)
-}
-
-// Skip link
-const $skipLink = document.querySelector('[data-module="govuk-skip-link"]')
-
-// No checking if it exists because we can safely assume there will always be
-// a skip link on a page
-new SkipLink($skipLink)
+createAll(Button)
+createAll(NotificationBanner)
+createAll(SkipLink)
 
 // Initialise cookie banner
 const $cookieBanner = document.querySelector(

--- a/src/stylesheets/_example-init.scss
+++ b/src/stylesheets/_example-init.scss
@@ -1,3 +1,3 @@
-@import "govuk/settings/all";
-@import "govuk/helpers/all";
-@import "govuk/tools/all";
+@import "govuk/settings";
+@import "govuk/helpers";
+@import "govuk/tools";

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -1,10 +1,10 @@
 $govuk-new-typography-scale: true;
 
-@import "govuk/settings/all";
-@import "govuk/helpers/all";
-@import "govuk/tools/all";
-@import "govuk/core/all";
-@import "govuk/objects/all";
+@import "govuk/settings";
+@import "govuk/helpers";
+@import "govuk/tools";
+@import "govuk/core";
+@import "govuk/objects";
 
 @import "govuk/components/back-link";
 @import "govuk/components/breadcrumbs";
@@ -33,7 +33,7 @@ $govuk-new-typography-scale: true;
 @import "govuk/components/task-list";
 @import "govuk/components/warning-text";
 
-@import "govuk/utilities/all";
+@import "govuk/utilities";
 
 @import "govuk/overrides/spacing";
 @import "govuk/overrides/text-align";


### PR DESCRIPTION
## What
Makes 3 changes across our sass and js importing and initialisation:

1. Removes the workaround to issues with our treeshaking introduced in https://github.com/alphagov/govuk-design-system/pull/3766 now that https://github.com/alphagov/govuk-frontend/issues/4957 is resolved and published
2. Uses the `createAll` method to initialise our js following it's introduction in https://github.com/alphagov/govuk-frontend/issues/4945
3. Removes `all` from the sass import paths as per the changes in https://github.com/alphagov/govuk-frontend/issues/4960

## Why
This is a redux of https://github.com/alphagov/govuk-design-system/issues/3732 following all the work done via https://github.com/alphagov/govuk-design-system/issues/3731 in the last cycle.

## Notes
There are no changes in file size for compiled js and css assets between `main` and this branch. The primary benefit is that the build now no longer spits out a bunch of sass warnings and our imports are a bit neater.