### PR TITLE
Update index.md to mention that govuk-frontend javascript will auto-focus

### DIFF
--- a/src/components/error-summary/index.md
+++ b/src/components/error-summary/index.md
@@ -23,7 +23,7 @@ Always show an error summary when there is a validation error, even if there’s
 
 You must:
 
-- move keyboard focus to the error summary
+- move keyboard focus to the error summary (the govuk-frontend javascript will do this for you)
 - include the heading ‘There is a problem’
 - link to each of the answers that have validation errors
 - make sure the error messages in the error summary are worded the same as those which appear next to the inputs with errors


### PR DESCRIPTION
The guidance makes it clear that the errorSummary should be focused on page load, but doesn't mention that this should happen for free with the govuk-frontend javascript.

Hopefully this makes it clearer so teams don't spend time trying to re-impliment this.

See similar PR on the [NHS Service manual](https://github.com/nhsuk/nhsuk-service-manual/pull/1980)

Fixes #3818 