### PR TITLE
Improve link text in phase banner examples and restructure guidance

### DIFF
--- a/src/components/phase-banner/beta/index.njk
+++ b/src/components/phase-banner/beta/index.njk
@@ -9,5 +9,5 @@ layout: layout-example.njk
   tag: {
     text: "Beta"
   },
-  html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  html: 'This is a new service. Help us improve it and <a class="govuk-link" href="#">give your feedback (opens in new tab)</a>.'
 }) }}

--- a/src/components/phase-banner/default/index.njk
+++ b/src/components/phase-banner/default/index.njk
@@ -9,5 +9,5 @@ layout: layout-example.njk
   tag: {
     text: "Alpha"
   },
-  html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  html: 'This is a new service. Help us improve it and <a class="govuk-link" href="#">give your feedback by email</a>.'
 }) }}

--- a/src/components/phase-banner/index.md
+++ b/src/components/phase-banner/index.md
@@ -40,9 +40,11 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
 
 Services hosted on a service.gov.uk domain must use the phase banner until they pass a live assessment.
 
-Use an alpha banner when your service is in alpha, and a beta banner if your service is in private or public beta.
-
 ## How it works
+
+There are 2 ways to use the phase banner component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
+
+Use an alpha banner when your service is in alpha, and a beta banner if your service is in private or public beta.
 
 Your banner must be directly under the black GOV.UK header and colour bar.
 
@@ -54,14 +56,14 @@ Your banner must be directly under the black GOV.UK header and colour bar.
   <p>Do not make the phase banner ‘sticky’ to the top of the page by using `position: fixed` or any other method. This is to make sure it does not cover or obscure any content which has a focus applied. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html">2.4.11 Focus not Obscured (minimum)</a>.</p>
 </div>
 
-There are 2 ways to use the phase banner component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
+### Add a feedback link
+
+Use a ‘feedback’ link to collect on-page feedback about your service. This can open an email or take the user to a dedicated page or form.
 
 {{ example({ group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 {{ example({ group: "components", item: "phase-banner", example: "beta", html: true, nunjucks: true, open: false }) }}
 
-### Add a feedback link
-
-Use a ‘feedback’ link to collect on-page feedback about your service. This can open an email or take the user to a dedicated page or form. Whatever option you use, make sure that users do not lose their place in the service and can return to the page they were on.
+Whatever option you use, make sure that users do not lose their place in the service and can return to the page they were on.
 
 Find out what [feedback you need to collect at each phase](https://www.gov.uk/service-manual/measuring-success/measuring-user-satisfaction#user-satisfaction-through-each-service-phase) in the GOV.UK Service Manual.


### PR DESCRIPTION
The link text in our examples isn’t very good. It’s just the word ‘feedback’ that’s linked, which is ambiguous and so it's unclear where the page takes you – it could be a way to view feedback that the service has received, for example.

Improve the link text by making more of the sentence part of the link, and also make it clear how the user will give feedback (by email, or in a form that opens in a new tab).

Restructure the sentence to put the link at the end of the sentence.

Also tweak the structure of the guidance to:

- Move ‘Use an alpha banner when your service is in alpha, and a beta banner if your service is in private or public beta.’ under ‘How it works’ as it’s more about how to use the component than when to use the component.
- Move the paragraph starting ‘There are 2 ways to use the phase banner component…’ further up ‘How it works’ as it feels like it’s the logical thing to say first.
- Move the examples under ‘Add a feedback link’

Closes #3650 