### PR TITLE
Fix a11y page descriptions

### DIFF
--- a/src/accessibility/index.md
+++ b/src/accessibility/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout-pane.njk
 title: Accessibility
-description:  tbd
+description: How we make the GOV.UK Design System accessible and our strategy for improving its accessibility over time.
 showSubNav: true
 ---
 

--- a/src/accessibility/wcag-2.2/index.md
+++ b/src/accessibility/wcag-2.2/index.md
@@ -1,6 +1,6 @@
 ---
 title: Changes to the Design System to meet WCAG 2.2
-description: Outlines the current principles and work needed to improve the accessibility of the GOV.UK Design System
+description: Outlines the work done to improve the accessibility of the GOV.UK Design System to meet WCAG 2.2 guidelines.
 section: Accessibility
 layout: layout-pane.njk
 showPageNav: true


### PR DESCRIPTION
I noticed that the meta descriptions for these pages were either incorrect or holder copy, so I fixed them. I’m not precious about what I’ve written so feel free to rewrite both, @calvin-lau-sig7. 