### PR TITLE
Fix heading level of tabular numbers override class

### DIFF
--- a/src/styles/font-override-classes/index.md
+++ b/src/styles/font-override-classes/index.md
@@ -51,7 +51,7 @@ You can use bold to highlight critical information and emphasise particular word
 
 For example, "Your reference number is **ABC12345678**. Use this to track your application. Updates will be sent to **name<i></i>@example.com**"
 
-### Tabular numbers
+## Tabular numbers
 
 Tabular numbers are an alternative style where each digit is given equal width.
 


### PR DESCRIPTION
The 'tabular numbers' section is nested beneath the 'font weight' heading, but tabular numbers are unrelated to font weight.

This PR bumps tabular numbers up to a second-level heading. This means that it will appear in the in-page navigation sidebar.