### PR TITLE
Add GA4 cookies to our cookie functions

### DIFF
--- a/__tests__/cookie-functions.test.mjs
+++ b/__tests__/cookie-functions.test.mjs
@@ -138,7 +138,7 @@ describe('Cookie settings', () => {
       })
 
       it('deletes existing analytics cookies', async () => {
-        document.cookie = '_ga=test;_gid=test;_gat_govuk_shared=test'
+        document.cookie = '_ga=test;_ga_govuk_shared=test'
 
         CookieHelpers.setConsentCookie({ analytics: false })
 
@@ -147,8 +147,7 @@ describe('Cookie settings', () => {
         )
         // Make sure those analytics cookies are definitely gone
         expect(CookieHelpers.Cookie('_ga')).toEqual(null)
-        expect(CookieHelpers.Cookie('_gid')).toEqual(null)
-        expect(CookieHelpers.Cookie('_gat_govuk_shared')).toEqual(null)
+        expect(CookieHelpers.Cookie('_ga_govuk_shared')).toEqual(null)
       })
     })
 
@@ -184,7 +183,6 @@ describe('Cookie settings', () => {
   describe('resetCookies', () => {
     it('deletes cookies the user has not consented to', async () => {
       document.cookie = '_ga=test'
-      document.cookie = '_gid=test'
       document.cookie =
         'design_system_cookies_policy={"analytics":false,"version":1}'
 
@@ -197,7 +195,6 @@ describe('Cookie settings', () => {
 
     it('deletes cookies if the consent cookie is not present', async () => {
       document.cookie = '_ga=test'
-      document.cookie = '_gid=test'
 
       CookieHelpers.resetCookies()
 
@@ -251,7 +248,6 @@ describe('Cookie settings', () => {
 
     it('resetCookies deletes cookies if consent cookie is old version', async () => {
       document.cookie = '_ga=test'
-      document.cookie = '_gid=test'
       document.cookie =
         'design_system_cookies_policy={"analytics":false,"version":0}'
 

--- a/src/cookies.njk
+++ b/src/cookies.njk
@@ -91,14 +91,9 @@ layout: layout-single-page.njk
               { text: "2 years" }
             ],
             [
-              { text: "_gid" },
-              { text: "Helps us count how many people visit the GOV.UK Design System by telling us if you’ve visited before." },
-              { text: "24 hours" }
-            ],
-            [
-              { text: "_gat_UA-[random number]" },
+              { text: "ga_[random number]" },
               { text: "Used to reduce the number of requests." },
-              { text: "1 minute" }
+              { text: "2 years" }
             ]
           ]
         }) }}

--- a/src/javascripts/components/cookie-functions.mjs
+++ b/src/javascripts/components/cookie-functions.mjs
@@ -18,16 +18,22 @@ import Analytics from './analytics.mjs'
 const CONSENT_COOKIE_NAME = 'design_system_cookies_policy'
 
 /* Google Analytics tracking IDs for preview and live environments. */
-const TRACKING_PREVIEW_ID = '26179049-17'
-const TRACKING_LIVE_ID = '116229859-1'
+const TRACKING_PREVIEW_ID = '8F2EMQL51V'
+const TRACKING_LIVE_ID = 'GHT8W0QGD9'
+
+/* Legacy GA tracking for UA to ensure we're properly deleting cookies */
+const TRACKING_PREVIEW_ID_UA = '26179049-17'
+const TRACKING_LIVE_ID_UA = '116229859-1'
 
 /* Users can (dis)allow different groups of cookies. */
 const COOKIE_CATEGORIES = {
   analytics: [
     '_ga',
+    `_ga_${TRACKING_PREVIEW_ID}`,
+    `_ga_${TRACKING_LIVE_ID}`,
     '_gid',
-    `_gat_UA-${TRACKING_PREVIEW_ID}`,
-    `_gat_UA-${TRACKING_LIVE_ID}`
+    `_gat_UA-${TRACKING_PREVIEW_ID_UA}`,
+    `_gat_UA-${TRACKING_LIVE_ID_UA}`
   ],
   /* Essential cookies
    *
@@ -176,13 +182,13 @@ export function resetCookies() {
     // Initialise analytics if allowed
     if (cookieType === 'analytics' && options[cookieType]) {
       // Enable GA if allowed
-      window[`ga-disable-UA-${TRACKING_PREVIEW_ID}`] = false
-      window[`ga-disable-UA-${TRACKING_LIVE_ID}`] = false
+      window[`ga-disable-UA-${TRACKING_PREVIEW_ID_UA}`] = false
+      window[`ga-disable-UA-${TRACKING_LIVE_ID_UA}`] = false
       Analytics()
     } else {
       // Disable GA if not allowed
-      window[`ga-disable-UA-${TRACKING_PREVIEW_ID}`] = true
-      window[`ga-disable-UA-${TRACKING_LIVE_ID}`] = true
+      window[`ga-disable-UA-${TRACKING_PREVIEW_ID_UA}`] = true
+      window[`ga-disable-UA-${TRACKING_LIVE_ID_UA}`] = true
     }
 
     if (!options[cookieType]) {


### PR DESCRIPTION
## What
Adds GA4 cookies to our cookie functions and updates our cookie policy, as per [GA4's cookie docs](https://support.google.com/analytics/answer/11397207?hl=en).

Part of https://github.com/alphagov/govuk-design-system/issues/3863

## Why
We've started migrating to GA4 and need to handle GA4's settings in our consent. This change reflects what GA4 is capturing and ensures we are deleting the correct cookies when a user withdraws consent after accepting.

## Notes
GA4 appears to be stripping out UA cookies at initialisation, meaning that we in theory don't need to worry about UA anymore. I'm opting to play it safe though and maintain UA's consent management with a view to go back in and get rid of it after July 1st when our UA properties are due to be shut down.