### PR TITLE
Refactor functions in the `analytics.mjs` module

### DIFF
--- a/__tests__/cookie-functions.test.mjs
+++ b/__tests__/cookie-functions.test.mjs
@@ -111,7 +111,7 @@ describe('Cookie settings', () => {
   describe('setConsentCookie', () => {
     beforeEach(() => {
       // Clear all instances and calls to constructor and all methods:
-      Analytics.default.mockClear()
+      Analytics.loadAnalytics.mockClear()
     })
 
     afterEach(() => {
@@ -134,7 +134,7 @@ describe('Cookie settings', () => {
       it('does not load the analytics script', async () => {
         CookieHelpers.setConsentCookie({ analytics: false })
 
-        expect(Analytics.default).toHaveBeenCalledTimes(0)
+        expect(Analytics.loadAnalytics).toHaveBeenCalledTimes(0)
       })
 
       it('deletes existing analytics cookies', async () => {
@@ -165,7 +165,7 @@ describe('Cookie settings', () => {
       it('loads analytics script if consenting to analytics cookies', async () => {
         CookieHelpers.setConsentCookie({ analytics: true })
 
-        expect(Analytics.default).toHaveBeenCalledTimes(1)
+        expect(Analytics.loadAnalytics).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -207,7 +207,7 @@ describe('Cookie settings', () => {
 
       CookieHelpers.resetCookies()
 
-      expect(Analytics.default).toHaveBeenCalledTimes(1)
+      expect(Analytics.loadAnalytics).toHaveBeenCalledTimes(1)
     })
 
     it('disables analytics by setting a window property', async () => {

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -2,7 +2,7 @@
 
 import { createAll, Button, NotificationBanner, SkipLink } from 'govuk-frontend'
 
-import Analytics from './components/analytics.mjs'
+import { loadAnalytics } from './components/analytics.mjs'
 import BackToTop from './components/back-to-top.mjs'
 import CookieBanner from './components/cookie-banner.mjs'
 import {
@@ -33,7 +33,7 @@ if ($cookieBanner) {
 // Initialise analytics if consent is given
 const userConsent = getConsentCookie()
 if (userConsent && isValidConsentCookie(userConsent) && userConsent.analytics) {
-  Analytics()
+  loadAnalytics()
 }
 
 // Initialise example frames

--- a/src/javascripts/components/analytics.mjs
+++ b/src/javascripts/components/analytics.mjs
@@ -22,3 +22,38 @@ export function loadAnalytics() {
     })(window, document, 'script', 'dataLayer', 'GTM-53XG2JT')
   }
 }
+
+/**
+ * Push to Google Analytics
+ *
+ * @param {object} payload - Google Analytics payload
+ */
+export function addToDataLayer(payload) {
+  // @ts-expect-error Property does not exist on window
+  window.dataLayer = window.dataLayer || []
+  // @ts-expect-error Property does not exist on window
+  window.dataLayer.push(payload)
+}
+
+/**
+ * Strip possible personally identifiable information (PII)
+ *
+ * @param {string} string - Input string
+ * @returns {string} Output string
+ */
+export function stripPossiblePII(string) {
+  // Try to detect emails, postcodes, and NI numbers, and redact them.
+  // Regexes copied from GTM variable 'JS - Remove PII from Hit Payload'
+  string = string.replace(/[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g, '[REDACTED EMAIL]')
+  string = string.replace(
+    /\b[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}\b/gi,
+    '[REDACTED POSTCODE]'
+  )
+  string = string.replace(
+    /^\s*[a-zA-Z]{2}(?:\s*\d\s*){6}[a-zA-Z]?\s*$/g,
+    '[REDACTED NI NUMBER]'
+  )
+  // If someone has typed in a number it's likely not related so redact it
+  string = string.replace(/[0-9]+/g, '[REDACTED NUMBER]')
+  return string
+}

--- a/src/javascripts/components/analytics.mjs
+++ b/src/javascripts/components/analytics.mjs
@@ -1,7 +1,7 @@
 // @ts-nocheck
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-export default function loadAnalytics() {
+export function loadAnalytics() {
   if (!window.ga || !window.ga.loaded) {
     // Load gtm script
     // Script based on snippet at https://developers.google.com/tag-manager/quickstart

--- a/src/javascripts/components/cookie-functions.mjs
+++ b/src/javascripts/components/cookie-functions.mjs
@@ -12,7 +12,7 @@
  * The consent cookie version is defined in cookie-banner.njk
  */
 
-import Analytics from './analytics.mjs'
+import { loadAnalytics } from './analytics.mjs'
 
 /* Name of the cookie to save users cookie preferences to. */
 const CONSENT_COOKIE_NAME = 'design_system_cookies_policy'
@@ -184,7 +184,7 @@ export function resetCookies() {
       // Enable GA if allowed
       window[`ga-disable-UA-${TRACKING_PREVIEW_ID_UA}`] = false
       window[`ga-disable-UA-${TRACKING_LIVE_ID_UA}`] = false
-      Analytics()
+      loadAnalytics()
     } else {
       // Disable GA if not allowed
       window[`ga-disable-UA-${TRACKING_PREVIEW_ID_UA}`] = true

--- a/src/javascripts/components/search.tracking.mjs
+++ b/src/javascripts/components/search.tracking.mjs
@@ -1,37 +1,4 @@
-/**
- * Push to Google Analytics
- *
- * @param {object} payload - Google Analytics payload
- */
-function addToDataLayer(payload) {
-  // @ts-expect-error Property does not exist on window
-  window.dataLayer = window.dataLayer || []
-  // @ts-expect-error Property does not exist on window
-  window.dataLayer.push(payload)
-}
-
-/**
- * Strip possible personally identifiable information (PII)
- *
- * @param {string} string - Input string
- * @returns {string} Output string
- */
-function stripPossiblePII(string) {
-  // Try to detect emails, postcodes, and NI numbers, and redact them.
-  // Regexes copied from GTM variable 'JS - Remove PII from Hit Payload'
-  string = string.replace(/[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g, '[REDACTED EMAIL]')
-  string = string.replace(
-    /\b[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}\b/gi,
-    '[REDACTED POSTCODE]'
-  )
-  string = string.replace(
-    /^\s*[a-zA-Z]{2}(?:\s*\d\s*){6}[a-zA-Z]?\s*$/g,
-    '[REDACTED NI NUMBER]'
-  )
-  // If someone has typed in a number it's likely not related so redact it
-  string = string.replace(/[0-9]+/g, '[REDACTED NUMBER]')
-  return string
-}
+import { addToDataLayer, stripPossiblePII } from './analytics.mjs'
 
 /**
  * Track confirmed autocomplete result


### PR DESCRIPTION
As described by the two commits:
* Use named export for `loadAnalytics` to limit renaming when imported, so code is easier follow.
* Move generic analytics functions `addToDataLayer` and `stripPossiblePII` out of `search.tracking.mjs` and into `analytics.mjs`.