### PR TITLE
Update GA4 cookie setup (again)

### DIFF
--- a/__tests__/cookie-functions.test.mjs
+++ b/__tests__/cookie-functions.test.mjs
@@ -218,6 +218,8 @@ describe('Cookie settings', () => {
 
       expect(window['ga-disable-UA-26179049-17']).toEqual(true)
       expect(window['ga-disable-UA-116229859-1']).toEqual(true)
+      expect(window['ga-disable-G-8F2EMQL51V']).toEqual(true)
+      expect(window['ga-disable-G-GHT8W0QGD9']).toEqual(true)
     })
 
     it('re-enables analytics by setting a window property', async () => {
@@ -228,6 +230,8 @@ describe('Cookie settings', () => {
 
       expect(window['ga-disable-UA-26179049-17']).toEqual(false)
       expect(window['ga-disable-UA-116229859-1']).toEqual(false)
+      expect(window['ga-disable-G-8F2EMQL51V']).toEqual(false)
+      expect(window['ga-disable-G-GHT8W0QGD9']).toEqual(false)
     })
   })
 

--- a/src/cookies.njk
+++ b/src/cookies.njk
@@ -94,6 +94,16 @@ layout: layout-single-page.njk
               { text: "ga_[random number]" },
               { text: "Used to reduce the number of requests." },
               { text: "2 years" }
+            ],
+            [
+              { text: "_gid" },
+              { text: "Helps us count how many people visit the GOV.UK Design System by telling us if you’ve visited before." },
+              { text: "24 hours" }
+            ],
+            [
+              { text: "_gat_UA-[random number]" },
+              { text: "Used to reduce the number of requests." },
+              { text: "1 minute" }
             ]
           ]
         }) }}

--- a/src/javascripts/components/cookie-functions.mjs
+++ b/src/javascripts/components/cookie-functions.mjs
@@ -182,11 +182,15 @@ export function resetCookies() {
     // Initialise analytics if allowed
     if (cookieType === 'analytics' && options[cookieType]) {
       // Enable GA if allowed
+      window[`ga-disable-G-${TRACKING_PREVIEW_ID}`] = false
+      window[`ga-disable-G-${TRACKING_LIVE_ID}`] = false
       window[`ga-disable-UA-${TRACKING_PREVIEW_ID_UA}`] = false
       window[`ga-disable-UA-${TRACKING_LIVE_ID_UA}`] = false
       Analytics()
     } else {
       // Disable GA if not allowed
+      window[`ga-disable-G-${TRACKING_PREVIEW_ID}`] = true
+      window[`ga-disable-G-${TRACKING_LIVE_ID}`] = true
       window[`ga-disable-UA-${TRACKING_PREVIEW_ID_UA}`] = true
       window[`ga-disable-UA-${TRACKING_LIVE_ID_UA}`] = true
     }


### PR DESCRIPTION
A followup to https://github.com/alphagov/govuk-design-system/pull/3866 because we missed a few things:

- We're in fact still setting UA cookies so we should still list these in our cookie policy
- We should still set the `ga-disable` `window` property using GA4 monitoring IDs to be absolutely sure that GA doesn't erroneously track interactions after a user has opted out of tracking consent