### PR TITLE
Remove linting from 'test' npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "serve": "cross-env NODE_ENV=production DEBUG=build* node tasks/serve.js",
     "start": "cross-env NODE_ENV=development DEBUG=build* node tasks/start.js",
     "pretest": "npm run build",
-    "test": "npm run lint && jest",
+    "test": "jest",
     "lint": "npm run lint:editorconfig && npm run lint:prettier && npm run lint:js && npm run lint:types && npm run lint:scss && npm run lint:html --ignore-scripts",
     "prelint:html": "npm run build",
     "lint:editorconfig": "editorconfig-checker",


### PR DESCRIPTION
I found tests being prevented to run by linting errors that would be fixed on commit quite annoying during development,
as it forces you to fix formatting issue before getting feedback on whether your changes work OK from a functional standpoint.

Linting will run on commit and [CI (in parallel to tests there)](https://github.com/alphagov/govuk-design-system/blob/main/.github/workflows/test.yaml#L66-L88) to pick on formatting errors, so formatting issues will not slip through even if they are not checked by the `test` script.

