### PR TITLE
Rename site-search to site_search

### DIFF
--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -179,7 +179,7 @@ describe('Site search', () => {
             ecommerce: {
               impressions: []
             },
-            event: 'site-search',
+            event: 'site_search',
             eventDetails: {
               action: 'no result',
               category: 'site search',
@@ -222,7 +222,7 @@ describe('Site search', () => {
                 })
               ])
             },
-            event: 'site-search',
+            event: 'site_search',
             eventDetails: {
               action: 'results',
               category: 'site search',
@@ -272,7 +272,7 @@ describe('Site search', () => {
                 ])
               }
             },
-            event: 'site-search',
+            event: 'site_search',
             eventDetails: {
               action: 'click',
               category: 'site search',

--- a/src/javascripts/components/search.tracking.mjs
+++ b/src/javascripts/components/search.tracking.mjs
@@ -24,7 +24,7 @@ export function trackConfirm(searchQuery, searchResults, result) {
     .filter((product) => product.name === result.title)
 
   addToDataLayer({
-    event: 'site-search',
+    event: 'site_search',
     eventDetails: {
       category: 'site search',
       action: 'click',
@@ -62,7 +62,7 @@ export function trackSearchResults(searchQuery, searchResults) {
   }))
 
   addToDataLayer({
-    event: 'site-search',
+    event: 'site_search',
     eventDetails: {
       category: 'site search',
       action: hasResults ? 'results' : 'no result',


### PR DESCRIPTION
## What

Change the `site-search` event name to `site_search`.

## Why

To ensure that the event name for when a user searches is in keeping the GA4 Event Naming Rules which state that underscores should be used in event names.
