### PR TITLE
Remove references to UA from code

### DIFF
--- a/__tests__/cookie-functions.test.mjs
+++ b/__tests__/cookie-functions.test.mjs
@@ -301,4 +301,16 @@ describe('Cookie settings', () => {
       expect(document.cookie).toEqual('')
     })
   })
+
+  describe('removeUACookies', () => {
+    it('removes cookies specifc to UA', () => {
+      document.cookie = '_gid=test'
+      document.cookie = '_gat_UA-26179049-17=test'
+      document.cookie = '_gat_UA-116229859-1=test'
+
+      CookieHelpers.removeUACookies()
+
+      expect(document.cookie).toEqual('')
+    })
+  })
 })

--- a/__tests__/cookie-functions.test.mjs
+++ b/__tests__/cookie-functions.test.mjs
@@ -212,12 +212,9 @@ describe('Cookie settings', () => {
 
     it('disables analytics by setting a window property', async () => {
       document.cookie = '_ga=test'
-      document.cookie = '_gid=test'
 
       CookieHelpers.resetCookies()
 
-      expect(window['ga-disable-UA-26179049-17']).toEqual(true)
-      expect(window['ga-disable-UA-116229859-1']).toEqual(true)
       expect(window['ga-disable-G-8F2EMQL51V']).toEqual(true)
       expect(window['ga-disable-G-GHT8W0QGD9']).toEqual(true)
     })
@@ -228,8 +225,6 @@ describe('Cookie settings', () => {
 
       CookieHelpers.resetCookies()
 
-      expect(window['ga-disable-UA-26179049-17']).toEqual(false)
-      expect(window['ga-disable-UA-116229859-1']).toEqual(false)
       expect(window['ga-disable-G-8F2EMQL51V']).toEqual(false)
       expect(window['ga-disable-G-GHT8W0QGD9']).toEqual(false)
     })

--- a/src/cookies.njk
+++ b/src/cookies.njk
@@ -94,16 +94,6 @@ layout: layout-single-page.njk
               { text: "ga_[random number]" },
               { text: "Used to reduce the number of requests." },
               { text: "2 years" }
-            ],
-            [
-              { text: "_gid" },
-              { text: "Helps us count how many people visit the GOV.UK Design System by telling us if you’ve visited before." },
-              { text: "24 hours" }
-            ],
-            [
-              { text: "_gat_UA-[random number]" },
-              { text: "Used to reduce the number of requests." },
-              { text: "1 minute" }
             ]
           ]
         }) }}

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -7,7 +7,8 @@ import BackToTop from './components/back-to-top.mjs'
 import CookieBanner from './components/cookie-banner.mjs'
 import {
   getConsentCookie,
-  isValidConsentCookie
+  isValidConsentCookie,
+  removeUACookies
 } from './components/cookie-functions.mjs'
 import CookiesPage from './components/cookies-page.mjs'
 import Copy from './components/copy.mjs'
@@ -34,6 +35,10 @@ if ($cookieBanner) {
 const userConsent = getConsentCookie()
 if (userConsent && isValidConsentCookie(userConsent) && userConsent.analytics) {
   loadAnalytics()
+
+  // Remove UA cookies if the user previously had them set or Google attempts
+  // to set them
+  removeUACookies()
 }
 
 // Initialise example frames

--- a/src/javascripts/components/cookie-functions.mjs
+++ b/src/javascripts/components/cookie-functions.mjs
@@ -21,20 +21,9 @@ const CONSENT_COOKIE_NAME = 'design_system_cookies_policy'
 const TRACKING_PREVIEW_ID = '8F2EMQL51V'
 const TRACKING_LIVE_ID = 'GHT8W0QGD9'
 
-/* Legacy GA tracking for UA to ensure we're properly deleting cookies */
-const TRACKING_PREVIEW_ID_UA = '26179049-17'
-const TRACKING_LIVE_ID_UA = '116229859-1'
-
 /* Users can (dis)allow different groups of cookies. */
 const COOKIE_CATEGORIES = {
-  analytics: [
-    '_ga',
-    `_ga_${TRACKING_PREVIEW_ID}`,
-    `_ga_${TRACKING_LIVE_ID}`,
-    '_gid',
-    `_gat_UA-${TRACKING_PREVIEW_ID_UA}`,
-    `_gat_UA-${TRACKING_LIVE_ID_UA}`
-  ],
+  analytics: ['_ga', `_ga_${TRACKING_PREVIEW_ID}`, `_ga_${TRACKING_LIVE_ID}`],
   /* Essential cookies
    *
    * Essential cookies cannot be deselected, but we want our cookie code to
@@ -184,15 +173,11 @@ export function resetCookies() {
       // Enable GA if allowed
       window[`ga-disable-G-${TRACKING_PREVIEW_ID}`] = false
       window[`ga-disable-G-${TRACKING_LIVE_ID}`] = false
-      window[`ga-disable-UA-${TRACKING_PREVIEW_ID_UA}`] = false
-      window[`ga-disable-UA-${TRACKING_LIVE_ID_UA}`] = false
       loadAnalytics()
     } else {
       // Disable GA if not allowed
       window[`ga-disable-G-${TRACKING_PREVIEW_ID}`] = true
       window[`ga-disable-G-${TRACKING_LIVE_ID}`] = true
-      window[`ga-disable-UA-${TRACKING_PREVIEW_ID_UA}`] = true
-      window[`ga-disable-UA-${TRACKING_LIVE_ID_UA}`] = true
     }
 
     if (!options[cookieType]) {

--- a/src/javascripts/components/cookie-functions.mjs
+++ b/src/javascripts/components/cookie-functions.mjs
@@ -174,6 +174,9 @@ export function resetCookies() {
       window[`ga-disable-G-${TRACKING_PREVIEW_ID}`] = false
       window[`ga-disable-G-${TRACKING_LIVE_ID}`] = false
       loadAnalytics()
+
+      // Unset UA cookies if they've been set by GTM
+      removeUACookies()
     } else {
       // Disable GA if not allowed
       window[`ga-disable-G-${TRACKING_PREVIEW_ID}`] = true
@@ -189,6 +192,24 @@ export function resetCookies() {
         Cookie(cookie, null)
       })
     }
+  }
+}
+
+/**
+ * Remove UA cookies for user and prevent Google setting them.
+ *
+ * We've migrated our analytics from UA (Universal Analytics) to GA4, however
+ * users may still have the UA cookie set from our previous implementation.
+ * Additionally, our UA properties are scheduled for deletion but until they are
+ * entirely deleted, GTM is still setting UA cookies.
+ */
+export function removeUACookies() {
+  for (const UACookie of [
+    '_gid',
+    '_gat_UA-26179049-17',
+    '_gat_UA-116229859-1'
+  ]) {
+    Cookie(UACookie, null)
   }
 }
 


### PR DESCRIPTION
A followup of our migration to GA4 (https://github.com/alphagov/govuk-design-system/issues/3822)

We've finished moving our existing tags to GA4 and the old UA properties aren't collecting data and are in fact scheduled for deletion therefore we can get rid of our UA-specific code.

We still need to account for users who previously accepted UA cookies and GTM setting UA cookies still whilst our UA properties are waiting to be deleted, so we specifically target UA specific cookies for removal at the point they might be set and when we know a user has previously accepted marketing consent.