### PR TITLE
Small style and punctuation fixes to DSDay24 pages

### DIFF
--- a/src/community/call-for-speakers-2024/index.md
+++ b/src/community/call-for-speakers-2024/index.md
@@ -11,14 +11,14 @@ order: 16
 {% from "_promo-banner.njk" import promoBanner %}
 
 <p class="govuk-!-font-size-24">
-  This year our in person Design System Day event will be held on <strong>5 September 2024</strong>. We’re excited to announce that we will be holding the event at <a href="https://www.stgeorgeshallliverpool.co.uk/" class="govuk-link">St George’s Hall</a> in Liverpool.
+  This year our in-person Design System Day event will be held on <strong>5 September 2024</strong>. We’re excited to announce that we will be holding the event at <a href="https://www.stgeorgeshallliverpool.co.uk/" class="govuk-link">St George’s Hall</a> in Liverpool.
 </p>
 
 <img class="app-image--no-border govuk-!-margin-top-9 govuk-!-margin-bottom-9" src="/images/dsd24-hello.svg" alt="Hello">
 
 As ever, we want the conference to be a community-driven event. So come and take part to make Design System Day 2024 special.
 
-We are looking for keynote speakers, as well as folks to host show and tell sessions, panel discussions and talks throughout the day.
+We're looking for keynote speakers, as well as folks to host show and tell sessions, panel discussions and talks throughout the day.
 
 {% call promoBanner({
   img: "/images/dsd24-star.svg",
@@ -80,37 +80,37 @@ Sessions are 45 minutes long. If you need longer let us know.
 ### Short summary
 
 - this will be what we use to promote your session
-- keep it short - 20 to 50 words
+- keep it short – 20 to 50 words
 - be honest and informative so you get the right people at your session
 
 ### Session description
 
 - this is where we want details about your session, including anything you want participants to take away
-- tell us what you will be covering and what you expect your outcomes to be
+- tell us what you'll cover and what you expect your outcomes to be
 - tell us whether this is session for beginners or more advanced
 - let us know if your session is going to be interactive or not, so that participants can be aware of what will be expected of them
 
-### What we don't want
+### What we do not want
 
 #### Rants
 
-Things don’t always turn out the way we want, that’s fine as long as you learn from them. The audience will want to know what lessons you took away so that they can be sure to learn from any issues you faced.
+Things do not always turn out the way we want, that’s fine as long as you learn from them. The audience will want to know what lessons you took away so that they can be sure to learn from any issues you faced.
 
 #### A hard sell
 
-We know that there are lots of really interesting things going on in the digital space right now, and that getting new talent is hard work, but this is not why people will be here. Feel free to make connections with people and remember that they are here for a conference, not a job fair.
+We know that there are lots of really interesting things going on in the digital space right now, and that getting new talent is hard work, but this is not why people will be here. Feel free to make connections with people and remember that they're here for a conference, not a job fair.
 
 #### Rudeness
 
-The people attending this conference are all specialists at something. They will also have unique and interesting ways of doing things that will probably differ from how you do them. This is a great thing! In government we want new and interesting ideas, so be respectful and inclusive of innovative ideas that others have.
+The people attending this conference are all specialists at something. They'll also have unique and interesting ways of doing things that will probably differ from how you do them. This is a great thing! In government we want new and interesting ideas, so be respectful and inclusive of innovative ideas that others have.
 
 ### What we're offering
 
 All speakers will receive a ticket to the event.
 
-We intend to record the keynotes, show and tells, panel discussions and talks. We will share these after we have edited and transcribed them. We will inform you when we are planning to share recordings using the mailing list.
+We intend to record the keynotes, show and tells, panel discussions and talks. We'll share these after we have edited and transcribed them. We'll inform you when we are planning to share recordings using the mailing list.
 
-We will assess your pitches and have a decision for you by **Friday 2 August 2024**. We will be looking for diverse perspectives and people who are passionate about their roles. We welcome your pitch, whether this be your first time with us or your third!
+We'll assess your pitches and have a decision for you by **Friday 2 August 2024**. We'll be looking for diverse perspectives and people who are passionate about their roles. We welcome your pitch, whether this be your first time with us or your third!
 
 We hope you can join us!
 
@@ -120,7 +120,7 @@ We hope you can join us!
 }) %}
 
   <p class="govuk-!-font-size-24">
-    Head over to <a href="https://surveys.publishing.service.gov.uk/s/1R00EG/" class="govuk-link">this form</a>, to submit your session.
+    Head over to the form <a href="https://surveys.publishing.service.gov.uk/s/1R00EG/" class="govuk-link">submit your session</a>.
   </p>
-  <p><strong>Closing date 11:59pm on Sunday 28 July 2024.</strong><br>If you have any further questions, <a class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">contact us.</a></p>
+  <p><strong>Closing date: 11:59pm on Sunday 28 July 2024.</strong><br>If you have any further questions, <a class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk">contact us</a></p>.
 {% endcall %}


### PR DESCRIPTION
Makes some edits to the Call for speakers page, mostly on punctuations and link text.