### PR TITLE
Make dependabot ignore `eslint` and `eslint-*` dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,12 @@ updates:
           - '@types/jest'
           - '@types/jest-*'
 
+    # Ignore eslint and is plugins for now
+    # the time they all get compatible with each other
+    ignore:
+      - dependency-name: 'eslint-*'
+      - dependency-name: 'eslint'
+
     reviewers:
       - alphagov/design-system-developers
 


### PR DESCRIPTION
Similarly to [the GOV.UK Frontend repository](https://github.com/alphagov/govuk-frontend/pull/4999), make dependabot ignore eslint packages updates for now to avoid its process timing out and preventing the update of other packages.