### PR TITLE
Add guidance for break-word override class

### DIFF
--- a/src/styles/font-override-classes/break-word/index.njk
+++ b/src/styles/font-override-classes/break-word/index.njk
@@ -1,0 +1,19 @@
+---
+title: Break word – Typography
+layout: layout-example.njk
+---
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <p class="govuk-body">
+      <strong>With class</strong><br>
+      We'll send an email to: <span class="govuk-!-text-break-word">communications@llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogochuchaf.gov.uk</span>.
+    </p>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <p class="govuk-body">
+      <strong>With <code>wbr</code></strong><br>
+      We'll send an email to: <span class="govuk-!-text-break-word">communications@<wbr>llanfair<wbr>pwll<wbr>gwyngyll<wbr>gogerych<wbr>wyrndrob<wbr>wll<wbr>llanty<wbr>silio<wbr>gogogoch<wbr>uchaf<wbr>.gov.uk</span>.
+    </p>
+  </div>
+</div>

--- a/src/styles/font-override-classes/index.md
+++ b/src/styles/font-override-classes/index.md
@@ -60,3 +60,19 @@ Using tabular numbers can make numbers intended for comparison to one another ea
 You can also use tabular numbers for numbers that dynamically update, such as in a counter. The equal width of each digit prevents the numbers from visually moving towards and away from each other as the counter updates.
 
 Activate tabular numbers by using `govuk-!-font-tabular-numbers`.
+
+## Breaking up long words
+
+You might need to show long words that cannot be changed or broken into smaller parts, such as:
+
+- technical or scientific terms
+- long email addresses
+- words from other languages
+
+Long words can create issues in constrained spaces such as mobile device screens and data tables. They can 'break out' of the layout, resulting in a broken visual appearance and requiring users to scroll horizontally to view all of your content.
+
+You can help to reduce these issues by surrounding content likely to 'break out' with `govuk-!-text-break-word`.
+
+This class forcibly splits long words onto multiple lines when they become longer than the width of the container. It'll make the split exactly where the word would otherwise 'break out', which might make compound words more difficult to read. You can control where words can be split by inserting [the `wbr` HTML tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr) into your content.
+
+{{ example({ group: "styles", item: "font-override-classes", example: "break-word", html: true, open: true }) }}


### PR DESCRIPTION
We added a new typography override class (`govuk-!-text-break-word`) into govuk-frontend that breaks long words across multiple lines if the word would otherwise not fit into its parent container. https://github.com/alphagov/govuk-frontend/pull/5159

The most common example of this is probably long email addresses on narrow viewports, but it may also be an issue for the text in data tables, technical and scientific terms, or when localising content into languages with long compound words such as German.

This is a first pass at some guidance about the override class.

**[Quick link to the draft guidance.](https://deploy-preview-3968--govuk-design-system-preview.netlify.app/styles/font-override-classes/#breaking-up-long-words)**

> [!WARNING]
> This should not be merged until a version of GOV.UK Frontend featuring the override class has been released.

> [!NOTE]
> The code example included won't appear correctly until after a new release of Frontend is made and merged with the Design System website.

## Changes

- Adds a new section to the font override classes page: "Breaking up long words"
- Adds an example of the class in use by itself and in combination with the `wbr` HTML tag.

## Thoughts

### Inclusion of `wbr` guidance

I've included a paragraph and an example that shows the class being used in conjunction with [the `wbr` HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr). This element indicates where it is 'safe' to break a long word across multiple lines. 

Using `wbr` isn't required to use the class at all, but it's a useful companion to what problems the class is intended to solve. It's a somewhat obscure element, so calling it out here specifically seemed like it might be useful. 

<details><summary>Visual explainer of what <code>wbr</code> actually does</summary>

To illustrate what it does visually, given this HTML: 

```html
<p>Send an email to <span class="govuk-!-text-break-word">big.john@theoldassemblybuilding.fake</span>.</p>
```

Without `wbr`, the email address could be wrapped at any point, leading to potentially confusing (or rude) 'partial' sentences in narrow content containers.

```
=====================
Send an email to big.
john@theoldassemblybu
ilding.fake.

==========================
Send an email to big.john@
theoldassemblybuilding.fak
e.

===================================
Send an email to big.john@theoldass
emblybuilding.fake.
```

By adding `wbr`s into the HTML content, we can define where to prioritise line breaks should one need to occur: 
```html
<p>Send an email to <span class="govuk-!-text-break-word">big.john<wbr>@<wbr>the<wbr>old<wbr>assembly<wbr>building.fake</span>.</p>
```

This basically creates a list of 'segments' that we don't want line breaks to appear within:
* big.john
* @ 
* the
* old
* assembly
* building.fake

(Note that there is still potential for line breaks to appear within a segment, but this will now only happen if the individual segment is itself too long for the containing element.)

At similar container widths to the above, you'll now end up with something like:

```
=====================
Send an email to 
big.john@theold
assembly
building.fake.

==========================
Send an email to big.john@
theoldassembly
building.fake.

===================================
Send an email to big.john@theold
assemblybuilding.fake.
```

</details>

Given it isn't directly related to the override class, I'm not sure if including this is extraneous or has the potential to confuse or mislead. It would be simpler to omit it, but it also feels like it could be helpful for a subset of users.