### PR TITLE
Remove deprecated Husky setup code

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx --no-install lint-staged
+npx --no lint-staged


### PR DESCRIPTION
These lines of Husky setup code have been non-operational since Husky 9.0. It is now recommended to remove them, as they are likely to error with future releases of Husky.

## Changes
- Removes the now deprecated code.
- Changes the npx command to replace [the deprecated `--no-install` flag](https://docs.npmjs.com/cli/v9/commands/npx?v=true#compatibility-with-older-npx-versions) with the replacement `--no` flag. 

## Timeline
- [Husky 9.0.0/9.0.1](https://github.com/typicode/husky/releases/tag/v9.0.1) removed the requirement to include shebang declarations and the Husky shell file in hook files. Husky still supported the code being present for backwards compatibility purposes, but silently ignored it. 
- [Husky 9.1.1](https://github.com/typicode/husky/releases/tag/v9.1.1) officially deprecated the lines and initially attempted to remove the lines automatically.
- [Husky 9.1.2](https://github.com/typicode/husky/releases/tag/v9.1.2) reversed this automatic removal after various issues were reported relating to it. It now produces a deprecation warning instructing users to remove the lines manually.

