### PR TITLE
Prevent puppeteer from exiting when an error happens on the page

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -7,6 +7,12 @@ module.exports = {
   browserContext: 'incognito',
 
   /**
+   * TEMPORARY: Disable puppeteer exiting when an error happens on the page,
+   * making tests fail when GTM throws an error in its execution
+   */
+  exitOnPageError: false,
+
+  /**
    * Puppeteer launch options
    */
   launch: {


### PR DESCRIPTION
When run through jest-puppeteer, Puppeteer exits by default when an error is caught by the browser (both JavaScript errors, but also error status code from the server).

In our situation, this makes tests fail when an error happens in a 3rd party code (Google Tag Manager), preventing us from merging PRs while our own code is actually OK.

This change is only temporary and will be reversed when we implement a longer term solution to [isolate our tests from Google Tag Manager errors](https://github.com/alphagov/govuk-design-system/issues/3969).

