### PR TITLE
Mock script injected to load Google Tag Manager

### DIFF
--- a/__tests__/accessibility-audit.test.js
+++ b/__tests__/accessibility-audit.test.js
@@ -1,6 +1,6 @@
 const { AxePuppeteer } = require('@axe-core/puppeteer')
 
-const { goTo } = require('../lib/puppeteer-helpers.js')
+const { goTo } = require('./helpers/puppeteer.js')
 
 async function analyze(page, path) {
   await goTo(page, path)

--- a/__tests__/back-to-top.test.js
+++ b/__tests__/back-to-top.test.js
@@ -1,4 +1,4 @@
-const { goTo, isVisible } = require('../lib/puppeteer-helpers.js')
+const { goTo, isVisible } = require('./helpers/puppeteer.js')
 
 describe('Back to top', () => {
   let $module

--- a/__tests__/component-options.test.js
+++ b/__tests__/component-options.test.js
@@ -1,4 +1,4 @@
-const { goTo } = require('../lib/puppeteer-helpers.js')
+const { goTo } = require('./helpers/puppeteer.js')
 
 describe('Component page', () => {
   it('should contain a "Nunjucks" tab heading', async () => {

--- a/__tests__/cookie-banner.test.js
+++ b/__tests__/cookie-banner.test.js
@@ -1,9 +1,9 @@
 const { ports } = require('../config')
-const { goTo, getAttribute, isVisible } = require('../lib/puppeteer-helpers.js')
 
 const {
   mockGoogleTagManagerScript
 } = require('./helpers/google-tag-manager.js')
+const { goTo, getAttribute, isVisible } = require('./helpers/puppeteer.js')
 
 describe('Cookie banner', () => {
   let $module

--- a/__tests__/cookies-page.test.js
+++ b/__tests__/cookies-page.test.js
@@ -1,9 +1,9 @@
 const { ports } = require('../config')
-const { goTo, getProperty, isVisible } = require('../lib/puppeteer-helpers.js')
 
 const {
   mockGoogleTagManagerScript
 } = require('./helpers/google-tag-manager.js')
+const { goTo, getProperty, isVisible } = require('./helpers/puppeteer.js')
 
 describe('Cookies page', () => {
   let $module

--- a/__tests__/cookies-page.test.js
+++ b/__tests__/cookies-page.test.js
@@ -1,6 +1,10 @@
 const { ports } = require('../config')
 const { goTo, getProperty, isVisible } = require('../lib/puppeteer-helpers.js')
 
+const {
+  mockGoogleTagManagerScript
+} = require('./helpers/google-tag-manager.js')
+
 describe('Cookies page', () => {
   let $module
 
@@ -22,9 +26,18 @@ describe('Cookies page', () => {
     })
 
     await page.setJavaScriptEnabled(true)
+    // Set up network interception
+    // https://pptr.dev/guides/network-interception
+    await page.setRequestInterception(true)
+    page.on('request', mockGoogleTagManagerScript)
 
     await goTo(page, '/cookies')
     await setup(page)
+  })
+
+  afterEach(async () => {
+    page.off('request', mockGoogleTagManagerScript)
+    await page.setRequestInterception(false)
   })
 
   it('without JavaScript it has no visible inputs', async () => {

--- a/__tests__/cookies-page.test.js
+++ b/__tests__/cookies-page.test.js
@@ -110,6 +110,37 @@ describe('Cookies page', () => {
     )
   })
 
+  it('injects Google Tag Manager script if user accepts cookies', async () => {
+    // Click 'Yes' and submit
+    await $radioYes.click()
+    await $buttonSave.click()
+
+    expect(
+      page.$('script[src*="www.googletagmanager.com"]')
+    ).resolves.toBeTruthy()
+  })
+
+  it('does not inject Google Tag Manager script if user rejects cookies', async () => {
+    await $radioNo.click()
+    await $buttonSave.click()
+
+    expect(
+      page.$('script[src*="www.googletagmanager.com"]')
+    ).resolves.toBeNull()
+  })
+
+  it('immediately disables analytics if user rejects cookies', async () => {
+    await $radioNo.click()
+    await $buttonSave.click()
+
+    expect(
+      page.evaluate(() => window['ga-disable-G-8F2EMQL51V'])
+    ).resolves.toEqual(true)
+    expect(
+      page.evaluate(() => window['ga-disable-G-GHT8W0QGD9'])
+    ).resolves.toEqual(true)
+  })
+
   it('shows the users existing preferences when the page is loaded', async () => {
     // Click 'No' and submit
     await $radioNo.click()

--- a/__tests__/example.test.js
+++ b/__tests__/example.test.js
@@ -1,4 +1,4 @@
-const { goTo } = require('../lib/puppeteer-helpers.js')
+const { goTo } = require('./helpers/puppeteer.js')
 
 describe('Example page', () => {
   describe('that has a form', () => {

--- a/__tests__/helpers/google-tag-manager.js
+++ b/__tests__/helpers/google-tag-manager.js
@@ -1,0 +1,24 @@
+/**
+ * Mocks requests to Google Tag Manager so our tests are not impacted by
+ * possible errors in third party scripts
+ *
+ * @param {import('puppeteer').HTTPRequest} interceptedRequest
+ * @returns
+ */
+function mockGoogleTagManagerScript(interceptedRequest) {
+  if (interceptedRequest.isInterceptResolutionHandled()) return
+
+  const requestURL = interceptedRequest.url()
+
+  if (requestURL.startsWith('https://www.googletagmanager.com/')) {
+    return interceptedRequest.respond({
+      status: 200,
+      contentType: 'text/javascript',
+      body: 'window.GTMScriptIncluded=true;'
+    })
+  }
+
+  return interceptedRequest.continue()
+}
+
+module.exports = { mockGoogleTagManagerScript }

--- a/__tests__/helpers/puppeteer.js
+++ b/__tests__/helpers/puppeteer.js
@@ -1,4 +1,4 @@
-const { ports } = require('../config')
+const { ports } = require('../../config')
 
 /**
  * Navigate to path

--- a/__tests__/navigation.test.js
+++ b/__tests__/navigation.test.js
@@ -1,6 +1,6 @@
 const { KnownDevices } = require('puppeteer')
 
-const { goTo, getAttribute, isVisible } = require('../lib/puppeteer-helpers.js')
+const { goTo, getAttribute, isVisible } = require('./helpers/puppeteer.js')
 
 describe('Homepage', () => {
   let $navigation

--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -1,4 +1,4 @@
-const { goTo, getProperty } = require('../lib/puppeteer-helpers.js')
+const { goTo, getProperty } = require('./helpers/puppeteer.js')
 
 // Regex that can be used to match on fingerprinted search index files
 const isSearchIndex = /.*\/search-index(-[0-9a-f]{32})?.json$/

--- a/__tests__/tabs.test.js
+++ b/__tests__/tabs.test.js
@@ -1,4 +1,4 @@
-const { goTo, getAttribute, isVisible } = require('../lib/puppeteer-helpers.js')
+const { goTo, getAttribute, isVisible } = require('./helpers/puppeteer.js')
 
 describe('Component page', () => {
   let $module

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -35,6 +35,6 @@ export default {
   testMatch: ['**/*.test.{js,mjs}'],
   transform: { '^.+\\.m?js$': ['babel-jest'] },
 
-  // Ignore built fixtures during `--watch`
-  watchPathIgnorePatterns: ['fixtures/build']
+  // Ignore built fixtures during `--watch` and node_modules folders
+  watchPathIgnorePatterns: ['fixtures/build', '/node_modules/']
 }


### PR DESCRIPTION
Use Puppeteer's [request interception feature](https://pptr.dev/guides/network-interception) to isolate our tests from the actual Google Tag Manager (GTM) script, returning a mock script rather than the whole analytics script downloaded from Google.

This makes our tests no longer dependent to GTM having issues (either return 4XX response or errors in the script themselves), which make our tests fails as jest-puppeteer would exit the browser when uncaught errors occur.

The PR also add extra tests to the cookie-banner and cookie-page test suites, to verify that the script for GTM is actually loaded in the page when necessary and analytics immediately disabled when needs be. So far, we didn't have any tests for that, with the cookies-functions tests only checking [that `loadAnalytics` was getting called (or not, depending on the test)](https://github.com/alphagov/govuk-design-system/blob/d24941bd38e1b3f789862769e838f18d021b3de9/__tests__/cookie-functions.test.mjs#L168), but nothing checking what it was actually doing.

Fixes #3969