### PR TITLE
Add group for our own dependencies in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
 
     # Group packages into shared PR
     groups:
+      # First in list so Dependabot looks at updating those first
+      design-system:
+        patterns:
+          - 'govuk-frontend'
+          - 'accessible-autocomplete'
+
       babel:
         patterns:
           - '@babel/*'


### PR DESCRIPTION
This should make Dependabot look at updating our own dependencies before the other groups.