### PR TITLE
Make dependabot ignore major bumps for iframe-resizer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,6 +71,10 @@ updates:
     ignore:
       - dependency-name: 'eslint-*'
       - dependency-name: 'eslint'
+      # iframe-resizer has switched to GPL licence in v5
+      # so we need to avoid upgrading to their next major version
+      - dependency-name: 'iframe-resizer'
+        update-types: ['version-update:semver-major']
 
     reviewers:
       - alphagov/design-system-developers


### PR DESCRIPTION
It seems to have done it so far, but with the update popping up on the Design System site, better be safe than inadvertentnly use a GPL dependency which would make us have to change our licence as well