### PR TITLE
Add overflow checks to code blocks to dynamically remove `tabindex`

### DIFF
--- a/lib/marked/renderer.js
+++ b/lib/marked/renderer.js
@@ -12,7 +12,7 @@ exports.code = function (token) {
 
   // Ensure code blocks can be focused and scrolled
   // with the keyboard via `tabindex="0"`
-  return `<pre><code tabindex="0" class="language-${token.lang}">${token.text}</code></pre>\n`
+  return `<pre><code data-module="app-scroll-container" tabindex="0" class="language-${token.lang}">${token.text}</code></pre>\n`
 }
 
 /**

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -16,6 +16,7 @@ import EmbedCard from './components/embed-card.mjs'
 import ExampleFrame from './components/example-frame.mjs'
 import Navigation from './components/navigation.mjs'
 import OptionsTable from './components/options-table.mjs'
+import ScrollContainer from './components/scroll-container.mjs'
 import Search from './components/search.mjs'
 import AppTabs from './components/tabs.mjs'
 
@@ -41,12 +42,16 @@ if (userConsent && isValidConsentCookie(userConsent) && userConsent.analytics) {
 // Code examples
 createAll(ExampleFrame)
 createAll(AppTabs)
+
 // Do this after initialising tabs
 createAll(Copy)
 new OptionsTable()
 
 // Initialise mobile navigation
 new Navigation(document)
+
+// Initialise scrollable container handling
+createAll(ScrollContainer)
 
 // Initialise search
 createAll(Search)

--- a/src/javascripts/components/scroll-container.mjs
+++ b/src/javascripts/components/scroll-container.mjs
@@ -1,0 +1,49 @@
+const scrollContainerResizeObserver = new window.ResizeObserver((entries) => {
+  for (const entry of entries) {
+    if (ScrollContainer.isOverflowing(entry.target)) {
+      entry.target.setAttribute('tabindex', '0')
+    } else {
+      entry.target.removeAttribute('tabindex')
+    }
+  }
+})
+
+/**
+ *
+ */
+class ScrollContainer {
+  static moduleName = 'app-scroll-container'
+
+  /**
+   * @param {Element} $module - HTML element
+   */
+  constructor($module) {
+    if (
+      !($module instanceof HTMLElement) ||
+      !document.body.classList.contains('govuk-frontend-supported') ||
+      !('ResizeObserver' in window)
+    ) {
+      return this
+    }
+
+    scrollContainerResizeObserver.observe($module)
+  }
+
+  /**
+   * Checks if the elements scrollable width or height is greater than the
+   * width or height the element is being rendered at.
+   *
+   * @param {Element} $element - The element to check
+   * @returns {boolean} - Returns `true` if the given element is overflowing
+   *   in either dimension, otherwise returns `false`
+   * @static
+   */
+  static isOverflowing($element) {
+    return (
+      $element.scrollHeight > $element.clientHeight ||
+      $element.scrollWidth > $element.clientWidth
+    )
+  }
+}
+
+export default ScrollContainer


### PR DESCRIPTION
The recent audit noted a usability issue for users who navigated using the <kbd>Tab</kbd> key, wherein they would be made to stop at every code block as they all have the `tabindex` attribute set. #4007

We set `tabindex` intentionally so that long lines of code can overflow the container and be scrolled by using the keyboard's arrow keys. We want to maintain this ability (removing it entirely would be a likely violation of [Success Criterion 2.1: Keyboard Accessible](https://www.w3.org/WAI/WCAG21/Understanding/keyboard-accessible)) but would like to limit it only to blocks that need to scroll.

## Changes
- Adds a `data-module` attribute to code blocks processed by Markdown.
- Adds JavaScript to attach a ResizeObserver to each code block.
  - When the page is initially loaded, or the elements are resized, checks if the content of the code block overflows the container.
  - If so, it adds the `tabindex` attribute. Otherwise, it removes it. 

## Thoughts
This is only one possible solution to this issue, if we opt to implement a 'fix' at all.

Personally, I'm a little iffy on how necessary it is. Having some code blocks focusable and some not, contextual depending upon things like font size and screen width, feels inconsistent and confusing to a keyboard navigation user—potentially being more detrimental to their experience than having each code block just be focusable.  