### PR TITLE
Fix non-sequential heading hierarchy on accessibility page

### DIFF
--- a/src/accessibility/index.md
+++ b/src/accessibility/index.md
@@ -9,10 +9,10 @@ Our work to make the GOV.UK Design System meet public sector accessibility regul
 
 Using the GOV.UK Design System in a service does not immediately make that service accessible. You’ll need additional research, design, development and testing work to make sure your service is accessible, even when using accessible styles, components and patterns.
 
-### Accessibility changes to the Design System to meet WCAG 2.2
+## Accessibility changes to the Design System to meet WCAG 2.2
 
 [Read our guidance on the Web Content Accessibility Guidelines (WCAG) 2.2](/accessibility/wcag-2.2) to make sure teams using the Design System are aware of the changes and can make the necessary adjustments to their services.
 
-### Accessibility strategy
+## Accessibility strategy
 
 [Read our accessibility strategy](/accessibility/accessibility-strategy/) for more information on our current principles and work needed to improve the accessibility of the GOV.UK Design System.


### PR DESCRIPTION
Resolves cases of headings jumping straight from h1 to h3 on the accessibility landing page.

Partially resolves #4025.

## Changes

- Bumps up the heading levels on the accessibility landing page from h3 → h2.