### PR TITLE
Fix extra whitespace around link to National Archives

### DIFF
--- a/views/layouts/layout-archived.njk
+++ b/views/layouts/layout-archived.njk
@@ -15,11 +15,11 @@
 
       <div class="app-prose-scope">
         {{ contents | safe}}
-
         <p>
-          You can also <a href="https://webarchive.nationalarchives.gov.uk/*/https://design-system.service.gov.uk/{{ permalink }}">
-            check for previous versions of this page in the UK Government Web Archive
-          </a>.
+          You can also
+          <a
+            href="https://webarchive.nationalarchives.gov.uk/*/https://design-system.service.gov.uk/{{ permalink }}"
+          >check for previous versions of this page in the UK Government Web Archive</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Whitespace inside the link was causing:
- a visible underlined space on Chrome
	<img width="1624" alt="Screenshot of an archived page of the GOV.UK Design System site in Chrome" src="https://github.com/user-attachments/assets/ad5d0b82-f075-4910-92a9-5646b62b882f">
- the period to go to the next line on Firefox
	<img width="1624" alt="Screenshot 2024-08-16 at 15 13 26" src="https://github.com/user-attachments/assets/2551046c-886f-4ad2-acfc-77e52c18efbe">
