### PR TITLE
Use `createAll` to initialise components in the Design System site

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,6 +1,9 @@
 # This list builds on the GOV.UK service manual's browser testing recommendations
 # https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices
 
+[javascripts]
+supports es6-module
+
 [stylesheets]
 > 0.1% in GB and not dead
 last 6 Chrome versions

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,13 +4,23 @@
  * @type {import('@babel/core').ConfigFunction}
  */
 module.exports = function (api) {
-  const browserslistEnv = !api.env('test') ? 'production' : 'node'
+  const isBrowser = !api.env('test')
+
+  const browserslistEnv = isBrowser ? 'javascripts' : 'node'
 
   const presets = [
     [
       '@babel/preset-env',
       {
-        browserslistEnv
+        browserslistEnv,
+        // Apply bug fixes to avoid transforms
+        bugfixes: true,
+
+        // Apply smaller "loose" transforms for browsers
+        loose: isBrowser,
+
+        // Skip ES module transforms for browsers
+        modules: isBrowser ? false : 'auto'
       }
     ]
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@metalsmith/permalinks": "^3.0.1",
         "@metalsmith/postcss": "^5.4.1",
         "@metalsmith/sass": "^1.10.0",
+        "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
@@ -3150,6 +3151,33 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@rollup/plugin-babel": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.0.4.tgz",
+      "integrity": "sha512-YF7Y52kFdFT/xVSuVdjkV5ZdX/3YtmX0QulG+x0taQOtJdHYzVU61aSSkAgVJ7NOv6qPkIYiJSgSWWN/DM5sGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.18.6",
+        "@rollup/pluginutils": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@types/babel__core": "^7.1.9",
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/babel__core": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@metalsmith/permalinks": "^3.0.1",
     "@metalsmith/postcss": "^5.4.1",
     "@metalsmith/sass": "^1.10.0",
+    "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+const babel = require('@rollup/plugin-babel')
 const commonjs = require('@rollup/plugin-commonjs')
 const resolve = require('@rollup/plugin-node-resolve')
 const terser = require('@rollup/plugin-terser')
@@ -35,5 +36,11 @@ module.exports = defineConfig({
   ],
 
   // Input plugins
-  plugins: [resolve(), commonjs()]
+  plugins: [
+    resolve(),
+    commonjs(),
+    babel({
+      babelHelpers: 'bundled'
+    })
+  ]
 })

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -9,10 +9,13 @@ module.exports = {
       extends: ['plugin:es-x/restrict-to-es2015', 'prettier'],
       parserOptions: {
         // Note: Allow ES2015 for import/export syntax
-        ecmaVersion: '2015'
+        ecmaVersion: 'latest'
       },
       plugins: ['es-x'],
       rules: {
+        // Babel transpiles ES2020 class fields
+        'es-x/no-class-fields': 'off',
+
         // JSDoc blocks are mandatory in source code
         'jsdoc/require-jsdoc': [
           'error',

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -24,12 +24,7 @@ createAll(NotificationBanner)
 createAll(SkipLink)
 
 // Initialise cookie banner
-const $cookieBanner = document.querySelector(
-  '[data-module="govuk-cookie-banner"]'
-)
-if ($cookieBanner) {
-  new CookieBanner($cookieBanner)
-}
+createAll(CookieBanner)
 
 // Initialise analytics if consent is given
 const userConsent = getConsentCookie()

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -40,10 +40,7 @@ if (userConsent && isValidConsentCookie(userConsent) && userConsent.analytics) {
 createAll(Example)
 
 // Initialise tabs
-const $tabs = document.querySelectorAll('[data-module="app-tabs"]')
-$tabs.forEach(($tabs) => {
-  new AppTabs($tabs)
-})
+createAll(AppTabs)
 
 // Do this after initialising tabs
 new OptionsTable()

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -61,7 +61,4 @@ createAll(Search)
 createAll(BackToTop)
 
 // Initialise cookie page
-const $cookiesPage = document.querySelector('[data-module="app-cookies-page"]')
-if ($cookiesPage) {
-  new CookiesPage($cookiesPage)
-}
+createAll(CookiesPage)

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -23,10 +23,11 @@ createAll(Button)
 createAll(NotificationBanner)
 createAll(SkipLink)
 
-// Initialise cookie banner
+// Cookies and analytics
 createAll(CookieBanner)
+createAll(CookiesPage)
 
-// Initialise analytics if consent is given
+// Check for consent before initialising analytics
 const userConsent = getConsentCookie()
 if (userConsent && isValidConsentCookie(userConsent) && userConsent.analytics) {
   loadAnalytics()
@@ -36,17 +37,12 @@ if (userConsent && isValidConsentCookie(userConsent) && userConsent.analytics) {
   removeUACookies()
 }
 
-// Initialise example frames
+// Code examples
 createAll(Example)
-
-// Initialise tabs
 createAll(AppTabs)
-
 // Do this after initialising tabs
-new OptionsTable()
-
-// Add copy to clipboard to code blocks inside tab containers
 createAll(Copy)
+new OptionsTable()
 
 // Initialise mobile navigation
 new Navigation(document)
@@ -56,6 +52,3 @@ createAll(Search)
 
 // Initialise back to top
 createAll(BackToTop)
-
-// Initialise cookie page
-createAll(CookiesPage)

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -55,10 +55,7 @@ $codeBlocks.forEach(($codeBlock) => {
 new Navigation(document)
 
 // Initialise search
-const $searchContainer = document.querySelector('[data-module="app-search"]')
-if ($searchContainer) {
-  new Search($searchContainer)
-}
+createAll(Search)
 
 // Initialise back to top
 const $backToTop = document.querySelector('[data-module="app-back-to-top"]')

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -37,10 +37,7 @@ if (userConsent && isValidConsentCookie(userConsent) && userConsent.analytics) {
 }
 
 // Initialise example frames
-const $examples = document.querySelectorAll('[data-module="app-example-frame"]')
-$examples.forEach(($example) => {
-  new Example($example)
-})
+createAll(Example)
 
 // Initialise tabs
 const $tabs = document.querySelectorAll('[data-module="app-tabs"]')

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -12,7 +12,7 @@ import {
 } from './components/cookie-functions.mjs'
 import CookiesPage from './components/cookies-page.mjs'
 import Copy from './components/copy.mjs'
-import Example from './components/example.mjs'
+import ExampleFrame from './components/example-frame.mjs'
 import Navigation from './components/navigation.mjs'
 import OptionsTable from './components/options-table.mjs'
 import Search from './components/search.mjs'
@@ -38,7 +38,7 @@ if (userConsent && isValidConsentCookie(userConsent) && userConsent.analytics) {
 }
 
 // Code examples
-createAll(Example)
+createAll(ExampleFrame)
 createAll(AppTabs)
 // Do this after initialising tabs
 createAll(Copy)

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -46,10 +46,7 @@ createAll(AppTabs)
 new OptionsTable()
 
 // Add copy to clipboard to code blocks inside tab containers
-const $codeBlocks = document.querySelectorAll('[data-module="app-copy"] pre')
-$codeBlocks.forEach(($codeBlock) => {
-  new Copy($codeBlock)
-})
+createAll(Copy)
 
 // Initialise mobile navigation
 new Navigation(document)

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -58,10 +58,7 @@ new Navigation(document)
 createAll(Search)
 
 // Initialise back to top
-const $backToTop = document.querySelector('[data-module="app-back-to-top"]')
-if ($backToTop) {
-  new BackToTop($backToTop)
-}
+createAll(BackToTop)
 
 // Initialise cookie page
 const $cookiesPage = document.querySelector('[data-module="app-cookies-page"]')

--- a/src/javascripts/components/back-to-top.mjs
+++ b/src/javascripts/components/back-to-top.mjs
@@ -2,6 +2,8 @@
  * Website back to top link
  */
 class BackToTop {
+  static moduleName = 'app-back-to-top'
+
   /**
    * @param {Element} $module - HTML element
    */

--- a/src/javascripts/components/cookie-banner.mjs
+++ b/src/javascripts/components/cookie-banner.mjs
@@ -11,6 +11,7 @@ const cookieConfirmationRejectSelector = '.js-cookie-banner-confirmation-reject'
  * Website cookie banner
  */
 class CookieBanner {
+  static moduleName = 'govuk-cookie-banner'
   /**
    * @param {Element} $module - HTML element
    */

--- a/src/javascripts/components/cookies-page.mjs
+++ b/src/javascripts/components/cookies-page.mjs
@@ -4,6 +4,7 @@ import { getConsentCookie, setConsentCookie } from './cookie-functions.mjs'
  * Website cookies page
  */
 class CookiesPage {
+  static moduleName = 'app-cookies-page'
   /**
    * @param {Element} $module - HTML element
    */

--- a/src/javascripts/components/copy.mjs
+++ b/src/javascripts/components/copy.mjs
@@ -4,6 +4,8 @@ import ClipboardJS from 'clipboard'
  * Copy button for code examples
  */
 class Copy {
+  static moduleName = 'app-copy'
+
   /**
    * @param {Element} $module - HTML element
    */
@@ -18,6 +20,9 @@ class Copy {
 
     this.$module = $module
 
+    this.$pre = this.$module.querySelector('pre')
+    // TODO: Throw once GOV.UK Frontend exports its errors
+
     /** @type {number | null} */
     this.resetTimeoutId = null
 
@@ -29,11 +34,11 @@ class Copy {
     this.$status.className = 'govuk-visually-hidden'
     this.$status.setAttribute('aria-live', 'assertive')
 
-    this.$module.insertAdjacentElement('beforebegin', this.$status)
-    this.$module.insertAdjacentElement('beforebegin', this.$button)
+    this.$module.prepend(this.$status)
+    this.$module.prepend(this.$button)
 
     const $clipboard = new ClipboardJS(this.$button, {
-      target: (trigger) => trigger.nextElementSibling
+      target: () => this.$pre
     })
 
     $clipboard.on('success', (event) => this.successAction(event))

--- a/src/javascripts/components/example-frame.mjs
+++ b/src/javascripts/components/example-frame.mjs
@@ -8,7 +8,7 @@ import iFrameResize from 'iframe-resizer/js/iframeResizer.js'
  *
  * @param {Element} $module - HTML element to use for example
  */
-class Example {
+class ExampleFrame {
   static moduleName = 'app-example-frame'
   /**
    * @param {Element} $module - HTML element
@@ -40,4 +40,4 @@ class Example {
   }
 }
 
-export default Example
+export default ExampleFrame

--- a/src/javascripts/components/example.mjs
+++ b/src/javascripts/components/example.mjs
@@ -9,6 +9,7 @@ import iFrameResize from 'iframe-resizer/js/iframeResizer.js'
  * @param {Element} $module - HTML element to use for example
  */
 class Example {
+  static moduleName = 'app-example-frame'
   /**
    * @param {Element} $module - HTML element
    */

--- a/src/javascripts/components/search.mjs
+++ b/src/javascripts/components/search.mjs
@@ -37,6 +37,7 @@ const DEBOUNCE_TIME_TO_WAIT = () => {
  * Website search
  */
 class Search {
+  static moduleName = 'app-search'
   /**
    * @param {Element} $module - HTML element
    */

--- a/src/javascripts/components/tabs.mjs
+++ b/src/javascripts/components/tabs.mjs
@@ -9,6 +9,8 @@
  * - panels - the content that is shown/hidden/switched; same across all breakpoints
  */
 class AppTabs {
+  static moduleName = 'app-tabs'
+
   /**
    * @param {Element} $module - HTML element
    */


### PR DESCRIPTION
As using `createAll` requires component to hold a static `moduleName` property, this PR updates the build process to add transpilation of the JavaScript with Babel (rather than relying on code being authored to match JavaScript features, linted by [es-x](https://eslint-community.github.io/eslint-plugin-es-x/)).

It then uses createAll to instantiate components that were previously looked up using `document.querySelector[All]` in `application.js`.

## Components not updated

- `OptionsTable` works based on the hash, rather than specific elements on the page. It could actually be refactored as a function rather than a class.
- `Navigation` doesn't really have a 'root' element as it looks things up in the document. It could be broken down into two components with root elements, one for the menu itself and the other for the subnav collapsing, but that's a different refactoring.

Fixes #3812