### PR TITLE
Turn the WCAG 2.2 design elements into macros

### DIFF
--- a/src/components/back-link/index.md
+++ b/src/components/back-link/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Use the back link component to help users go back to the previous page in a multi-page transaction.
 
@@ -49,22 +49,16 @@ Always place back links at the top of a page, before the `<main>` element. Placi
 
 Make sure the link takes users to the previous page they were on, in the state they last saw it.
 
-<div class="app-wcag-22" id="wcag-avoid-information-reentry" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>If a user decides to go back to a previous page, make sure information they have already entered is pre-populated.</p>
-  <p>Do not pre-populate if the information is no longer valid, or when pre-populating would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-avoid-information-reentry"}) %}
 
-<div class="app-wcag-22" id="wcag-interact-back-links" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure no other interactive elements are too close to the back link. This is to make sure users can easily interact with the back link. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
-</div>
+<p>If a user decides to go back to a previous page, make sure information they have already entered is pre-populated.</p>
+<p>Do not pre-populate if the information is no longer valid, or when pre-populating would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
+
+{% call wcagNote({id: "wcag-interact-back-links"}) %}
+
+<p>Make sure no other interactive elements are too close to the back link. This is to make sure users can easily interact with the back link. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
+{% endcall %}
 
 Where possible, ensure the back link works even when JavaScript is not available. If this is not possible, you should hide the back link when JavaScript is not available.
 

--- a/src/components/back-link/index.md
+++ b/src/components/back-link/index.md
@@ -8,31 +8,25 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Use the back link component to help users go back to the previous page in a multi-page transaction.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this component
-
-To use the ‘Back link’ and comply with new success criteria introduced in Web Content Accessibility Guidelines (WCAG) 2.2, make sure that users can successfully:
-
-- [avoid re-entering information they've previously given when they go back to a page](/components/back-link/#wcag-avoid-information-reentry)
-- [interact with back links](/components/back-link/#wcag-interact-back-links)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "component",
+  introAction: "use the",
+  name: "Back link",
+  criteria: [
+    {
+      text: "avoid re-entering information they've previously given when they go back to a page",
+      anchor: "wcag-avoid-information-reentry"
+    },
+    {
+      text: "interact with back links",
+      anchor: "wcag-interact-back-links"
+    }
+  ]
 }) }}
 
 Although browsers have a back button, some sites break when you use it - so many users avoid it, instead of losing their progress in a service. Also, not all users are aware of the back button.

--- a/src/components/breadcrumbs/index.md
+++ b/src/components/breadcrumbs/index.md
@@ -8,30 +8,21 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 The breadcrumbs component helps users to understand where they are within a website’s structure and move between levels.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this component
-
-To use ‘Breadcrumbs' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [interact with breadcrumbs](/components/breadcrumbs/#wcag-interact-breadcrumbs)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "component",
+  introAction: "use",
+  name: "Breadcrumbs",
+  criteria: [
+    {
+      text: "interact with breadcrumbs",
+      anchor: "wcag-interact-breadcrumbs"
+    }
+  ]
 }) }}
 
 {{ example({ group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}

--- a/src/components/breadcrumbs/index.md
+++ b/src/components/breadcrumbs/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 The breadcrumbs component helps users to understand where they are within a website’s structure and move between levels.
 
@@ -43,13 +43,10 @@ Always place breadcrumbs at the top of a page, before the `<main>` element. Plac
 
 The breadcrumbs should start with your 'home' page and end with the parent section of the current page.
 
-<div class="app-wcag-22" id="wcag-interact-breadcrumbs" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure no other interactive elements are too close to the breadcrumbs. This is to make sure users can easily interact with the breadcrumbs. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-interact-breadcrumbs"}) %}
+
+<p>Make sure no other interactive elements are too close to the breadcrumbs. This is to make sure users can easily interact with the breadcrumbs. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
+{% endcall %}
 
 There are 2 ways to use the breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 

--- a/src/components/button/index.md
+++ b/src/components/button/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 {{ wcagCallout({
   type: "component",
@@ -48,13 +48,10 @@ You may need to include more or different words to better describe the action. F
 
 Align the primary action button to the left edge of your form.
 
-<div class="app-wcag-22" id="wcag-interact-button" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Do not decrease the height or target area of buttons. This is to make sure users can easily interact with buttons. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-interact-button"}) %}
+
+<p>Do not decrease the height or target area of buttons. This is to make sure users can easily interact with buttons. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
+{% endcall %}
 
 There are 2 ways to use the button component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 

--- a/src/components/button/index.md
+++ b/src/components/button/index.md
@@ -8,28 +8,19 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this component
-
-To use the ‘Button' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [interact with buttons](/components/button/#wcag-interact-button)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "component",
+  introAction: "use the",
+  name: "Button",
+  criteria: [
+    {
+      text: "interact with buttons",
+      anchor: "wcag-interact-button"
+    }
+  ]
 }) }}
 
 {{ example({ group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}

--- a/src/components/cookie-banner/index.md
+++ b/src/components/cookie-banner/index.md
@@ -8,31 +8,25 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Allow users to accept or reject cookies which are not essential to making your service work.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this component
-
-To use the ‘Cookie banner' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [see items that are in focus at all times](/components/cookie-banner/#wcag-see-focus)
-- [interact with buttons and links in the cookie banner](/components/cookie-banner/#wcag-interact-cookie-banner)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "component",
+  introAction: "use the",
+  name: "Cookie banner",
+  criteria: [
+    {
+      text: "see items that are in focus at all times",
+      anchor: "wcag-see-focus"
+    },
+    {
+      text: "interact with buttons and links in the cookie banner",
+      anchor: "wcag-interact-cookie-banner"
+    }
+  ]
 }) }}
 
 {{ example({ group: "components", item: "cookie-banner", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}

--- a/src/components/cookie-banner/index.md
+++ b/src/components/cookie-banner/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Allow users to accept or reject cookies which are not essential to making your service work.
 
@@ -81,21 +81,15 @@ Make sure the cookie banner does not:
 
 Position the cookie banner after the opening `<body>` tag and before the ’skip to main content‘ link. If you're using the Nunjucks page template, use the `bodyStart` block.
 
-<div class="app-wcag-22" id="wcag-see-focus" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Do not make the cookie banner ‘sticky’ to the top of the page by using `position: fixed` or any other method. This is to make sure it does not cover or obscure any content which has a focus applied. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html">2.4.11 Focus not obscured (minimum)</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-see-focus"}) %}
 
-<div class="app-wcag-22" id="wcag-interact-cookie-banner" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Do not change the padding or margins of buttons and links within the cookie banner. This is to make sure there’s adequate space for the user to interact with the buttons and links. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
-</div>
+<p>Do not make the cookie banner ‘sticky’ to the top of the page by using `position: fixed` or any other method. This is to make sure it does not cover or obscure any content which has a focus applied. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html">2.4.11 Focus not obscured (minimum)</a>.</p>
+{% endcall %}
+
+{% call wcagNote({id: "wcag-interact-cookie-banner"}) %}
+
+<p>Do not change the padding or margins of buttons and links within the cookie banner. This is to make sure there’s adequate space for the user to interact with the buttons and links. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
+{% endcall %}
 
 ### Option 1: If you’re only using essential cookies
 

--- a/src/components/error-message/index.md
+++ b/src/components/error-message/index.md
@@ -8,30 +8,21 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this component
-
-To use the ‘Error message' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [edit information they've previously given, so that they can correct an error](/components/error-message/#wcag-clear-answers-error)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "component",
+  introAction: "use the",
+  name: "Error message",
+  criteria: [
+    {
+      text: "edit information they've previously given, so that they can correct an error",
+      anchor: "wcag-clear-answers-error"
+    }
+  ]
 }) }}
 
 Follow the [validation pattern](/patterns/validation/) and show an error message when there is a validation error. In the error message explain what went wrong and how to fix it.

--- a/src/components/error-message/index.md
+++ b/src/components/error-message/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
@@ -55,13 +55,10 @@ For each error:
 - use a red border to visually connect the message and the question it belongs to
 - if the error relates to a specific field within the question, give it a red border and refer to that field in the error message - for example: "you must enter a year"
 
-<div class="app-wcag-22" id="wcag-clear-answers-error" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Do not clear any form fields when adding error messages. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-clear-answers-error"}) %}
+
+<p>Do not clear any form fields when adding error messages. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 Keeping information that caused errors helps users to:
 

--- a/src/components/file-upload/index.md
+++ b/src/components/file-upload/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
@@ -44,23 +44,17 @@ To upload a file, the user can either:
 - use the ‘Choose file’ button
 - ‘drag and drop’ a file into the file upload input area
 
-<div class="app-wcag-22" id="wcag-multi-method-drag-drop" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Do not use ‘drag and drop’ as the only way to upload files. You must provide another method, such as the ‘Choose file’ button. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html">2.5.7 Dragging movements</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-multi-method-drag-drop"}) %}
 
-<div class="app-wcag-22" id="wcag-use-previous-uploads" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure users can easily reuse a previously uploaded file within a single journey, unless doing so would be a major security or privacy concern.</p>
-  <p>For example, a user might need to upload a photo of their driving licence to prove their identity, and again to prove their address.</p>
-  <p>You can make it easier for the user to reuse a file by showing it as an option for the user to select instead of the file upload. Consider users on public devices before choosing to make the file available to preview or download. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+<p>Do not use ‘drag and drop’ as the only way to upload files. You must provide another method, such as the ‘Choose file’ button. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html">2.5.7 Dragging movements</a>.</p>
+{% endcall %}
+
+{% call wcagNote({id: "wcag-use-previous-uploads"}) %}
+
+<p>Make sure users can easily reuse a previously uploaded file within a single journey, unless doing so would be a major security or privacy concern.</p>
+<p>For example, a user might need to upload a photo of their driving licence to prove their identity, and again to prove their address.</p>
+<p>You can make it easier for the user to reuse a file by showing it as an option for the user to select instead of the file upload. Consider users on public devices before choosing to make the file available to preview or download. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 There are 2 ways to use the file upload component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 

--- a/src/components/file-upload/index.md
+++ b/src/components/file-upload/index.md
@@ -8,32 +8,25 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this component
-
-To use the ‘File upload' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [upload a file without relying on 'drag and drop' movements](/components/file-upload/#wcag-multi-method-drag-drop)
-- [reuse files they've uploaded](/components/file-upload/#wcag-use-previous-uploads)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "component",
+  introAction: "use the",
+  name: "File upload",
+  criteria: [
+    {
+      text: "upload a file without relying on 'drag and drop' movements",
+      anchor: "wcag-multi-method-drag-drop"
+    },
+    {
+      text: "reuse files they've uploaded",
+      anchor: "wcag-use-previous-uploads"
+    }
+  ]
 }) }}
 
 Help users select and upload a file.

--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -8,30 +8,21 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 The footer provides copyright, licensing and other information about your service.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this component
-
-To use the ‘Footer' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [find help links in a consistent place on each page](/components/footer/#wcag-consistent-links)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "component",
+  introAction: "use the",
+  name: "Footer",
+  criteria: [
+    {
+      text: "find help links in a consistent place on each page",
+      anchor: "wcag-consistent-links"
+    }
+  ]
 }) }}
 
 {{ example({ group: "components", item: "footer", example: "default", id: "default-1", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}

--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 The footer provides copyright, licensing and other information about your service.
 
@@ -60,13 +60,10 @@ You can add links to:
 
 Use ‘Privacy’, ‘Accessibility’, ‘Cookies’ and ‘Terms and conditions’ for the link text.
 
-<div class="app-wcag-22" id="wcag-consistent-links" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>If you include links to ‘help’ pages within a footer, make sure to place those links consistently within the footer content. Also make sure that ‘help’ links always function in a similar way across each page. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-consistent-links"}) %}
+
+<p>If you include links to ‘help’ pages within a footer, make sure to place those links consistently within the footer content. Also make sure that ‘help’ links always function in a similar way across each page. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
+{% endcall %}
 
 ## Adding secondary navigation
 

--- a/src/components/header/index.md
+++ b/src/components/header/index.md
@@ -8,7 +8,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 The GOV.UK header shows users that they are on GOV.UK and which service they are using.
 
@@ -62,24 +62,18 @@ Use the header with a service name if your service is more than 5 pages long - t
 
 Use the header with navigation if you need to include basic navigation, contact or account management links.
 
-<div class="app-wcag-22" id="wcag-do-not-cover-content" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Do not make header elements, like dropdown menus, ‘sticky’ to the top of the page by using `position: fixed` or any other method. In other words, avoid any implementations that cause menus to sit on top of page content.</p>
-  <p>This is to make sure it does not hide or obscure any content which has a focus applied and comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html">2.4.11 Focus not obscured (minimum)</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-do-not-cover-content"}) %}
+
+<p>Do not make header elements, like dropdown menus, ‘sticky’ to the top of the page by using `position: fixed` or any other method. In other words, avoid any implementations that cause menus to sit on top of page content.</p>
+<p>This is to make sure it does not hide or obscure any content which has a focus applied and comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html">2.4.11 Focus not obscured (minimum)</a>.</p>
+{% endcall %}
 
 In November 2021, [the GOV.UK homepage introduced a menu bar](https://insidegovuk.blog.gov.uk/2021/11/11/launching-gov-uks-new-menu-bar/) that avoids obscuring content by shifting the page down.
 
 {{ example({group: "components", item: "header", example: "with-service-name-and-navigation", html: true, nunjucks: true, open: false, size: "s"}) }}
 
-<div class="app-wcag-22" id="wcag-consistent-help-links" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>You can add a link to a ‘help’ page in your service’s header. If you do, the link must be positioned consistently within the header, and must always link to the same place.</p>
-  <p>For example, a header link to “Get help with this service” must go to the same place as similar header links elsewhere in your service. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-consistent-help-links"}) %}
+
+<p>You can add a link to a ‘help’ page in your service’s header. If you do, the link must be positioned consistently within the header, and must always link to the same place.</p>
+<p>For example, a header link to “Get help with this service” must go to the same place as similar header links elsewhere in your service. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
+{% endcall %}

--- a/src/components/header/index.md
+++ b/src/components/header/index.md
@@ -7,31 +7,25 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 The GOV.UK header shows users that they are on GOV.UK and which service they are using.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this component
-
-To use the ‘Header' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [see all page content when interacting with a dropdown menu](/components/header/#wcag-do-not-cover-content)
-- [find help links in a consistent place on each page](/components/header/#wcag-consistent-help-links)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "component",
+  introAction: "use the",
+  name: "Header",
+  criteria: [
+    {
+      text: "see all page content when interacting with a dropdown menu",
+      anchor: "wcag-do-not-cover-content"
+    },
+    {
+      text: "find help links in a consistent place on each page",
+      anchor: "wcag-consistent-help-links"
+    }
+  ]
 }) }}
 
 {{ example({ group: "components", item: "header", example: "default", id: "default-1", html: true, nunjucks: true, open: false, loading: "eager" }) }}

--- a/src/components/password-input/index.md
+++ b/src/components/password-input/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Help users to create and enter passwords.
 
@@ -73,13 +73,10 @@ See how to handle incorrect login attempts and help users who forget their passw
 
 Hide passwords by default until the user chooses to show it using the ‘show’ button. Users might not be in a private space when entering or creating a password, so you should hide passwords by default.
 
-<div class="app-wcag-22" id="wcag-interact-show-password" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure any ‘show password’ button is at least 24px by 24px in size, or has adequate spacing. This is to make sure users can easily interact with the button. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-interact-show-password"}) %}
+
+<p>Make sure any ‘show password’ button is at least 24px by 24px in size, or has adequate spacing. This is to make sure users can easily interact with the button. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
+{% endcall %}
 
 If you do choose to include two or more password inputs on a page, the ‘show’ and ‘hide’ toggles and labels for each password input must be different.
 
@@ -108,13 +105,10 @@ Use the `autocomplete` attribute on password inputs to help users complete forms
 
 Set the `autocomplete` attribute to `new-password` if the user is creating a password. Otherwise, use `current-password`.
 
-<div class="app-wcag-22" id="wcag-autocomplete-attribute" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
+{% call wcagNote({id: "wcag-autocomplete-attribute"}) %}
+
 <p>Providing an <code>autocomplete</code> attribute is one way to avoid making the user memorise or transcribe a password from somewhere else in order to use your service. This is to help comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum">3.3.8 Accessible authentication (minimum)</a>.</p>
-</div>
+{% endcall %}
 
 Many browsers will autofill password inputs, even when the `autocomplete` attribute is missing or set to `off`.
 
@@ -122,13 +116,10 @@ Many browsers will autofill password inputs, even when the `autocomplete` attrib
 
 Always allow users to copy and paste in password fields. People may have very good reasons why they want to do this, for example if they’re using a password manager.
 
-<div class="app-wcag-22" id="wcag-copy-paste-password" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>You must allow users to paste in or use autofill to enter their password. Avoid making the user memorise or transcribe a password from somewhere else in order to use your service. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum">3.3.8 Accessible authentication (minimum)</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-copy-paste-password"}) %}
+
+<p>You must allow users to paste in or use autofill to enter their password. Avoid making the user memorise or transcribe a password from somewhere else in order to use your service. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum">3.3.8 Accessible authentication (minimum)</a>.</p>
+{% endcall %}
 
 #### Copying text from password fields
 

--- a/src/components/password-input/index.md
+++ b/src/components/password-input/index.md
@@ -8,32 +8,29 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Help users to create and enter passwords.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this component
-
-To use the ‘Password input’ and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [interact with any 'show password' button](/components/password-input/#wcag-interact-show-password)
-- [use `autocomplete` to securely create and enter passwords](/components/password-input/#wcag-autocomplete-attribute)
-- [copy and paste into a password input](/components/password-input/#wcag-copy-paste-password)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "component",
+  introAction: "use the",
+  name: "Password input",
+  criteria: [
+    {
+      text: "interact with any 'show password' button",
+      anchor: "wcag-interact-show-password"
+    },
+    {
+      text: "use `autocomplete` to securely create and enter passwords",
+      anchor: "wcag-autocomplete-attribute"
+    },
+    {
+      text: "copy and paste into a password input",
+      anchor: "wcag-copy-paste-password"
+    }
+  ]
 }) }}
 
 {{ example({ group: "components", item: "password-input", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}

--- a/src/components/phase-banner/index.md
+++ b/src/components/phase-banner/index.md
@@ -8,30 +8,21 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Use the phase banner component to show users your service is still being worked on.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this component
-
-To use the ‘Phase banner' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [see all page content when a phase banner is shown](/components/phase-banner/#wcag-do-not-cover-content)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "component",
+  introAction: "use the",
+  name: "Phase banner",
+  criteria: [
+    {
+      text: "see all page content when a phase banner is shown",
+      anchor: "wcag-do-not-cover-content"
+    }
+  ]
 }) }}
 
 {{ example({ group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}

--- a/src/components/phase-banner/index.md
+++ b/src/components/phase-banner/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Use the phase banner component to show users your service is still being worked on.
 
@@ -39,13 +39,10 @@ Use an alpha banner when your service is in alpha, and a beta banner if your ser
 
 Your banner must be directly under the black GOV.UK header and colour bar.
 
-<div class="app-wcag-22" id="wcag-do-not-cover-content" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Do not make the phase banner ‘sticky’ to the top of the page by using `position: fixed` or any other method. This is to make sure it does not cover or obscure any content which has a focus applied. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html">2.4.11 Focus not obscured (minimum)</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-do-not-cover-content"}) %}
+
+<p>Do not make the phase banner ‘sticky’ to the top of the page by using `position: fixed` or any other method. This is to make sure it does not cover or obscure any content which has a focus applied. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html">2.4.11 Focus not obscured (minimum)</a>.</p>
+{% endcall %}
 
 ### Add a feedback link
 

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -8,28 +8,19 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this component
-
-To use the ‘Select' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [use the select without relying on 'click and drag' movements (if you choose to add functionality to select multiple options)](/components/select/#wcag-avoid-dragging-multiple-options)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "component",
+  introAction: "use the",
+  name: "Select",
+  criteria: [
+    {
+      text: "use the select without relying on 'click and drag' movements (if you choose to add functionality to select multiple options)",
+      anchor: "wcag-avoid-dragging-multiple-options"
+    }
+  ]
 }) }}
 
 {{ example({ group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 {{ wcagCallout({
   type: "component",
@@ -63,13 +63,10 @@ Style error messages as shown in the example:
 
 The select component does not support selecting multiple options, [as there’s a history of poor usability and assistive technology support for `<select multiple>`](https://www.24a11y.com/2019/select-your-poison/). If you need to ask the user to pick more than one item from a list, it’s almost always better to use another method, such as a list of checkboxes.
 
-<div class="app-wcag-22" id="wcag-avoid-dragging-multiple-options" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Any input that’s designed to let a user select multiple options must offer a way to do so without relying on ‘click and drag’ movements or keyboard and mouse combination actions. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html">2.5.7 Dragging movements</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-avoid-dragging-multiple-options"}) %}
+
+<p>Any input that’s designed to let a user select multiple options must offer a way to do so without relying on ‘click and drag’ movements or keyboard and mouse combination actions. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html">2.5.7 Dragging movements</a>.</p>
+{% endcall %}
 
 ## Research on this component
 

--- a/src/components/summary-list/index.md
+++ b/src/components/summary-list/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Use a summary list to summarise information, for example, a user’s responses at the end of a form.
 
@@ -66,22 +66,16 @@ When navigating visually, the borders above and below each row help to show whic
 
 There's a few things to keep in mind to ensure that users can successfully use row actions.
 
-<div class="app-wcag-22" id="wcag-interact-row-actions" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure any 'action links' are at least 24px by 24px in size, or have adequate spacing. This is to make sure users can easily interact with the links. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-interact-row-actions"}) %}
 
-<div class="app-wcag-22" id="wcag-change-answers" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>If a user decides to go back to a previous answer through a card or row action, make sure information they have already entered is pre-populated.</p>
-  <p>Do not pre-populate if the information is no longer valid, or when pre-populating would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+<p>Make sure any 'action links' are at least 24px by 24px in size, or have adequate spacing. This is to make sure users can easily interact with the links. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
+{% endcall %}
+
+{% call wcagNote({id: "wcag-change-answers"}) %}
+
+<p>If a user decides to go back to a previous answer through a card or row action, make sure information they have already entered is pre-populated.</p>
+<p>Do not pre-populate if the information is no longer valid, or when pre-populating would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 Assistive technology users, including those who use a screen reader, might hear a row action link out of context and might not know what it will do.
 

--- a/src/components/summary-list/index.md
+++ b/src/components/summary-list/index.md
@@ -8,31 +8,25 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Use a summary list to summarise information, for example, a user’s responses at the end of a form.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### WCAG 2.2 criteria might affect this component
-
-To use ‘Summary list’ and comply with new success criteria introduced in Web Content Accessibility Guidelines (WCAG) 2.2, make sure that users can successfully:
-
-- [interact with row actions](/components/summary-list/#wcag-interact-row-actions)
-- [change information they've previously given in an answer](/components/summary-list/#wcag-change-answers)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "component",
+  introAction: "use",
+  name: "Summary list",
+  criteria: [
+    {
+      text: "interact with row actions",
+      anchor: "wcag-interact-row-actions"
+    },
+    {
+      text: "change information they've previously given in an answer",
+      anchor: "wcag-change-answers"
+    }
+  ]
 }) }}
 
 {{ example({ group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}

--- a/src/components/tag/index.md
+++ b/src/components/tag/index.md
@@ -8,30 +8,21 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Use the tag component to show users the status of something.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this component
-
-To use the ‘Tag' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [interact with tags without relying on 'click and drag' movements (if you choose to add functionality to reorder tags)](/components/tag/#wcag-tag-no-dragging-reorder)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "component",
+  introAction: "use the",
+  name: "Tag",
+  criteria: [
+    {
+      text: "interact with tags without relying on 'click and drag' movements (if you choose to add functionality to reorder tags)",
+      anchor: "wcag-tag-no-dragging-reorder"
+    }
+  ]
 }) }}
 
 {{ example({ group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}

--- a/src/components/tag/index.md
+++ b/src/components/tag/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Use the tag component to show users the status of something.
 
@@ -58,13 +58,10 @@ Tags should be helpful to users. The more you add, the harder it is for users to
 
 {{ example({ group: "components", item: "tag", example: "coloured-tags", html: true, nunjucks: true, open: false }) }}
 
-<div class="app-wcag-22" id="wcag-tag-no-dragging-reorder" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Any tag implementation that allows the user to change the order of tags must offer a way to do so without relying on ‘click and drag’ movements. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html">2.5.7 Dragging movements</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-tag-no-dragging-reorder"}) %}
+
+<p>Any tag implementation that allows the user to change the order of tags must offer a way to do so without relying on ‘click and drag’ movements. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html">2.5.7 Dragging movements</a>.</p>
+{% endcall %}
 
 ## Using colour with tags
 

--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -9,30 +9,21 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To ask users for 'Addresses' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [reuse a previously entered address](/patterns/addresses/#wcag-reuse-addresses)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "ask users for",
+  name: "Addresses",
+  criteria: [
+    {
+      text: "reuse previously entered address",
+      anchor: "wcag-reuse-addresses"
+    }
+  ]
 }) }}
 
 Help users provide an address using one of the following:

--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
@@ -34,13 +34,10 @@ Help users provide an address using one of the following:
 
 ### Reusing entered addresses
 
-<div class="app-wcag-22" id="wcag-reuse-addresses" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure users can easily reuse a previously entered address within a single journey, unless doing so would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-reuse-addresses"}) %}
+
+<p>Make sure users can easily reuse a previously entered address within a single journey, unless doing so would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 You can make it easier to reuse addresses through one of these methods:
 

--- a/src/patterns/bank-details/index.md
+++ b/src/patterns/bank-details/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
@@ -50,14 +50,11 @@ If your service does not support building society accounts, remove building soci
 
 ### Reusing entered bank details
 
-<div class="app-wcag-22" id="wcag-reuse-bank-details" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Do not ask for bank details more than once within a single journey if only one transaction is taking place.</p>
-  <p>Make sure users can easily reuse previously entered bank details within a single journey, unless the information is no longer valid or doing so would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-reuse-bank-details"}) %}
+
+<p>Do not ask for bank details more than once within a single journey if only one transaction is taking place.</p>
+<p>Make sure users can easily reuse previously entered bank details within a single journey, unless the information is no longer valid or doing so would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 You can make it easier to reuse bank details through one of these methods:
 

--- a/src/patterns/bank-details/index.md
+++ b/src/patterns/bank-details/index.md
@@ -9,30 +9,21 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To ask users for 'Bank details' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [reuse previously entered bank details](/patterns/bank-details/#wcag-reuse-bank-details)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "ask users for",
+  name: "Bank details",
+  criteria: [
+    {
+      text: "reuse previously entered bank details",
+      anchor: "wcag-reuse-bank-details"
+    }
+  ]
 }) }}
 
 {{ example({ group: "patterns", item: "bank-details", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}

--- a/src/patterns/check-a-service-is-suitable/index.md
+++ b/src/patterns/check-a-service-is-suitable/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 ---
 
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Ask users questions to help them work out if they can or should use your service.
 
@@ -29,20 +29,17 @@ Doing this helps users save time as it tells them upfront whether they are eligi
 
 It can also help reduce time and money spent processing queries from users confused about whether they’re eligible to use your service, or if it’s suitable for them.
 
-<div class="app-wcag-22" id="wcag-avoid-repeating-questions" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure to not repeat questions or request information the user will need to re-provide later.</p>
-  <p>If during the process a service is determined to be suitable, consider offering a secure method to carry forward relevant responses into the service journey, unless carrying forward would be a major safety concern.</p>
-  <p>You can make it easier to enter the same information within the service through one of these methods:</p>
-  <ul>
-    <li>pre-populating the relevant fields</li>
-    <li>showing carried-forward responses as an option for the user to select</li>
-  </ul>
-  <p>This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-avoid-repeating-questions"}) %}
+
+<p>Make sure to not repeat questions or request information the user will need to re-provide later.</p>
+<p>If during the process a service is determined to be suitable, consider offering a secure method to carry forward relevant responses into the service journey, unless carrying forward would be a major safety concern.</p>
+<p>You can make it easier to enter the same information within the service through one of these methods:</p>
+<ul>
+  <li>pre-populating the relevant fields</li>
+  <li>showing carried-forward responses as an option for the user to select</li>
+</ul>
+<p>This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 ![‘Check a service is suitable’ flow diagram. Contains an introduction page followed by a series of simple questions. If at any point a user is deemed not eligible for the service they will be pointed to a page that explains why they are not eligible. Otherwise they will be presented an ‘application complete’ page. ](check-a-service-is-suitable-new.svg)
 

--- a/src/patterns/check-a-service-is-suitable/index.md
+++ b/src/patterns/check-a-service-is-suitable/index.md
@@ -8,30 +8,21 @@ backlogIssueId: 35
 layout: layout-pane.njk
 ---
 
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Ask users questions to help them work out if they can or should use your service.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To help users to 'Check a service is suitable' and meet the new WCAG 2.2 criteria, make sure that users can successfully:
-
-- [use the service without repeating answers they've already given](/patterns/check-a-service-is-suitable/#wcag-avoid-repeating-questions)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "help users to",
+  name: "Check a service is suitable",
+  criteria: [
+    {
+      text: "use the service without repeating answers they've already given",
+      anchor: "wcag-avoid-repeating-questions"
+    }
+  ]
 }) }}
 
 Doing this helps users save time as it tells them upfront whether they are eligible to use it and if they need it.

--- a/src/patterns/check-answers/index.md
+++ b/src/patterns/check-answers/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Let users check their answers before submitting information to a service.
 
@@ -69,14 +69,11 @@ On the page, you should also:
 
 You should provide a ‘Change’ link next to each section on your check answers page so that users can add or change the information. 'Change' links contain hidden text to make them accessible to screen reader users. Update the hidden text to describe what each 'change' link is for.
 
-<div class="app-wcag-22" id="wcag-prepopulate-information" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>If a user decides to go back to a previous answer, make sure information they've already entered is pre-populated.</p>
-  <p>Do not pre-populate if the information is no longer valid, or when pre-populating would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-prepopulate-information"}) %}
+
+<p>If a user decides to go back to a previous answer, make sure information they've already entered is pre-populated.</p>
+<p>Do not pre-populate if the information is no longer valid, or when pre-populating would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 The answers pages should look the same way they did when the user last used them.
 

--- a/src/patterns/check-answers/index.md
+++ b/src/patterns/check-answers/index.md
@@ -9,30 +9,21 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Let users check their answers before submitting information to a service.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To help users to 'Check answers' and meet the new WCAG 2.2 criteria, make sure that users can successfully:
-
-- [go back and edit information they've already entered](/patterns/check-answers/#wcag-prepopulate-information)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "help users to",
+  name: "Check answers",
+  criteria: [
+    {
+      text: "go back and edit information they've already entered",
+      anchor: "wcag-prepopulate-information"
+    }
+  ]
 }) }}
 
 {{ example({ group: "patterns", item: "check-answers", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}

--- a/src/patterns/complete-multiple-tasks/index.md
+++ b/src/patterns/complete-multiple-tasks/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Help users understand:
 
@@ -67,13 +67,10 @@ Where possible, task names should:
 - describe what the task or activity will involve
 - start with verbs, for example, ‘check’, ‘declare’, ‘report’
 
-<div class="app-wcag-22" id="wcag-interact-without-click-drag-task" role="note">
-    {{ govukTag({
-        text: "WCAG 2.2",
-        classes: "app-tag"
-    }) }}
-    <p>Any task list that allows the user to rearrange the order that tasks are shown must offer a way to do so without relying on ‘click and drag’ movements. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html">2.5.7 Dragging movements</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-interact-without-click-drag-task"}) %}
+
+<p>Any task list that allows the user to rearrange the order that tasks are shown must offer a way to do so without relying on ‘click and drag’ movements. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html">2.5.7 Dragging movements</a>.</p>
+{% endcall %}
 
 ### Show the status of the tasks
 
@@ -150,14 +147,11 @@ If the user selects ‘No, I’ll come back to it later,’ mark the task as 'In
 
 If the user selects ‘Yes, I’ve completed this section,’ mark the task as 'Completed'.
 
-<div class="app-wcag-22" id="wcag-edit-information-previous-task" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>If a user decides to go back to a previous task, make sure information they have already entered is pre-populated.</p>
-  <p>Do not pre-populate if the information is no longer valid, or when pre-populating would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-edit-information-previous-task"}) %}
+
+<p>If a user decides to go back to a previous task, make sure information they have already entered is pre-populated.</p>
+<p>Do not pre-populate if the information is no longer valid, or when pre-populating would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 {{ example({ group: "patterns", item: "complete-multiple-tasks", example: "have-you-completed-this-section", html: true, nunjucks: true, open: false }) }}
 

--- a/src/patterns/complete-multiple-tasks/index.md
+++ b/src/patterns/complete-multiple-tasks/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Help users understand:
@@ -18,26 +18,20 @@ Help users understand:
 - the order they should complete tasks in
 - when they've completed tasks
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To help users to 'Complete multiple tasks' and meet the new WCAG 2.2 criteria, make sure that users can successfully:
-
-- [interact with tasks without relying on 'click and drag' movements (if you choose to add functionality to reorder tasks)](/patterns/complete-multiple-tasks/#wcag-interact-without-click-drag-task)
-- [edit information they've given when going back to a previous task](/patterns/complete-multiple-tasks/#wcag-edit-information-previous-task)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "help users to",
+  name: "Complete multiple tasks",
+  criteria: [
+    {
+      text: "interact with tasks without relying on 'click and drag' movements (if you choose to add functionality to reorder tasks)",
+      anchor: "wcag-interact-without-click-drag-task"
+    },
+    {
+      text: "edit information they've given when going back to a previous task",
+      anchor: "wcag-edit-information-previous-task"
+    }
+  ]
 }) }}
 
 {{ example({ group: "patterns", item: "complete-multiple-tasks", example: "default", html: true, nunjucks: true, open: false }) }}

--- a/src/patterns/confirm-a-phone-number/index.md
+++ b/src/patterns/confirm-a-phone-number/index.md
@@ -8,32 +8,27 @@ backlogIssueId: 25
 layout: layout-pane.njk
 ---
 
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "_example.njk" import example %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 Check that a user has access to a specific mobile phone number using a security code sent by text message.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To help users to 'Confirm a phone number' and meet the new WCAG 2.2 criteria, make sure that users can successfully:
-
-- [use a link to resend the security code when the user creates an account](/patterns/confirm-a-phone-number/#wcag-resend-security-code-creation)
-- [use a link to resend the security code when the user signs in](/patterns/confirm-a-phone-number/#wcag-resend-security-code-sign-in)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "help users to",
+  name: "Confirm a phone number",
+  criteria: [
+    {
+      text: "use a link to resend the security code when the user creates an account",
+      anchor: "wcag-resend-security-code-creation"
+    },
+    {
+      text: "use a link to resend the security code when the user signs in",
+      anchor: "wcag-resend-security-code-sign-in"
+    }
+  ]
 }) }}
 
 {{ example({ group: "patterns", item: "confirm-a-phone-number", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}

--- a/src/patterns/confirm-a-phone-number/index.md
+++ b/src/patterns/confirm-a-phone-number/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_wcag-callout.njk" import wcagCallout %}
 {% from "_example.njk" import example %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 Check that a user has access to a specific mobile phone number using a security code sent by text message.
@@ -73,13 +73,10 @@ If the user enters an expired code that was sent more than:
 
 If the user follows the ‘Not received a text message?’ link, allow them to check which mobile number they entered, and to change it if necessary. This prevents the user becoming stuck if they entered a mobile number incorrectly. Do not allow the user to change the number when they're signing in.
 
-<div class="app-wcag-22" id="wcag-resend-security-code-creation" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>You must always include the link for 'Not received a text message?’ so the user can find help in a consistent way. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-resend-security-code-creation"}) %}
+
+<p>You must always include the link for 'Not received a text message?’ so the user can find help in a consistent way. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
+{% endcall %}
 
 {{ example({ group: "patterns", item: "confirm-a-phone-number", example: "resend-first-time", html: true, nunjucks: true, open: false }) }}
 
@@ -97,13 +94,10 @@ Ask the user to enter this code. Use the same pattern and time limit as when cre
 
 If they follow the ‘Not received a text message?’ link, show them a page allowing them to request a new code. Do not reveal the mobile number you sent it to.
 
-<div class="app-wcag-22" id="wcag-resend-security-code-sign-in" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>You must always include the link for 'Not received a text message?’ so the user can find help in a consistent way. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-resend-security-code-sign-in"}) %}
+
+<p>You must always include the link for 'Not received a text message?’ so the user can find help in a consistent way. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
+{% endcall %}
 
 {{ example({group: "patterns", item: "confirm-a-phone-number", example: "resend", html: true, nunjucks: true, open: false}) }}
 

--- a/src/patterns/confirm-an-email-address/index.md
+++ b/src/patterns/confirm-an-email-address/index.md
@@ -9,30 +9,21 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To help users to 'Confirm an email address' and meet the new WCAG 2.2 criteria, make sure that users can successfully:
-
-- [copy and paste a security code (if you're asking the user to enter a security code you've sent them)](/patterns/confirm-an-email-address/#wcag-copy-paste-security-codes)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "help users to",
+  name: "Confirm an email address",
+  criteria: [
+    {
+      text: "copy and paste a security code (if you're asking the user to enter a security code you've sent them)",
+      anchor: "wcag-copy-paste-security-codes"
+    }
+  ]
 }) }}
 
 Check that a user has access to a specific email account using an email confirmation&nbsp;loop.

--- a/src/patterns/confirm-an-email-address/index.md
+++ b/src/patterns/confirm-an-email-address/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
@@ -59,13 +59,10 @@ If you use email confirmation loops you must consider:
 
 Most email confirmation loops will send the user a link and ask them to click it to return to the service. Another approach is to send the user a security code, similar to the [Confirm a phone number](/patterns/confirm-a-phone-number/) pattern, and ask the user to enter it.
 
-<div class="app-wcag-22" id="wcag-copy-paste-security-codes" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>You must allow users to copy and paste any security codes. Avoid making the user memorise or transcribe a security code between apps or browser tabs to use your service. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum">3.3.8 Accessible authentication (minimum)</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-copy-paste-security-codes"}) %}
+
+<p>You must allow users to copy and paste any security codes. Avoid making the user memorise or transcribe a security code between apps or browser tabs to use your service. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum">3.3.8 Accessible authentication (minimum)</a>.</p>
+{% endcall %}
 
 ### Set expiry conditions
 

--- a/src/patterns/contact-a-department-or-service-team/index.md
+++ b/src/patterns/contact-a-department-or-service-team/index.md
@@ -9,30 +9,21 @@ layout: layout-pane.njk
 ---
 
 {%- from "_example.njk" import example -%}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Give users contact information within your service.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To help users to 'Contact a department or service team' and meet the new WCAG 2.2 criteria, make sure that users can successfully:
-
-- [find contact details in a consistent place across a set of pages](/patterns/contact-a-department-or-service-team/#wcag-consistent-contact)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "help users to",
+  name: "Contact a department or service team",
+  criteria: [
+    {
+      text: "find contact details in a consistent place across a set of pages",
+      anchor: "wcag-consistent-contact"
+    }
+  ]
 }) }}
 
 {{ example({ group: "patterns", item: "contact-a-department-or-service-team", example: "default", html: true, open: false, size: "s" }) }}

--- a/src/patterns/contact-a-department-or-service-team/index.md
+++ b/src/patterns/contact-a-department-or-service-team/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {%- from "_example.njk" import example -%}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Give users contact information within your service.
 
@@ -42,15 +42,12 @@ Order contact channels based on what research shows your users need, and what yo
 
 Show contact channels in the same order throughout your service. This helps users to find what they need more easily.
 
-<div class="app-wcag-22" id="wcag-consistent-contact" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>If you repeat a particular set of contact details on different pages, show them in the same place on each page.</p>
-  <p>For example, if you show a ‘contact us’ section at the end of one help page, any other help pages that include the same ‘contact us’ section should have them shown at the end of the page as well.</p>
-  <p>This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-consistent-contact"}) %}
+
+<p>If you repeat a particular set of contact details on different pages, show them in the same place on each page.</p>
+<p>For example, if you show a ‘contact us’ section at the end of one help page, any other help pages that include the same ‘contact us’ section should have them shown at the end of the page as well.</p>
+<p>This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
+{% endcall %}
 
 ### Social media
 

--- a/src/patterns/create-accounts/index.md
+++ b/src/patterns/create-accounts/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 ---
 
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Help users create an account for your service.
 
@@ -67,13 +67,10 @@ Make it clear what you need users to do when they create an account.
 
 Show a clear difference between creating an account and signing in. Presenting the options side by side is not enough because users might miss one of them or not understand the&nbsp;difference.
 
-<div class="app-wcag-22" id="wcag-reuse-account-information" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure users do not need to enter the same information more than once when creating an account, unless the information is no longer valid or it’s necessary for security reasons. Use the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete">HTML autocomplete attribute</a> to allow password managers and user agents to automatically populate fields. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-reuse-account-information"}) %}
+
+<p>Make sure users do not need to enter the same information more than once when creating an account, unless the information is no longer valid or it’s necessary for security reasons. Use the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete">HTML autocomplete attribute</a> to allow password managers and user agents to automatically populate fields. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 ### Make the sign-up process clear
 
@@ -87,14 +84,11 @@ Make sure the account creation screen is solely about that task. Do not add any 
 
 These are tests of cognitive function, which might be difficult for some users. Users can also struggle to recognise specific words or pictures due to differences in culture and locale.
 
-<div class="app-wcag-22" id="wcag-avoid-cognitive-test" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Avoid making users do a cognitive test to use your service. If you do, you must also offer an alternative method. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum">3.3.8 Accessible authentication (minimum)</a>.</p>
-  <p>See more about <a href="https://www.gov.uk/service-manual/technology/using-captchas">using CAPTCHAs and why they’re problematic</a> in the Service Manual. <a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum#object-recognition">WCAG lists some other security measures</a> you can implement to prevent misuse and automated abuse in your service.</p>
-</div>
+{% call wcagNote({id: "wcag-avoid-cognitive-test"}) %}
+
+<p>Avoid making users do a cognitive test to use your service. If you do, you must also offer an alternative method. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum">3.3.8 Accessible authentication (minimum)</a>.</p>
+<p>See more about <a href="https://www.gov.uk/service-manual/technology/using-captchas">using CAPTCHAs and why they’re problematic</a> in the Service Manual. <a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum#object-recognition">WCAG lists some other security measures</a> you can implement to prevent misuse and automated abuse in your service.</p>
+{% endcall %}
 
 ### Never use National Insurance numbers to verify a user’s identity
 

--- a/src/patterns/create-accounts/index.md
+++ b/src/patterns/create-accounts/index.md
@@ -8,31 +8,25 @@ backlogIssueId: 41
 layout: layout-pane.njk
 ---
 
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Help users create an account for your service.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To help users to 'Create accounts' and meet the new WCAG 2.2 criteria, make sure that users can successfully:
-
-- [reuse information they've already entered](/patterns/create-accounts/#wcag-reuse-account-information)
-- [avoid doing a cognitive test, such as a CAPTCHA, to create an account](/patterns/create-accounts/#wcag-avoid-cognitive-test)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "help users to",
+  name: "Create accounts",
+  criteria: [
+    {
+      text: "reuse information they've already entered",
+      anchor: "wcag-reuse-account-information"
+    },
+    {
+      text: "avoid doing a cognitive test, such as a CAPTCHA, to create an account",
+      anchor: "wcag-avoid-cognitive-test"
+    }
+  ]
 }) }}
 
 ## When to use this pattern

--- a/src/patterns/email-addresses/index.md
+++ b/src/patterns/email-addresses/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 ---
 
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 {% from "_example.njk" import example %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
@@ -46,13 +46,10 @@ You may also need to check that users have access to the email account they give
 
 ### Reusing entered email addresses
 
-<div class="app-wcag-22" id="wcag-reuse-email-addresses" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure users can easily reuse a previously entered email address within a single journey, unless doing so would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-reuse-email-addresses"}) %}
+
+<p>Make sure users can easily reuse a previously entered email address within a single journey, unless doing so would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 You can make it easier to reuse email addresses through one of these methods:
 

--- a/src/patterns/email-addresses/index.md
+++ b/src/patterns/email-addresses/index.md
@@ -8,35 +8,23 @@ backlogIssueId: 45
 layout: layout-pane.njk
 ---
 
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
-
-This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
-
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To ask users for 'Email addresses' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [reuse a previously entered email address](/patterns/email-addresses/#wcag-reuse-email-addresses)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
-}) }}
-
 {% from "_example.njk" import example %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
+
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "ask users for",
+  name: "Email addresses",
+  criteria: [
+    {
+      text: "reuse a previously entered email address",
+      anchor: "wcag-reuse-email-addresses"
+    }
+  ]
+}) }}
 
 {{ example({ group: "patterns", item: "email-addresses", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 

--- a/src/patterns/equality-information/index.md
+++ b/src/patterns/equality-information/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Public sector organisations have a duty to consider the need to avoid discrimination and advance equality of opportunity as part of what they do. This is part of what’s called the [public sector equality duty](https://www.gov.uk/guidance/equality-act-2010-guidance#public-sector-equality-duty).
 
@@ -73,13 +73,10 @@ When possible, offer users the option to update their equality information. User
 
 Updating equality information is especially relevant for longer term services and services that use the same equality information multiple times.
 
-<div class="app-wcag-22" id="wcag-do-not-ask-reentry-equality-info" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>When users are updating equality information, only ask them to enter the information that has changed. Do not ask them to re-enter all existing equality information. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-do-not-ask-reentry-equality-info"}) %}
+
+<p>When users are updating equality information, only ask them to enter the information that has changed. Do not ask them to re-enter all existing equality information. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 ## Get specialist privacy or data protection advice
 

--- a/src/patterns/equality-information/index.md
+++ b/src/patterns/equality-information/index.md
@@ -9,30 +9,21 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Public sector organisations have a duty to consider the need to avoid discrimination and advance equality of opportunity as part of what they do. This is part of what’s called the [public sector equality duty](https://www.gov.uk/guidance/equality-act-2010-guidance#public-sector-equality-duty).
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To ask users for 'Equality information' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [update their equality information without re-entering existing information](/patterns/equality-information/#wcag-do-not-ask-reentry-equality-info)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "ask users for",
+  name: "Equality information",
+  criteria: [
+    {
+      text: "update their equality information without re-entering existing information",
+      anchor: "wcag-do-not-ask-reentry-equality-info"
+    }
+  ]
 }) }}
 
 Public sector bodies often collect equality information about service users to help them meet this duty.

--- a/src/patterns/names/index.md
+++ b/src/patterns/names/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 {{ wcagCallout({
   type: "pattern",
@@ -96,13 +96,10 @@ You will not normally need to use the `autocomplete` attribute in prototypes, as
 
 ### Reusing entered names
 
-<div class="app-wcag-22" id="wcag-reuse-name" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure users can easily reuse a previously entered name within a single journey, unless doing so would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-reuse-name"}) %}
+
+<p>Make sure users can easily reuse a previously entered name within a single journey, unless doing so would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 You can make it easier to reuse names through one of these methods:
 

--- a/src/patterns/names/index.md
+++ b/src/patterns/names/index.md
@@ -9,28 +9,19 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To ask users for 'Names' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [reuse a previously entered name](/patterns/names/#wcag-reuse-name)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "ask users for",
+  name: "National insurance numbers",
+  criteria: [
+    {
+      text: "reuse a previously entered name",
+      anchor: "wcag-reuse-name"
+    }
+  ]
 }) }}
 
 {{ example({ group: "patterns", item: "names", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}

--- a/src/patterns/national-insurance-numbers/index.md
+++ b/src/patterns/national-insurance-numbers/index.md
@@ -9,30 +9,21 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To ask users for 'National insurance numbers' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [reuse a previously entered National Insurance number](/patterns/national-insurance-numbers/#wcag-reuse-national-insurance-number)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "ask users for",
+  name: "National insurance numbers",
+  criteria: [
+    {
+      text: "reuse a previously entered National Insurance number",
+      anchor: "wcag-reuse-national-insurance-number"
+    }
+  ]
 }) }}
 
 Ask users to provide their National Insurance number.

--- a/src/patterns/national-insurance-numbers/index.md
+++ b/src/patterns/national-insurance-numbers/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
@@ -58,14 +58,11 @@ When asking for a National Insurance number:
 
 ### Reusing entered National Insurance numbers
 
-<div class="app-wcag-22" id="wcag-reuse-national-insurance-number" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Do not ask for a National Insurance number more than once within a single journey, if only one person’s details are needed.</p>
-  <p>Make sure users can easily reuse previously entered National Insurance numbers within a single journey, unless doing so would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-reuse-national-insurance-number"}) %}
+
+<p>Do not ask for a National Insurance number more than once within a single journey, if only one person’s details are needed.</p>
+<p>Make sure users can easily reuse previously entered National Insurance numbers within a single journey, unless doing so would be a major safety or security concern. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 You can make it easier to reuse National Insurance numbers through one of these methods:
 

--- a/src/patterns/page-not-found-pages/index.md
+++ b/src/patterns/page-not-found-pages/index.md
@@ -9,30 +9,21 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 A page not found tells someone we cannot find the page they were trying to view. They are also known as 404 pages.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To use ‘Page not found pages' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [find contact information in a consistent way](/patterns/page-not-found-pages/#wcag-consistent-content-page-not-found)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "use",
+  name: "Page not found pages",
+  criteria: [
+    {
+      text: "find contact information in a consistent way",
+      anchor: "wcag-consistent-content-page-not-found"
+    }
+  ]
 }) }}
 
 {{ example({ group: "patterns", item: "page-not-found-pages", example: "default", html: true, nunjucks: true, size: "xl", loading: "eager" }) }}

--- a/src/patterns/page-not-found-pages/index.md
+++ b/src/patterns/page-not-found-pages/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 A page not found tells someone we cannot find the page they were trying to view. They are also known as 404 pages.
 
@@ -55,13 +55,10 @@ Contact information should either:
 
 The content should be clear and concise, not blame the user.
 
-<div class="app-wcag-22" id="wcag-consistent-content-page-not-found" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>You must always write contact information in a clear and consistent way across ‘Page not found’ and similar service error pages. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-consistent-content-page-not-found"}) %}
+
+<p>You must always write contact information in a clear and consistent way across ‘Page not found’ and similar service error pages. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
+{% endcall %}
 
 Do not use:
 

--- a/src/patterns/passwords/index.md
+++ b/src/patterns/passwords/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 ---
 
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Help users to create and enter secure and memorable passwords.
 
@@ -92,13 +92,10 @@ When helping users who’ve forgotten their password, you should:
 - avoid password reset questions
 - avoid password reminders
 
-<div class="app-wcag-22" id="wcag-consistent-reset" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>If you include instructions or a link to help users reset their password, make sure to place them consistently on the page. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-consistent-reset"}) %}
+
+<p>If you include instructions or a link to help users reset their password, make sure to place them consistently on the page. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
+{% endcall %}
 
 Also make sure any password reset links always perform the same action across each page.
 

--- a/src/patterns/passwords/index.md
+++ b/src/patterns/passwords/index.md
@@ -8,30 +8,21 @@ backlogIssueId: 56
 layout: layout-pane.njk
 ---
 
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Help users to create and enter secure and memorable passwords.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To ask users for 'Passwords' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [find 'reset password' links in a consistent place on each page](/patterns/passwords/#wcag-consistent-reset)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "ask users for",
+  name: "Passwords",
+  criteria: [
+    {
+      text: "find 'reset password' links in a consistent place on each page",
+      anchor: "wcag-consistent-reset"
+    }
+  ]
 }) }}
 
 ## When to use this pattern

--- a/src/patterns/payment-card-details/index.md
+++ b/src/patterns/payment-card-details/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 ---
 
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
@@ -43,13 +43,10 @@ Let users enter payment card numbers in whatever format is familiar to them. All
 
 Present all fields on a single page, in the order in which they appear on a credit or debit card. This makes it easy for users to transcribe the information from their payment card.
 
-<div class="app-wcag-22" id="wcag-spacing-month-year" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure to add adequate spacing between the month and year fields. Ideally, leave at least 24px of space between the fields, either horizontally (inline) or vertically. This is to make sure users can easily interact with the fields. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-spacing-month-year"}) %}
+
+<p>Make sure to add adequate spacing between the month and year fields. Ideally, leave at least 24px of space between the fields, either horizontally (inline) or vertically. This is to make sure users can easily interact with the fields. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
+{% endcall %}
 
 Show logos for the cards you accept as icons so users can see whether their card is supported.
 

--- a/src/patterns/payment-card-details/index.md
+++ b/src/patterns/payment-card-details/index.md
@@ -8,30 +8,21 @@ backlogIssueId: 80
 layout: layout-pane.njk
 ---
 
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To ask users for 'Payment card details' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [interact the with month and year fields, by adding adequate spacing between them](/patterns/payment-card-details/#wcag-spacing-month-year)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "ask users for",
+  name: "Payment card details",
+  criteria: [
+    {
+      text: "interact the with month and year fields, by adding adequate spacing between them",
+      anchor: "wcag-spacing-month-year"
+    }
+  ]
 }) }}
 
 ![A form entitled enter card details which asks for a card number, an expiry date, a name on the card and the card security code.](enter-card-details.jpg)

--- a/src/patterns/problem-with-the-service-pages/index.md
+++ b/src/patterns/problem-with-the-service-pages/index.md
@@ -9,31 +9,25 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To use ‘There is a problem with the service pages' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [get contact information in a consistent way](/patterns/problem-with-the-service-pages/#wcag-consistent-content-problem-service)
-- [resume the service using information they've previously entered, if possible](/patterns/problem-with-the-service-pages/#wcag-resume-previous-entered-information)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "use",
+  name: "There is a problem with the service pages",
+  criteria: [
+    {
+      text: "get contact information in a consistent way",
+      anchor: "wcag-consistent-content-problem-service"
+    },
+    {
+      text: "resume the service using information they've previously entered, if possible",
+      anchor: "wcag-resume-previous-entered-information"
+    }
+  ]
 }) }}
 
 Tell the user there is something wrong with the service. These are also known as 500 and internal server error pages.

--- a/src/patterns/problem-with-the-service-pages/index.md
+++ b/src/patterns/problem-with-the-service-pages/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
@@ -67,14 +67,11 @@ Have clear and concise content and do not use:
 
 Store previously entered information for a reasonable amount of time so users can resume a journey with re-populated information when the service becomes available again.
 
-<div class="app-wcag-22" id="wcag-resume-previous-entered-information" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Whenever possible, save and store any information the user has previously entered, unless doing so would be a major safety or security concern.</p>
-  <p>This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-resume-previous-entered-information"}) %}
+
+<p>Whenever possible, save and store any information the user has previously entered, unless doing so would be a major safety or security concern.</p>
+<p>This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 ### Showing contact information
 
@@ -85,13 +82,10 @@ Contact information should either:
 
 You might choose to link to a ‘contact information’ page, such as one shown in the ‘[Contact a department or service team](https://design-system.service.gov.uk/patterns/contact-a-department-or-service-team/)’ pattern.
 
-<div class="app-wcag-22" id="wcag-consistent-content-problem-service" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>You must always write contact information in a clear and consistent way across ‘There is a problem with the service’ and similar service error pages. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-consistent-content-problem-service"}) %}
+
+<p>You must always write contact information in a clear and consistent way across ‘There is a problem with the service’ and similar service error pages. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
+{% endcall %}
 
 ### Service has a specific page that includes numbers and opening times
 

--- a/src/patterns/question-pages/index.md
+++ b/src/patterns/question-pages/index.md
@@ -9,31 +9,25 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 This pattern explains when to use question pages and what elements they need to include.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To use ‘Question pages' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [avoid re-entering information they've given in a previous answer](/patterns/question-pages/#wcag-reenter-previous-answer)
-- [select an answer without relying on 'click and drag' movement](/patterns/question-pages/#wcag-select-without-click-drag)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "use",
+  name: "Question pages",
+  criteria: [
+    {
+      text: "avoid re-entering information they've given in a previous answer",
+      anchor: "wcag-reenter-previous-answer"
+    },
+    {
+      text: "select an answer without relying on 'click and drag' movement",
+      anchor: "wcag-select-without-click-drag"
+    }
+  ]
 }) }}
 
 {{ example({ group: "patterns", item: "question-pages", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}

--- a/src/patterns/question-pages/index.md
+++ b/src/patterns/question-pages/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 This pattern explains when to use question pages and what elements they need to include.
 
@@ -64,13 +64,10 @@ Question pages must include a:
 
 If research shows it’s helpful for users, you can also include a [progress indicator](#using-progress-indicators).
 
-<div class="app-wcag-22" id="wcag-reenter-previous-answer" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure to only ask for a piece of information once within a single journey. Whenever possible, do not ask a user to re-enter information they’ve already provided. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-reenter-previous-answer"}) %}
+
+<p>Make sure to only ask for a piece of information once within a single journey. Whenever possible, do not ask a user to re-enter information they’ve already provided. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 If the same type of information is needed more than once, make it easier to reuse previously entered answers through one of these methods:
 
@@ -185,11 +182,8 @@ A number of GOV.UK services have removed this style of progress indicator withou
 
 ### Using range sliders
 
-<div class="app-wcag-22" id="wcag-select-without-click-drag" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Avoid using <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range">range slider</a> questions, where the user needs to click and drag a selector across a range of answers or values. These types of controls are difficult for some users to interact with.</p>
-  <p>If you do use a range slider, you must provide a method for selecting an answer that doesn’t rely on ‘click and drag’ movements. This relates to WCAG success criterion <a href="https://www.w3.org/TR/WCAG22/#pointer-gestures">2.5.1 Pointer Gestures</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-select-without-click-drag"}) %}
+
+<p>Avoid using <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range">range slider</a> questions, where the user needs to click and drag a selector across a range of answers or values. These types of controls are difficult for some users to interact with.</p>
+<p>If you do use a range slider, you must provide a method for selecting an answer that doesn’t rely on ‘click and drag’ movements. This relates to WCAG success criterion <a href="https://www.w3.org/TR/WCAG22/#pointer-gestures">2.5.1 Pointer Gestures</a>.</p>
+{% endcall %}

--- a/src/patterns/service-unavailable-pages/index.md
+++ b/src/patterns/service-unavailable-pages/index.md
@@ -10,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
@@ -54,13 +54,10 @@ Contact information should either be:
 - a link to a specific page that includes numbers and opening times
 - include all numbers and opening times
 
-<div class="app-wcag-22" id="wcag-consistent-content-service-unavailable" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>You must always write contact information in a clear and consistent way across ‘Service unavailable’ and similar service error pages. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-consistent-content-service-unavailable"}) %}
+
+<p>You must always write contact information in a clear and consistent way across ‘Service unavailable’ and similar service error pages. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
+{% endcall %}
 
 Have clear and concise content and do not use:
 

--- a/src/patterns/service-unavailable-pages/index.md
+++ b/src/patterns/service-unavailable-pages/index.md
@@ -9,30 +9,21 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 This guidance is for government teams that build online services. [To find information and services for the public, go to GOV.UK](https://www.gov.uk/).
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To use ‘Service unavailable pages' and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:
-
-- [get contact information in a consistent way](/patterns/service-unavailable-pages/#wcag-consistent-content-service-unavailable)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "use",
+  name: "Service unavailable pages",
+  criteria: [
+    {
+      text: "get contact information in a consistent way",
+      anchor: "wcag-consistent-content-service-unavailable"
+    }
+  ]
 }) }}
 
 Tell the user a service is unavailable on purpose. These are also known as 503 and shutter pages.

--- a/src/patterns/validation/index.md
+++ b/src/patterns/validation/index.md
@@ -7,30 +7,21 @@ aliases:
 layout: layout-pane.njk
 ---
 
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Check the information the user gives you to make sure it’s valid. If there's a validation error, tell the user what's gone wrong and how to fix it. Turn off HTML5 validation.
 
-{% set wcagCallout %}
-
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect this pattern
-
-To help users to 'Recover from validation errors' and meet the new WCAG 2.2 criteria, make sure that users can successfully:
-
-- [edit information they've previously given to correct an error](/patterns/validation/#wcag-edit-to-correct-errors)
-
-See the full list of [components and patterns affected by WCAG 2.2](/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system).
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
+{{ wcagCallout({
+  type: "pattern",
+  introAction: "help users to",
+  name: "Recover from validation errors",
+  criteria: [
+    {
+      text: "edit information they've previously given to correct an error",
+      anchor: "wcag-edit-to-correct-errors"
+    }
+  ]
 }) }}
 
 ## When to use this pattern

--- a/src/patterns/validation/index.md
+++ b/src/patterns/validation/index.md
@@ -8,7 +8,7 @@ layout: layout-pane.njk
 ---
 
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Check the information the user gives you to make sure it’s valid. If there's a validation error, tell the user what's gone wrong and how to fix it. Turn off HTML5 validation.
 
@@ -74,13 +74,10 @@ If the user's answers fail validation:
 
 Read guidance on [writing good error messages](/components/error-message/#be-clear-and-concise).
 
-<div class="app-wcag-22" id="wcag-edit-to-correct-errors" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Do not clear any form fields when validating users’ answers. Keep both passing and failing answers. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-edit-to-correct-errors"}) %}
+
+<p>Do not clear any form fields when validating users’ answers. Keep both passing and failing answers. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">3.3.7 Redundant entry</a>.</p>
+{% endcall %}
 
 Keeping information that failed validation helps users to:
 

--- a/src/styles/images/index.md
+++ b/src/styles/images/index.md
@@ -11,8 +11,7 @@ order: 13
 
 {% from "_example.njk" import example %}
 {% from "_wcag-callout.njk" import wcagCallout %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "_wcag-note.njk" import wcagNote %}
 
 Avoid using images for unnecessary decoration. Only use images if there’s a real user need.
 
@@ -73,13 +72,10 @@ Icons can be more useful in case working systems, where users are familiar with 
 
 Do not use a single icon to represent more than one thing. For example, the search icon (magnifying glass) should only be used for search functionality, and not also for screen magnification.
 
-<div class="app-wcag-22" id="wcag-icon-focus" role="note">
-  {{ govukTag({
-    text: "WCAG 2.2",
-    classes: "app-tag"
-  }) }}
-  <p>Make sure any icons and images used in links are at least 24px by 24px in size, with adequate spacing. This is to make sure users can easily interact with the link. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
-</div>
+{% call wcagNote({id: "wcag-icon-focus"}) %}
+
+<p>Make sure any icons and images used in links are at least 24px by 24px in size, with adequate spacing. This is to make sure users can easily interact with the link. This relates to WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">2.5.8 Target size (minimum)</a>.</p>
+{% endcall %}
 
 ## Avoid images that contain text
 

--- a/src/styles/images/index.md
+++ b/src/styles/images/index.md
@@ -10,27 +10,19 @@ order: 13
 ---
 
 {% from "_example.njk" import example %}
+{% from "_wcag-callout.njk" import wcagCallout %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 Avoid using images for unnecessary decoration. Only use images if there’s a real user need.
 
-{% set wcagCallout %}
+{% call wcagCallout({
+  name: "Images",
+  heading: "New WCAG 2.2 criteria affect how you use images"
+}) %}
 
-{{ govukTag({
-  text: "WCAG 2.2",
-  classes: "app-tag"
-}) }}
-
-### New WCAG 2.2 criteria affect how you use images
-
-To meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, [make sure any icons and images used in links meet the minimum target size](/styles/images/#wcag-icon-focus). This is to make sure users can easily interact with the link.
-{% endset %}
-
-{{ govukInsetText({
-  html: wcagCallout,
-  classes: "app-inset-text"
-}) }}
+  <p>To meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, <a href="#wcag-icon-focus">make sure any icons and images used in links meet the minimum target size</a>. This is to make sure users can easily interact with the link.</p>
+{% endcall %}
 
 Make sure any information contained in an image can be understood by someone who cannot see it. Also consider partially-sighted users with visual impairments and the assistive technologies they might use.
 
@@ -252,6 +244,12 @@ To help us validate that this guidance is useful and practical for service teams
 We’re looking for feedback about any of these areas:
 
 - how you use images to give information to users
+- examples of the types of images used in services
+- how you create and choose images to use in your service
+- how you implement images (for frontend performance)
+
+Give us your feedback and examples by [posting a comment on the ‘Images’ discussion on GitHub](https://github.com/alphagov/govuk-design-system-backlog/issues/70).
+
 - examples of the types of images used in services
 - how you create and choose images to use in your service
 - how you implement images (for frontend performance)

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -423,8 +423,15 @@ pre .language-plaintext {
   }
 }
 
-.app-inset-text {
+.app-wcag-callout {
   border-left-color: govuk-colour("blue");
+}
+
+// Change headings in WCAG callouts to look like H3s,
+// even though they semantically are H2s
+.app-wcag-callout h2 {
+  @extend %govuk-heading-m;
+  max-width: 30em;
 }
 
 .app-tag {

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -357,6 +357,12 @@ pre .language-plaintext {
     @include govuk-typography-weight-bold;
   }
 
+  // Govuk tags are strong elements and prose scope reinforces strong's being
+  // bold, so we need to 'override' it back to regular
+  .govuk-tag {
+    @include govuk-typography-weight-regular;
+  }
+
   ul,
   ol {
     @extend %govuk-list;
@@ -424,8 +430,4 @@ pre .language-plaintext {
 .app-tag {
   margin-top: 1px;
   margin-bottom: govuk-spacing(2);
-
-  .app-prose-scope & {
-    font-weight: normal;
-  }
 }

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -413,16 +413,6 @@ pre .language-plaintext {
   background-color: $app-light-grey;
 }
 
-.app-wcag-22 {
-  margin-top: govuk-spacing(6);
-
-  // Add highlight styling for WCAG 2.2 content
-  &:target {
-    outline: 4px solid $govuk-brand-colour;
-    outline-offset: 6px;
-  }
-}
-
 .app-wcag-callout {
   border-left-color: govuk-colour("blue");
 }
@@ -434,7 +424,17 @@ pre .language-plaintext {
   max-width: 30em;
 }
 
-.app-tag {
+.app-wcag-callout__tag {
   margin-top: 1px;
   margin-bottom: govuk-spacing(2);
+}
+
+.app-wcag-note {
+  margin-top: govuk-spacing(6);
+
+  // Add highlight styling for WCAG 2.2 content
+  &:target {
+    outline: 4px solid $govuk-brand-colour;
+    outline-offset: 6px;
+  }
 }

--- a/views/partials/_wcag-callout.njk
+++ b/views/partials/_wcag-callout.njk
@@ -1,0 +1,30 @@
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText -%}
+{% from "govuk/components/tag/macro.njk" import govukTag -%}
+
+{% macro wcagCallout(params) -%}
+{% set tagContent -%}
+  {{- govukTag({
+    text: "WCAG 2.2",
+    classes: "app-tag"
+  }) }}
+  <h2>
+    {{ params.heading if params.heading else "New WCAG 2.2 criteria affect this " + params.type }}
+  </h2>
+  {% if caller -%}
+    {{ caller() }}
+  {% else -%}
+    <p class="govuk-body">To {{params.introAction}} ‘{{params.name}}’ and meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, make sure that users can successfully:</p>
+    <ul class="govuk-list">
+    {% for criterion in params.criteria %}
+      <li><a class="govuk-link" href="#{{criterion.anchor}}">{{criterion.text}}</a></li>
+    {% endfor %}
+    </ul>
+  {% endif -%}
+  <p class="govuk-body">See the full list of <a class="govuk-link" href="/accessibility/wcag-2.2/#components-and-patterns-affected-in-the-design-system">components and patterns affected by WCAG 2.2</a>.</p>
+{% endset -%}
+
+{{ govukInsetText({
+  html: tagContent,
+  classes: "app-wcag-callout"
+}) }}
+{% endmacro %}

--- a/views/partials/_wcag-callout.njk
+++ b/views/partials/_wcag-callout.njk
@@ -5,7 +5,7 @@
 {% set tagContent -%}
   {{- govukTag({
     text: "WCAG 2.2",
-    classes: "app-tag"
+    classes: "app-wcag-callout__tag"
   }) }}
   <h2>
     {{ params.heading if params.heading else "New WCAG 2.2 criteria affect this " + params.type }}

--- a/views/partials/_wcag-note.njk
+++ b/views/partials/_wcag-note.njk
@@ -1,0 +1,11 @@
+{% from "govuk/components/tag/macro.njk" import govukTag -%}
+
+{% macro wcagNote(params) -%}
+<div class="app-wcag-note" id="{{params.id}}" role="note">
+  {{ govukTag({
+    text: "WCAG 2.2",
+    classes: "app-wcag-callout__tag"
+  }) }}
+  {{ caller() if caller else params.content | safe }}
+</div>
+{% endmacro %}


### PR DESCRIPTION
## What
Turns the WCAG 2.2 callouts and criteria notes linked to by the callouts into respective macros and replaces all instances of the callouts and notes in guidance with the macros.

Additionally, this PR fixes few missed duplicate content issues found in content, adjusts the classes used for the WCAG designs to be more specific to their function and moves the override of `strong` element styling when they're govuk tags into prose scope since we always want our tags to be regular font size.

## Why
The WCAG 2.2 designs are repeated across 34 pages of content and we're effectively rebuilding them every time we use them. Turning them into macros makes the website lighter and our content less complex.

We've gone back and forth around if we want to do this since the designs are going to be removed eventually, however even if it's a few months, it's still worth doing for neatness and it makes these designs easier to repurpose in the future.

## Notes
I'm not super happy with how I've managed inconsistencies between the callout content. The `introType` attribute feels a bit hacky but managable, however the override attributes which I'm only using for the images page feel messy. I'm not sure if there's a better alternative though and welcome suggestions from others on this.