### PR TITLE
Update the guidance on when to use the checkboxes component

### DIFF
--- a/src/components/checkboxes/index.md
+++ b/src/components/checkboxes/index.md
@@ -15,10 +15,7 @@ Let users select one or more options by using the checkboxes component.
 
 ## When to use this component
 
-Use the checkboxes component when you need to help users:
-
-- select multiple options from a list
-- toggle a single option on or off
+Use the checkboxes component when you need to help users select multiple options from a list.
 
 ## When not to use this component
 


### PR DESCRIPTION
The guidance currently says you can use the component when you need to help users toggle a single option on or off. For these cases, it would be better to use 2 radios with yes/no or on/off because it makes users deliberately choose the option they want. Otherwise, there's the risk that users miss the single checkbox on the page and end up not selecting something they might have had selected if the page was using radio buttons.