### PR TITLE
[SPIKE] Move Nunjucks macro parameter tables into page content

### DIFF
--- a/src/components/accordion/index.md
+++ b/src/components/accordion/index.md
@@ -2,6 +2,7 @@
 title: Accordion
 description: The accordion component lets users show and hide sections of related content on a page
 section: Components
+item: accordion
 aliases:
 backlogIssueId: 1
 layout: layout-pane.njk
@@ -11,7 +12,7 @@ layout: layout-pane.njk
 
 The accordion component lets users show and hide sections of related content on a page.
 
-{{ example({ group: "components", item: "accordion", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -79,7 +80,7 @@ The heading button includes all of these areas:
 
 For users of screen readers, all the text in the button will be read as a single statement (separated by commas to allow for slight pauses). There’s also some visually hidden content in the heading text to help announce the call-to-action as 'show this section' or 'hide this section'.
 
-{{ example({ group: "components", item: "accordion", example: "default", html: true, nunjucks: true, open: false, size: "xl", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "xl", titleSuffix: "second" }) }}
 
 #### Write clear button text
 
@@ -95,7 +96,7 @@ Only add a summary line if it’s actually needed, as it's likely to make the bu
 
 If you’ve decided that you need the summary line, you must make it as short as possible.
 
-{{ example({ group: "components", item: "accordion", example: "with-summary-section", html: true, nunjucks: true, open: false, size: "xl" }) }}
+{{ example({ group: "components", item: item, example: "with-summary-section", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 #### Structure section headings with the rest of the page
 

--- a/src/components/back-link/index.md
+++ b/src/components/back-link/index.md
@@ -2,6 +2,7 @@
 title: Back link
 description: Use the back link component to help users go back to the previous page in a multi-page transaction
 section: Components
+item: back-link
 aliases: return link, back button
 backlogIssueId: 32
 layout: layout-pane.njk
@@ -37,7 +38,7 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
 
 Although browsers have a back button, some sites break when you use it - so many users avoid it, instead of losing their progress in a service. Also, not all users are aware of the back button.
 
-{{ example({ group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -76,7 +77,7 @@ Where possible, ensure the back link works even when JavaScript is not available
 
 There are 2 ways to use the back link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "back-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 Using the default link text ('Back') is ideal for services with a simple journey. For example, [applying for a National Insurance number](https://www.gov.uk/apply-national-insurance-number). Users will only ever go back to the previous page in the service.
 
@@ -88,4 +89,4 @@ Use the `govuk-back-link--inverse` modifier class to show a white link on a dark
 
 Make sure all users can see the back link – the background colour [must have a contrast ratio of at least 4.5:1](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) with white.
 
-{{ example({ group: "components", item: "back-link", example: "inverse", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "inverse", html: true, nunjucks: true, open: false }) }}

--- a/src/components/breadcrumbs/index.md
+++ b/src/components/breadcrumbs/index.md
@@ -2,6 +2,7 @@
 title: Breadcrumbs
 description: Help users orientate themselves and navigate pages within a hierarchical structure
 section: Components
+item: breadcrumbs
 aliases: navigation path, cookie crumb
 backlogIssueId: 33
 layout: layout-pane.njk
@@ -34,7 +35,7 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
   classes: "app-inset-text"
 }) }}
 
-{{ example({ group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -62,7 +63,7 @@ The breadcrumbs should start with your 'home' page and end with the parent secti
 
 There are 2 ways to use the breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### Collapsing breadcrumbs on mobile devices
 
@@ -70,7 +71,7 @@ If you have long breadcrumbs you can configure the component to only show the fi
 
 To do this, add a `govuk-breadcrumbs--collapse-on-mobile` class to the outer `<div>` element of the component HTML. Or if you’re using Nunjucks, add `collapseOnMobile: true` to the Nunjucks macro as shown in this example.
 
-{{ example({ group: "components", item: "breadcrumbs", example: "collapse-mobile", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "collapse-mobile", html: true, nunjucks: true, open: false }) }}
 
 ### Breadcrumbs on dark backgrounds
 
@@ -78,4 +79,4 @@ Use the `govuk-breadcrumbs--inverse` modifier class to show white links and arro
 
 Make sure all users can see the breadcrumbs – the background colour [must have a contrast ratio of at least 4.5:1](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) with white.
 
-{{ example({ group: "components", item: "breadcrumbs", example: "inverse", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "inverse", html: true, nunjucks: true, open: false }) }}

--- a/src/components/button/index.md
+++ b/src/components/button/index.md
@@ -2,6 +2,7 @@
 title: Button
 description: Use the button component to help users carry out an action
 section: Components
+item: button
 aliases:
 backlogIssueId: 34
 layout: layout-pane.njk
@@ -32,7 +33,7 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
   classes: "app-inset-text"
 }) }}
 
-{{ example({ group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -73,14 +74,14 @@ Use a default button for the main call to action on a page.
 
 Avoid using multiple default buttons on a single page. Having more than one main call to action reduces their impact, and makes it harder for users to know what to do next.
 
-{{ example({ group: "components", item: "button", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### Start buttons
 
 Use a start button for the main call to action on your service’s [start page](/patterns/start-using-a-service/).
 Start buttons do not usually submit form data, so use a link tag instead of a button tag.
 
-{{ example({ group: "components", item: "button", example: "start", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "start", html: true, nunjucks: true, open: false }) }}
 
 ### Secondary buttons
 
@@ -88,7 +89,7 @@ Use secondary buttons for secondary calls to action on a page.
 
 Pages with too many calls to action make it hard for users to know what to do next. Before adding lots of secondary buttons, try to simplify the page or break the content down across multiple pages.
 
-{{ example({ group: "components", item: "button", example: "secondary", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "secondary", html: true, nunjucks: true, open: false }) }}
 
 You can also [group default and secondary buttons together](#grouping-buttons).
 
@@ -96,7 +97,7 @@ You can also [group default and secondary buttons together](#grouping-buttons).
 
 Warning buttons are designed to make users think carefully before they use them. They only work if used very sparingly. Most services should not need one.
 
-{{ example({ group: "components", item: "button", example: "warning", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "warning", html: true, nunjucks: true, open: false }) }}
 
 Only use warning buttons for actions with serious destructive consequences that cannot be easily undone by a user. For example, permanently deleting an account.
 
@@ -112,7 +113,7 @@ Use the `govuk-button--inverse` modifier class to show white buttons on dark bac
 
 Make sure all users can see the button – the white button and background colour [must have a contrast ratio of at least 3:1](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html).
 
-{{ example({ group: "components", item: "button", example: "inverse", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "inverse", html: true, nunjucks: true, open: false }) }}
 
 ### Disabled buttons
 
@@ -120,17 +121,17 @@ Disabled buttons have poor contrast and can confuse some users, so avoid them if
 
 Only use disabled buttons if research shows it makes the user interface easier to&nbsp;understand.
 
-{{ example({ group: "components", item: "button", example: "disabled", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "disabled", html: true, nunjucks: true, open: false }) }}
 
 ### Grouping buttons
 
 Use a button group when two or more buttons are placed together.
 
-{{ example({ group: "components", item: "button", example: "secondary-combo", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "secondary-combo", html: true, nunjucks: true, open: false }) }}
 
 Any links within a button group will automatically align with the buttons.
 
-{{ example({ group: "components", item: "button", example: "button-group", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "button-group", html: true, nunjucks: true, open: false }) }}
 
 ### Stop users from accidentally sending information more than once
 
@@ -148,7 +149,7 @@ If you are working in production and research shows that users are frequently se
 
 To do this, set the `data-prevent-double-click` attribute to `true`. You can do this directly in the HTML or, if you’re using Nunjucks, you can use the Nunjucks macro as shown in this example.
 
-{{ example({ group: "components", item: "button", example: "prevent-double-click", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "prevent-double-click", html: true, nunjucks: true, open: false }) }}
 
 This feature will prevent double clicks for users that have JavaScript enabled, however you should also think about the issue server-side to protect against attacks.
 

--- a/src/components/character-count/index.md
+++ b/src/components/character-count/index.md
@@ -2,6 +2,7 @@
 title: Character count
 description: Tell users how many characters or words they can enter into a textarea
 section: Components
+item: character-count
 aliases: word count
 backlogIssueId: 67
 layout: layout-pane.njk
@@ -11,7 +12,7 @@ layout: layout-pane.njk
 
 Help users know how much text they can enter when there is a limit on the number of characters.
 
-{{ example({ group: "components", item: "character-count", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -46,13 +47,13 @@ This component uses JavaScript. If JavaScript is not available, users will see a
 
 There are 2 ways to use the character count component. You can use HTML or, if you’re using Nunjucks or the GOV.UK Prototype Kit, you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "character-count", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### If you’re asking more than one question on the page
 
 If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking multiple questions on question pages](/patterns/question-pages/#asking-multiple-questions-on-a-page).
 
-{{ example({ group: "components", item: "character-count", example: "without-heading", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "without-heading", html: true, nunjucks: true, open: false }) }}
 
 ### Consider if a word count is more helpful
 
@@ -60,7 +61,7 @@ In some cases it may be more helpful to show a word count. For example, if your 
 
 Do this by setting `data-maxwords` in the component markup. For example, `data-maxwords="150"` will set a word limit of 150.
 
-{{ example({ group: "components", item: "character-count", example: "word-count", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "word-count", html: true, nunjucks: true, open: false }) }}
 
 ### Avoid narrow limits
 
@@ -74,13 +75,13 @@ To do this, set the threshold in the component markup as a percentage. For examp
 
 Screen reader users will hear the character limit when they first interact with a textarea using the threshold option. Sighted users will not see anything until the count message is shown – though you might choose to include the character limit in the hint text.
 
-{{ example({ group: "components", item: "character-count", example: "threshold", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "threshold", html: true, nunjucks: true, open: false }) }}
 
 ### Error messages
 
 Error messages should be styled like this:
 
-{{ example({ group: "components", item: "character-count", example: "error", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "error", html: true, nunjucks: true, open: false }) }}
 
 If a user tries to send their response with too many characters, you must show an error message above the field as well as the count message below it.
 

--- a/src/components/checkboxes/index.md
+++ b/src/components/checkboxes/index.md
@@ -2,6 +2,7 @@
 title: Checkboxes
 description: Let users select one or more options by using the checkboxes component
 section: Components
+item: checkboxes
 aliases: check boxes, tickboxes, tick boxes
 backlogIssueId: 37
 layout: layout-pane.njk
@@ -11,7 +12,7 @@ layout: layout-pane.njk
 
 Let users select one or more options by using the checkboxes component.
 
-{{ example({ group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -51,19 +52,19 @@ Read more about [why and how to set legends as headings](/get-started/labels-leg
 
 There are 2 ways to use the checkboxes component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "checkboxes", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
 
 ### If you’re asking more than one question on the page
 
 If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking multiple questions on question pages](/patterns/question-pages/#asking-multiple-questions-on-a-page).
 
-{{ example({ group: "components", item: "checkboxes", example: "without-heading", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "without-heading", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ### Checkbox items with hints
 
 You can add hints to checkbox items to provide additional information about the options.
 
-{{ example({ group: "components", item: "checkboxes", example: "hint", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "hint", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Add an option for ‘none’
 
@@ -79,11 +80,11 @@ For example, for the question 'Will you be travelling to any of these countries?
 
 To enable some JavaScript that unchecks all other checkboxes when the user clicks 'None', add the `exclusive` behaviour to the 'none' checkbox.
 
-{{ example({ group: "components", item: "checkboxes", example: "with-none-option", html: true, nunjucks: true, open: false, size: "xl" }) }}
+{{ example({ group: "components", item: item, example: "with-none-option", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 If JavaScript is unavailable, and a user selects both the ‘none’ checkbox and another checkbox, display an error message.
 
-{{ example({ group: "components", item: "checkboxes", example: "with-none-option-in-error", html: true, nunjucks: true, open: false, size: "xl" }) }}
+{{ example({ group: "components", item: item, example: "with-none-option-in-error", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 ### Conditionally revealing a related question
 
@@ -91,7 +92,7 @@ You can ask the user a related question when they select a particular checkbox, 
 
 This might make 2 related questions easier to answer by grouping them on the same page. For example, you could reveal a phone number input when the user selects the 'Contact me by phone' option.
 
-{{ example({ group: "components", item: "checkboxes", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl" }) }}
+{{ example({ group: "components", item: item, example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 Keep it simple. If the related question is complicated or has more than one part, show it on the next page in the process instead.
 
@@ -111,7 +112,7 @@ Use standard-sized checkboxes in most cases. However, smaller checkboxes work we
 
 For example, on a page of search results, the main user need is to see the results. Using smaller checkboxes lets users see and change search filters without distracting them from the main content.
 
-{{ example({ group: "components", item: "checkboxes", example: "small", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "small", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 Small checkboxes can work well on information dense screens in services designed for repeat use, like caseworking systems.
 
@@ -121,7 +122,7 @@ In services like these, the risk that they will not be noticed is lower because 
 
 Error messages should be styled like this:
 
-{{ example({ group: "components", item: "checkboxes", example: "error", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "error", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/components/cookie-banner/index.md
+++ b/src/components/cookie-banner/index.md
@@ -2,6 +2,7 @@
 title: Cookie banner
 description: Allow users to accept or reject cookies which are not essential to making your service work.
 section: Components
+item: cookie-banner
 aliases: Cookies banner, consent banner, GDPR banner, tracking banner, analytics banner
 backlogIssueId: 12
 layout: layout-pane.njk
@@ -35,7 +36,7 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
   classes: "app-inset-text"
 }) }}
 
-{{ example({ group: "components", item: "cookie-banner", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -119,13 +120,13 @@ All users will be able to see the banner as this approach does not rely on JavaS
 
 Here's an example of a cookie banner inside a form:
 
-{{ example({ group: "components", item: "cookie-banner", example: "server-side", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "server-side", html: true, nunjucks: true, open: false }) }}
 
 Once the user has accepted or rejected cookies and set their cookie preferences, reload the page to show a confirmation message.
 
 Here's an example of a confirmation message inside a form:
 
-{{ example({ group: "components", item: "cookie-banner", example: "server-side-confirmation", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "server-side-confirmation", html: true, nunjucks: true, open: false }) }}
 
 #### Show the same message to all users
 
@@ -141,11 +142,11 @@ Include all possible messages that the user could see in the cookie banner when 
 
 Here's an example of a progressively enhanced cookie banner that includes all possible messages which are hidden using HTML – the cookie banner message is shown using JavaScript to remove the `hidden` attribute:
 
-{{ example({ group: "components", item: "cookie-banner", example: "server-side-multiple-messages-question-visible", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "server-side-multiple-messages-question-visible", html: true, nunjucks: true, open: false }) }}
 
 Here's the same example of a progressively enhanced cookie banner, with the confirmation message shown instead:
 
-{{ example({ group: "components", item: "cookie-banner", example: "server-side-multiple-messages-confirmation-visible", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "server-side-multiple-messages-confirmation-visible", html: true, nunjucks: true, open: false }) }}
 
 ### Option 3: If you set non-essential cookies, but only on the client
 
@@ -166,17 +167,17 @@ Write your own JavaScript code so that when the user accepts or rejects cookies,
 
 Here’s an example:
 
-{{ example({ group: "components", item: "cookie-banner", example: "client-side", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "client-side", html: true, nunjucks: true, open: false }) }}
 
 #### When the user has accepted cookies
 
 Show a confirmation message confirming that the user has either accepted or rejected cookies by removing the `hidden` attribute.
 
-{{ example({ group: "components", item: "cookie-banner", example: "client-side-accepted", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "client-side-accepted", html: true, nunjucks: true, open: false }) }}
 
 #### When the user has rejected cookies
 
-{{ example({ group: "components", item: "cookie-banner", example: "client-side-rejected", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "client-side-rejected", html: true, nunjucks: true, open: false }) }}
 
 ## What to cover in your cookie banner
 
@@ -195,7 +196,7 @@ Keep the text as short as possible while making sure it’s an accurate descript
 
 You can use this example text for a service which sets essential and analytics cookies. Analytics cookies are those set by your organisation to collect information about how people are using your digital service.
 
-{{ example({ group: "components", item: "cookie-banner", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### If you’re using more than one type of non-essential cookie
 
@@ -205,7 +206,7 @@ You can use this example text for a service that set:
 - analytics cookies
 - functional cookies to remember the user’s settings but are not essential
 
-{{ example({ group: "components", item: "cookie-banner", example: "multiple-cookies", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "multiple-cookies", html: true, nunjucks: true, open: false }) }}
 
 ## Creating a cookies page
 

--- a/src/components/date-input/index.md
+++ b/src/components/date-input/index.md
@@ -2,6 +2,7 @@
 title: Date input
 description: Use the date input component to help users enter a memorable date
 section: Components
+item: date-input
 aliases:
 backlogIssueId: 42
 layout: layout-pane.njk
@@ -11,7 +12,7 @@ layout: layout-pane.njk
 
 Use the date input component to help users enter a memorable date or one they can easily look up.
 
-{{ example({ group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -39,7 +40,7 @@ Accept month names written out in full or abbreviated form (for example, ‘janu
 
 There are 2 ways to use the date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 Never automatically tab users between the fields of the date input because this can be confusing and may clash with normal keyboard controls.
 
@@ -47,7 +48,7 @@ Never automatically tab users between the fields of the date input because this 
 
 If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking multiple questions on question pages](/patterns/question-pages/#asking-multiple-questions-on-a-page).
 
-{{ example({ group: "components", item: "date-input", example: "without-heading", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "without-heading", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 ### Use the autocomplete attribute for a date of birth
 
@@ -55,7 +56,7 @@ Use the `autocomplete` attribute on the date input component when you're asking 
 
 To do this, set the `autocomplete` attribute on the 3 fields to `bday-day`, `bday-month` and `bday-year`. See how to do this in the HTML and Nunjucks tabs in the following example.
 
-{{ example({ group: "components", item: "date-input", example: "date-of-birth", html: true, nunjucks: true, open: true, size: "s", id: "default-2" }) }}
+{{ example({ group: "components", item: item, example: "date-of-birth", html: true, nunjucks: true, open: true, size: "s", id: "default-2" }) }}
 
 If you are working in production you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
 
@@ -65,11 +66,11 @@ You will not normally need to use the `autocomplete` attribute in prototypes, as
 
 If you’re highlighting the whole date, style all the fields like this:
 
-{{ example({ group: "components", item: "date-input", example: "error", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "error", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 If you’re highlighting just one field - either the day, month or year - only style the field that has an error. The error message must say which field has an error, like this:
 
-{{ example({ group: "components", item: "date-input", example: "error-single", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "error-single", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/components/details/index.md
+++ b/src/components/details/index.md
@@ -2,6 +2,7 @@
 title: Details
 description: Make a page easier to scan by letting users reveal more detailed information only if they need it
 section: Components
+item: details
 aliases: reveal, progressive disclosure, hidden text, show and hide, ShowyHideyThing
 backlogIssueId: 44
 layout: layout-pane.njk
@@ -11,7 +12,7 @@ layout: layout-pane.njk
 
 Make a page easier to scan by letting users reveal more detailed information only if they need it.
 
-{{ example({ group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -35,7 +36,7 @@ The details component is a short link that shows more detailed help text when a 
 
 There are 2 ways to use the details component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "details", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 ### Write clear link text
 

--- a/src/components/error-message/index.md
+++ b/src/components/error-message/index.md
@@ -2,6 +2,7 @@
 title: Error message
 description: When there's a validation error, use an error message to explain what went wrong and how to fix it
 section: Components
+item: error-message
 aliases: validation message
 backlogIssueId: 47
 layout: layout-pane.njk
@@ -36,7 +37,7 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
 
 Follow the [validation pattern](/patterns/validation/) and show an error message when there is a validation error. In the error message explain what went wrong and how to fix it.
 
-{{ example({ group: "components", item: "error-message", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -82,7 +83,7 @@ To help screen reader users, the error message component includes a hidden 'Erro
 
 If your error message is written in another language, you can change the prefix as needed, as shown in this example.
 
-{{ example({ group: "components", item: "error-message", example: "custom-prefix", html: true, nunjucks: true, open: true, displayExample: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "custom-prefix", html: true, nunjucks: true, open: true, displayExample: false, size: "s" }) }}
 
 Summarise all errors at the top of the page the user is on using an [error summary](/components/error-summary/).
 
@@ -90,11 +91,11 @@ There are 2 ways to use the error message component. You can use HTML or, if you
 
 ### Legend
 
-{{ example({ group: "components", item: "error-message", example: "legend", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "legend", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ### Label
 
-{{ example({ group: "components", item: "error-message", example: "label", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "label", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Match up error messages to labels
 

--- a/src/components/error-summary/index.md
+++ b/src/components/error-summary/index.md
@@ -2,6 +2,7 @@
 title: Error summary
 description: Use an error summary when there is a validation error
 section: Components
+item: error-summary
 aliases:
 backlogIssueId: 46
 layout: layout-pane.njk
@@ -13,7 +14,7 @@ Use this component at the top of a page to summarise any errors a user has made.
 
 When a user makes an error, you must show both an error summary and an [error message](/components/error-message/) next to each answer that contains an error.
 
-{{ example({ group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -34,7 +35,7 @@ And make your [error messages](/components/error-message/#be-clear-and-concise) 
 
 There are 2 ways to use the error summary component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "error-summary", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 ### Linking from the error summary to each answer
 
@@ -42,20 +43,20 @@ You must link the errors in the error summary to the answer they relate to.
 
 For questions that require a user to answer using a single field, like a file upload, select, textarea, text input or character count, link to the field.
 
-{{ example({ group: "components", item: "error-summary", example: "linking", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "linking", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 When a user has to enter their answer into multiple fields, such as the day, month and year fields in the date input component, link to the first field that contains an error.
 
 If you do not know which field contains an error, link to the first field.
 
-{{ example({ group: "components", item: "error-summary", example: "linking-multiple-fields", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "linking-multiple-fields", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 For questions that require a user to select one or more options from a list using radios or checkboxes, link to the first radio or checkbox.
 
-{{ example({ group: "components", item: "error-summary", example: "linking-checkboxes-radios", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "linking-checkboxes-radios", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Where to put the error summary
 
 Put the error summary at the top of the `main` container. If your page includes breadcrumbs or a back link, place it below these, but above the `<h1>`.
 
-{{ example({ group: "components", item: "error-summary", example: "full-page-example", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "full-page-example", html: true, nunjucks: true, open: false, size: "s" }) }}

--- a/src/components/exit-this-page/index.md
+++ b/src/components/exit-this-page/index.md
@@ -2,6 +2,7 @@
 title: Exit this page
 description: Give users a way to quickly and safely exit a service, website or application.
 section: Components
+item: exit-this-page
 aliases:
 backlogIssueId: 213
 layout: layout-pane.njk
@@ -13,7 +14,7 @@ Give users a way to quickly and safely exit a service, website or application.
 
 For service journeys, you must use this component with the pattern to help a user [Exit a page quickly](/patterns/exit-a-page-quickly/).
 
-{{ example({ group: "components", item: "exit-this-page", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -59,7 +60,7 @@ Add the code for the 'secondary link' into the layout file of your service. The 
 
 When the user interacts with the 'secondary link', it will perform the same action as pressing the button to activate Exit this Page.
 
-{{ example({ group: "components", item: "exit-this-page", example: "secondary-link", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "secondary-link", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 The `href` for the 'secondary link' should be the same as the URL used for the button.
 

--- a/src/components/fieldset/index.md
+++ b/src/components/fieldset/index.md
@@ -2,6 +2,7 @@
 title: Fieldset
 description: Use the fieldset component to group related form inputs
 section: Components
+item: fieldset
 aliases:
 backlogIssueId: 48
 layout: layout-pane.njk
@@ -15,7 +16,7 @@ Use the fieldset component to group related form inputs.
 
 Use the fieldset component when you need to show a relationship between multiple form inputs. For example, you may need to group a set of text inputs into a single fieldset when [asking for an address](/patterns/addresses/).
 
-{{ example({ group: "components", item: "fieldset", example: "address-group", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "address-group", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
 
 If you’re using the examples or macros for [radios](/components/radios/), [checkboxes](/components/checkboxes/) or [date input](/components/date-input/), the fieldset will already be included.
 
@@ -27,7 +28,7 @@ If you’re asking just [one question per page](/patterns/question-pages/#start-
 
 Read more about [why and how to set legends as headings](/get-started/labels-legends-headings/).
 
-{{ example({ group: "components", item: "fieldset", example: "default", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false }) }}
 
 On [question pages](/patterns/question-pages/) containing a group of inputs, including the question as the legend helps users of screen readers to understand that the inputs are all related to that&nbsp;question.
 

--- a/src/components/file-upload/index.md
+++ b/src/components/file-upload/index.md
@@ -2,6 +2,7 @@
 title: File upload
 description: Help users select and upload a file
 section: Components
+item: file-upload
 aliases:
 backlogIssueId: 49
 layout: layout-pane.njk
@@ -38,7 +39,7 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
 
 Help users select and upload a file.
 
-{{ example({ group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -71,13 +72,13 @@ To upload a file, the user can either:
 
 There are 2 ways to use the file upload component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "file-upload", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### Error messages
 
 Error messages should be styled like this:
 
-{{ example({ group: "components", item: "file-upload", example: "error", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "error", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -2,6 +2,7 @@
 title: Footer
 description: The footer provides copyright, licensing and other information about your service and department
 section: Components
+item: footer
 aliases: privacy notice, accessibility statement, terms and conditions
 backlogIssueId: 96
 layout: layout-pane.njk
@@ -34,7 +35,7 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
   classes: "app-inset-text"
 }) }}
 
-{{ example({ group: "components", item: "footer", example: "default", id: "default-1", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", id: "default-1", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 If you use the page template, you'll also get the footer without having to add it, as it's included by default. However, if you want to customise the default footer, read the [page template guidance about customising components](/styles/page-template/#changing-template-content).
 
@@ -50,11 +51,11 @@ Make it clear whether content is available for re-use - and if it is, under what
 
 ### Footer without links
 
-{{ example({ group: "components", item: "footer", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
 
 ### Footer with links
 
-{{ example({ group: "components", item: "footer", example: "with-meta", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "with-meta", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ## Adding links
 
@@ -83,8 +84,8 @@ Only add secondary GOV.UK navigation if you’re creating a GOV.UK service, and 
 
 ### Footer with secondary navigation
 
-{{ example({ group: "components", item: "footer", example: "with-navigation", html: true, nunjucks: true, open: false, size: "xl" }) }}
+{{ example({ group: "components", item: item, example: "with-navigation", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 ### Footer with links and secondary navigation
 
-{{ example({ group: "components", item: "footer", example: "full", html: true, nunjucks: true, open: false, size: "xl" }) }}
+{{ example({ group: "components", item: item, example: "full", html: true, nunjucks: true, open: false, size: "xl" }) }}

--- a/src/components/header/index.md
+++ b/src/components/header/index.md
@@ -2,6 +2,7 @@
 title: Header
 description: The GOV.UK header shows users that they are on GOV.UK and which service they are using
 section: Components
+item: header
 backlogIssueId: 97
 layout: layout-pane.njk
 ---
@@ -34,7 +35,7 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
   classes: "app-inset-text"
 }) }}
 
-{{ example({ group: "components", item: "header", example: "default", id: "default-1", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", id: "default-1", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 If you use the page template, you'll also get the header without having to add it, as it's included by default. However, if you want to customise the default header, read the [page template guidance about customising components](/styles/page-template/#changing-template-content).
 
@@ -56,13 +57,13 @@ You must not use the GOV.UK header if your service is not being hosted on one of
 
 Use the default header if your service has 5 pages or fewer.
 
-{{ example({ group: "components", item: "header", example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", titleSuffix: "second", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### Header with service name
 
 Use the header with a service name if your service is more than 5 pages long - this can help users understand which service they are using.
 
-{{ example({ group: "components", item: "header", example: "with-service-name", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "with-service-name", html: true, nunjucks: true, open: false }) }}
 
 ### Header with service name and navigation
 
@@ -79,7 +80,7 @@ Use the header with navigation if you need to include basic navigation, contact 
 
 In November 2021, [the GOV.UK homepage introduced a menu bar](https://insidegovuk.blog.gov.uk/2021/11/11/launching-gov-uks-new-menu-bar/) that avoids obscuring content by shifting the page down.
 
-{{ example({group: "components", item: "header", example: "with-service-name-and-navigation", html: true, nunjucks: true, open: false, size: "s"}) }}
+{{ example({group: "components", item: item, example: "with-service-name-and-navigation", html: true, nunjucks: true, open: false, size: "s"}) }}
 
 <div class="app-wcag-22" id="wcag-consistent-help-links" role="note">
   {{ govukTag({

--- a/src/components/inset-text/index.md
+++ b/src/components/inset-text/index.md
@@ -2,6 +2,7 @@
 title: Inset text
 description: Use the inset text component to differentiate a block of text from the content that surrounds it
 section: Components
+item: inset-text
 aliases: highlighted text, callout
 backlogIssueId: 136
 layout: layout-pane.njk
@@ -9,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({ group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -31,4 +32,4 @@ Use inset text very sparingly - it’s less effective if it’s overused.
 
 There are 2 ways to use the inset text component. You can use HTML or, if you’re using Nunjucks or the GOV.UK Prototype Kit, you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "inset-text", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}

--- a/src/components/notification-banner/index.md
+++ b/src/components/notification-banner/index.md
@@ -2,6 +2,7 @@
 title: Notification banner
 description: Use a notification banner to tell the user about something they need to know about, but that’s not directly related to the page content
 section: Components
+item: notification-banner
 aliases: alert, warning, success message, important message, flash message
 backlogIssueId: 2
 layout: layout-pane.njk
@@ -11,7 +12,7 @@ layout: layout-pane.njk
 
 Use a notification banner to tell the user about something they need to know about, but that’s not directly related to the page content.
 
-{{ example({ group: "components", item: "notification-banner", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -55,7 +56,7 @@ For example:
 - in a service that lets the user register or apply for something, they might need to know that it’s taking longer than usual to process applications because of an emergency
 - in an account-type service, the user might need to know that the service will be down for scheduled maintenance
 
-{{ example({ group: "components", item: "notification-banner", example: "whole-service", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "whole-service", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 If your service is on GOV.UK and it’s affected by an emergency, ask your department’s content team to [request a change to the service start page](https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#change-govuk-content).
 If your service is getting more demand than usual, check that you’ve set up [There is a problem with the service pages](/patterns/problem-with-the-service-pages/) and [Service unavailable pages](/patterns/service-unavailable-pages/), and the wording is up to date.
@@ -67,7 +68,7 @@ Use a ‘neutral’ notification banner if the user needs to know about somethin
 - in a case working system, the user might need to know that there are new cases waiting for their attention
 - in an account-type service, you might need to tell the user that there’s a deadline approaching or that a payment is overdue
 
-{{ example({ group: "components", item: "notification-banner", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 ## Reacting to something the user has done
 
@@ -77,7 +78,7 @@ Using a notification banner is unlikely to be the right approach in a linear ser
 
 Use the green version of the notification banner to confirm that something they’re expecting to happen has happened.
 
-{{ example({ group: "components", item: "notification-banner", example: "success", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "success", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 Since you’re using the notification banner to tell the user about the outcome of something they’ve just done, add `role="alert"` so focus shifts to the notification banner on page load.
 

--- a/src/components/pagination/index.md
+++ b/src/components/pagination/index.md
@@ -2,6 +2,7 @@
 title: Pagination
 description: Help users navigate collections of numbered pages like search results
 section: Components
+item: pagination
 aliases:
 backlogIssueId: 77
 layout: layout-pane.njk
@@ -11,7 +12,7 @@ layout: layout-pane.njk
 
 Help users navigate forwards and backwards through a series of pages. For example, search results or guidance that's divided into multiple website pages – like [the GOV.UK mainstream guide format](https://prototype-kit.service.gov.uk/docs/templates/mainstream-guide).
 
-{{ example({ group: "components", item: "pagination", example: "default", html: true, nunjucks: true, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -44,13 +45,13 @@ Use the 'block' style of pagination to let users navigate through related conten
 
 You can use link labels to give context on what the neighbouring pages are about.
 
-{{ example({ group: "components", item: "pagination", example: "for-content-pages", html: true, nunjucks: true }) }}
+{{ example({ group: "components", item: item, example: "for-content-pages", html: true, nunjucks: true }) }}
 
 ## For navigating between pages of items
 
 Use a list-type layout if users need to navigate through pages of similar items. For example, a list of search results or a list of cases in a case working system.
 
-{{ example({ group: "components", item: "pagination", example: "for-list-pages", html: true, nunjucks: true }) }}
+{{ example({ group: "components", item: item, example: "for-list-pages", html: true, nunjucks: true }) }}
 
 Show the page number in the page `<title>` so that screen reader users know they’ve navigated to a different page. For example, 'Search results (page 1 of 4)'.
 
@@ -83,9 +84,9 @@ Use ellipses (…) to replace any skipped pages. For example:
 
 Do not show the previous page link on the first page – and do not show the next page link on the last page.
 
-{{ example({ group: "components", item: "pagination", example: "first-page", html: true, nunjucks: true }) }}
+{{ example({ group: "components", item: item, example: "first-page", html: true, nunjucks: true }) }}
 
-{{ example({ group: "components", item: "pagination", example: "last-page", html: true, nunjucks: true }) }}
+{{ example({ group: "components", item: item, example: "last-page", html: true, nunjucks: true }) }}
 
 ### Filtering and sorting
 

--- a/src/components/panel/index.md
+++ b/src/components/panel/index.md
@@ -2,6 +2,7 @@
 title: Panel
 description: The panel component is a visible container used on confirmation or results pages
 section: Components
+item: panel
 aliases: confirmation box, results box, reference number, application complete, application number
 backlogIssueId: 55
 layout: layout-pane.njk
@@ -10,7 +11,7 @@ layout: layout-pane.njk
 {% from "_example.njk" import example %}
 
 The panel component is a visible container used on confirmation or results pages to highlight important content.
-{{ example({ group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -26,7 +27,7 @@ Never use the panel component to highlight important information within body con
 
 There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
 
 ### How to write panel text
 

--- a/src/components/password-input/index.md
+++ b/src/components/password-input/index.md
@@ -2,6 +2,7 @@
 title: Password input
 description: Help users accessibly enter passwords
 section: Components
+item: password-input
 aliases: pass word, pass phrase
 backlogIssueId: 240
 layout: layout-pane.njk
@@ -36,7 +37,7 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
   classes: "app-inset-text"
 }) }}
 
-{{ example({ group: "components", item: "password-input", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -64,7 +65,7 @@ This allows users to visually check their password before they submit it, which 
 
 ### Error messages
 
-{{ example({ group: "components", item: "password-input", example: "error", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "error", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 If the user enters their account details incorrectly, do not reveal whether they got the username or password wrong. Clear any information entered into the password input.
 

--- a/src/components/phase-banner/index.md
+++ b/src/components/phase-banner/index.md
@@ -2,6 +2,7 @@
 title: Phase banner
 description: Use the phase banner component to show users your service is still being worked on
 section: Components
+item: phase-banner
 aliases: alpha banner, beta banner, prototype banner, status banner, feedback banner
 backlogIssueId: 57
 layout: layout-pane.njk
@@ -34,7 +35,7 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
   classes: "app-inset-text"
 }) }}
 
-{{ example({ group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -60,9 +61,9 @@ Your banner must be directly under the black GOV.UK header and colour bar.
 
 Use a ‘feedback’ link to collect on-page feedback about your service. This can open an email or take the user to a dedicated page or form.
 
-{{ example({ group: "components", item: "phase-banner", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
-{{ example({ group: "components", item: "phase-banner", example: "beta", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "beta", html: true, nunjucks: true, open: false }) }}
 
 Whatever option you use, make sure that users do not lose their place in the service and can return to the page they were on.
 

--- a/src/components/radios/index.md
+++ b/src/components/radios/index.md
@@ -2,6 +2,7 @@
 title: Radios
 description: Let users select a single option from a list using the radios component
 section: Components
+item: radios
 aliases: radio buttons, option buttons
 backlogIssueId: 59
 layout: layout-pane.njk
@@ -9,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({ group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -50,13 +51,13 @@ Read more about [why and how to set legends as headings](/get-started/labels-leg
 
 There are 2 ways to use the radios component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "radios", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 ### If you’re asking more than one question on the page
 
 If you're asking more than one question on the page, do not set the contents of the `<legend>` as the page heading. Read more about [asking multiple questions on question pages](/patterns/question-pages/#asking-multiple-questions-on-a-page).
 
-{{ example({ group: "components", item: "radios", example: "without-heading", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "without-heading", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Inline radios
 
@@ -69,19 +70,19 @@ Only use inline radios when:
 
 Remember that on small screens such as mobile devices, the radios will still be 'stacked' on top of one another (vertically).
 
-{{ example({ group: "components", item: "radios", example: "inline", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "inline", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Radio items with hints
 
 You can add hints to radio items to provide additional information about the options.
 
-{{ example({ group: "components", item: "radios", example: "hint", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "hint", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Radio items with a text divider
 
 If one or more of your radio options is different from the others, it can help users if you separate them using a text divider. The text is usually the word ‘or’.
 
-{{ example({ group: "components", item: "radios", example: "divider", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "divider", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Conditionally revealing a related question
 
@@ -89,7 +90,7 @@ You can ask the user a related question when they select a particular radio opti
 
 This might make two related questions easier to answer by grouping them on the same page. For example, you could reveal a phone number input when the user selects the 'Contact me by phone' option.
 
-{{ example({ group: "components", item: "radios", example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl" }) }}
+{{ example({ group: "components", item: item, example: "conditional-reveal", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 Keep it simple. If the related question is complicated or has more than one part, show it on the next page in the process instead.
 
@@ -111,7 +112,7 @@ Use standard-sized radios in nearly all cases. However, smaller versions work we
 
 For example, on a page of search results, the primary user need is to see the results. Using smaller radios lets users see and change search filters without distracting them from the main content.
 
-{{ example({ group: "components", item: "radios", example: "small", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "small", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 Small radios can work well on information dense screens in services designed for repeat use, like caseworking systems.
 
@@ -126,7 +127,7 @@ Display an error message if the user has not:
 
 Error messages should be styled like this:
 
-{{ example({ group: "components", item: "radios", example: "error", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "error", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 
@@ -146,7 +147,7 @@ Say ‘Select [whatever it is]’. For example, ‘Select the day of the week yo
 
 Include an [error message](/components/error-message/) that is clearly related to the initial question.
 
-{{ example({ group: "components", item: "radios", example: "conditional-reveal-error", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "conditional-reveal-error", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ## Research on this component
 

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -2,6 +2,7 @@
 title: Select
 description: Help users select an item from a list
 section: Components
+item: select
 aliases: drop down menu, list box, drop down list, combo box, pop-up menu
 backlogIssueId: 60
 layout: layout-pane.njk
@@ -32,7 +33,7 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
   classes: "app-inset-text"
 }) }}
 
-{{ example({ group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -52,13 +53,13 @@ If you use the component for questions, you should not pre-select any of the opt
 
 There are 2 ways to use the select component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "select", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 ### Select with hint
 
 You can add hint text to help the user understand the options and choose one of them.
 
-{{ example({ group: "components", item: "select", example: "with-hint", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "with-hint", html: true, nunjucks: true, open: false }) }}
 
 ### Error messages
 
@@ -66,7 +67,7 @@ Display an error message if the user has not selected an option.
 
 Style error messages as shown in the example:
 
-{{ example({ group: "components", item: "select", example: "error", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "error", html: true, nunjucks: true, open: false }) }}
 
 ### Avoid adding functionality to allow selecting multiple options
 

--- a/src/components/skip-link/index.md
+++ b/src/components/skip-link/index.md
@@ -2,6 +2,7 @@
 title: Skip link
 description: Use the skip link component to help keyboard-only users skip to the main content on a page
 section: Components
+item: skip-link
 aliases: Skip navigation link
 backlogIssueId: 66
 layout: layout-pane.njk
@@ -11,7 +12,7 @@ layout: layout-pane.njk
 
 Use the skip link component to help keyboard-only users skip to the main content on a page.
 
-{{ example({ group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 If you use the page template, you'll also get the skip link without having to add it, as it's included by default. However, if you want to customise the default skip link, read the [page template guidance about customising components](/styles/page-template/#changing-template-content).
 
@@ -31,4 +32,4 @@ The skip link component is visually hidden until a keyboard press activates it.
 
 There are 2 ways to use the skip link component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "skip-link", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}

--- a/src/components/summary-list/index.md
+++ b/src/components/summary-list/index.md
@@ -2,6 +2,7 @@
 title: Summary list
 description: Use the summary list to summarise information, for example, a user’s responses at the end of a form.
 section: Components
+item: summary-list
 aliases: Summary card
 backlogIssueId: 182
 layout: layout-pane.njk
@@ -35,7 +36,7 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
   classes: "app-inset-text"
 }) }}
 
-{{ example({ group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -62,7 +63,7 @@ You can show a single or multiple summary lists on a page. If you’re showing m
 
 There are 2 ways to use the summary list component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "summary-list", example: "without-actions", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "without-actions", html: true, nunjucks: true, open: false }) }}
 
 ### Adding actions to each row
 
@@ -93,13 +94,13 @@ Assistive technology users, including those who use a screen reader, might hear 
 
 To give more context, add visually hidden text to the links. This means a screen reader user will hear the row action and the ‘key’ label for the information it will affect, like ‘Change name’ or ‘Change date of birth’.
 
-{{ example({ group: "components", item: "summary-list", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 #### Showing rows with and without actions
 
 If you’re showing a mix of rows (where some rows include actions and some do not), add the `govuk-summary-list__row--no-actions` modifier class to the rows without actions. This is to ensure the bottom border is drawn correctly in some browsers.
 
-{{ example({ group: "components", item: "summary-list", example: "mixed-actions", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "mixed-actions", html: true, nunjucks: true, open: false }) }}
 
 ### Removing the borders
 
@@ -109,7 +110,7 @@ Think carefully before you remove row borders. Borders help many users find and 
 
 If your summary list does not have any actions, you can choose to remove the separating borders with the `govuk-summary-list--no-border` class.
 
-{{ example({ group: "components", item: "summary-list", example: "without-borders", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "without-borders", html: true, nunjucks: true, open: false }) }}
 
 To remove borders on a single row, use the `govuk-summary-list__row--no-border` class.
 
@@ -122,7 +123,7 @@ In some contexts, you might need to show rows that have missing information. Thi
 
 Show a link to the appropriate question page in the `value` column so the user can enter the missing information, instead of showing a 'change' link on that row.
 
-{{ example({ group: "components", item: "summary-list", example: "with-missing-information", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "with-missing-information", html: true, nunjucks: true, open: false }) }}
 
 ## Summary cards
 
@@ -147,7 +148,7 @@ Each title must be unique and help identify what the summary list describes. For
 
 Try to keep titles short and relevant. You can use one or two important values in the summary list – such as the first and last name of a person.
 
-{{ example({ group: "components", item: "summary-list", example: "card-with-title", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "card-with-title", html: true, nunjucks: true, open: false }) }}
 
 ### Adding card actions
 
@@ -171,7 +172,7 @@ Keep it short and do not add more than 2 to 3 actions in a header.
 
 If a card action cannot easily be undone or might have serious consequences, consider adding a warning or asking the user for confirmation.
 
-{{ example({ group: "components", item: "summary-list", example: "card-with-actions", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "card-with-actions", html: true, nunjucks: true, open: false }) }}
 
 ## Research on this component
 

--- a/src/components/table/index.md
+++ b/src/components/table/index.md
@@ -2,6 +2,7 @@
 title: Table
 description: Use the table component to make information easier to compare and scan for users
 section: Components
+item: table
 aliases:
 backlogIssueId: 61
 layout: layout-pane.njk
@@ -13,7 +14,7 @@ layout: layout-pane.njk
 
 Use the table component to make information easier to compare and scan for users.
 
-{{ example({ group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -31,7 +32,7 @@ Use the `<caption>` element to describe a table in the same way you would use a 
 
 There are other styling options for table captions. You can use `govuk-table__caption--s`, `govuk-table__caption--m`, `govuk-table__caption--l` and `govuk-table__caption--xl` classes to make them larger or smaller from the default.
 
-{{ example({ group: "components", item: "table", example: "caption-l", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "caption-l", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ### Table headers
 
@@ -39,25 +40,25 @@ Use table headers to tell users what the rows and columns represent. Use the `sc
 
 There are 2 ways to use the table component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "table", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
 
 ## Numbers in a table
 
 When comparing columns of numbers, align the numbers to the right in table cells.
 
-{{ example({ group: "components", item: "table", example: "numbers", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "numbers", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ## Custom column widths
 
 You can use the [width override classes](/styles/layout/#width-override-classes) to set the width of table columns.
 
-{{ example({ group: "components", item: "table", example: "column-widths", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "column-widths", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 If the [width override classes](/styles/layout/#width-override-classes) do not meet your needs you can create your own width classes and apply them to the cells in the table head. These can be added using the `classes` option in the Nunjucks macro or adding the class directly to the individual cells within `govuk-table__head` as below.
 
 To learn more about this, read guidance on [extending and modifying components in production](/get-started/extending-and-modifying-components/).
 
-{{ example({ group: "components", item: "table", example: "column-widths-custom-classes", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "column-widths-custom-classes", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 ## Tables with a lot of data
 
@@ -71,4 +72,4 @@ If you cannot split your data, you can use the CSS class `govuk-table--small-tex
 
 You should not use this class on tables unless your table has a lot of data, because a smaller amount of data is easier to read if the text is larger.
 
-{{ example({ group: "components", item: "table", example: "lots-of-data", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "lots-of-data", html: true, nunjucks: true, open: false, size: "m" }) }}

--- a/src/components/tabs/index.md
+++ b/src/components/tabs/index.md
@@ -2,6 +2,7 @@
 title: Tabs
 description: Tabs can be a helpful way of letting users quickly switch between related information
 section: Components
+item: tabs
 aliases:
 backlogIssueId: 100
 layout: layout-pane.njk
@@ -11,7 +12,7 @@ layout: layout-pane.njk
 
 The tabs component lets users navigate between related sections of content, displaying one section at a time.
 
-{{ example({ group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -56,7 +57,7 @@ If you decide to use one of these components, consider if:
 
 There are 2 ways to use the tabs component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "tabs", example: "default", html: true, nunjucks: true, open: false, size: "xl", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "xl", titleSuffix: "second" }) }}
 
 The tabs component uses JavaScript. When JavaScript is not available, users will see the tabbed content on a single page, in order from first to last, with a table of contents that links to each of the sections.
 

--- a/src/components/tag/index.md
+++ b/src/components/tag/index.md
@@ -2,6 +2,7 @@
 title: Tag
 description: The tag component indicates the status of something, such as an item on a task list or a phase banner
 section: Components
+item: tag
 aliases: chip, badge, flag, token
 backlogIssueId: 62
 layout: layout-pane.njk
@@ -34,7 +35,7 @@ See the full list of [components and patterns affected by WCAG 2.2](/accessibili
   classes: "app-inset-text"
 }) }}
 
-{{ example({ group: "components", item: "tag", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -59,13 +60,13 @@ The [complete multiple tasks pattern](/patterns/complete-multiple-tasks/) has an
 
 Or it can make sense to have two statuses. For example you may find that there’s a need to have one tag for ‘Active’ users and one for ‘Inactive’ users.
 
-{{ example({ group: "components", item: "tag", example: "multiple-tags", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "multiple-tags", html: true, nunjucks: true, open: false }) }}
 
 ## Showing multiple statuses
 
 Tags should be helpful to users. The more you add, the harder it is for users to remember them. So start with the smallest number of statuses you think might work, then add more if your user research shows there’s a need for them.
 
-{{ example({ group: "components", item: "tag", example: "coloured-tags", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "coloured-tags", html: true, nunjucks: true, open: false }) }}
 
 <div class="app-wcag-22" id="wcag-tag-no-dragging-reorder" role="note">
   {{ govukTag({
@@ -85,7 +86,7 @@ You can use colour to help distinguish between different tags – or to help dra
 
 If you need more tag colours, you can use the following colours.
 
-{{ example({ group: "components", item: "tag", example: "all-colours", html: true, nunjucks: true, open: false }) }}
+{{ example({ group: "components", item: item, example: "all-colours", html: true, nunjucks: true, open: false }) }}
 
 ## Research on this component
 

--- a/src/components/task-list/index.md.njk
+++ b/src/components/task-list/index.md.njk
@@ -2,6 +2,7 @@
 title: Task list
 description: The task list component displays all the tasks a user needs to do, and allows users to easily identify which ones are done and which they still need to do.
 section: Components
+item: task-list
 aliases:
 backlogIssueId: 72
 layout: layout-pane.njk
@@ -11,7 +12,7 @@ layout: layout-pane.njk
 
 The task list component displays all the tasks a user needs to do, and allows users to easily identify which ones are done and which they still need to do.
 
-{{ example({ group: "components", item: "task-list", example: "default", id: "default-1", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", id: "default-1", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -34,7 +35,7 @@ The task list should not be used as a way of showing users their answers. For th
 
 There are 2 ways to use the task list component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "task-list", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 Users should be able to complete tasks in whatever order they like.
 

--- a/src/components/text-input/index.md
+++ b/src/components/text-input/index.md
@@ -2,6 +2,7 @@
 title: Text input
 description: Help users enter information with the text input component
 section: Components
+item: text-input
 aliases: text box, text field, input field, text entry box
 backlogIssueId: 51
 layout: layout-pane.njk
@@ -9,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({ group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -41,13 +42,13 @@ Read more about [why and how to set legends as headings](/get-started/labels-leg
 
 There are 2 ways to use the text input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second" }) }}
 
 ### If you’re asking more than one question on the page
 
 If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking multiple questions on question pages](/patterns/question-pages/#asking-multiple-questions-on-a-page).
 
-{{ example({ group: "components", item: "text-input", example: "without-heading", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "without-heading", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Use appropriately-sized text inputs
 
@@ -65,7 +66,7 @@ The widths are designed for specific character lengths and to be consistent acro
 
 On fixed width inputs, the width will remain fixed on all screens unless it is wider than the viewport, in which case it will shrink to fit.
 
-{{ example({ group: "components", item: "text-input", example: "input-fixed-width", html: true, nunjucks: true, open: false, size: "l" }) }}
+{{ example({ group: "components", item: item, example: "input-fixed-width", html: true, nunjucks: true, open: false, size: "l" }) }}
 
 #### Fluid width inputs
 
@@ -73,13 +74,13 @@ Use the width override classes to reduce the width of an input in relation to it
 
 Fluid width inputs will resize with the viewport.
 
-{{ example({ group: "components", item: "text-input", example: "input-fluid-width", html: true, nunjucks: true, open: false, size: "xl" }) }}
+{{ example({ group: "components", item: item, example: "input-fluid-width", html: true, nunjucks: true, open: false, size: "xl" }) }}
 
 ### Hint text
 
 Use hint text for help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
-{{ example({ group: "components", item: "text-input", example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 #### When not to use hint text
 
@@ -99,7 +100,7 @@ If you're asking the user to enter a whole number, set the `inputmode` attribute
 
 See how to do this by opening the HTML and Nunjucks tabs in this example:
 
-{{ example({ group: "components", item: "text-input", example: "number-input", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "number-input", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 There is specific guidance on how to ask for:
 
@@ -112,7 +113,7 @@ If you're asking the user to enter a number that might include decimal places, u
 
 Do not set the `inputmode` attribute to `decimal` as it causes some devices to bring up a keypad without a key for the decimal separator.
 
-{{ example({ group: "components", item: "text-input", example: "decimal-input", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "decimal-input", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 #### Avoid using inputs with a type of number
 
@@ -124,7 +125,7 @@ Help the user visually check the code they've typed is correct by styling the in
 
 You do not need to do this for memorable information, such as phone numbers and postcodes.
 
-{{ example({ group: "components", item: "text-input", example: "code-sequence", html: true, nunjucks: true, open: false, size: "m" }) }}
+{{ example({ group: "components", item: item, example: "code-sequence", html: true, nunjucks: true, open: false, size: "m" }) }}
 
 There is specific guidance on how to:
 
@@ -136,7 +137,7 @@ There is specific guidance on how to:
 
 Use prefixes and suffixes to help users enter things like currencies and measurements.
 
-{{ example({ group: "components", item: "text-input", example: "input-prefix-suffix", html: true, nunjucks: true, closed: true, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "input-prefix-suffix", html: true, nunjucks: true, closed: true, size: "s" }) }}
 
 Prefixes and suffixes are useful when there's a commonly understood symbol or abbreviation for the type of information you're asking for. Do not rely on prefixes or suffixes alone, because screen readers will not read them out.
 
@@ -148,11 +149,11 @@ Some users may miss that the input already has a suffix or prefix, and enter a p
 
 #### Text inputs with a prefix
 
-{{ example({ group: "components", item: "text-input", example: "input-prefix", html: true, nunjucks: true, closed: true, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "input-prefix", html: true, nunjucks: true, closed: true, size: "s" }) }}
 
 #### Text inputs with a suffix
 
-{{ example({ group: "components", item: "text-input", example: "input-suffix", html: true, nunjucks: true, closed: true, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "input-suffix", html: true, nunjucks: true, closed: true, size: "s" }) }}
 
 ### Use the autocomplete attribute
 
@@ -160,7 +161,7 @@ Use the `autocomplete` attribute on text inputs to help users complete forms mor
 
 For example, to enable autofill on a postcode field, set the `autocomplete` attribute to `postal-code`. See how to do this in the HTML and Nunjucks tabs in the following example.
 
-{{ example({ group: "components", item: "text-input", example: "input-autocomplete-attribute", displayExample: false, html: true, nunjucks: true, open: true, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "input-autocomplete-attribute", displayExample: false, html: true, nunjucks: true, open: true, size: "s" }) }}
 
 If you are working in production and there is a relevant [input purpose](https://www.w3.org/TR/WCAG21/#input-purposes), you'll need to use the `autocomplete` attribute to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
 
@@ -188,7 +189,7 @@ If you are asking users for information which is not appropriate to spellcheck, 
 
 To do this set the `spellcheck` attribute to `false` as shown in this example.
 
-{{ example({ group: "components", item: "text-input", example: "input-spellcheck-disabled", html: true, nunjucks: true, displayExample: false, open: true, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "input-spellcheck-disabled", html: true, nunjucks: true, displayExample: false, open: true, size: "s" }) }}
 
 Browsers do not consistently spellcheck user’s input by default. If you are asking a question where spellcheck would be useful, set the `spellcheck` attribute to `true`.
 
@@ -196,11 +197,11 @@ Browsers do not consistently spellcheck user’s input by default. If you are as
 
 Error messages should be styled like this:
 
-{{ example({ group: "components", item: "text-input", example: "error", html: true, nunjucks: true, closed: true, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "error", html: true, nunjucks: true, closed: true, size: "s" }) }}
 
 #### If the input has a prefix or a suffix
 
-{{ example({ group: "components", item: "text-input", example: "input-prefix-suffix-error", html: true, nunjucks: true, closed: true, size: "s" }) }}
+{{ example({ group: "components", item: item, example: "input-prefix-suffix-error", html: true, nunjucks: true, closed: true, size: "s" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/components/textarea/index.md
+++ b/src/components/textarea/index.md
@@ -2,6 +2,7 @@
 title: Textarea
 description: Help users provide detailed information using the textarea component
 section: Components
+item: textarea
 aliases: multi-line text box, multi-line text field
 backlogIssueId: 65
 layout: layout-pane.njk
@@ -9,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({ group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
@@ -31,13 +32,13 @@ Labels must be aligned above the textarea they refer to. They should be short, d
 
 There are 2 ways to use the textarea component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "textarea", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
 
 ### Use appropriately-sized textareas
 
 Make the height of a textarea proportional to the amount of text you expect users to enter. You can set the height of a textarea by by specifying the `rows` attribute.
 
-{{ example({ group: "components", item: "textarea", example: "specifying-rows", html: true, nunjucks: true, open: false, size: "l" }) }}
+{{ example({ group: "components", item: item, example: "specifying-rows", html: true, nunjucks: true, open: false, size: "l" }) }}
 
 ### Do not disable copy and paste
 
@@ -47,7 +48,7 @@ Users will often need to copy and paste information into a textarea, so do not s
 
 If you're asking more than one question on the page, do not set the contents of the `<label>` as the page heading. Read more about [asking multiple questions on question pages](/patterns/question-pages/#asking-multiple-questions-on-a-page).
 
-{{ example({ group: "components", item: "textarea", example: "without-heading", html: true, nunjucks: true, open: false, size: "l" }) }}
+{{ example({ group: "components", item: item, example: "without-heading", html: true, nunjucks: true, open: false, size: "l" }) }}
 
 ### Limiting the number of characters
 
@@ -57,7 +58,7 @@ If there’s a good reason to limit the number of characters users can enter, yo
 
 Error messages should be styled like this:
 
-{{ example({ group: "components", item: "textarea", example: "error", html: true, nunjucks: true, open: false, size: "l" }) }}
+{{ example({ group: "components", item: item, example: "error", html: true, nunjucks: true, open: false, size: "l" }) }}
 
 Make sure errors follow the guidance in [error message](/components/error-message/) and have specific error messages for specific error states.
 

--- a/src/components/warning-text/index.md
+++ b/src/components/warning-text/index.md
@@ -2,6 +2,7 @@
 title: Warning text
 description: Use the warning text component when you need to warn users about something important, such as legal consequences of an action, or lack of action, that they might take
 section: Components
+item: warning-text
 aliases: important text, legal text
 backlogIssueId: 71
 layout: layout-pane.njk
@@ -9,7 +10,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-{{ example({ group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 
@@ -19,6 +20,6 @@ Use the warning text component when you need to warn users about something impor
 
 There are 2 ways to use the warning text component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
-{{ example({ group: "components", item: "warning-text", example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
+{{ example({ group: "components", item: item, example: "default", html: true, nunjucks: true, open: false, titleSuffix: "second" }) }}
 
 You might need to rewrite the hidden text (‘Warning’ in the example) to make it appropriate for your context.

--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -1,6 +1,12 @@
 /* eslint-disable no-new */
 
-import { createAll, Button, NotificationBanner, SkipLink } from 'govuk-frontend'
+import {
+  createAll,
+  Accordion,
+  Button,
+  NotificationBanner,
+  SkipLink
+} from 'govuk-frontend'
 
 import { loadAnalytics } from './components/analytics.mjs'
 import BackToTop from './components/back-to-top.mjs'
@@ -19,6 +25,7 @@ import Search from './components/search.mjs'
 import AppTabs from './components/tabs.mjs'
 
 // Initialise GOV.UK Frontend
+createAll(Accordion)
 createAll(Button)
 createAll(NotificationBanner)
 createAll(SkipLink)

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -6,6 +6,7 @@ $govuk-new-typography-scale: true;
 @import "govuk/core";
 @import "govuk/objects";
 
+@import "govuk/components/accordion";
 @import "govuk/components/back-link";
 @import "govuk/components/breadcrumbs";
 @import "govuk/components/button";

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -52,6 +52,8 @@
         {{ contents | safe }}
       </div>
 
+      {% include "_nunjucks-params.njk" %}
+
       {# No JS fallback to show overview #}
       {% if showSubNav %}
         {% include "_category-nav.njk" %}

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -79,73 +79,9 @@
       <div class="app-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
     {% endif -%}
     <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-nunjucks" role="tabpanel">
-      {%- if (params.group == 'components') %}
-        {% set macroOptions = getMacroOptions(params.item) %}
-
-        {% set macroOptionsHTML %}
-          <p>
-          Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
-          </p>
-          <p>
-          Some options are required for the macro to work; these are marked as "Required" in the option description.
-          </p>
-          <p>
-          If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must sanitise the HTML to protect against  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting exploits</a>.
-          </p>
-          {% for table in macroOptions %}
-            <table class="govuk-table app-options__table" id="options-{{ exampleId }}--{{ table.slug }}">
-              <caption class="govuk-table__caption govuk-heading-m {% if table.slug == 'primary' %} govuk-visually-hidden{% endif %}">{{ table.name | safe }}</caption>
-              <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                  <th class="govuk-table__header app-options__limit-table-cell" scope="col">Name</th>
-                  <th class="govuk-table__header app-options__limit-table-cell" scope="col">Type</th>
-                  <th class="govuk-table__header" scope="col">Description</th>
-                </tr>
-              </thead>
-              <tbody class="govuk-table__body">
-                {% for option in table.options -%}
-                  {# Option name only, without parent prefix -#}
-                  {% set optionName = option.name.split(" ") | last %}
-                  <tr class="govuk-table__row">
-                    <th class="govuk-table__header" scope="row">{{ optionName | safe }}</th>
-                    <td class="govuk-table__cell">{{ option.type }}</td>
-                    <td class="govuk-table__cell">
-                    {% if (option.required) %}
-                      <strong>Required.</strong>
-                    {% endif %}
-                      {{ option.description | safe }}
-                    {% if (option.params) or (option.isComponent and ["hint", "label"].includes(option.id)) %}
-                      {% if option.isComponent and not ["hint", "label"].includes(option.id) %}
-                        {# Link to subset of Nunjucks macro options table and Design System component page -#}
-                        See supported <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name | safe }}</a> options for <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ optionName | safe }}</a>.
-                      {% else %}
-                        {# Link to Nunjucks macro options table only -#}
-                        See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name | safe }}</a>.
-                      {% endif %}
-                    {% elif option.isComponent %}
-                      {# Link to Design System component page for nested components -#}
-                      See <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ optionName | safe }}</a>.
-                    {% endif %}
-                    </td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          {% endfor %}
-
-        {%- endset %}
-
-        {%- from "govuk/components/details/macro.njk" import govukDetails %}
-
-        {{- govukDetails({
-          summaryHtml: '<span data-components="github-component-arguments">Nunjucks macro options</span>',
-          html: macroOptionsHTML,
-          classes: "app-options",
-          attributes:{
-            id: "options-" + exampleId + "-details"
-          }
-        })}}
-      {% endif -%}
+      {%- if ["Components"].includes(section) %}
+      <p><a href="#nunjucks-options"> Nunjucks options for this component</a></p>
+      {%- endif %}
       <div class="app-example__code" data-module="app-copy">
 
 ```njk

--- a/views/partials/_nunjucks-params.njk
+++ b/views/partials/_nunjucks-params.njk
@@ -1,0 +1,81 @@
+{% if ["Components"].includes(section) %}
+  {% from "govuk/components/accordion/macro.njk" import govukAccordion %}
+
+  {% set macroOptions = getMacroOptions(item) %}
+  {% set accordionSections = [] %}
+
+  {# Utility macro for holding all the table code #}
+  {% macro _paramTable(table) %}
+  <table class="govuk-table app-options__table" id="options--{{ table.slug }}">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header app-options__limit-table-cell" scope="col">Name</th>
+        <th class="govuk-table__header app-options__limit-table-cell" scope="col">Type</th>
+        <th class="govuk-table__header" scope="col">Description</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      {% for option in table.options -%}
+        {# Option name only, without parent prefix -#}
+        {% set optionName = option.name.split(" ") | last %}
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="row">{{ optionName | safe }}</th>
+          <td class="govuk-table__cell">{{ option.type }}</td>
+          <td class="govuk-table__cell">
+          {% if (option.required) %}
+            <strong>Required.</strong>
+          {% endif %}
+            {{ option.description | safe }}
+          {% if (option.params) or (option.isComponent and ["hint", "label"].includes(option.id)) %}
+            {% if option.isComponent and not ["hint", "label"].includes(option.id) %}
+              {# Link to subset of Nunjucks macro options table and Design System component page -#}
+              See supported <a href="#options--{{ option.slug }}">{{ option.name | safe }}</a> options for <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ optionName | safe }}</a>.
+            {% else %}
+              {# Link to Nunjucks macro options table only -#}
+              See <a href="#options--{{ option.slug }}">{{ option.name | safe }}</a>.
+            {% endif %}
+          {% elif option.isComponent %}
+            {# Link to Design System component page for nested components -#}
+            See <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ optionName | safe }}</a>.
+          {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endmacro %}
+
+  <h2 class="govuk-heading-l govuk-!-padding-top-7" id="nunjucks-options">Nunjucks options for this component</h2>
+  <div class="app-prose-scope">
+    <p>Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.</p>
+    <p>Some options are required for the macro to work; these are marked as "Required" in the option description.</p>
+    <p>If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must sanitise the HTML to protect against  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting exploits</a>.</p>
+
+    {# If there is only one table, just output it to the page #}
+    {% if macroOptions.length === 1 %}
+      {{ _paramTable(macroOptions[0]) }}
+
+    {# Otherwise, loop through them all and build out an accordion #}
+    {% else %}
+      {% for table in macroOptions %}
+        {% set tableName %}{{ table.name | safe }}{% endset %}
+        {% set tableHtml %}
+          {{ _paramTable(table) }}
+        {% endset %}
+
+        {# Push content into an array, formatted as needed by the accordion #}
+        {% set accordionSections = (accordionSections.push({
+          heading: { html: tableName },
+          content: { html: tableHtml }
+        }), accordionSections)%}
+      {% endfor %}
+
+      {{ govukAccordion({
+        id: "nunjucks-options-accordion",
+        headingLevel: 3,
+        rememberExpanded: false,
+        items: accordionSections
+      }) }}
+    {% endif %}
+  </div>
+{% endif %}


### PR DESCRIPTION
Currently, Nunjucks macro parameter tables are listed alongside every Nunjucks code example that appears on the page. This leads to fairly a significant duplication of code/content on any component guidance that has more than one example.

This PR looks into moving those tables to be standalone within the page, de-duplicating them in the process.

There was a bit of busywork involved in updating the front matter for all of the component guidance changes. For ease of review, all of the functional changes are in a97e3090f2461e7bf8bd1cf74eeeac152df2a64a. 

## Changes
- Moves parameter table generation code into its own partial, separate from the example partial.
- Updates the layout so that the parameter tables are inserted automatically if the current page about a component.
- Add some new logic so that if there is more than one parameter table to show, they are rendered as an accordion. Otherwise, the table is rendered directly on the page.
- Adds a link to examples where the Nunjucks parameters used to be listed, now linking to the parameters section of the page.
- Updates all of the component pages to have a global `item` value set, used by both examples and parameter tables. 

## Todo
- Tests haven't been updated to account for this change yet.
- The link from examples to the Nunjucks parameter section is currently broken. 

## Thoughts
- The placement of the tables doesn't seem ideal (being nestled between 'Research' and 'Help improve' on most pages). This is a consequence of having the partial be automatically inserted after the individually authored guidance. We could move it up, but doing that would mean duplicating the partial's `include` on each of the guidance pages.
- This doesn't completely remove the use of `details` from the Design System site, as it's also used on the font sizes guidance page.