### PR TITLE
Adjust code colours to have minimum 7:1 contrast

### DIFF
--- a/src/stylesheets/components/_highlight.scss
+++ b/src/stylesheets/components/_highlight.scss
@@ -18,12 +18,12 @@
 .hljs-variable,
 .hljs-template-variable,
 .hljs-tag .hljs-attr {
-  color: #00703c;
+  color: #055f03;
 }
 
 .hljs-string,
 .hljs-doctag {
-  color: #d13118;
+  color: #9b2412;
 }
 
 .hljs-title,

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -42,7 +42,7 @@ $govuk-new-typography-scale: true;
 
 // App-specific variables
 $app-light-grey: #f8f8f8;
-$app-code-color: #d13118;
+$app-code-color: #9b2412;
 
 // App-specific components
 @import "components/back-to-top";


### PR DESCRIPTION
Changes the shades of red and green used in code blocks to ensure a minimum 7:1 contrast on a light grey background, satisfying WCAG Level AAA. Resolves https://github.com/alphagov/govuk-design-system/issues/4012.

## Changes
- Changes the red and green colours used within inline `code` and Highlight.js to have a minimum 7:1 contrast ratio with light grey.

## Thoughts
- Not sure I like this, personally. Large code blocks look a lot more 'muddy' now, with many colours looking similar enough to black or dark grey that it feels rather ineffective at the actual syntax highlighting aspect.
- We don't guarantee that the Design System website meets Level AAA. The old colours were already compliant with Level AA, so we're under no obligation to change this.
- This change aims to maintain the existing palette with minimal changes and didn't explore more significant changes, such as changing all colours within highlighted code.