### PR TITLE
Add visually hidden text between section and page in search result section info

### DIFF
--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -7,7 +7,7 @@ module.exports = function lunrPlugin() {
     const outputPath = 'search-index.json'
 
     const separator =
-      '<span class="app-site-search__separator" aria-hidden="true">›</span>'
+      '<span class="govuk-visually-hidden">, in page</span><span class="app-site-search__separator" aria-hidden="true">›</span>'
 
     const includedSections = navigationConfig
       .filter((section) => !section.ignoreInSearch)

--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -242,5 +242,7 @@ $icon-size: 40px;
 .app-site-search__separator {
   display: inline-block;
   margin-right: govuk-spacing(1);
-  margin-left: govuk-spacing(1);
+  // Unfortunate magic number here to account for the non-breaking space created
+  // by visually hidden spans being moved onto new lines in the result markup
+  margin-left: 4px;
 }


### PR DESCRIPTION
## What
Adds a visually hidden span containing ', in page' before the `app-site-search__separator` span and adjusts styling of the separator to account for the extra markup spacing.

## Why
This is an offshoot from https://github.com/alphagov/govuk-design-system/issues/4006. Whilst we've resolved the relationship between search result and section info, testing for that solution outlined the same problem between search info where the search result was a heading within a page and so the search info was '[section] > [page]' eg: The searh info for result 'Responsive spacing' is 'Styles > Spacing'.

This solution replicates in part the solution between result and ifo where a comma is added, with extra visually hidden content for context.
[
Testing spreadsheet](https://docs.google.com/spreadsheets/d/1X7mWc89XiCzuh9G1S9wS59j4SRJVOU0B1pe_uOj5aTE/edit?gid=0#gid=0)

## Notes
the space between the section and the comma is a pain. This is a result of the spans that make up search item markup being moved onto their own lines. There's not a lot we can do about it and I personally don't think it's a huge issue, even though it's bothersome.

The magic number added here is similarly annoying.

I'm interested in opinions on if the visually hidden text is necessary. I think some extra context might be useful to screen readers, but just a comma is as effective in separating the section and page.