### PR TITLE
Update header to use full width border class

### DIFF
--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -1,17 +1,6 @@
-// Move the blue border from the container to the header so that it spans
-// the full width of the page
-.app-header {
-  border-bottom: 10px solid $govuk-brand-colour;
-}
-
-.app-header__container {
-  margin-bottom: 0;
-  border-bottom: 0;
-}
-
 // Override the default 33% width on the logo in GOV.UK Frontend (prevents
 // unnecessary wrapping of "GOV.UK Design System" on smaller tablet / desktop
 // viewports)
-.app-header__logo {
+.app-header-logo {
   width: auto;
 }

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -1,6 +1,6 @@
-<header class="govuk-header app-header" role="banner">
-  <div class="govuk-header__container app-width-container app-header__container">
-    <div class="govuk-header__logo app-header__logo">
+<header class="govuk-header govuk-header--full-width-border" role="banner">
+  <div class="govuk-header__container app-width-container">
+    <div class="govuk-header__logo app-header-logo">
       <a href="/" class="govuk-header__link govuk-header__link--homepage">
         {#- We use an inline SVG for the crown so that we can cascade the
         currentColor into the crown whilst continuing to support older browsers


### PR DESCRIPTION
GOV.UK Frontend 5.6.0 includes a new modifier class to make the Header's bottom border full width, negating the need for the Design System website to keep doing this with custom CSS.

Resolves https://github.com/alphagov/govuk-design-system/issues/4086.

## Changes

- Adds the new modifier class to the sitewide header.
- Removes the custom CSS and classes previously being used to do this.
- Renames the remaining class name, used to alter the size of the logo container, so that it meets BEM conventions.