### PR TITLE
Update phase banner guidance, plus fix typos

### DIFF
--- a/src/components/header/index.md
+++ b/src/components/header/index.md
@@ -102,8 +102,6 @@ In November 2021, [the GOV.UK homepage introduced a menu bar](https://insidegovu
 <p>For example, a header link to “Get help with this service” must go to the same place as similar header links elsewhere in your service. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
 {% endcall %}
 
-Help links must always link to the same place. For example, a header link to “Get help with this service” must go to the same place as similar header links elsewhere in your service.
-
 ### GOV.UK header with One Login
 
 GOV.UK One Login maintains their own header on the [Let users navigate to their GOV.UK One Login and sign out easily](https://www.sign-in.service.gov.uk/documentation/design-recommendations/let-users-navigate-sign-out) page.

--- a/src/components/phase-banner/index.md
+++ b/src/components/phase-banner/index.md
@@ -37,7 +37,14 @@ There are 2 ways to use the phase banner component. You can use HTML or, if you 
 
 Use an alpha banner when your service is in alpha, and a beta banner if your service is in private or public beta.
 
-Your banner must be directly under the black GOV.UK header and colour bar.
+Show the Phase banner directly under either:
+
+- the [Service navigation](/components/service-navigation/) component
+- the [GOV.UK header](/components/header/) and its blue colour bar (if your service does not use the Service navigation component)
+
+Phase banners are shown across all pages of a service, so users should understand it as a service-level message.
+
+You can choose to place the Phase banner in a more appropriate place for your service, however you’ll need to customise the component and provide your own CSS code to make it show correctly.
 
 {% call wcagNote({id: "wcag-do-not-cover-content"}) %}
 

--- a/src/components/service-navigation/index.md
+++ b/src/components/service-navigation/index.md
@@ -43,7 +43,7 @@ This also assures users that they’re in the right place to use your service an
 
 For guidance on how to plan your header and navigation, see the [Help users navigate a service](/patterns/navigate-a-service/) pattern.
 
-### Change the GOV.UK header bottom blue border to full width
+### Change the blue colour bar under the GOV.UK header to full width
 
 To use the GOV.UK header and Service navigation and make them fit together visually, you’ll need to change the bottom blue border of the GOV.UK header to full width.
 
@@ -76,8 +76,6 @@ In November 2021, [the GOV.UK homepage introduced a menu bar](https://insidegovu
 <p>You can add a link to a ‘help’ page in your service’s header. If you do, the link must be positioned consistently within the header, and must always link to the same place.</p>
 <p>For example, a header link to “Get help with this service” must go to the same place as similar header links elsewhere in your service. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
 {% endcall %}
-
-Help links must always link to the same place. For example, a header link to “Get help with this service” must go to the same place as similar header links elsewhere in your service.
 
 ## Use ‘slots’ to add custom elements
 

--- a/src/patterns/navigate-a-service/index.md
+++ b/src/patterns/navigate-a-service/index.md
@@ -124,8 +124,6 @@ In November 2021, [the GOV.UK homepage introduced a menu bar](https://insidegovu
 <p>For example, a header link to “Get help with this service” must go to the same place as similar header links elsewhere in your service. This is to comply with WCAG 2.2 success criterion <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">3.2.6 Consistent help</a>.</p>
 {% endcall %}
 
-Help links must always link to the same place. For example, a header link to “Get help with this service” must go to the same place as similar header links elsewhere in your service.
-
 #### External links
 
 Links that go outside of your service should usually:
@@ -143,7 +141,7 @@ GOV.UK One Login [publishes its own header component](https://www.sign-in.servic
 
 To help maintain consistency across services on GOV.UK, we’ve outlined some guidance on how to use the space in your header, and where to add other components and elements.
 
-As a general rule, the ordering of header and navigation elements should start with most general (GOV.UK-wide) elements at the top, with the more specific (service-level) elements further down.
+As a general rule, the ordering of header and navigation elements should start with the most general (GOV.UK-wide) elements at the top, with the more specific (service-level) elements further down.
 
 ### Start with GOV.UK-wide, general elements
 
@@ -153,10 +151,7 @@ In the GOV.UK header, only add GOV.UK-wide elements.
 
 You can add space between the GOV.UK header and Service navigation to insert important elements that apply to your entire service.
 
-Elements you might add here include:
-
-- [Phase banners](/components/phase-banner/)
-- ‘organisation switchers’, or similar tools that help users use your service across a set of things
+Elements you might add here include ‘organisation switchers’, or similar tools that help users use your service across a set of things
 
 See an example of an [organisation switcher](https://design-patterns.service.justice.gov.uk/components/organisation-switcher/) component in the Ministry of Justice Design System.
 
@@ -174,6 +169,17 @@ Elements you might add to Service navigation include:
 - search inputs, if they only search within your service
 
 To help users understand what the search input will cover, include ‘Search [your service]’ as placeholder text within the search input.
+
+#### Phase banners
+
+Show the [Phase banner](/components/phase-banner/) component directly under either:
+
+- the Service navigation component
+- the GOV.UK header and blue colour bar (if your service does not use the Service navigation component)
+
+Phase banners are shown across all pages of a service, so users should understand it as a service-level message.
+
+You can choose to place the Phase banner in a more appropriate place for your service, however you’ll need to customise the component and provide your own CSS code to make it show correctly.
 
 ### Finally, show page-specific elements
 


### PR DESCRIPTION
Resolves inconsistent guidance on Phase banners in the navigation pattern.

Also fixes some issues caught in proofreading in https://github.com/alphagov/govuk-design-system/issues/4089

