### PR TITLE
Add GOV.UK Vue to community resources

### DIFF
--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -93,6 +93,11 @@ A set of non-form Rails components using GOV.UK Frontend. You can use these toge
 [GOV.UK Rails Template](https://github.com/DFE-Digital/rails-template) -
 A complete Rails application template using GOV.UK Frontend.
 
+### Vue.js
+
+[GOV.UK Vue](https://govukvue.org) -
+A Vue 3 component library for GOV.UK Frontend
+
 ## Write code
 
 You can download GOV.UK Frontend Nunjucks macro snippets for:


### PR DESCRIPTION
Hi,

Hope this is the right way to submit this. I've written a Vue component library called [GOV.UK Vue](https://govukvue.org). It supports almost every component in Frontend - the exception being 'Exit this page', as it's probably not an appropriate choice for the kinds of public-facing services that might use that component.

Generated markup is the same as Frontend, with the exception of `data-` attributes. GOV.UK Vue doesn't use Frontend's JS, so these aren't needed. This also means that GOV.UK Vue components can coexist on pages alongside server-rendered components that do use the Frontend JS, as the Vue components don't have `data-module` attributes and won't be picked up by Frontend. This is documented on [Differences between GOV.UK Vue and GOV.UK Frontend](https://govukvue.org/get-started/differences-to-govuk-frontend#govuk-frontend-javascript-is-not-used)