### PR TITLE
Add more service navigation examples

### DIFF
--- a/src/components/service-navigation/default/index.njk
+++ b/src/components/service-navigation/default/index.njk
@@ -1,0 +1,24 @@
+---
+title: Service navigation
+layout: layout-example.njk
+---
+
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
+{{ govukServiceNavigation({
+  navigation: [
+    {
+      href: "#",
+      text: "Navigation item 1"
+    },
+    {
+      href: "#",
+      text: "Navigation item 2",
+      active: true
+    },
+    {
+      href: "#",
+      text: "Navigation item 3"
+    }
+  ]
+}) }}

--- a/src/components/service-navigation/index.md
+++ b/src/components/service-navigation/index.md
@@ -29,6 +29,8 @@ Service navigation helps users understand that they’re using your service and 
   ]
 }) }}
 
+{{ example({ group: "components", item: "service-navigation", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+
 ## When to use this component
 
 Use the Service navigation to help users understand that they’re using your service.
@@ -49,11 +51,13 @@ To use the GOV.UK header and Service navigation and make them fit together visua
 
 Apply a class `govuk-header--full-width-border` to the GOV.UK header.
 
+{{ example({ group: "components", item: "service-navigation", example: "with-govuk-header", html: true, nunjucks: true, open: false }) }}
+
 ### Showing your service name only
 
 We recommend that you use the Service navigation component to show your service name, instead of the GOV.UK header, and to start updating existing services.
 
-{{ example({ group: "components", item: "service-navigation", example: "with-service-name", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+{{ example({ group: "components", item: "service-navigation", example: "with-service-name", html: true, nunjucks: true, open: false }) }}
 
 ### Showing service name and navigation links
 

--- a/src/components/service-navigation/with-govuk-header/index.njk
+++ b/src/components/service-navigation/with-govuk-header/index.njk
@@ -1,0 +1,28 @@
+---
+title: Service navigation used alongside the GOV.UK header – Service navigation
+layout: layout-example.njk
+---
+
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
+{{ govukHeader({
+  classes: "govuk-header--full-width-border"
+}) }}
+{{ govukServiceNavigation({
+  navigation: [
+    {
+      href: "#",
+      text: "Navigation item 1"
+    },
+    {
+      href: "#",
+      text: "Navigation item 2",
+      active: true
+    },
+    {
+      href: "#",
+      text: "Navigation item 3"
+    }
+  ]
+}) }}


### PR DESCRIPTION
Adds a couple more examples of the service navigation component to the guidance page.

- A 'default' example that has navigation links and no service name. 
  - This is probably the most basic intended use of the component—as a navigational element.
  - All existing examples included a service name, but this made it less clear that element landmarks are different if there isn't a service name.
- An example of the component alongside the GOV.UK header.
  - This shows how they're intended to be used together, as there were questions about whether the Service navigation should be within the `<header>` element or not.
  - This also visually demonstrates using the full-width border modifier class, which not all users were confident using from the written guidance.