### PR TITLE
Make use of default category var

### DIFF
--- a/views/partials/_cookie-banner.njk
+++ b/views/partials/_cookie-banner.njk
@@ -124,7 +124,7 @@
       }
 
       function categoryIsNull (options) {
-        return (options && options.{{ params.category }} === null)
+        return (options && options.{{ category }} === null)
       }
 
       // Don't show the banner on the cookies page

--- a/views/partials/_cookie-banner.njk
+++ b/views/partials/_cookie-banner.njk
@@ -2,21 +2,9 @@
 
   {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
-  {%- set category -%}
-    {%- if params.category -%}
-      {{ params.category }}
-    {%- else -%}
-      analytics
-    {%- endif -%}
-  {%- endset -%}
+  {%- set category = params.category or "analytics" -%}
 
-  {%- set title -%}
-    {%- if params.title -%}
-      {{ params.title }}
-    {%- else -%}
-      Cookies on GOV.UK Design System
-    {%- endif -%}
-  {%- endset -%}
+  {%- set title = params.title or "Cookies on GOV.UK Design System" -%}
 
   {%- set html %}
     {% if params.html %}


### PR DESCRIPTION
Earlier in the code a default `category` is set if one is not sent:

```
 {%- set category -%}
    {%- if params.category -%}
      {{ params.category }}
    {%- else -%}
      analytics
    {%- endif -%}
  {%- endset -%}
```

However later on the code refers to `params.category` - which could be null. If it is null the javascript breaks. This PR refers to `category` instead to make sure a value is present.