### PR TITLE
Remove no need to use autocomplete in prototypes

### DIFF
--- a/src/components/date-input/index.md
+++ b/src/components/date-input/index.md
@@ -59,8 +59,6 @@ To do this, set the `autocomplete` attribute on the 3 fields to `bday-day`, `bda
 
 If you are working in production you’ll need to do this to meet [WCAG 2.1 Level AA](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
 
-You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
-
 ### Error messages
 
 If you’re highlighting the whole date, style all the fields like this:


### PR DESCRIPTION
A user suggested:

> On this page: https://design-system.service.gov.uk/components/date-input/
> 
> You say: “You will not normally need to use the autocomplete attribute in prototypes, as users will not generally be using their own devices.”
> I’d like to suggest removing this because:
>
> * It might have been true once, but these days so much UR is done over video call
> * You’d particularly expect accessibility users to use their own devices with their own settings
> * Omitting this from prototypes might result in it also being missed out of final designs, as it means someone has to remember to put it back in
> 
> So would you consider deleting this?

I think that makes sense. I was thinking about rephrasing it, but there is no harm in removing it completely and more harm in having it there.