### PR TITLE
Fix incorrect heading hierarchies

### DIFF
--- a/src/accessibility/wcag-2.2/index.md
+++ b/src/accessibility/wcag-2.2/index.md
@@ -15,11 +15,11 @@ In 2023, the Design System team assessed and updated the GOV.UK Design System to
 
 We [included code changes in GOV.UK Frontend v5.0.0](https://frontend.design-system.service.gov.uk/changes-to-govuk-frontend-v5/) to make it easier for services to make changes to comply with WCAG 2.2. We also added guidance to make teams aware of the changes and help them make necessary adjustments to their services.
 
-### Make sure your service meets the new WCAG 2.2 criteria
+## Make sure your service meets the new WCAG 2.2 criteria
 
 WCAG 2.2 was published in October 2023. You’ll need to comply with the new criteria no later than October 2024. See more about [Meeting government accessibility requirements](https://www.gov.uk/service-manual/helping-people-to-use-your-service/understanding-wcag) in the GOV.UK Service Manual.
 
-### What you need to do
+## What you need to do
 
 1. Revisit the [Government Digital Service (GDS) guidance](https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps) on what accessibility is and why your service needs to invest in it
 2. Read [What’s new in WCAG 2.2](https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/) to understand the new criteria your service will need to comply with
@@ -31,7 +31,7 @@ WCAG 2.2 was published in October 2023. You’ll need to comply with the new cri
 
 Make sure there's expertise within your organisation by advocating for people to receive training in accessibility. To provide some help with this, the Design System team is [organising community events](/community/) to help service teams share information with each other.
 
-### Components and patterns affected in the Design System
+## Components and patterns affected in the Design System
 
 We've made changes to these components and patterns to comply with WCAG 2.2 level AA. You must check if your service needs amending to align with these changes.
 

--- a/src/components/accordion/index.md
+++ b/src/components/accordion/index.md
@@ -123,7 +123,7 @@ We updated this component in December 2021 to solve an accessibility issue where
 
 The team made sure the component is accessible, for example that users can interact with it using just the keyboard.
 
-#### Users that navigate using ‘elements lists’
+### Users that navigate using ‘elements lists’
 
 We need to find out more about users that navigate using ‘elements lists’ of headings, buttons, links and other elements – such as users of speech recognition software and partially-sighted users of screen readers.
 

--- a/src/design-system-team.md
+++ b/src/design-system-team.md
@@ -12,7 +12,7 @@ The GOV.UK Design System at the [Government Digital Service](https://www.gov.uk/
 
 If you want to contact the team you can [get in touch via email or Slack](/get-in-touch/).
 
-### Team leads
+## Team leads
 
 - Charlotte Downs – Senior Interaction Designer
 - Kelly Lee – Senior Delivery Manager
@@ -20,7 +20,7 @@ If you want to contact the team you can [get in touch via email or Slack](/get-i
 - Romaric Pascal – Senior Frontend Developer
 - Trang Erskine – Senior Product Manager
 
-### Design System team
+## Design System team
 
 - Anika Henke – Senior Accessibility Specialist
 - Brett Kyle – Senior Frontend Developer


### PR DESCRIPTION
Taking the instances of bad heading hierarchy found via https://github.com/alphagov/govuk-design-system/pull/2957 and publishing them.