### PR TITLE
Update guidance and examples on hint text, particularly on use of full stops

### DIFF
--- a/src/components/character-count/default/index.njk
+++ b/src/components/character-count/default/index.njk
@@ -15,6 +15,6 @@ layout: layout-example-form.njk
     isPageHeading: true
   },
   hint: {
-    text: "Do not include personal or financial information like your National Insurance number or credit card details."
+    text: "Do not include personal or financial information like your National Insurance number or credit card details"
   }
 }) }}

--- a/src/components/checkboxes/conditional-reveal/index.njk
+++ b/src/components/checkboxes/conditional-reveal/index.njk
@@ -56,7 +56,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "Select all options that are relevant to you."
+    text: "Select all options that are relevant to you"
   },
   items: [
     {

--- a/src/components/checkboxes/default/index.njk
+++ b/src/components/checkboxes/default/index.njk
@@ -15,7 +15,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "Select all that apply."
+    text: "Select all that apply"
   },
   items: [
     {

--- a/src/components/checkboxes/error/index.njk
+++ b/src/components/checkboxes/error/index.njk
@@ -15,7 +15,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "If you have dual nationality, select all options that are relevant to you."
+    text: "If you have dual nationality, select all options that are relevant to you"
   },
   errorMessage: {
     text: "Select if you are British, Irish or a citizen of a different country"

--- a/src/components/checkboxes/index.md
+++ b/src/components/checkboxes/index.md
@@ -63,6 +63,10 @@ If you're asking more than one question on the page, do not set the contents of 
 
 You can add hints to checkbox items to provide additional information about the options.
 
+Keep each hint to a single short sentence, without any full stops. Screen readers will read out the entire text when users interact with an item. This could frustrate users if the text is long.
+
+Do not use links in hint text. While screen readers will read out the link text when describing the item, they usually do not tell users the text is a link.
+
 {{ example({ group: "components", item: "checkboxes", example: "hint", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Add an option for ‘none’

--- a/src/components/checkboxes/without-heading/index.njk
+++ b/src/components/checkboxes/without-heading/index.njk
@@ -13,7 +13,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "Select all that apply."
+    text: "Select all that apply"
   },
   items: [
     {

--- a/src/components/error-message/label/index.njk
+++ b/src/components/error-message/label/index.njk
@@ -10,7 +10,7 @@ layout: layout-example-form.njk
     text: "National Insurance number"
   },
   hint: {
-    text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    text: "It’s on your National Insurance card, benefit letter, payslip or P60 – for example, ‘QQ 12 34 56 C’"
   },
   id: "national-insurance-number",
   name: "nationalInsuranceNumber",

--- a/src/components/error-message/legend/index.njk
+++ b/src/components/error-message/legend/index.njk
@@ -15,7 +15,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "If you have dual nationality, select all options that are relevant to you."
+    text: "If you have dual nationality, select all options that are relevant to you"
   },
   errorMessage: {
     text: "Select if you are British, Irish or a citizen of a different country"

--- a/src/components/error-summary/linking-checkboxes-radios/index.njk
+++ b/src/components/error-summary/linking-checkboxes-radios/index.njk
@@ -26,7 +26,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "If you have dual nationality, select all options that are relevant to you."
+    text: "If you have dual nationality, select all options that are relevant to you"
   },
   errorMessage: {
     text: "Select if you are British, Irish or a citizen of a different country"

--- a/src/components/radios/conditional-reveal-error/index.njk
+++ b/src/components/radios/conditional-reveal-error/index.njk
@@ -59,7 +59,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "Select one option."
+    text: "Select one option"
   },
   items: [
     {

--- a/src/components/radios/conditional-reveal/index.njk
+++ b/src/components/radios/conditional-reveal/index.njk
@@ -56,7 +56,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "Select one option."
+    text: "Select one option"
   },
   items: [
     {

--- a/src/components/radios/hint/index.njk
+++ b/src/components/radios/hint/index.njk
@@ -15,21 +15,21 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "You’ll need an account to prove your identity and complete your Self Assessment."
+    text: "You’ll need an account to prove your identity and complete your Self Assessment"
   },
   items: [
     {
       value: "government-gateway",
       text: "Sign in with Government Gateway",
       hint: {
-        text: "You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before."
+        text: "You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before"
       }
     },
     {
       value: "govuk-one-login",
       text: "Sign in with GOV.UK One Login",
       hint: {
-        text: "If you don’t have a GOV.UK One Login, you can create one."
+        text: "If you don’t have a GOV.UK One Login, you can create one"
       }
     }
   ]

--- a/src/components/radios/index.md
+++ b/src/components/radios/index.md
@@ -75,6 +75,10 @@ Remember that on small screens such as mobile devices, the radios will still be 
 
 You can add hints to radio items to provide additional information about the options.
 
+Keep each hint to a single short sentence, without any full stops. Screen readers will read out the entire text when users interact with an item. This could frustrate users if the text is long.
+
+Do not use links in hint text. While screen readers will read out the link text when describing the item, they usually do not tell users the text is a link.
+
 {{ example({ group: "components", item: "radios", example: "hint", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 ### Radio items with a text divider

--- a/src/components/radios/inline/index.njk
+++ b/src/components/radios/inline/index.njk
@@ -16,7 +16,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "This includes changing your last name or spelling your name differently."
+    text: "This includes changing your last name or spelling your name differently"
   },
   items: [
     {

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -49,6 +49,10 @@ There are 2 ways to use the select component. You can use HTML or, if you’re u
 
 You can add hint text to help the user understand the options and choose one of them.
 
+Keep hint text to a single short sentence, without any full stops.
+
+Do not use links in hint text. While screen readers will read out the link text, they usually do not tell users the text is a link.
+
 {{ example({ group: "components", item: "select", example: "with-hint", html: true, nunjucks: true, open: false }) }}
 
 ### Error messages

--- a/src/components/task-list/default/index.njk
+++ b/src/components/task-list/default/index.njk
@@ -34,7 +34,7 @@ layout: layout-example.njk
         text: "Financial history"
       },
       hint: {
-        text: "Include 5 years of the company’s relevant financial information."
+        text: "Include 5 years of the company’s relevant financial information"
       },
       href: "#",
       status: {

--- a/src/components/task-list/index.md.njk
+++ b/src/components/task-list/index.md.njk
@@ -62,7 +62,7 @@ If you’re finding it difficult to come up with a clear and concise task name, 
 
 Only use hint text if there is evidence that the user needs more information about what the task will include.
 
-Keep hint text to a single, short sentence. Screen readers read out the entire text when users interact with the task link. This could frustrate users if the text is long.
+Keep hint text to a single short sentence, without any full stops. Screen readers will read out the entire text when users interact with the task link. This could frustrate users if the text is long.
 
 Do not include links within the hint text. The whole task row links users to the task itself, so any links within the hint text will not work.
 

--- a/src/components/text-input/code-sequence/index.njk
+++ b/src/components/text-input/code-sequence/index.njk
@@ -10,7 +10,7 @@ layout: layout-example-form.njk
     text: "Company authentication code"
   },
   hint: {
-    text: "This is on the company incorporation letter sent to the registered office address."
+    text: "This is on the company incorporation letter sent to the registered office address"
   },
   classes: "govuk-input--width-5 govuk-input--extra-letter-spacing",
   id: "authentication-code",

--- a/src/components/text-input/index.md
+++ b/src/components/text-input/index.md
@@ -79,13 +79,17 @@ Fluid width inputs will resize with the viewport.
 
 Use hint text for help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
+Keep hint text to a single short sentence, without any full stops.
+
+Do not use links in hint text. While screen readers will read out the link text when describing the field, they usually do not tell users the text is a link.
+
 {{ example({ group: "components", item: "text-input", example: "input-hint-text", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 #### When not to use hint text
 
-Do not use hint text if you need to give a lengthy explanation with lists and paragraphs. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+Do not use hint text to explain anything that's longer than a short, simple sentence. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-If you’re asking a question that needs a detailed explanation, read more about [asking complex questions without using hint text](/patterns/question-pages/#asking-complex-questions-without-using-hint-text).
+If you’re asking a question that needs a detailed explanation, see [asking complex questions without using hint text](/patterns/question-pages/#asking-complex-questions-without-using-hint-text).
 
 #### Avoid links
 

--- a/src/components/textarea/default/index.njk
+++ b/src/components/textarea/default/index.njk
@@ -14,6 +14,6 @@ layout: layout-example-form.njk
     isPageHeading: true
   },
   hint: {
-    text: "Do not include personal or financial information, like your National Insurance number or credit card details."
+    text: "Do not include personal or financial information, like your National Insurance number or credit card details"
   }
 }) }}

--- a/src/components/textarea/error/index.njk
+++ b/src/components/textarea/error/index.njk
@@ -14,7 +14,7 @@ layout: layout-example-form.njk
     isPageHeading: true
   },
   hint: {
-    text: "Do not include personal or financial information, like your National Insurance number or credit card details."
+    text: "Do not include personal or financial information, like your National Insurance number or credit card details"
   },
   errorMessage: {
     text: "Enter more detail"

--- a/src/components/textarea/specifying-rows/index.njk
+++ b/src/components/textarea/specifying-rows/index.njk
@@ -15,6 +15,6 @@ layout: layout-example-form.njk
     isPageHeading: true
   },
   hint: {
-    text: "Do not include personal or financial information, like your National Insurance number or credit card details."
+    text: "Do not include personal or financial information, like your National Insurance number or credit card details"
   }
 }) }}

--- a/src/get-started/labels-legends-headings/legend-h1/index.njk
+++ b/src/get-started/labels-legends-headings/legend-h1/index.njk
@@ -15,7 +15,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "This example shows an <h1> inside a <legend> with the class of govuk-fieldset__legend--l."
+    text: "This example shows an <h1> inside a <legend> with the class of govuk-fieldset__legend--l"
   },
   items: [
     {

--- a/src/get-started/labels-legends-headings/legend-m-s/index.njk
+++ b/src/get-started/labels-legends-headings/legend-m-s/index.njk
@@ -14,7 +14,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "This example shows a <legend> with the class of govuk-fieldset__legend--m."
+    text: "This example shows a <legend> with the class of govuk-fieldset__legend--m"
   },
   items: [
     {
@@ -41,7 +41,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "This example shows a <legend> with the class of govuk-fieldset__legend--s."
+    text: "This example shows a <legend> with the class of govuk-fieldset__legend--s"
   },
   items: [
     {

--- a/src/patterns/bank-details/international/index.njk
+++ b/src/patterns/bank-details/international/index.njk
@@ -12,7 +12,7 @@ layout: layout-example-form.njk
   },
   classes: "govuk-input--width-10 govuk-input--extra-letter-spacing",
   hint: {
-    text: "Must be between 8 and 11 characters long. You can ask your bank or check your bank statement"
+    text: "Must be between 8 and 11 characters long – you can ask your bank or check your bank statement"
   },
   id: "bic-code",
   name: "bicCode",

--- a/src/patterns/equality-information/date-of-birth/index.njk
+++ b/src/patterns/equality-information/date-of-birth/index.njk
@@ -17,7 +17,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "For example, 31 3 1980. If you prefer not to say, continue without entering any information."
+    text: "For example, 31 3 1980 – if you prefer not to say, continue without entering any information"
   },
   items: [
     {

--- a/src/patterns/equality-information/disability-impact/index.njk
+++ b/src/patterns/equality-information/disability-impact/index.njk
@@ -16,7 +16,7 @@ layout: layout-example-form.njk
     }
   },
   hint: {
-    text: "For example eating, washing, walking or going shopping."
+    text: "For example eating, washing, walking or going shopping"
   },
   items: [
     {

--- a/src/patterns/equality-information/error-date-of-birth/index.njk
+++ b/src/patterns/equality-information/error-date-of-birth/index.njk
@@ -20,7 +20,7 @@ layout: layout-example-form.njk
     text: "Enter your date of birth or leave blank"
   },
   hint: {
-    text: "For example, 31 3 1980. If you prefer not to say, continue without entering any information."
+    text: "For example, 31 3 1980 – if you prefer not to say, continue without entering any information"
   },
   items: [
     {

--- a/src/patterns/equality-information/religion/index.njk
+++ b/src/patterns/equality-information/religion/index.njk
@@ -37,7 +37,7 @@ layout: layout-example-form.njk
       value: "christian",
       text: "Christian",
       hint: {
-        text: "Including Church of England, Catholic, Protestant and all other Christian denominations."
+        text: "Including Church of England, Catholic, Protestant and all other Christian denominations"
       }
     },
     {

--- a/src/patterns/national-insurance-numbers/default/index.njk
+++ b/src/patterns/national-insurance-numbers/default/index.njk
@@ -10,7 +10,7 @@ layout: layout-example-form.njk
     text: "National Insurance number"
   },
   hint: {
-    text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    text: "It’s on your National Insurance card, benefit letter, payslip or P60 – for example, ‘QQ 12 34 56 C’"
   },
   classes: "govuk-input--width-10 govuk-input--extra-letter-spacing",
   id: "national-insurance-number",

--- a/src/patterns/national-insurance-numbers/error/index.njk
+++ b/src/patterns/national-insurance-numbers/error/index.njk
@@ -10,7 +10,7 @@ layout: layout-example-form.njk
     text: "National Insurance number"
   },
   hint: {
-    text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    text: "It’s on your National Insurance card, benefit letter, payslip or P60 – for example, ‘QQ 12 34 56 C’"
   },
   classes: "govuk-input--width-10 govuk-input--extra-letter-spacing",
   id: "national-insurance-number",

--- a/src/patterns/question-pages/index.md
+++ b/src/patterns/question-pages/index.md
@@ -116,11 +116,17 @@ For example, ‘About you’
 
 You can also learn more about how starting with [one thing per page](https://www.gov.uk/service-manual/design/form-structure#start-with-one-thing-per-page) helps users in the GOV.UK Service Manual.
 
+#### Hint text
+
+Use hint text to show information that helps the majority of users answer the question, like like how their information will be used, or where to find it.
+
+Keep each hint to a single short sentence, without any full stops.
+
+If you need to give a long, detailed explanation, do not use hint text. Screen readers will read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+
+Do not use links in hint text. While screen readers will read out the link text when describing the field, they usually do not tell users the text is a link.
+
 #### Asking complex questions without using hint text
-
-Do not use hint text if you need to give a lengthy explanation with lists and paragraphs. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
-
-Do not use links in hint text. While screen readers will read out the link text when describing the field, they will not tell users the text is a link.
 
 If you're asking a question that needs a detailed explanation, use:
 


### PR DESCRIPTION
To progress on #2090:
- make all examples of hint text consistent under the original premise that hint text should be 'short, simple sentences with no full stops'
- add the 'short, simple sentence with no full stops' guidance where relevant
- also add guidance not to add links in hint text, as screen readers will not make users aware of links within hint text