### PR TITLE
Remove tilde from accessibility strategy content

### DIFF
--- a/src/accessibility/accessibility-strategy/index.md
+++ b/src/accessibility/accessibility-strategy/index.md
@@ -229,7 +229,7 @@ The team also uses general inspection techniques, including:
 
 The team currently uses [jest-axe](https://github.com/nickcolley/jest-axe) as part of our deployment process, along with [@axe-core/puppeteer](https://github.com/dequelabs/axe-core-npm/blob/develop/packages/puppeteer). These tools test the example code snippets in the GOV.UK Design System against [axe-core](https://github.com/dequelabs/axe-core).
 
-The team does not solely rely on automated testing processes, as a 2017 study from GDS concluded that [only ~30% of issues are found by automated testing tools](https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage), such as axe-core.
+The team does not solely rely on automated testing processes, as a 2017 study from GDS concluded that [only about 30% of issues are found by automated testing tools](https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage), such as axe-core.
 
 As of May 2023, we have improved our automated accessibility testing processes:
 


### PR DESCRIPTION
## Change
Replaces the tilde on the accessibility strategy page with 'around'.

Resolves https://github.com/alphagov/govuk-design-system/issues/4024

## Notes
Following a discussion of [the remaining issues from the 2024 audit of the design system website](https://github.com/alphagov/govuk-design-system/labels/audit%20july%202024), we've decided that we'll fix this specific reported issue but won't be auditing the website for instances of special characters, in the same way we're auditing our link text for https://github.com/alphagov/govuk-design-system/issues/4023 and https://github.com/alphagov/govuk-design-system/issues/4013.

The reason for this is that special characters are the lowest priority issue for the accessible content audit we're carrying out in response to DAC's reported content issues and we're confident that compared to the other content issues raised, this isn't a significant content issue that we need to investigate further for the moment.