### PR TITLE
Add link to Frontend docs related to v5.7.0

### DIFF
--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -19,7 +19,7 @@ Last updated 10 October 2024.
 
 We’ve released [GOV.UK Frontend v5.7.1](https://github.com/alphagov/govuk-frontend/releases/tag/v5.7.1) with updated department colours.
 
-Previously, we’ve released [GOV.UK Frontend v5.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.7.0), which includes an update to the Royal Arms in the [GOV.UK footer](/components/footer/). We’ve also added new features to help services create their own components using GOV.UK Frontend.
+Previously, we’ve released [GOV.UK Frontend v5.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.7.0), which includes an update to the Royal Arms in the [GOV.UK footer](/components/footer/). We’ve also added new features to help services [create their own JavaScript components using GOV.UK Frontend](https://frontend.design-system.service.gov.uk/building-your-own-javascript-components/).
 
 We’ve also recently:
 

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -5,7 +5,7 @@
         <div class="govuk-grid-column-two-thirds-from-desktop">
           <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
           <p class="govuk-body">11 October 2024: We’ve released GOV.UK Frontend v5.7.1 with updated department colours.</p>
-          <p class="govuk-body">Previously, on 10 October 2024: We’ve released GOV.UK Frontend v5.7.0, which includes an update to the Royal Arms in the <a href="/components/footer/" class="govuk-link">GOV.UK footer component</a>. We’ve also added new features to help services create their own components using GOV.UK Frontend.</p>
+          <p class="govuk-body">Previously, on 10 October 2024: We’ve released GOV.UK Frontend v5.7.0, which includes an update to the Royal Arms in the <a href="/components/footer/" class="govuk-link">GOV.UK footer component</a>. We’ve also added new features to help services <a href="https://frontend.design-system.service.gov.uk/building-your-own-javascript-components/">create their own JavaScript components using GOV.UK Frontend</a>.</p>
           <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.7.0" class="govuk-link">full release notes</a> to see what’s changed.</p>
           <br>
           <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design System</a>.</p>


### PR DESCRIPTION
@calvin-lau-sig7 This came to mind after approving the updates to the Design System site content. I'm wondering if we could add a link to the Frontend Docs to get people to how you'd go and build your JavaScript component.

I've also clarified that what we're offering is only for building JavaScript components, not any components.