### PR TITLE
Add shorthand ambient module definition for 'govuk-frontend'

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,9 @@
+/**  
+ * As govuk-frontend provides no types, TypeScript will type its exports as `any`,
+ * but be unable to acknowledge fields inherited from parent classes  
+ * leading to errors when trying to assign or use them.  
+ * 
+ * TypeScript's shorthand ambient modules seem to also make inherited fields typed as `any`.
+ * https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#shorthand-ambient-module-declarations
+ */
+declare module "govuk-frontend";

--- a/src/javascripts/components/back-to-top.mjs
+++ b/src/javascripts/components/back-to-top.mjs
@@ -4,18 +4,6 @@ import { Component } from 'govuk-frontend'
  * Website back to top link
  */
 class BackToTop extends Component {
-  /**
-   * Returns the root element of the component
-   *
-   * @returns {any} - the root element of component
-   */
-  get $root() {
-    // Unfortunately, govuk-frontend does not provide type definitions
-    // so TypeScript does not know of `this._$root`
-    // @ts-expect-error
-    return this._$root
-  }
-
   static moduleName = 'app-back-to-top'
 
   /**

--- a/src/javascripts/components/cookie-banner.mjs
+++ b/src/javascripts/components/cookie-banner.mjs
@@ -13,18 +13,6 @@ const cookieConfirmationRejectSelector = '.js-cookie-banner-confirmation-reject'
  * Website cookie banner
  */
 class CookieBanner extends Component {
-  /**
-   * Returns the root element of the component
-   *
-   * @returns {any} - the root element of component
-   */
-  get $root() {
-    // Unfortunately, govuk-frontend does not provide type definitions
-    // so TypeScript does not know of `this._$root`
-    // @ts-expect-error
-    return this._$root
-  }
-
   static moduleName = 'govuk-cookie-banner'
   /**
    * @param {Element} $module - HTML element

--- a/src/javascripts/components/cookies-page.mjs
+++ b/src/javascripts/components/cookies-page.mjs
@@ -6,18 +6,6 @@ import { getConsentCookie, setConsentCookie } from './cookie-functions.mjs'
  * Website cookies page
  */
 class CookiesPage extends Component {
-  /**
-   * Returns the root element of the component
-   *
-   * @returns {any} - the root element of component
-   */
-  get $root() {
-    // Unfortunately, govuk-frontend does not provide type definitions
-    // so TypeScript does not know of `this._$root`
-    // @ts-expect-error
-    return this._$root
-  }
-
   static moduleName = 'app-cookies-page'
   /**
    * @param {Element} $module - HTML element

--- a/src/javascripts/components/copy.mjs
+++ b/src/javascripts/components/copy.mjs
@@ -5,18 +5,6 @@ import { Component } from 'govuk-frontend'
  * Copy button for code examples
  */
 class Copy extends Component {
-  /**
-   * Returns the root element of the component
-   *
-   * @returns {any} - the root element of component
-   */
-  get $root() {
-    // Unfortunately, govuk-frontend does not provide type definitions
-    // so TypeScript does not know of `this._$root`
-    // @ts-expect-error
-    return this._$root
-  }
-
   static moduleName = 'app-copy'
 
   /**

--- a/src/javascripts/components/embed-card.mjs
+++ b/src/javascripts/components/embed-card.mjs
@@ -19,18 +19,6 @@ class EmbedCard extends Component {
     }
   }
 
-  /**
-   * Returns the root element of the component
-   *
-   * @returns {any} - the root element of component
-   */
-  get $root() {
-    // Unfortunately, govuk-frontend does not provide type definitions
-    // so TypeScript does not know of `this._$root`
-    // @ts-expect-error
-    return this._$root
-  }
-
   static moduleName = 'app-embed-card'
 
   /**

--- a/src/javascripts/components/example-frame.mjs
+++ b/src/javascripts/components/example-frame.mjs
@@ -11,18 +11,6 @@ import iFrameResize from 'iframe-resizer/js/iframeResizer.js'
  * @augments Component<HTMLIFrameElement>
  */
 class ExampleFrame extends Component {
-  /**
-   * Returns the root element of the component
-   *
-   * @returns {any} - the root element of component
-   */
-  get $root() {
-    // Unfortunately, govuk-frontend does not provide type definitions
-    // so TypeScript does not know of `this._$root`
-    // @ts-expect-error
-    return this._$root
-  }
-
   static moduleName = 'app-example-frame'
   /**
    * @param {Element} $module - HTML element

--- a/src/javascripts/components/navigation.mjs
+++ b/src/javascripts/components/navigation.mjs
@@ -11,18 +11,6 @@ const subNavJSClass = '.js-app-navigation__subnav'
  */
 class Navigation extends Component {
   /**
-   * Returns the root element of the component
-   *
-   * @returns {any} - the root element of component
-   */
-  get $root() {
-    // Unfortunately, govuk-frontend does not provide type definitions
-    // so TypeScript does not know of `this._$root`
-    // @ts-expect-error
-    return this._$root
-  }
-
-  /**
    * Name for the component used when initialising using data-module attributes.
    */
   static moduleName = 'app-navigation'

--- a/src/javascripts/components/scroll-container.mjs
+++ b/src/javascripts/components/scroll-container.mjs
@@ -14,18 +14,6 @@ const scrollContainerResizeObserver = new window.ResizeObserver((entries) => {
  *
  */
 class ScrollContainer extends Component {
-  /**
-   * Returns the root element of the component
-   *
-   * @returns {any} - the root element of component
-   */
-  get $root() {
-    // Unfortunately, govuk-frontend does not provide type definitions
-    // so TypeScript does not know of `this._$root`
-    // @ts-expect-error
-    return this._$root
-  }
-
   static moduleName = 'app-scroll-container'
 
   /**

--- a/src/javascripts/components/search.mjs
+++ b/src/javascripts/components/search.mjs
@@ -38,18 +38,6 @@ const DEBOUNCE_TIME_TO_WAIT = () => {
  * Website search
  */
 class Search extends Component {
-  /**
-   * Returns the root element of the component
-   *
-   * @returns {any} - the root element of component
-   */
-  get $root() {
-    // Unfortunately, govuk-frontend does not provide type definitions
-    // so TypeScript does not know of `this._$root`
-    // @ts-expect-error
-    return this._$root
-  }
-
   static moduleName = 'app-search'
   /**
    * @param {Element} $module - HTML element

--- a/src/javascripts/components/tabs.mjs
+++ b/src/javascripts/components/tabs.mjs
@@ -11,18 +11,6 @@ import { Component } from 'govuk-frontend'
  * - panels - the content that is shown/hidden/switched; same across all breakpoints
  */
 class AppTabs extends Component {
-  /**
-   * Returns the root element of the component
-   *
-   * @returns {any} - the root element of component
-   */
-  get $root() {
-    // Unfortunately, govuk-frontend does not provide type definitions
-    // so TypeScript does not know of `this._$root`
-    // @ts-expect-error
-    return this._$root
-  }
-
   static moduleName = 'app-tabs'
 
   /**

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
-  "include": ["**/*.js", "**/*.mjs"],
+  "include": ["**/*.js", "**/*.mjs", "**/*.ts"],
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
     "target": "ES2015"


### PR DESCRIPTION
As govuk-frontend provides no types, TypeScript will type its exports as `any` but be unable to acknowledge fields inherited from parent classes. This leads to errors when trying to assign or use them.

[TypeScript's shorthand ambient modules](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#shorthand-ambient-module-declarations) seem to also make inherited fields typed as `any`.

This "empty" module will override any other definition of the `govuk-frontend` module, either in another `.d.ts` file or in `@types/govuk-frontend`.

Issue was, our project was not configured to look up for `.ts` file, meaning any `global.d.ts` file was overlooked by TypeScript. Adding `**/*.d.ts` file to the `tsconfig.json` in `src` allows TypeScript to find the shorthand ambient module and TypeScript is happy with accessing `this.$root` in classes inheriting from `Component` 🥳 