### PR TITLE
Add styling for site search input 'flowing' into dropdown

### DIFF
--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -54,6 +54,33 @@ $icon-size: 40px;
 .app-site-search__wrapper {
   display: block;
   position: relative;
+
+  // Adds a 'fake border' that's shorter than the width of the menu to create
+  // separation between the input and search items.
+  // This is here on the wrapper element and absolute positioned under the input
+  // rather than on the menu because we can't move a pseudo element out of the
+  // menu eg: using minus margins or absolute positioning without breaking the
+  // menu's overflow conditions.
+  // The use of :has means that this is an enhancement but the 'flowing' input
+  // feature is still visible without this.
+  &:has(
+      .app-site-search__input[aria-expanded="true"],
+      .app-site-search__input[aria-expanded="false"]:not([aria-describedby])
+    )::before {
+    content: "";
+    display: block;
+    position: absolute;
+    z-index: 101; // ensure the separator is above the menu
+    bottom: govuk-spacing(-1);
+    width: calc(100% - #{govuk-spacing(6)});
+    height: 1px;
+    margin: 0 0 govuk-spacing(1) govuk-spacing(3);
+    background-color: govuk-colour("black");
+
+    @media (forced-colors: active) {
+      background-color: currentcolor;
+    }
+  }
 }
 
 .app-site-search__hint,
@@ -90,6 +117,21 @@ $icon-size: 40px;
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
     background-image: _search-icon($colour: govuk-colour("white"));
   }
+
+  // If a dropdown is visible ie: there are search results or the 'no results'
+  // dialog, adjust the focus state so that the bottom 'border' focus state
+  // disappears and the input 'flows' into the menu.
+  // The box-shadow from app-site-search__input--focused sets an inset shadow
+  // on all edges of the input ala the standard input focus state. This splits
+  // the box shadow into 2 insets; one that's nudged to the right so that it
+  // appears that only the top and left edges have a shadow and a similar one
+  // for the right edge, leaving the bottom without an indented shadow.
+  &[aria-expanded="true"],
+  &[aria-expanded="false"]:not([aria-describedby]).app-site-search__input--focused {
+    box-shadow:
+      inset $govuk-border-width-form-element $govuk-border-width-form-element 0 0,
+      inset ($govuk-border-width-form-element * -1) 0 0 0;
+  }
 }
 
 .app-site-search__input--focused {
@@ -97,6 +139,20 @@ $icon-size: 40px;
   outline: $govuk-focus-width solid $govuk-focus-colour;
   outline-offset: 0;
   box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+
+  // Reduce the width of the menu when the input is focused so that the edges
+  // line up with the indented box shadow from the input focus state
+  & ~ .app-site-search__menu--visible {
+    width: calc(100% - ($govuk-border-width-form-element * 4));
+    margin-left: ($govuk-border-width-form-element * 2);
+
+    // ...unless forced colours are active. Forced colour modes remove the indented
+    // box shadow meaning the menu's edges don't line up with the input
+    @media (forced-colors: active) {
+      width: 100%;
+      margin-left: 0;
+    }
+  }
 }
 
 .app-site-search__input--show-all-values {
@@ -136,9 +192,18 @@ $icon-size: 40px;
 .app-site-search__menu--overlay {
   position: absolute;
   z-index: 100;
-  top: 100%;
+  top: calc(100% - $govuk-border-width-form-element);
   left: 0;
-  box-shadow: rgba(govuk-colour("black"), 0.256863) 0 2px 6px; // stylelint-disable-line number-max-precision
+  // Creates a fake extra portion of the menu above the scrollable area to
+  // provide some space between the list items highlight-able top edge and the
+  // bottom of the input.
+  border-top: govuk-colour("white") solid govuk-spacing(1);
+  box-shadow: rgba(govuk-colour("black"), 0.256863) 0 govuk-spacing(1) govuk-spacing(1); // stylelint-disable-line number-max-precision
+
+  // Ensure the border still looks like part of the menu in forced color modes
+  @media (forced-colors: active) {
+    border-top-color: Canvas;
+  }
 }
 
 .app-site-search__menu--inline {


### PR DESCRIPTION
## Change
Adds a visual cue to the site search so that users whre zoomed into the input know that there is a dialog below that they may be able to interact with. When a dialog is displayed, the input will be given 'bottomless' styling to remove it's bottom border, making it visually flow into the menu and drawing the eye down.

This applies _any time_ there's a visible drop down, so for any number of results and when the 'no results' dialog displays.

Fixes https://github.com/alphagov/govuk-design-system/issues/4015

## Visual changes
| Scenario | Before | After |
| - | - | - |
| Input focused | <img width="314" alt="Focused site search without bottomless styling" src="https://github.com/user-attachments/assets/7ea69934-34a1-4cb4-8986-285607c663a8"> | <img width="313" alt="Focused site search with bottomless styling" src="https://github.com/user-attachments/assets/c72560f6-1d20-48b8-a6ca-fc65e6986f16"> |
Input not focused (theoretically impossible without messing with inspect) | ![Unfocused site search without bottomless styling](https://github.com/user-attachments/assets/d773836f-9f0d-43cc-bd61-4546a59825af) | <img width="310" alt="Unfocused site search with bottomless styling" src="https://github.com/user-attachments/assets/c4f52e48-a4d0-4efc-a16c-a3059c1b91c0"> |
Forced colours (used Firefox's dark theme) | ![Site search in forced colours mode without bottomless styling](https://github.com/user-attachments/assets/6b951cc7-13d9-4965-8eff-27b9dd21dca5) | <img width="315" alt="Site search in forced colours mode with bottomless styling" src="https://github.com/user-attachments/assets/bc8848c7-35de-41d9-8b55-4de2c2872ce5"> |

## Notes
This PR follows https://github.com/alphagov/accessible-autocomplete/pull/753. See https://github.com/alphagov/accessible-autocomplete/pull/753#issuecomment-2407259328 for testing notes from that PR.

There's a little gap between the fake `:before` border at the top of the dropdown and the first item's top edge when highlighted. This is becuase we found through testing that some forced colour modes set the colour of the `:before` element to be the same ass the background colour of the dropdown, effectively erasing it. If the top item is at the very top of the dropdown, right under the input, and is highlighted, it looks like the bottom border of the input making this effect even more subtle. The gap helps with drawing the eye down.