### PR TITLE
Remove duplicated image guidance 

### DIFF
--- a/src/styles/images/index.md
+++ b/src/styles/images/index.md
@@ -245,9 +245,3 @@ We’re looking for feedback about any of these areas:
 - how you implement images (for frontend performance)
 
 Give us your feedback and examples by [posting a comment on the ‘Images’ discussion on GitHub](https://github.com/alphagov/govuk-design-system-backlog/issues/70).
-
-- examples of the types of images used in services
-- how you create and choose images to use in your service
-- how you implement images (for frontend performance)
-
-Give us your feedback and examples by [posting a comment on the ‘Images’ discussion on GitHub](https://github.com/alphagov/govuk-design-system-backlog/issues/70).


### PR DESCRIPTION
Remove content duplicated at the end of the image guidance page. Presumably it got there due to a merge conflict. 