### PR TITLE
Add information about upcoming Design System Hack Day to the website

### DIFF
--- a/src/community/design-system-day-2024/index.md
+++ b/src/community/design-system-day-2024/index.md
@@ -17,7 +17,38 @@ Thanks to all who joined us in Liverpool for this year's face to face event!
 
 Our latest event took place on Thursday 5 September 2024 at St George's Hall in Liverpool. 200 members of our community joined us to hear [a wide range of talks](/community/design-system-day-2024/session-information) on this year's theme 'unsung heroes of design systems' from our brilliant [speakers](/community/design-system-day-2024/speaker-information). Each session was recorded and will be shared through [our mailing list](https://mailchi.mp/707ce8dec373/get-updated-by-email-govuk-design-system) in the coming months.
 
-We plan to run one final online Design System Day later this year. More details on this will be released soon.
+## A Design System "Hack" Day is coming
+
+Join us for our third and final Design System Day event of 2024. We'll be hosting a hackathon looking at improving the journey between the GOV.UK Design System and other government design systems.
+
+<table class="govuk-table">
+  <tbody>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">
+        Date
+      </th>
+      <td class="govuk-table__cell">
+        28 November 2024
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">
+        Location
+      </th>
+      <td class="govuk-table__cell">
+        Hybrid
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+The hackathon will be hands-on with participants encouraged to work with others to ideate, investigate and prototype. We’re also hoping to have some lightning talks from colleagues in other government departments.
+
+In-person activities will take place at the Government Digital Service’s office in central London. If you’re unable to make it in person, you can join the event online via Zoom.
+
+Tickets will be released on **Thursday 4 November 2024 at 14:00 GMT**. We’ll let you know via our [mailing list](https://mailchi.mp/707ce8dec373/get-updated-by-email-govuk-design-system) and [cross-government Slack](https://ukgovernmentdigital.slack.com/archives/C6DMEH5R6) when tickets are available.
+
+Tickets for previous events have gone fast, however we routinely see a 50% drop out rate for our online events. Please be responsible when securing tickets for our events. Please do not order duplicate tickets, and if you can no longer attend, please cancel your ticket so someone else can take your spot.
 
 {% call promoBanner({
   img: "/images/dsd24-mail.svg",

--- a/src/community/design-system-day/index.md
+++ b/src/community/design-system-day/index.md
@@ -31,11 +31,11 @@ The first event this year was hosted online on 21 May 2024. Recordings from the 
 
 ## Event 2
 
-The second event will be a face to face conference, hosted in Liverpool on Thursday 5 September 2024. You can find out more about this event on [Design System Day 2024](/community/design-system-day-2024) page.
+The second event was a face to face conference, hosted in Liverpool on Thursday 5 September 2024. Recordings from the event will be available soon.
 
 ## Event 3
 
-We hope to host a third event later in 2024. This will be an online event, hosted on a conferencing platform. Details about this event will be released soon.
+We'll host our final event, a hackathon, on Thursday 28 November. This will be a hybrid event, with both in-person and online tickets available. Details about this event can be found on [Design System Day 2024](/community/design-system-day-2024) page.
 
 ## Previous events
 


### PR DESCRIPTION
- Update to [Design System Day 2024 page](https://design-system.service.gov.uk/community/design-system-day-2024/)
- Update to[ Design System Day Events page](https://design-system.service.gov.uk/community/design-system-day/)