### PR TITLE
Only show the site search results separator when input is focused

### DIFF
--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -65,7 +65,7 @@ $icon-size: 40px;
   // feature is still visible without this.
   &:has(
       .app-site-search__input[aria-expanded="true"],
-      .app-site-search__input[aria-expanded="false"]:not([aria-describedby])
+      .app-site-search__input--focused[aria-expanded="false"]:not([aria-describedby])
     )::before {
     content: "";
     display: block;


### PR DESCRIPTION
Something we missed in #4220. We control how the separator is displayed via 2 accessible autocompelte states:

1. the input has `aria-expanded="true"`, indicating it has results
2. the input has `aria-expanded="false"` but also no `aria-describedby` attribute, indicating that the 'no results' dialog is visible

The 2nd state however is also true when a user has entered text into the input and clicked away, resulting in the border being visible when there's no dropdown:

![site search with separator when there's no dropdown](https://github.com/user-attachments/assets/4bde74b0-b256-44ee-8854-efb582622882)

This change uses `app-site-search__input--focused` as an additional hook for that state. We already do something similar for controlling the focus state of the input further down.
