### PR TITLE
Reformat search results metadata to be more verbose

### DIFF
--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -5,10 +5,6 @@ const navigationConfig = require('../../config/navigation')
 module.exports = function lunrPlugin() {
   return (files, metalsmith, done) => {
     const outputPath = 'search-index.json'
-
-    const separator =
-      '<span class="app-site-search__separator" aria-hidden="true">›</span>'
-
     const includedSections = navigationConfig
       .filter((section) => !section.ignoreInSearch)
       .map((section) => section.label)
@@ -88,7 +84,7 @@ module.exports = function lunrPlugin() {
         store[doc.permalink] = {
           permalink: doc.permalink,
           title: doc.title,
-          section: doc.section,
+          section: `in ${doc.section}`,
           aliases: doc.aliases
         }
         this.add(doc)
@@ -98,7 +94,7 @@ module.exports = function lunrPlugin() {
         store[doc.permalink] = {
           permalink: doc.permalink,
           title: doc.title,
-          section: `${doc.section}${separator}${doc.page}`,
+          section: `part of ${doc.page} in ${doc.section}`,
           aliases: doc.aliases
         }
         this.add(doc)

--- a/lib/metalsmith-lunr-index/index.test.js
+++ b/lib/metalsmith-lunr-index/index.test.js
@@ -59,7 +59,7 @@ describe('metalsmith-lunr-index plugin', () => {
         ({ title }) => title === 'Checkboxes'
       )
 
-      expect(entry.section).toEqual('Components')
+      expect(entry.section).toEqual('in Components')
     })
 
     it('uses a custom permalink if in document metadata', () => {

--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -303,9 +303,3 @@ $icon-size: 40px;
     content: ")";
   }
 }
-
-.app-site-search__separator {
-  display: inline-block;
-  margin-right: govuk-spacing(1);
-  margin-left: govuk-spacing(1);
-}


### PR DESCRIPTION
## What
Reformats the metadata aka the 'section info' of search results in the site search so that they are more verbose. Specifically:

- results that are pages will now say 'in [Section]' where before they just said '[Section]'
- results that are headings in pages will now say 'part of [Page] in [Section]' where before we generated a visual only chevron and the metadata read '[page] [chevron] [Section]'

## Why
Spelling out our search results is both better for screen reader users and more clearly communicates our info hierarchy. Part of https://github.com/alphagov/govuk-design-system/issues/4195

## Visual changes
### Before
![Search results from typing 'te' showing a page and section result before change](https://github.com/user-attachments/assets/e6d58883-2dee-4b99-a706-bfb3aed1c7e6)

### After
![Search results from typing 'te' showing a page and section result after change](https://github.com/user-attachments/assets/f78b735b-075d-4450-89c3-ef4e0bbc8f29)

## Notes
This doesn't outright close https://github.com/alphagov/govuk-design-system/issues/4195 as we still want to write up some extra thoughts and findings and potentially iterate this design, based on feedback from designers in GDS that the longer search results could warrant a longer input to make them easier to read. We'll do that in a followup PR.