### PR TITLE
Update the links on the blogs, talks and podcasts page

### DIFF
--- a/src/community/blogs-talks-podcasts/index.md
+++ b/src/community/blogs-talks-podcasts/index.md
@@ -13,97 +13,97 @@ To learn more about the GOV.UK Design System and Prototype Kit, check out these 
 
 Find out how the Design System and Prototype Kit work and what they do to make services more accessible and inclusive.
 
-[Get to WCAG 2.2 faster with the GOV.UK Design System](https://accessibility.blog.gov.uk/2024/01/11/get-to-wcag-2-2-faster-with-the-gov-uk-design-system/) (blog post) – 11 January 2024
+[Get to WCAG 2.2 faster with the GOV.UK Design System (blog post)](https://accessibility.blog.gov.uk/2024/01/11/get-to-wcag-2-2-faster-with-the-gov-uk-design-system/) – 11 January 2024
 
-[Exit this page fast with the Design System’s new component](https://designnotes.blog.gov.uk/2023/08/14/exit-this-page-fast-with-the-design-systems-new-component/) (blog post) – 14 August 2023
+[Exit this page fast with the Design System’s new component (blog post)](https://designnotes.blog.gov.uk/2023/08/14/exit-this-page-fast-with-the-design-systems-new-component/) – 14 August 2023
 
-[A new accessibility strategy for the GOV.UK Design System](https://accessibility.blog.gov.uk/2023/01/06/a-new-accessibility-strategy-for-the-gov-uk-design-system/) (blog post) – 6 January 2023
+[A new accessibility strategy for the GOV.UK Design System (blog post)](https://accessibility.blog.gov.uk/2023/01/06/a-new-accessibility-strategy-for-the-gov-uk-design-system/) – 6 January 2023
 
-[Making the GOV.UK Frontend typography scale more accessible](https://designnotes.blog.gov.uk/2022/12/12/making-the-gov-uk-frontend-typography-scale-more-accessible/) (blog post) – 12 December 2022
+[Making the GOV.UK Frontend typography scale more accessible (blog post)](https://designnotes.blog.gov.uk/2022/12/12/making-the-gov-uk-frontend-typography-scale-more-accessible/) – 12 December 2022
 
-[How we prioritise additions to the GOV.UK Design System](https://designnotes.blog.gov.uk/2022/09/07/how-we-prioritise-additions-to-the-gov-uk-design-system/) (blog post) – 7 September 2022
+[How we prioritise additions to the GOV.UK Design System (blog post)](https://designnotes.blog.gov.uk/2022/09/07/how-we-prioritise-additions-to-the-gov-uk-design-system/) – 7 September 2022
 
-[The GOV.UK Design System is now live](https://gds.blog.gov.uk/2022/03/31/the-gov-uk-design-system-is-now-live/) (blog post) – 31 March 2022
+[The GOV.UK Design System is now live (blog post)](https://gds.blog.gov.uk/2022/03/31/the-gov-uk-design-system-is-now-live/) – 31 March 2022
 
-[Help us shape the GOV.UK Design System](https://designnotes.blog.gov.uk/2022/02/23/help-us-shape-the-gov-uk-design-system/) (blog post) – 23 February 2022
+[Help us shape the GOV.UK Design System (blog post)](https://designnotes.blog.gov.uk/2022/02/23/help-us-shape-the-gov-uk-design-system/) – 23 February 2022
 
-[Letting users tick a ‘none’ checkbox](https://designnotes.blog.gov.uk/2021/11/15/letting-users-tick-a-none-checkbox/) (blog post) – 15 November 2021
+[Letting users tick a ‘none’ checkbox (blog post)](https://designnotes.blog.gov.uk/2021/11/15/letting-users-tick-a-none-checkbox/) – 15 November 2021
 
-[An update on the accessibility of conditionally revealed questions](https://accessibility.blog.gov.uk/2021/09/21/an-update-on-the-accessibility-of-conditionally-revealed-questions/) (blog post) – 21 September 2021
+[An update on the accessibility of conditionally revealed questions (blog post)](https://accessibility.blog.gov.uk/2021/09/21/an-update-on-the-accessibility-of-conditionally-revealed-questions/) – 21 September 2021
 
-[Making links easier to see and read on GOV.UK](https://designnotes.blog.gov.uk/2021/07/07/making-links-easier-to-see-and-read-on-gov-uk/) (blog post) – 7 July 2021
+[Making links easier to see and read on GOV.UK (blog post)](https://designnotes.blog.gov.uk/2021/07/07/making-links-easier-to-see-and-read-on-gov-uk/) – 7 July 2021
 
-[Designing the service behind the GOV.UK Design System](https://www.youtube.com/watch?v=kOXt36nIVPQ) (video) – 9 January 2020
+[Designing the service behind the GOV.UK Design System (video)](https://www.youtube.com/watch?v=kOXt36nIVPQ) – 9 January 2020
 
-[Inclusive Documentation](https://www.youtube.com/watch?v=dZOf973QzmE) (video) – 4 October 2019
+[Inclusive Documentation (video)](https://www.youtube.com/watch?v=dZOf973QzmE) – 4 October 2019
 
-[Making the Design System more accessible](https://designnotes.blog.gov.uk/2019/07/29/weve-made-the-gov-uk-design-system-more-accessible/) (blog post) – 29 July 2019
+[Making the Design System more accessible (blog post)](https://designnotes.blog.gov.uk/2019/07/29/weve-made-the-gov-uk-design-system-more-accessible/) – 29 July 2019
 
-[Inclusive forms, Anatomy of a (fictional) GOV.UK service](https://www.youtube.com/watch?v=JHaLzm-FGsc) (video) – 26 February 2019
+[Inclusive forms, Anatomy of a (fictional) GOV.UK service (video)](https://www.youtube.com/watch?v=JHaLzm-FGsc) – 26 February 2019
 
-[Accessibility in the GOV.UK Design System](https://nickcolley.co.uk/2018/11/16/accessibility-in-the-govuk-design-system/) (blog post and video) – 30 November 2018
+[Accessibility in the GOV.UK Design System (blog post and video)](https://nickcolley.co.uk/2018/11/16/accessibility-in-the-govuk-design-system/) – 30 November 2018
 
-[Introducing the GOV.UK Design System](https://gds.blog.gov.uk/2018/06/22/introducing-the-gov-uk-design-system/) (blog post) – 22 June 2018
+[Introducing the GOV.UK Design System (blog post)](https://gds.blog.gov.uk/2018/06/22/introducing-the-gov-uk-design-system/) – 22 June 2018
 
-[Building Accessible Components and the GOV.UK Design System](https://www.youtube.com/watch?v=wprWuTvhec4) (video) – 11 June 2018
+[Building Accessible Components and the GOV.UK Design System (video)](https://www.youtube.com/watch?v=wprWuTvhec4) – 11 June 2018
 
-[Building the GOV.UK Design System](https://gds.blog.gov.uk/2017/10/30/building-the-gov-uk-design-system/) (blog post) – 30 October 2017
+[Building the GOV.UK Design System (blog post)](https://gds.blog.gov.uk/2017/10/30/building-the-gov-uk-design-system/) – 30 October 2017
 
-[We've updated the radios and checkboxes on GOV.UK](https://designnotes.blog.gov.uk/2016/11/30/weve-updated-the-radios-and-checkboxes-on-gov-uk/) (blog post) – 30 November 2016
+[We've updated the radios and checkboxes on GOV.UK (blog post)](https://designnotes.blog.gov.uk/2016/11/30/weve-updated-the-radios-and-checkboxes-on-gov-uk/) – 30 November 2016
 
 ## Benefits of the Design System
 
 See how the Design System helps service teams across government.
 
-[GDS Podcast, GOV.UK Design System](https://gds.blog.gov.uk/2020/02/28/podcast-gov-uk-design-system/) (podcast) – 28 February 2020
+[GDS Podcast, GOV.UK Design System (podcast)](https://gds.blog.gov.uk/2020/02/28/podcast-gov-uk-design-system/) – 28 February 2020
 
-[Measuring the value of the GOV.UK Design System](https://www.youtube.com/watch?v=eSkVtSEAe98) (video) – 5 February 2020
+[Measuring the value of the GOV.UK Design System (video)](https://www.youtube.com/watch?v=eSkVtSEAe98) – 5 February 2020
 
-[How the GOV.UK Design System can work alongside other government design resources](https://designnotes.blog.gov.uk/2019/02/14/how-the-gov-uk-design-system-can-work-alongside-other-government-design-resources/) (blog post) – 14 February 2019
+[How the GOV.UK Design System can work alongside other government design resources (blog post)](https://designnotes.blog.gov.uk/2019/02/14/how-the-gov-uk-design-system-can-work-alongside-other-government-design-resources/) – 14 February 2019
 
-[The benefits of migrating GOV.UK Pay’s codebase to the GOV.UK Design System](https://technology.blog.gov.uk/2018/12/21/the-benefits-of-migrating-gov-uk-pays-codebase-to-the-gov-uk-design-system/) (blog post) – 21 December 2018
+[The benefits of migrating GOV.UK Pay’s codebase to the GOV.UK Design System (blog post)](https://technology.blog.gov.uk/2018/12/21/the-benefits-of-migrating-gov-uk-pays-codebase-to-the-gov-uk-design-system/) – 21 December 2018
 
 ## How to use the Design System
 
 Get some practical advice on how to use the Design System and Prototype Kit.
 
-[Inspecting WCAG 2.2: Accessible Authentication](https://www.youtube.com/watch?v=9h5aLCS3wJQ) (video) – 26 October 2023
+[Inspecting WCAG 2.2: Accessible Authentication (video)](https://www.youtube.com/watch?v=9h5aLCS3wJQ) – 26 October 2023
 
-[Inspecting WCAG 2.2: Target Size](https://www.youtube.com/watch?v=91O_DzoLM3U) (video) – 31 July 2023
+[Inspecting WCAG 2.2: Target Size (video)](https://www.youtube.com/watch?v=91O_DzoLM3U) – 31 July 2023
 
-[Testing a component's accessibility](https://www.youtube.com/watch?v=C770bSvGr_E) (video) – 26 July 2023
+[Testing a component's accessibility (video)](https://www.youtube.com/watch?v=C770bSvGr_E) – 26 July 2023
 
-[Inspecting WCAG 2.2: Focus Not Obscured](https://www.youtube.com/watch?v=_fi7SsSkBtM) (video) – 5 July 2023
+[Inspecting WCAG 2.2: Focus Not Obscured (video)](https://www.youtube.com/watch?v=_fi7SsSkBtM) – 5 July 2023
 
-[Going beyond the GOV.UK Design System for MoJ Forms professional users](https://designnotes.blog.gov.uk/2022/03/21/going-beyond-the-gov-uk-design-system-for-moj-forms-professional-users/) (blog post) – 21 March 2022
+[Going beyond the GOV.UK Design System for MoJ Forms professional users (blog post)](https://designnotes.blog.gov.uk/2022/03/21/going-beyond-the-gov-uk-design-system-for-moj-forms-professional-users/) – 21 March 2022
 
-[Building digital services that work for everyone](https://www.youtube.com/watch?v=1cuZnBqQYKQ&feature=youtu.be) (video) – 21 May 2020
+[Building digital services that work for everyone (video)](https://www.youtube.com/watch?v=1cuZnBqQYKQ&feature=youtu.be) – 21 May 2020
 
-[Adapting the GOV.UK Design System for the NHS](https://gds.blog.gov.uk/2019/06/04/guest-post-adapting-the-gov-uk-design-system-for-the-nhs/) (blog post) – 4 June 2019
+[Adapting the GOV.UK Design System for the NHS (blog post)](https://gds.blog.gov.uk/2019/06/04/guest-post-adapting-the-gov-uk-design-system-for-the-nhs/) – 4 June 2019
 
-[How we document components and patterns in the GOV.UK Design System](https://designnotes.blog.gov.uk/2018/11/05/how-we-document-components-and-patterns-in-the-gov-uk-design-system/) (blog post) – 5 November 2018
+[How we document components and patterns in the GOV.UK Design System (blog post)](https://designnotes.blog.gov.uk/2018/11/05/how-we-document-components-and-patterns-in-the-gov-uk-design-system/) – 5 November 2018
 
-[We’ve updated the prototype kit](https://designnotes.blog.gov.uk/2016/01/18/weve-updated-the-prototype-kit/) (blog post) – 18 January 2016
+[We’ve updated the prototype kit (blog post)](https://designnotes.blog.gov.uk/2016/01/18/weve-updated-the-prototype-kit/) – 18 January 2016
 
 ## Contributing to the community
 
 Find out how our community works and how to be a part of it.
 
-[Working as a community to iterate the task list pattern](https://designnotes.blog.gov.uk/2023/12/15/working-as-a-community-to-iterate-the-task-list-pattern/) (blog post) – 15 December 2023
+[Working as a community to iterate the task list pattern (blog post)](https://designnotes.blog.gov.uk/2023/12/15/working-as-a-community-to-iterate-the-task-list-pattern/) – 15 December 2023
 
-[Iterating the GOV.UK Design System contribution model](https://designnotes.blog.gov.uk/2023/05/31/iterating-the-gov-uk-design-system-contribution-model/) (blog post) – 31 May 2023
+[Iterating the GOV.UK Design System contribution model (blog post)](https://designnotes.blog.gov.uk/2023/05/31/iterating-the-gov-uk-design-system-contribution-model/) – 31 May 2023
 
-[Why I contribute to the GOV.UK Design System (and why you should too)](https://x-govuk.github.io/posts/contributing-to-govuk-design-system/) (blog post) – 7 April 2022
+[Why I contribute to the GOV.UK Design System (and why you should too) (blog post)](https://x-govuk.github.io/posts/contributing-to-govuk-design-system/) – 7 April 2022
 
-[GDS Podcast, Maps in services](https://gds.blog.gov.uk/2021/11/30/podcast-maps-in-services/) (podcast) – 30 November 2021
+[GDS Podcast, Maps in services (podcast)](https://gds.blog.gov.uk/2021/11/30/podcast-maps-in-services/) – 30 November 2021
 
-[Building the Community Behind GOV.UK Design System](https://www.youtube.com/watch?v=REAO9Uqx_ZE) (video) – March 2020
+[Building the Community Behind GOV.UK Design System (video)](https://www.youtube.com/watch?v=REAO9Uqx_ZE) – March 2020
 
-[Contributing the bank details pattern to the GOV.UK Design System](https://mojdigital.blog.gov.uk/2019/10/23/contributing-the-bank-details-pattern-to-the-gov-uk-design-system/) – 23 October 2019
+[Contributing the bank details pattern to the GOV.UK Design System (blog post)](https://mojdigital.blog.gov.uk/2019/10/23/contributing-the-bank-details-pattern-to-the-gov-uk-design-system/) – 23 October 2019
 
-[Opening up the GOV.UK Design System for contributions](https://designnotes.blog.gov.uk/2018/09/26/opening-up-the-gov-uk-design-system-for-contributions/) (blog post) – 26 September 2018
+[Opening up the GOV.UK Design System for contributions (blog post)](https://designnotes.blog.gov.uk/2018/09/26/opening-up-the-gov-uk-design-system-for-contributions/) – 26 September 2018
 
-[Looking at design systems across government](https://designnotes.blog.gov.uk/2016/12/21/looking-at-design-systems-across-government/) (blog post) – 21 December 2016
+[Looking at design systems across government (blog post)](https://designnotes.blog.gov.uk/2016/12/21/looking-at-design-systems-across-government/) – 21 December 2016
 
 ## Add a link to this page
 


### PR DESCRIPTION
## What
Changes all links on the [Blog posts, talks and podacasts](https://design-system.service.gov.uk/community/blogs-talks-podcasts/) page to include what the thing is in the link eg: `[How we built the martial arts pattern] (blog post)` becomes `[How we built the martial arts pattern (blog post)]`.

## Why
This more clearly communicates what the link is and where it goes to. Part of https://github.com/alphagov/govuk-design-system/issues/4267.

Note that these changes have been pre-reviewed via [our link audit worksheet](https://docs.google.com/spreadsheets/d/1skSCpONh9VnPwOkhCvJimwH_9Az6d91A4ZxK4pDOmw4/edit?pli=1&gid=1372295640#gid=1372295640&fvid=1932937816).