### PR TITLE
Update sub-table link text in nunjucks macros

### DIFF
--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -117,14 +117,14 @@
                     {% if (option.params) or (option.isComponent and ["hint", "label"].includes(option.id)) %}
                       {% if option.isComponent and not ["hint", "label"].includes(option.id) %}
                         {# Link to subset of Nunjucks macro options table and Design System component page -#}
-                        See supported <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name | safe }}</a> options for <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ optionName | safe }}</a>.
+                        <a href="#options-{{ exampleId }}--{{ option.slug }}">See supported {{ option.name | safe }} macro options</a> for <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ optionName | safe }} component macro</a>.
                       {% else %}
                         {# Link to Nunjucks macro options table only -#}
-                        See <a href="#options-{{ exampleId }}--{{ option.slug }}">{{ option.name | safe }}</a>.
+                        <a href="#options-{{ exampleId }}--{{ option.slug }}"> See macro options for {{ option.name | safe }}</a>.
                       {% endif %}
                     {% elif option.isComponent %}
                       {# Link to Design System component page for nested components -#}
-                      See <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">{{ optionName | safe }}</a>.
+                      <a href="/components/{{ option.slug }}/#options-{{ option.slug }}-example">See macro options for {{ optionName | safe }}</a>.
                     {% endif %}
                     </td>
                   </tr>


### PR DESCRIPTION
## What
Updates the link text for the generated links in our examples partial, where a nunjucks macro option has it's own params and the link jumps to that option's own option table.

## Why
Part of https://github.com/alphagov/govuk-design-system/issues/4267. This change will resolve 64 identified links that need clearer link text.

## Notes
The first variation on line 120, which is used when a sub option is referencing a component that _isn't_ the hint or label "components", doesn't have any instances across our library. This makes it hard to test. I was able to hard code it appearing by removing the label and hint condition. See the below screen shot of an example from the Text input options:

<img width="768" alt="Screenshot of hint and label text input options with different link text" src="https://github.com/user-attachments/assets/81d2a55c-64bc-466f-9eb1-c67844404c80">
