### PR TITLE
Increase site search input to 370px

### DIFF
--- a/src/stylesheets/components/_site-search.scss
+++ b/src/stylesheets/components/_site-search.scss
@@ -30,7 +30,7 @@ $icon-size: 40px;
   }
 
   @include govuk-media-query($from: tablet) {
-    width: 300px;
+    width: 370px;
     max-width: 100%;
     float: none;
   }


### PR DESCRIPTION
What it says on the tin.

A followup of https://github.com/alphagov/govuk-design-system/pull/4290. With the new search results, it's easier to read the more verbose results across fewer lines.

370px has been picked because it's the longest we can make it whilst still conforming to the breakpoints.

Co-designed with @hazalarpalikli so just needs dev review.