### PR TITLE
Enable TypeScript's 'skipLibCheck' option

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "module": "NodeNext",
     "noEmit": true,
     "noImplicitThis": true,
+    "skipLibCheck": true,
     "strict": false,
     "strictBindCallApply": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
As we're running into the same type issues as on GOV.UK Frontend, where some of our dependencies code have type issues, implements the same fix as in https://github.com/alphagov/govuk-frontend/pull/5550. It turns on the `skibLibCheck` option of TypeScript, making it not check the code of our dependencies (but still check that we use them correctly).