### PR TITLE
Update file upload component to effectively accommodate WCAG 2.2 updates

### DIFF
--- a/src/components/file-upload/index.md
+++ b/src/components/file-upload/index.md
@@ -1,6 +1,6 @@
 ---
 title: File upload
-description: Help users select and upload a file
+description: Help users select and upload a file. To effectively accommodate WCAG 2.2 updates on file uploads and ensure users can reuse previously uploaded files, a "remove" link should be provided once a file is uploaded
 section: Components
 aliases:
 backlogIssueId: 49


### PR DESCRIPTION
To effectively accommodate WCAG 2.2 updates on file uploads and ensure users can reuse previously uploaded files, a "remove" link should be provided once a file is uploaded. This empowers user to decide when to delete a file, rather than having the system automatically remove it. This flexibility enhances usability and aligns with accessibility best practices.
 
For example, if a file upload is part of a filter alongside other inputs like checkboxes, users can retain the file for subsequent searches or remove it when it's no longer needed. Providing a "remove" link ensures users have full control over their uploaded files, improving both accessibility and the overall user experience.
 
User research has also shown that providing explicit controls, link a "remove" link, aligns with WCAG's emphasis on user autonomy and reduces frustration caused by automatic actions.