### PR TITLE
[SPIKE] Adding an example of metadata to the accordion component

### DIFF
--- a/src/components/accordion/index.md
+++ b/src/components/accordion/index.md
@@ -9,6 +9,17 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
+<div class="app-component-metadata">
+    <dl class="app-metadata">
+        <dt class="app-metadata-term">Status:</dt>
+        <dd class="app-metadata-definition"><a class="govuk-link" href="https://github.com/alphagov/govuk-design-system-backlog/issues/1">Theoretical and evidenced</a></dd>
+        <dt class="app-metadata-term">Published</dt>
+        <dd class="app-metadata-definition">00 date 00</dd>
+        <dt class="app-metadata-term">Last updated</dt>
+        <dd class="app-metadata-definition">00 date 00</dd>
+    </dl>
+</div>
+
 The accordion component lets users show and hide sections of related content on a page.
 
 {{ example({ group: "components", item: "accordion", example: "default", html: true, nunjucks: true, open: false, size: "xl", loading: "eager" }) }}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -443,3 +443,30 @@ pre .language-plaintext {
 .app-campaign-cookie-banner .govuk-grid-column-two-thirds {
   width: 100%;
 }
+
+// Add styling for metadata
+
+.app-component-metadata {
+  margin-bottom: govuk-spacing(5);
+  padding: govuk-spacing(2) 0;
+  border-top: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid $govuk-border-colour;
+}
+
+.app-metadata {
+  @include govuk-font(16);
+  @include govuk-typography-weight-regular;
+}
+
+.app-metadata-term {
+  box-sizing: border-box;
+  margin-top: 0;
+  padding-right: 5px;
+  float: left;
+  clear: left;
+}
+
+.app-metadata-definition {
+  margin: 0;
+  margin-bottom: govuk-spacing(1);
+}


### PR DESCRIPTION
## What
We've spoken as a team about adding more information on when content is changed in the Design System website. It could also help in situations where we need to draw attention to new content.

## Why
It can help users to know if something has changed, particularly if there's something that influences it.

## Further opportunities
This addition could be timed with removal of the WCAG 2.2 callouts.

At the moment the 'Status' link in this SPIKE links to the backlog issue thread (which I quite like as a prompt) but it could also link to:
- research section of the page 
- the github history of the poage
- archives

We also looked at the [node example](https://nodejs.org/api/documentation.html#stability-index), where they use:

> Stability: 0 - Deprecated. The feature may emit warnings. Backward compatibility is not guaranteed.

> Stability: 1 - Experimental. The feature is not subject to [semantic versioning](https://semver.org/) rules. Non-backward compatible changes or removal may occur in any future release. Use of the feature is not recommended in production environments.
Experimental features are subdivided into stages:
> - 1.0 - Early development. Experimental features at this stage are unfinished and subject to substantial change.
> - 1.1 - Active development. Experimental features at this stage are nearing minimum viability.
> - 1.2 - Release candidate. Experimental features at this stage are hopefully ready to become stable. No further breaking changes are anticipated but may still occur in response to user feedback. We encourage user testing and feedback so that we can know that this feature is ready to be marked as stable.

> Stability: 2 - Stable. Compatibility with the npm ecosystem is a high priority.

> Stability: 3 - Legacy. Although this feature is unlikely to be removed and is still covered by semantic versioning guarantees, it is no longer actively maintained, and other alternatives are available.

We could also be influenced from/include our [accessibility concern rating in the accessibility strategy](https://design-system.service.gov.uk/accessibility/accessibility-strategy/#accessibility-concern-types) and use 'theoretical' vs 'evidenced' terminology.