### PR TITLE
Remove old usage survey link

### DIFF
--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -32,14 +32,6 @@
       <a class="govuk-link app-contact-panel__link" href="/community/propose-a-content-change-using-github/">how to propose changes in GitHub</a>.
     </p>
   {% endif %}
-  {% if ["Components", "Patterns"].includes(section) %}
-    <h3 class="govuk-heading-m govuk-!-padding-top-7" id="tell-us-if-your-service-uses">
-      Tell us if your service uses this {{ section.slice(0, -1) | lower }}
-    </h3>
-    <p class="govuk-body">
-      <a class="govuk-link app-contact-panel__link" target="_blank" href="https://surveys.publishing.service.gov.uk/s/MPR0MV/">Take part in our usage survey (opens in a new tab)</a> to help us improve this {{ section.slice(0, -1) | lower }} to better meet the needs of the services that use it.
-    </p>
-  {% endif %}
 {% endif %}
 
 <div class="app-contact-panel">


### PR DESCRIPTION
This currently goes to an "unavailable" page. Remove it and reinstate if we decide to start this survey back up again.