### PR TITLE
Add deprecation tag

### DIFF
--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -87,7 +87,7 @@
           Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
           </p>
           <p>
-          Some options are required for the macro to work; these are marked as "Required" in the option description.
+          Some options are required for the macro to work; these are marked as "Required" in the option description. Deprecated options are marked as "Deprecated".
           </p>
           <p>
           If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must sanitise the HTML to protect against  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting exploits</a>.
@@ -110,6 +110,11 @@
                     <th class="govuk-table__header" scope="row">{{ optionName | safe }}</th>
                     <td class="govuk-table__cell">{{ option.type }}</td>
                     <td class="govuk-table__cell">
+                      {% if option.deprecated | length %}
+                        <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v{{ option.deprecated }}">Deprecated in {{ option.deprecated }}</a><br><br>
+                      {% elif option.deprecated %}
+                        <strong>Deprecated</strong><br><br>
+                      {% endif %}
                     {% if (option.required) %}
                       <strong>Required.</strong>
                     {% endif %}


### PR DESCRIPTION
Use the new `option.deprecated` field to flag when an option has been deprecated. Optionally (though most commonly), we can also flag the version it was deprecated in and link to the relevant release notes.

Here's what the [header](https://deploy-preview-4488--govuk-design-system-preview.netlify.app/components/header/) looks like:

<img width="748" alt="Multiple deprecated macro options" src="https://github.com/user-attachments/assets/8d182829-6693-47cc-a2c0-0c79ccaa1393" />

We've considered and dismissed other placements of the deprecated tag:

* In the name field
  * This is a table header cell, so will be read out often on screenreaders - it's better for it be succinct
* In the table caption
  * We felt that it's too easy to gloss over the table caption and look straight at the options you want to check
* As a heading above all sub-tables which have been fully deprecated
  * Another case of glossing over, and adds unnecessary code complexity
* In a seperate column
  * We're a bit pushed for space with these tables

We also considered adding a short message to the deprecation, but found this was too easy to confuse with the existing option description, so opted to link straight out to the relevant release notes instead.
