### PR TITLE
Adjust dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   # Update npm packages
   - package-ecosystem: npm
     directory: /
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 15
 
     # Group packages into shared PR
     groups:
@@ -81,7 +81,7 @@ updates:
 
     # Schedule run every Monday, local time
     schedule:
-      interval: weekly
+      interval: monthly
       time: '10:30'
       timezone: 'Europe/London'
 


### PR DESCRIPTION
Following discussions, and adjustment of dependabot frequency on govuk-frontend, we're adjusting this to monthly updates and changing how we triage dependabot PRs.