### PR TITLE
schedule github actions dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -98,6 +98,6 @@ updates:
 
     # Schedule run every Monday, local time
     schedule:
-      interval: weekly
+      interval: monthly
       time: '10:30'
       timezone: 'Europe/London'


### PR DESCRIPTION
We previously updated dependabot's schedule for npm updates to monthly. Apply this schedule to other types as well.