### PR TITLE
Update 'What's new' section for v5.10.0

### DIFF
--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -4,10 +4,10 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
           <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
-          <p class="govuk-body">4 March 2025: We’ve released GOV.UK Frontend v5.9.0</p>
-          <p class="govuk-body">This release includes a <a href="https://design-system.service.gov.uk/components/file-upload/#using-the-improved-file-upload-component" class="govuk-link">JavaScript enhancement to the File upload component</a>, which makes dragging and dropping files easier for users.</p>
-          <p class="govuk-body">We’ve also deprecated the options to show a service name, as well as navigation links, in the GOV.UK header component. Both options will be removed from the GOV.UK header in the next breaking release of GOV.UK Frontend.</p>
-          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0" class="govuk-link">full release notes</a> to see what’s changed.</p>
+          <p class="govuk-body">1 May 2025: We’ve released GOV.UK Frontend v5.10.0</p>
+          <p class="govuk-body">This the first step to refresh  the GOV.UK brand. It includes updates to the GOV.UK header, GOV.UK footer, Service navigation and Cookie banner components.</p>
+          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">full release notes</a> to see what’s changed.</p>
+          <p class="govuk-body">We’ve also recently deprecated the options to show a service name, as well as navigation links, in the GOV.UK header component. Both options will be removed from the GOV.UK header in the next breaking release of GOV.UK Frontend.</p>
           <br>
           <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design System</a>.</p>
         </div>

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -5,11 +5,15 @@
         <div class="govuk-grid-column-two-thirds-from-desktop">
           <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
           <p class="govuk-body">1 May 2025: We’ve released GOV.UK Frontend v5.10.0</p>
-          <p class="govuk-body">This the first step to refresh  the GOV.UK brand. It includes updates to the GOV.UK header, GOV.UK footer, Service navigation and Cookie banner components.</p>
-          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">full release notes</a> to see what’s changed.</p>
-          <p class="govuk-body">We’ve also recently deprecated the options to show a service name, as well as navigation links, in the GOV.UK header component. Both options will be removed from the GOV.UK header in the next breaking release of GOV.UK Frontend.</p>
-          <br>
-          <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design System</a>.</p>
+          <p class="govuk-body">This the first step to refresh the GOV.UK brand. It includes updates to the:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><a href="/components/header/" class="govuk-link">GOV.UK header component</a></li>
+            <li><a href="/components/footer/" class="govuk-link">GOV.UK footer component</a></li>
+            <li><a href="/components/service-navigation/" class="govuk-link">Service navigation component</a></li>
+            <li><a href="/components/cookie-banner/" class="govuk-link">Cookie banner component</a></li>
+          </ul>
+          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">full release notes</a> to see what's changed.</p>
+                    <p class="govuk-body">We’ve also recently deprecated the options to show a service name, as well as navigation links, in the GOV.UK header component. Both options will be removed from the GOV.UK header in the next breaking release of GOV.UK Frontend.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Add content about brand refresh mvp, but keep content about deprecation of service name and navigation header variants.