### PR TITLE
Create branded versions of examples

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -133,10 +133,13 @@ module.exports = metalsmith
     }
 
     await Promise.all([
-      copyAssets('{fonts/*,images/*,manifest.json}', {
-        cwd: join(dirname(require.resolve('govuk-frontend')), 'assets'),
-        dest: 'assets'
-      }),
+      copyAssets(
+        '{rebrand/images/*,rebrand/manifest.json,fonts/*,images/*,manifest.json}',
+        {
+          cwd: join(dirname(require.resolve('govuk-frontend')), 'assets'),
+          dest: 'assets'
+        }
+      ),
 
       copyAssets('govuk-frontend.min.css?(.map)', {
         cwd: dirname(require.resolve('govuk-frontend')),

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -15,6 +15,13 @@ const canonical = require('metalsmith-canonical') // add a canonical url propert
 const { paths, navigation: menuItems } = require('../config')
 const colours = require('../lib/colours.js') // get colours data
 const nunjucksOptions = require('../lib/nunjucks/index.js') // nunjucks options
+const rebrandedNunjucksOptions = {
+  ...nunjucksOptions,
+  globals: {
+    ...nunjucksOptions.globals,
+    govukRebrand: true
+  }
+}
 
 // Local metalsmith plugins
 const { hashAssets } = require('./fingerprints') // rename files with hash fingerprints
@@ -162,12 +169,32 @@ module.exports = metalsmith
   // check titles are set
   .use(titleChecker())
 
-  // render templating syntax in source files
+  // Duplicate files which should have branded examples
+  .use(async (files, metalsmith, done) => {
+    Object.keys(files).forEach((file) => {
+      if (files[file].rebrand) {
+        const newFile = file.replace('index.njk', 'branded.njk')
+        files[newFile] = { ...files[file] }
+      }
+    })
+    done()
+  })
+
+  // render legacy templating syntax in source files
   .use(
     inPlace({
-      pattern: '**/*.{md,njk}',
+      pattern: ['**/*.{md,njk}', '!**/branded.njk'],
       transform: 'jstransformer-nunjucks',
       engineOptions: nunjucksOptions
+    })
+  )
+
+  // render rebranded templating syntax in source files
+  .use(
+    inPlace({
+      pattern: '**/branded.njk',
+      transform: 'jstransformer-nunjucks',
+      engineOptions: rebrandedNunjucksOptions
     })
   )
 
@@ -214,8 +241,19 @@ module.exports = metalsmith
     layouts({
       default: 'layout.njk',
       directory: join(paths.views, 'layouts'),
-      pattern: '**/*.html',
+      pattern: ['**/*.html', '!**/branded/**/*.html'],
       engineOptions: nunjucksOptions,
+      transform: 'nunjucks'
+    })
+  )
+
+  // apply layouts to source files
+  .use(
+    layouts({
+      default: 'layout.njk',
+      directory: join(paths.views, 'layouts'),
+      pattern: '**/branded/**/*.html',
+      engineOptions: rebrandedNunjucksOptions,
       transform: 'nunjucks'
     })
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",
         "clipboard": "^2.0.11",
-        "govuk-frontend": "^5.9.0",
+        "govuk-frontend": "github:alphagov/govuk-frontend#f11022324",
         "iframe-resizer": "^4.4.5",
         "lunr": "^2.3.9"
       },
@@ -9413,9 +9413,8 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
-      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
+      "version": "5.10.0-internal.1-bk-testing",
+      "resolved": "git+ssh://git@github.com/alphagov/govuk-frontend.git#f110223241822490dfdf6002e94b3876f2b5766e",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "accessible-autocomplete": "^3.0.1",
     "clipboard": "^2.0.11",
-    "govuk-frontend": "^5.9.0",
+    "govuk-frontend": "github:alphagov/govuk-frontend#f11022324",
     "iframe-resizer": "^4.4.5",
     "lunr": "^2.3.9"
   },

--- a/src/components/cookie-banner/default/index.njk
+++ b/src/components/cookie-banner/default/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Cookie banner
 layout: layout-example.njk
+rebrand: true
 ---
 
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}

--- a/src/components/cookie-banner/index.md
+++ b/src/components/cookie-banner/index.md
@@ -16,7 +16,7 @@ Allow users to accept or reject cookies which are not essential to making your s
 
 {% call callout({ tagText: "Brand", colour: "green" }) %}
 
-<p class="govuk-body"><a href="#">See an example of the Cookie banner showing the refreshed GOV.UK branding</a>.</p>
+<p class="govuk-body"><a href="/components/cookie-banner/default/branded/index.html">See an example of the Cookie banner showing the refreshed GOV.UK branding</a>.</p>
 
 {% endcall %}
 

--- a/src/components/footer/default/index.njk
+++ b/src/components/footer/default/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Footer
 layout: layout-example.njk
+rebrand: true
 ---
 
 {% from "govuk/components/footer/macro.njk" import govukFooter %}

--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -17,7 +17,7 @@ The GOV.UK footer provides copyright, licensing and other information about your
 
 {% call callout({ tagText: "Brand", colour: "green" }) %}
 
-<p class="govuk-body"><a href="#">See an example of the GOV.UK footer showing the refreshed GOV.UK branding</a>.</p>
+<p class="govuk-body"><a href="/components/footer/default/branded/index.html">See an example of the GOV.UK footer showing the refreshed GOV.UK branding</a>.</p>
 
 {% endcall %}
 

--- a/src/components/header/default/index.njk
+++ b/src/components/header/default/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Header
 layout: layout-example.njk
+rebrand: true
 ---
 
 {% from "govuk/components/header/macro.njk" import govukHeader %}

--- a/src/components/header/index.md
+++ b/src/components/header/index.md
@@ -16,7 +16,7 @@ The GOV.UK header component tells users they’re using a service on GOV.UK and 
 
 {% call callout({ tagText: "Brand", colour: "green" }) %}
 
-<p class="govuk-body"><a href="#">See an example of the GOV.UK header showing the refreshed GOV.UK branding</a>.</p>
+<p class="govuk-body"><a href="/components/header/default/branded/index.html">See an example of the GOV.UK header showing the refreshed GOV.UK branding</a>.</p>
 {% endcall %}
 
 If you use the page template, you'll also get the GOV.UK header without having to add it, as it's included by default. However, if you want to customise the default GOV.UK header, read the [page template guidance about customising components](/styles/page-template/#changing-template-content).

--- a/src/components/service-navigation/default/index.njk
+++ b/src/components/service-navigation/default/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Service navigation
 layout: layout-example.njk
+rebrand: true
 ---
 
 {% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}

--- a/src/components/service-navigation/index.md
+++ b/src/components/service-navigation/index.md
@@ -29,7 +29,7 @@ Service navigation helps users understand that they’re using your service and 
 
 {% call callout({ tagText: "Brand", colour: "green" }) %}
 
-<p class="govuk-body"><a href="#">See an example of the Service navigation showing the refreshed GOV.UK branding</a>.</p>
+<p class="govuk-body"><a href="/components/service-navigation/default/branded/index.html">See an example of the Service navigation showing the refreshed GOV.UK branding</a>.</p>
 
 {% endcall %}
 


### PR DESCRIPTION
## What

- Adds a `rebrand` property to template frontmatter
- If this property is true, during build we create a duplicate of that file named `branded.njk`
- During build, we run metalsmith/in-place and metalsmith/layouts on the existing files as normal
- Then, we run each on the `branded` files, using a Nunjucks environment with the `govukRebranded` global
- Adds rebrand assets to build