### PR TITLE
Add rebrand MVP guidance

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -133,10 +133,13 @@ module.exports = metalsmith
     }
 
     await Promise.all([
-      copyAssets('{fonts/*,images/*,manifest.json}', {
-        cwd: join(dirname(require.resolve('govuk-frontend')), 'assets'),
-        dest: 'assets'
-      }),
+      copyAssets(
+        '{rebrand/images/*,rebrand/manifest.json,fonts/*,images/*,manifest.json}',
+        {
+          cwd: join(dirname(require.resolve('govuk-frontend')), 'assets'),
+          dest: 'assets'
+        }
+      ),
 
       copyAssets('govuk-frontend.min.css?(.map)', {
         cwd: dirname(require.resolve('govuk-frontend')),

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -15,6 +15,13 @@ const canonical = require('metalsmith-canonical') // add a canonical url propert
 const { paths, navigation: menuItems } = require('../config')
 const colours = require('../lib/colours.js') // get colours data
 const nunjucksOptions = require('../lib/nunjucks/index.js') // nunjucks options
+const rebrandedNunjucksOptions = {
+  ...nunjucksOptions,
+  globals: {
+    ...nunjucksOptions.globals,
+    govukRebrand: true
+  }
+}
 
 // Local metalsmith plugins
 const { hashAssets } = require('./fingerprints') // rename files with hash fingerprints
@@ -162,12 +169,32 @@ module.exports = metalsmith
   // check titles are set
   .use(titleChecker())
 
-  // render templating syntax in source files
+  // Duplicate files which should have branded examples
+  .use(async (files, metalsmith, done) => {
+    Object.keys(files).forEach((file) => {
+      if (files[file].rebrand) {
+        const newFile = file.replace('index.njk', 'branded.njk')
+        files[newFile] = { ...files[file] }
+      }
+    })
+    done()
+  })
+
+  // render legacy templating syntax in source files
   .use(
     inPlace({
-      pattern: '**/*.{md,njk}',
+      pattern: ['**/*.{md,njk}', '!**/branded.njk'],
       transform: 'jstransformer-nunjucks',
       engineOptions: nunjucksOptions
+    })
+  )
+
+  // render rebranded templating syntax in source files
+  .use(
+    inPlace({
+      pattern: '**/branded.njk',
+      transform: 'jstransformer-nunjucks',
+      engineOptions: rebrandedNunjucksOptions
     })
   )
 
@@ -214,8 +241,19 @@ module.exports = metalsmith
     layouts({
       default: 'layout.njk',
       directory: join(paths.views, 'layouts'),
-      pattern: '**/*.html',
+      pattern: ['**/*.html', '!**/branded/**/*.html'],
       engineOptions: nunjucksOptions,
+      transform: 'nunjucks'
+    })
+  )
+
+  // apply layouts to source files
+  .use(
+    layouts({
+      default: 'layout.njk',
+      directory: join(paths.views, 'layouts'),
+      pattern: '**/branded/**/*.html',
+      engineOptions: rebrandedNunjucksOptions,
       transform: 'nunjucks'
     })
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",
         "clipboard": "^2.0.11",
-        "govuk-frontend": "^5.9.0",
+        "govuk-frontend": "^5.10.0",
         "iframe-resizer": "^4.4.5",
         "lunr": "^2.3.9"
       },
@@ -9413,9 +9413,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
-      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.0.tgz",
+      "integrity": "sha512-9tjpB8PDwsDqutkQPJXfDalLvNOeKxzFhV7me21s/oyn7HcTg/ei/GC3Y4JvNsXauzjOkxv4eeCHntKeySkdMg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "accessible-autocomplete": "^3.0.1",
     "clipboard": "^2.0.11",
-    "govuk-frontend": "^5.9.0",
+    "govuk-frontend": "^5.10.0",
     "iframe-resizer": "^4.4.5",
     "lunr": "^2.3.9"
   },

--- a/src/accessibility/wcag-2.2/index.md
+++ b/src/accessibility/wcag-2.2/index.md
@@ -37,7 +37,7 @@ We've made changes to these components and patterns to comply with WCAG 2.2 leve
 
 See an [explanation of every success criteria in WCAG 2.2](https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/) on the W3C website.
 
-[Our Images page](/styles/images/) also includes guidance to help ensure icons and images in your service meet Target size (minimum).
+In June 2025, the Design System started to retire the WCAG 2.2 labels in our components and patterns, bringing the WCAG 2.2-specific messages into our overall guidance where it's useful.
 
 {{ govukTable({
   caption: "Components",
@@ -55,34 +55,10 @@ See an [explanation of every success criteria in WCAG 2.2](https://www.w3.org/WA
   rows: [
     [
       {
-        html: '<a href="/components/back-link/">Back link component</a>'
-      },
-      {
-        html: 'Redundant entry<br>Target size (minimum)'
-      }
-    ],
-    [
-      {
-        html: '<a href="/components/breadcrumbs/">Breadcrumbs component</a>'
-      },
-      {
-        html: 'Target size (minimum)'
-      }
-    ],
-    [
-      {
         html: '<a href="/components/button/">Button component</a>'
       },
       {
         html: 'Target size (minimum)'
-      }
-    ],
-    [
-      {
-        html: '<a href="/components/cookie-banner/">Cookie banner component</a>'
-      },
-      {
-        html: 'Focus not obscured (minimum)<br>Target size (minimum)'
       }
     ],
     [
@@ -103,22 +79,6 @@ See an [explanation of every success criteria in WCAG 2.2](https://www.w3.org/WA
     ],
     [
       {
-        html: '<a href="/components/footer/">GOV.UK footer component</a>'
-      },
-      {
-        html: 'Consistent help'
-      }
-    ],
-    [
-      {
-        html: '<a href="/components/header/">GOV.UK header component</a>'
-      },
-      {
-        html: 'Focus not obscured (Minimum)<br>Consistent help'
-      }
-    ],
-    [
-      {
         html: '<a href="/components/phase-banner/">Phase banner component</a>'
       },
       {
@@ -131,14 +91,6 @@ See an [explanation of every success criteria in WCAG 2.2](https://www.w3.org/WA
       },
       {
         html: 'Dragging movements'
-      }
-    ],
-    [
-      {
-        html: '<a href="/components/service-navigation/">Service navigation component</a>'
-      },
-      {
-        html: 'Focus not obscured (Minimum)<br>Consistent help'
       }
     ],
     [

--- a/src/components/back-link/index.md
+++ b/src/components/back-link/index.md
@@ -8,26 +8,8 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "_wcag-callout.njk" import wcagCallout %}
-{% from "_wcag-note.njk" import wcagNote %}
 
 Use the back link component to help users go back to the previous page in a multi-page transaction.
-
-{{ wcagCallout({
-  type: "component",
-  introAction: "use the",
-  name: "Back link",
-  criteria: [
-    {
-      text: "make sure users do not need to re-enter information they've previously given when they go back to a page",
-      anchor: "wcag-avoid-information-reentry"
-    },
-    {
-      text: "make sure users can interact with the Back link component",
-      anchor: "wcag-interact-back-links"
-    }
-  ]
-}) }}
 
 Although browsers have a back button, some sites break when you use it - so many users avoid it, instead of losing their progress in a service. Also, not all users are aware of the back button.
 
@@ -48,17 +30,6 @@ Never use the back link component together with the [Breadcrumbs component](/com
 Always place back links at the top of a page, before the `<main>` element. Placing them here means that the 'Skip to main content' link allows the user to skip all navigation links, including the back link.
 
 Make sure the link takes users to the previous page they were on, in the state they last saw it.
-
-{% call wcagNote({id: "wcag-avoid-information-reentry"}) %}
-
-<p>If a user decides to go back to a previous page, make sure information they have already entered is pre-populated.</p>
-<p>Do not pre-populate if the information is no longer valid, or when pre-populating would be a major safety or security concern. This is to comply with <a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">WCAG 2.2 success criterion 3.3.7 Redundant entry</a>.</p>
-{% endcall %}
-
-{% call wcagNote({id: "wcag-interact-back-links"}) %}
-
-<p>Make sure no other interactive elements are too close to the Back link component. This is to make sure users can easily interact with it. This relates to <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">WCAG 2.2 success criterion 2.5.8 Target size (minimum)</a>.</p>
-{% endcall %}
 
 Where possible, ensure the back link works even when JavaScript is not available. If this is not possible, you should hide the back link when JavaScript is not available.
 

--- a/src/components/breadcrumbs/index.md
+++ b/src/components/breadcrumbs/index.md
@@ -8,22 +8,8 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "_wcag-callout.njk" import wcagCallout %}
-{% from "_wcag-note.njk" import wcagNote %}
 
 The breadcrumbs component helps users to understand where they are within a website’s structure and move between levels.
-
-{{ wcagCallout({
-  type: "component",
-  introAction: "use",
-  name: "Breadcrumbs",
-  criteria: [
-    {
-      text: "make sure users can interact with the Breadcrumbs component",
-      anchor: "wcag-interact-breadcrumbs"
-    }
-  ]
-}) }}
 
 {{ example({ group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
@@ -42,11 +28,6 @@ If you’re using other navigational elements on the page, such as a sidebar, co
 Always place breadcrumbs at the top of a page, before the `<main>` element. Placing them here means that the 'Skip to main content' link allows the user to skip all navigation links, including breadcrumbs.
 
 The breadcrumbs should start with your 'home' page and end with the parent section of the current page.
-
-{% call wcagNote({id: "wcag-interact-breadcrumbs"}) %}
-
-<p>Make sure no other interactive elements are too close to the Breadcrumbs component. This is to make sure users can easily interact with it. This relates to <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">WCAG 2.2 success criterion 2.5.8 Target size (minimum)</a>.</p>
-{% endcall %}
 
 There are 2 ways to use the breadcrumbs component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 

--- a/src/components/cookie-banner/default/index.njk
+++ b/src/components/cookie-banner/default/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Cookie banner
 layout: layout-example.njk
+rebrand: true
 ---
 
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}

--- a/src/components/cookie-banner/index.md
+++ b/src/components/cookie-banner/index.md
@@ -8,28 +8,37 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "_wcag-callout.njk" import wcagCallout %}
-{% from "_wcag-note.njk" import wcagNote %}
+{% from "_callout.njk" import callout %}
 
 Allow users to accept or reject cookies which are not essential to making your service work.
 
-{{ wcagCallout({
-  type: "component",
-  introAction: "use the",
-  name: "Cookie banner",
-  criteria: [
-    {
-      text: "make sure that items in focus can be seen all times",
-      anchor: "wcag-see-focus"
-    },
-    {
-      text: "make sure users can interact with buttons and links in the Cookie banner component",
-      anchor: "wcag-interact-cookie-banner"
-    }
-  ]
-}) }}
-
 {{ example({ group: "components", item: "cookie-banner", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+
+{% call callout({ tagText: "Brand", colour: "green" }) %}
+
+<p class="govuk-body"><a href="#">See an example of the Cookie banner showing the refreshed GOV.UK branding</a>.</p>
+
+{% endcall %}
+
+If you use the page template, you'll also get the Cookie banner without having to add it, as it's included by default. However, if you want to customise the default Cookie banner, read the [page template guidance about customising components](/styles/page-template/#changing-template-content).
+
+{% call callout({ tagText: "Brand", colour: "green", isInset: "true" }) %}
+
+<h2 class="app-callout__heading">Brand changes to the {{title}} component</h2>
+<p class="govuk-body">From 25 June 2025, the {{title}} component will change to support a wider refresh of the GOV.UK brand. </p>
+
+<p class="govuk-body">The Cookie banner component’s background colour will change to light blue.</p>
+
+<p class="govuk-body">To help service teams in government get ready to use the new branding, we’ve provided several options to update their services.</p>
+{% endcall %}
+
+### Update to refresh the GOV.UK brand
+
+If you use the Nunjucks macro and page template across your service, you can enable the brand refresh by setting the page template’s `rebrand` option to `true`. This will automatically make all needed changes related to the brand refresh.
+
+You can enable the brand refresh within the GOV.UK header component by setting its `rebrand` option to true. You’ll also need to add some code to your `<html>` and `<head>` elements.
+
+[See the release notes for more details](https://github.com/alphagov/govuk-frontend/releases) and and other ways to update.
 
 ## When to use this component
 
@@ -81,15 +90,7 @@ Make sure the cookie banner does not:
 
 Position the cookie banner after the opening `<body>` tag and before the ’skip to main content‘ link. If you're using the Nunjucks page template, use the `bodyStart` block.
 
-{% call wcagNote({id: "wcag-see-focus"}) %}
-
-<p>Do not make the Cookie banner component ‘sticky’ to the top of the page by using `position: fixed` or any other method. This is to make sure it does not cover or obscure any content which has a focus applied. This is to comply with <a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html">WCAG 2.2 success criterion 2.4.11 Focus not obscured (minimum)</a>.</p>
-{% endcall %}
-
-{% call wcagNote({id: "wcag-interact-cookie-banner"}) %}
-
-<p>Do not change the padding or margins of buttons and links within the Cookie banner component. This is to make sure there’s adequate space for the user to interact with the buttons and links. This relates to <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">WCAG 2.2 success criterion 2.5.8 Target size (minimum)</a>.</p>
-{% endcall %}
+Do not make the Cookie banner component ‘sticky’ to the top of the page by using `position: fixed` or any other method. This is to make sure it does not cover or obscure any content which has a focus applied. This is to comply with [WCAG 2.2 success criterion 2.4.11 Focus not obscured (minimum)](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html).
 
 ### Option 1: If you’re only using essential cookies
 

--- a/src/components/cookie-banner/index.md
+++ b/src/components/cookie-banner/index.md
@@ -16,7 +16,7 @@ Allow users to accept or reject cookies which are not essential to making your s
 
 {% call callout({ tagText: "Brand", colour: "green" }) %}
 
-<p class="govuk-body"><a href="#">See an example of the Cookie banner showing the refreshed GOV.UK branding</a>.</p>
+<p class="govuk-body"><a href="/components/cookie-banner/default/branded/index.html">See an example of the Cookie banner showing the refreshed GOV.UK branding</a>.</p>
 
 {% endcall %}
 

--- a/src/components/cookie-banner/index.md
+++ b/src/components/cookie-banner/index.md
@@ -24,21 +24,15 @@ If you use the page template, you'll also get the Cookie banner without having t
 
 {% call callout({ tagText: "Brand", colour: "green", isInset: "true" }) %}
 
-<h2 class="app-callout__heading">Brand changes to the {{title}} component</h2>
+<h2 class="app-callout__heading">Brand refresh of the {{title}} component</h2>
 <p class="govuk-body">From 25 June 2025, the {{title}} component will change to support a wider refresh of the GOV.UK brand. </p>
 
 <p class="govuk-body">The Cookie banner component’s background colour will change to light blue.</p>
 
-<p class="govuk-body">To help service teams in government get ready to use the new branding, we’ve provided several options to update their services.</p>
+<p class="govuk-body">To help service teams in government get ready, we’ve released GOV.UK Frontend v5.10.0.</p>
+
+<p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">full release notes</a> to see more details and how to update.</p>
 {% endcall %}
-
-### Update to refresh the GOV.UK brand
-
-If you use the Nunjucks macro and page template across your service, you can enable the brand refresh by setting the page template’s `rebrand` option to `true`. This will automatically make all needed changes related to the brand refresh.
-
-You can enable the brand refresh within the GOV.UK header component by setting its `rebrand` option to true. You’ll also need to add some code to your `<html>` and `<head>` elements.
-
-[See the release notes for more details](https://github.com/alphagov/govuk-frontend/releases) and and other ways to update.
 
 ## When to use this component
 

--- a/src/components/footer/default/index.njk
+++ b/src/components/footer/default/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Footer
 layout: layout-example.njk
+rebrand: true
 ---
 
 {% from "govuk/components/footer/macro.njk" import govukFooter %}

--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -17,7 +17,7 @@ The GOV.UK footer provides copyright, licensing and other information about your
 
 {% call callout({ tagText: "Brand", colour: "green" }) %}
 
-<p class="govuk-body"><a href="#">See an example of the GOV.UK footer showing the refreshed GOV.UK branding</a>.</p>
+<p class="govuk-body"><a href="/components/footer/default/branded/index.html">See an example of the GOV.UK footer showing the refreshed GOV.UK branding</a>.</p>
 
 {% endcall %}
 

--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -8,26 +8,33 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "_wcag-callout.njk" import wcagCallout %}
-{% from "_wcag-note.njk" import wcagNote %}
+{% from "_callout.njk" import callout %}
+{%- from "govuk/components/tag/macro.njk" import govukTag -%}
 
 The GOV.UK footer provides copyright, licensing and other information about your service.
 
-{{ wcagCallout({
-  type: "component",
-  introAction: "use the",
-  name: "GOV.UK footer",
-  criteria: [
-    {
-      text: "make sure help links can be found in a consistent place on each page",
-      anchor: "wcag-consistent-links"
-    }
-  ]
-}) }}
-
 {{ example({ group: "components", item: "footer", example: "default", id: "default-1", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
+{% call callout({ tagText: "Brand", colour: "green" }) %}
+
+<p class="govuk-body"><a href="#">See an example of the GOV.UK footer showing the refreshed GOV.UK branding</a>.</p>
+
+{% endcall %}
+
 If you use the page template, you'll also get the footer without having to add it, as it's included by default. However, if you want to customise the default footer, read the [page template guidance about customising components](/styles/page-template/#changing-template-content).
+
+{% call callout({ tagText: "Brand", colour: "green", isInset: "true" }) %}
+
+<h2 class="app-callout__heading">Brand changes to the {{title}} component</h2><p class="govuk-body">From 25 June 2025, the {{title}} component will change to support a wider refresh of the GOV.UK brand.</p>
+
+<p class="govuk-body">The updated {{title}} component:</p>
+<ul class="govuk-list">
+<li>uses a light blue as the background colour, instead of grey</li>
+<li>adds a thick blue top border</li>
+<li>adds a small crown logo, in addition to the existing coat of arms</li>
+</ul>
+<p class="govuk-body">To help service teams in government get ready to use the new branding, <a href="#update-to-refresh-the-govuk-brand">we’ve provided several options to update their services</a>.</p>
+{% endcall %}
 
 ## When to use this component
 
@@ -38,6 +45,18 @@ Use the footer at the bottom of every page of your service.
 Add a copyright notice to the footer to clarify who owns the copyright. For GOV.UK services, add the coat of arms to keep things consistent with the rest of GOV.UK.
 
 Make it clear whether content is available for re-use - and if it is, under what sort of licence. Use an [Open Government Licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) unless you have permission from the National Archives to use a [different type of licence](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/other-licences/).
+
+### Update to refresh the GOV.UK brand
+
+<strong class="govuk-tag brand-tag-green">
+  Brand<span class="govuk-visually-hidden"> note</span>
+</strong>
+
+If you use the Nunjucks macro and page template across your service, you can enable the brand refresh by setting the page template’s `rebrand` option to `true`. This will automatically make all needed changes related to the brand refresh.
+
+You can enable the brand refresh within the GOV.UK footer component by setting its `rebrand` option to true. You’ll also need to add some code to your `<html>` and `<head>` elements.
+
+[See the release notes](https://github.com/alphagov/govuk-frontend/releases) for more details and other ways to update.
 
 ### Footer without links
 
@@ -60,10 +79,9 @@ You can add links to:
 
 Use ‘Privacy’, ‘Accessibility’, ‘Cookies’ and ‘Terms and conditions’ for the link text.
 
-{% call wcagNote({id: "wcag-consistent-links"}) %}
+If you include links to ‘help’ pages within the GOV.UK footer component, make sure to place those links consistently within the footer content.
 
-<p>If you include links to ‘help’ pages within the GOV.UK footer component, make sure to place those links consistently within the footer content. Also make sure that ‘help’ links always function in a similar way across each page. This is to comply with <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">WCAG 2.2 success criterion 3.2.6 Consistent help</a>.</p>
-{% endcall %}
+Also make sure that ‘help’ links always function in a similar way across each page. This is to comply with [WCAG 2.2 success criterion 3.2.6 Consistent help](https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html).
 
 ## Adding secondary navigation
 

--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -25,7 +25,7 @@ If you use the page template, you'll also get the footer without having to add i
 
 {% call callout({ tagText: "Brand", colour: "green", isInset: "true" }) %}
 
-<h2 class="app-callout__heading">Brand changes to the {{title}} component</h2><p class="govuk-body">From 25 June 2025, the {{title}} component will change to support a wider refresh of the GOV.UK brand.</p>
+<h2 class="app-callout__heading">Brand refresh of the {{title}} component</h2><p class="govuk-body">From 25 June 2025, the {{title}} component will change to support a wider refresh of the GOV.UK brand.</p>
 
 <p class="govuk-body">The updated {{title}} component:</p>
 <ul class="govuk-list">
@@ -33,7 +33,10 @@ If you use the page template, you'll also get the footer without having to add i
 <li>adds a thick blue top border</li>
 <li>adds a small crown logo, in addition to the existing coat of arms</li>
 </ul>
-<p class="govuk-body">To help service teams in government get ready to use the new branding, <a href="#update-to-refresh-the-govuk-brand">we’ve provided several options to update their services</a>.</p>
+
+<p class="govuk-body">To help service teams in government get ready, we’ve released GOV.UK Frontend v5.10.0.</p>
+
+<p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">full release notes</a> to see more details and how to update.</p>
 {% endcall %}
 
 ## When to use this component
@@ -45,18 +48,6 @@ Use the footer at the bottom of every page of your service.
 Add a copyright notice to the footer to clarify who owns the copyright. For GOV.UK services, add the coat of arms to keep things consistent with the rest of GOV.UK.
 
 Make it clear whether content is available for re-use - and if it is, under what sort of licence. Use an [Open Government Licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) unless you have permission from the National Archives to use a [different type of licence](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/other-licences/).
-
-### Update to refresh the GOV.UK brand
-
-<strong class="govuk-tag brand-tag-green">
-  Brand<span class="govuk-visually-hidden"> note</span>
-</strong>
-
-If you use the Nunjucks macro and page template across your service, you can enable the brand refresh by setting the page template’s `rebrand` option to `true`. This will automatically make all needed changes related to the brand refresh.
-
-You can enable the brand refresh within the GOV.UK footer component by setting its `rebrand` option to true. You’ll also need to add some code to your `<html>` and `<head>` elements.
-
-[See the release notes](https://github.com/alphagov/govuk-frontend/releases) for more details and other ways to update.
 
 ### Footer without links
 

--- a/src/components/header/default/index.njk
+++ b/src/components/header/default/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Header
 layout: layout-example.njk
+rebrand: true
 ---
 
 {% from "govuk/components/header/macro.njk" import govukHeader %}

--- a/src/components/header/index.md
+++ b/src/components/header/index.md
@@ -8,30 +8,34 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "_wcag-callout.njk" import wcagCallout %}
-{% from "_wcag-note.njk" import wcagNote %}
+{% from "_callout.njk" import callout %}
 
 The GOV.UK header component tells users they’re using a service on GOV.UK and lets them use GOV.UK-wide tools. Also known as the GOV.UK masthead.
 
-{{ wcagCallout({
-  type: "component",
-  introAction: "use the",
-  name: "GOV.UK header",
-  criteria: [
-    {
-      text: "make sure all page content can be seen when the user interacts with a dropdown menu",
-      anchor: "wcag-do-not-cover-content"
-    },
-    {
-      text: "make sure help links can be found in a consistent place on each page",
-      anchor: "wcag-consistent-help-links"
-    }
-  ]
-}) }}
-
 {{ example({ group: "components", item: "header", example: "default", id: "default-1", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
+{% call callout({ tagText: "Brand", colour: "green" }) %}
+
+<p class="govuk-body"><a href="#">See an example of the GOV.UK header showing the refreshed GOV.UK branding</a>.</p>
+{% endcall %}
+
 If you use the page template, you'll also get the GOV.UK header without having to add it, as it's included by default. However, if you want to customise the default GOV.UK header, read the [page template guidance about customising components](/styles/page-template/#changing-template-content).
+
+{% call callout({ tagText: "Brand", colour: "green", isInset: "true" }) %}
+
+<h2 class="app-callout__heading">Brand changes to the {{title}} component</h2>
+<p class="govuk-body">From 25 June 2025, the {{title}} component will change to support a wider refresh of the GOV.UK brand. </p>
+
+<p class="govuk-body">The updated {{title}} component:</p>
+
+<ul class="govuk-list">
+<li>uses blue as the background colour, instead of black</li>
+<li>uses a new logo and wordmark lockup</li>
+<li>adds 60px in height</li>
+</ul>
+
+<p class="govuk-body">To help service teams in government get ready to use the new branding, <a href="#update-to-refresh-the-govuk-brand">we’ve provided several options to update their services</a>.</p>
+{% endcall %}
 
 ## When to use this component
 
@@ -56,6 +60,18 @@ Together, the GOV.UK header and [Service navigation component](/components/servi
 This also assures users that they’re in the right place to use your service and to understand that GOV.UK functions as one website.
 
 For guidance on how to plan your header and navigation, see the [Help users navigate a service pattern](/patterns/navigate-a-service).
+
+### Update to refresh the GOV.UK brand
+
+<strong class="govuk-tag brand-tag-green">
+  Brand<span class="govuk-visually-hidden"> note</span>
+</strong>
+
+If you use the Nunjucks macro and page template across your service, you can enable the brand refresh by setting the page template’s `rebrand` option to `true`. This will automatically make all needed changes related to the brand refresh.
+
+You can enable the brand refresh within the GOV.UK header component by setting its `rebrand` option to true. You’ll also need to add some code to your `<html>` and `<head>` elements.
+
+[See the release notes for more details](https://github.com/alphagov/govuk-frontend/releases) and and other ways to update.
 
 ### Default GOV.UK header
 
@@ -91,20 +107,6 @@ Use the Service navigation component to show your service name instead. We recom
 We’ve deprecated the [GOV.UK header with navigation](/components/header/with-service-name-and-navigation/) and will remove this option in the next breaking release of GOV.UK Frontend.
 
 Use the Service navigation component to add navigation links instead.
-
-{% call wcagNote({id: "wcag-do-not-cover-content"}) %}
-
-<p>Do not make header elements, like dropdown menus, ‘sticky’ to the top of the page by using `position: fixed` or any other method. In other words, avoid any implementations that cause menus to sit on top of page content.</p>
-<p>This is to make sure elements do not hide or obscure any content which has a focus applied and comply with <a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html">WCAG 2.2 success criterion 2.4.11 Focus not obscured (minimum)</a>.</p>
-{% endcall %}
-
-In November 2021, [the GOV.UK homepage introduced a menu bar](https://insidegovuk.blog.gov.uk/2021/11/11/launching-gov-uks-new-menu-bar/) that avoids obscuring content by shifting the page down.
-
-{% call wcagNote({id: "wcag-consistent-help-links"}) %}
-
-<p>You can add a link to a ‘help’ page in your service’s GOV.UK header component. If you do, the link must be positioned consistently within the header, and must always link to the same place.</p>
-<p>For example, a header link to “Get help with this service” must go to the same place as similar header links elsewhere in your service. This is to comply with <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">WCAG 2.2 success criterion 3.2.6 Consistent help</a>.</p>
-{% endcall %}
 
 ### GOV.UK header with One Login
 

--- a/src/components/header/index.md
+++ b/src/components/header/index.md
@@ -23,18 +23,20 @@ If you use the page template, you'll also get the GOV.UK header without having t
 
 {% call callout({ tagText: "Brand", colour: "green", isInset: "true" }) %}
 
-<h2 class="app-callout__heading">Brand changes to the {{title}} component</h2>
+<h2 class="app-callout__heading">Brand refresh of the {{title}} component</h2>
 <p class="govuk-body">From 25 June 2025, the {{title}} component will change to support a wider refresh of the GOV.UK brand. </p>
 
 <p class="govuk-body">The updated {{title}} component:</p>
 
 <ul class="govuk-list">
 <li>uses blue as the background colour, instead of black</li>
-<li>uses a new logo and wordmark lockup</li>
+<li>uses a refreshed GOV.UK logo and wordmark lockup</li>
 <li>adds 60px in height</li>
 </ul>
 
-<p class="govuk-body">To help service teams in government get ready to use the new branding, <a href="#update-to-refresh-the-govuk-brand">we’ve provided several options to update their services</a>.</p>
+<p class="govuk-body">To help service teams in government get ready, we’ve released GOV.UK Frontend v5.10.0.</p>
+          
+<p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">full release notes</a> to see more details and how to update.</p>
 {% endcall %}
 
 ## When to use this component
@@ -60,18 +62,6 @@ Together, the GOV.UK header and [Service navigation component](/components/servi
 This also assures users that they’re in the right place to use your service and to understand that GOV.UK functions as one website.
 
 For guidance on how to plan your header and navigation, see the [Help users navigate a service pattern](/patterns/navigate-a-service).
-
-### Update to refresh the GOV.UK brand
-
-<strong class="govuk-tag brand-tag-green">
-  Brand<span class="govuk-visually-hidden"> note</span>
-</strong>
-
-If you use the Nunjucks macro and page template across your service, you can enable the brand refresh by setting the page template’s `rebrand` option to `true`. This will automatically make all needed changes related to the brand refresh.
-
-You can enable the brand refresh within the GOV.UK header component by setting its `rebrand` option to true. You’ll also need to add some code to your `<html>` and `<head>` elements.
-
-[See the release notes for more details](https://github.com/alphagov/govuk-frontend/releases) and and other ways to update.
 
 ### Default GOV.UK header
 

--- a/src/components/header/index.md
+++ b/src/components/header/index.md
@@ -16,7 +16,7 @@ The GOV.UK header component tells users they’re using a service on GOV.UK and 
 
 {% call callout({ tagText: "Brand", colour: "green" }) %}
 
-<p class="govuk-body"><a href="#">See an example of the GOV.UK header showing the refreshed GOV.UK branding</a>.</p>
+<p class="govuk-body"><a href="/components/header/default/branded/index.html">See an example of the GOV.UK header showing the refreshed GOV.UK branding</a>.</p>
 {% endcall %}
 
 If you use the page template, you'll also get the GOV.UK header without having to add it, as it's included by default. However, if you want to customise the default GOV.UK header, read the [page template guidance about customising components](/styles/page-template/#changing-template-content).

--- a/src/components/service-navigation/default/index.njk
+++ b/src/components/service-navigation/default/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Service navigation
 layout: layout-example.njk
+rebrand: true
 ---
 
 {% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}

--- a/src/components/service-navigation/index.md
+++ b/src/components/service-navigation/index.md
@@ -8,28 +8,32 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{% from "_wcag-callout.njk" import wcagCallout %}
-{% from "_wcag-note.njk" import wcagNote %}
+{% from "_callout.njk" import callout %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 Service navigation helps users understand that they’re using your service and lets them navigate around your service.
 
-{{ wcagCallout({
-  type: "component",
-  introAction: "use",
-  name: "Service navigation",
-  criteria: [
-    {
-      text: "make sure all page content can be seen when the user interacts with a dropdown menu",
-      anchor: "wcag-do-not-cover-content"
-    },
-    {
-      text: "make sure help links can be found in a consistent place on each page",
-      anchor: "wcag-consistent-help-links"
-    }
-  ]
-}) }}
+{% call callout({ tagText: "Brand", colour: "green", isInset: "true" }) %}
+
+<h2 class="app-callout__heading">Brand changes to the {{title}} component</h2><p class="govuk-body">From 25 June 2025, the {{title}} component will change to support a wider refresh of the GOV.UK brand.</p>
+
+<p class="govuk-body">The updated {{title}} component:</p>
+<ul class="govuk-list">
+<li>uses light blue as the background colour, instead of grey</li>
+<li>slightly reduces overall padding</li>
+</ul>
+<p class="govuk-body">To help service teams in government get ready to use the new branding, <a href="#update-to-refresh-the-govuk-brand">we’ve provided several options to update their services</a>.</p>
+{% endcall %}
 
 {{ example({ group: "components", item: "service-navigation", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
+
+{% call callout({ tagText: "Brand", colour: "green" }) %}
+
+<p class="govuk-body"><a href="#">See an example of the Service navigation showing the refreshed GOV.UK branding</a>.</p>
+
+{% endcall %}
+
+If you use the page template, you'll also get the Service navigation without having to add it, as it's included by default. However, if you want to customise the default Service navigation, read the [page template guidance about customising components](/styles/page-template/#changing-template-content).
 
 ## When to use this component
 
@@ -45,6 +49,16 @@ This also assures users that they’re in the right place to use your service an
 
 For guidance on how to plan your header and navigation, see the [Help users navigate a service pattern](/patterns/navigate-a-service/).
 
+### Update to refresh the GOV.UK brand
+
+<strong class="govuk-tag brand-tag-green">
+  Brand<span class="govuk-visually-hidden"> note</span>
+</strong>
+
+If you use the Nunjucks macro and page template across your service, you can enable the brand refresh by setting the page template’s `rebrand` option to `true`. This will automatically make all needed changes related to the brand refresh.
+
+You can enable the brand refresh within the [component] by setting its `rebrand` option to true. You’ll also need to add some code to your `<html>` and `<head>` elements.
+
 ### Change the blue colour bar under the GOV.UK header to full width
 
 To use the GOV.UK header and Service navigation and make them fit together visually, you’ll need to change the bottom blue border of the GOV.UK header to full width.
@@ -52,6 +66,12 @@ To use the GOV.UK header and Service navigation and make them fit together visua
 Apply a class `govuk-header--full-width-border` to the GOV.UK header.
 
 {{ example({ group: "components", item: "service-navigation", example: "with-govuk-header", html: true, nunjucks: true, open: false }) }}
+
+<strong class="govuk-tag brand-tag-green">
+  Brand<span class="govuk-visually-hidden"> note</span>
+</strong>
+
+You do not need to change the bottom border of the updated GOV.UK header component with the refreshed GOV.UK branding.
 
 ### Showing your service name only
 
@@ -67,19 +87,9 @@ Show navigation links to let users navigate to different parts of your service a
 
 See when and how to show navigation links in the [Help users navigate a service pattern](/patterns/navigate-a-service/).
 
-{% call wcagNote({id: "wcag-do-not-cover-content"}) %}
+You can add a link to a ‘help’ page in your Service navigation component. If you do, the link must be positioned consistently within the header, and must always link to the same place.
 
-<p>Do not make header elements, like dropdown menus, ‘sticky’ to the top of the page by using `position: fixed` or any other method. In other words, avoid any implementations that cause menus to sit on top of page content.</p>
-<p>This is to make sure elements do not hide or obscure any content which has a focus applied and comply with <a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html">WCAG 2.2 success criterion 2.4.11 Focus not obscured (minimum)</a>.</p>
-{% endcall %}
-
-In November 2021, [the GOV.UK homepage introduced a menu bar](https://insidegovuk.blog.gov.uk/2021/11/11/launching-gov-uks-new-menu-bar/) that avoids obscuring content by shifting the page down.
-
-{% call wcagNote({id: "wcag-consistent-help-links"}) %}
-
-<p>You can add a link to a ‘help’ page in your Service header component. If you do, the link must be positioned consistently within the header, and must always link to the same place.</p>
-<p>For example, a header link to 'Get help with this service' must go to the same place as similar header links elsewhere in your service. This is to comply with <a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">WCAG 2.2 success criterion 3.2.6 Consistent help</a>.</p>
-{% endcall %}
+For example, a link in the Service navigation component to 'Get help with this service' must go to the same place as similar links in the Service navigation component elsewhere in your service. This is to comply with [WCAG 2.2 success criterion 3.2.6 Consistent help](https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html).
 
 ## Use ‘slots’ to add custom elements
 
@@ -100,6 +110,12 @@ Depending on what you add in the slots, you might need to rename the `aria-label
 There’s a risk that slot contents may look or work differently in a future release of GOV.UK Frontend.
 
 You’ll need to ensure that slot content still works as intended after each update.
+
+## Accessibility
+
+You can add a link to a ‘help’ page in your Service header component. If you do, the link must be positioned consistently within the header, and must always link to the same place.
+
+For example, a header link to 'Get help with this service' must go to the same place as similar header links elsewhere in your service. This is to comply with [WCAG 2.2 success criterion 3.2.6 Consistent help](https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html).
 
 ## Research on this component
 

--- a/src/components/service-navigation/index.md
+++ b/src/components/service-navigation/index.md
@@ -29,7 +29,7 @@ Service navigation helps users understand that they’re using your service and 
 
 {% call callout({ tagText: "Brand", colour: "green" }) %}
 
-<p class="govuk-body"><a href="#">See an example of the Service navigation showing the refreshed GOV.UK branding</a>.</p>
+<p class="govuk-body"><a href="/components/service-navigation/default/branded/index.html">See an example of the Service navigation showing the refreshed GOV.UK branding</a>.</p>
 
 {% endcall %}
 

--- a/src/components/service-navigation/index.md
+++ b/src/components/service-navigation/index.md
@@ -15,14 +15,15 @@ Service navigation helps users understand that they’re using your service and 
 
 {% call callout({ tagText: "Brand", colour: "green", isInset: "true" }) %}
 
-<h2 class="app-callout__heading">Brand changes to the {{title}} component</h2><p class="govuk-body">From 25 June 2025, the {{title}} component will change to support a wider refresh of the GOV.UK brand.</p>
+<h2 class="app-callout__heading">Brand refresh of the {{title}} component</h2><p class="govuk-body">From 25 June 2025, the {{title}} component will change to support a wider refresh of the GOV.UK brand.</p>
 
 <p class="govuk-body">The updated {{title}} component:</p>
 <ul class="govuk-list">
 <li>uses light blue as the background colour, instead of grey</li>
 <li>slightly reduces overall padding</li>
 </ul>
-<p class="govuk-body">To help service teams in government get ready to use the new branding, <a href="#update-to-refresh-the-govuk-brand">we’ve provided several options to update their services</a>.</p>
+<p class="govuk-body">To help service teams in government get ready, we’ve released GOV.UK Frontend v5.10.0.</p>
+<p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">full release notes</a> to see more details and how to update.</p>
 {% endcall %}
 
 {{ example({ group: "components", item: "service-navigation", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
@@ -48,16 +49,6 @@ Together, the [GOV.UK header component](/components/header/) and Service navigat
 This also assures users that they’re in the right place to use your service and to understand that GOV.UK functions as one website.
 
 For guidance on how to plan your header and navigation, see the [Help users navigate a service pattern](/patterns/navigate-a-service/).
-
-### Update to refresh the GOV.UK brand
-
-<strong class="govuk-tag brand-tag-green">
-  Brand<span class="govuk-visually-hidden"> note</span>
-</strong>
-
-If you use the Nunjucks macro and page template across your service, you can enable the brand refresh by setting the page template’s `rebrand` option to `true`. This will automatically make all needed changes related to the brand refresh.
-
-You can enable the brand refresh within the [component] by setting its `rebrand` option to true. You’ll also need to add some code to your `<html>` and `<head>` elements.
 
 ### Change the blue colour bar under the GOV.UK header to full width
 
@@ -86,10 +77,6 @@ Show navigation links to let users navigate to different parts of your service a
 {{ example({ group: "components", item: "service-navigation", example: "with-service-name-and-navigation", html: true, nunjucks: true, open: false }) }}
 
 See when and how to show navigation links in the [Help users navigate a service pattern](/patterns/navigate-a-service/).
-
-You can add a link to a ‘help’ page in your Service navigation component. If you do, the link must be positioned consistently within the header, and must always link to the same place.
-
-For example, a link in the Service navigation component to 'Get help with this service' must go to the same place as similar links in the Service navigation component elsewhere in your service. This is to comply with [WCAG 2.2 success criterion 3.2.6 Consistent help](https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html).
 
 ## Use ‘slots’ to add custom elements
 

--- a/src/styles/images/index.md
+++ b/src/styles/images/index.md
@@ -10,18 +10,8 @@ order: 13
 ---
 
 {% from "_example.njk" import example %}
-{% from "_wcag-callout.njk" import wcagCallout %}
-{% from "_wcag-note.njk" import wcagNote %}
 
 Avoid using images for unnecessary decoration. Only use images if there’s a real user need.
-
-{% call wcagCallout({
-  name: "Images",
-  heading: "New WCAG 2.2 criteria affect how you use images"
-}) %}
-
-  <p>To meet the new Web Content Accessibility Guidelines (WCAG) 2.2 criteria, <a href="#wcag-icon-focus">make sure any icons and images used in links meet the minimum target size</a>. This is to make sure users can easily interact with the link.</p>
-{% endcall %}
 
 Make sure any information contained in an image can be understood by someone who cannot see it. Also consider partially-sighted users with visual impairments and the assistive technologies they might use.
 
@@ -71,11 +61,6 @@ Avoid using icons in most cases. People can understand a single icon to mean dif
 Icons can be more useful in case working systems, where users are familiar with the interface and return to it frequently. In this context, they can help users to scan pages more quickly. In most cases it’s still helpful to include a visible text label alongside any icons.
 
 Do not use a single icon to represent more than one thing. For example, the search icon (magnifying glass) should only be used for search functionality, and not also for screen magnification.
-
-{% call wcagNote({id: "wcag-icon-focus"}) %}
-
-<p>Make sure any icons and images used in links are at least 24px by 24px in size, with adequate spacing. This is to make sure users can easily interact with the link. This relates to <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">WCAG 2.2 success criterion 2.5.8 Target size (minimum)</a>.</p>
-{% endcall %}
 
 ## Avoid images that contain text
 

--- a/src/stylesheets/components/_callout.scss
+++ b/src/stylesheets/components/_callout.scss
@@ -1,0 +1,47 @@
+// Change callout <h2>'s to look like <h3>'s
+// Selector specificity needs to outweigh `.app-content h2`
+.app-callout {
+  .app-callout__heading {
+    @extend %govuk-heading-m;
+    max-width: 30em;
+  }
+
+  // Add highlight styling for callout content
+  &:target {
+    outline-offset: 6px;
+    outline-style: solid;
+    outline-width: 4px;
+  }
+}
+
+.app-callout__tag {
+  margin-top: 1px;
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+}
+
+.app-callout--blue {
+  border-left-color: govuk-colour("blue");
+
+  .app-callout__tag {
+    color: #0f385c;
+    background-color: #d2e2f1;
+  }
+
+  &:target {
+    outline-color: govuk-colour("blue");
+  }
+}
+
+.app-callout--green {
+  border-left-color: #11875a;
+
+  &:target {
+    outline-color: govuk-colour("green");
+  }
+
+  .app-callout__tag {
+    color: #09442d;
+    background-color: #cfe7de;
+  }
+}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -46,6 +46,7 @@ $app-code-color: #d13118;
 
 // App-specific components
 @import "components/back-to-top";
+@import "components/callout";
 @import "components/category-nav";
 @import "components/contact-panel";
 @import "components/cookies-page";
@@ -412,22 +413,6 @@ pre .language-plaintext {
 .app-whats-new {
   border-bottom: 1px solid $govuk-border-colour;
   background-color: $app-light-grey;
-}
-
-.app-wcag-callout {
-  border-left-color: govuk-colour("blue");
-}
-
-// Change headings in WCAG callouts to look like H3s,
-// even though they semantically are H2s
-.app-wcag-callout h2 {
-  @extend %govuk-heading-m;
-  max-width: 30em;
-}
-
-.app-wcag-callout__tag {
-  margin-top: 1px;
-  margin-bottom: govuk-spacing(2);
 }
 
 .app-wcag-note {

--- a/views/partials/_callout.njk
+++ b/views/partials/_callout.njk
@@ -1,0 +1,26 @@
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText -%}
+{% from "govuk/components/tag/macro.njk" import govukTag -%}
+
+{% macro callout(params) -%}
+  {% set calloutContent -%}
+    {{ govukTag({
+      html: params.tagText + '<span class="govuk-visually-hidden"> note</span>',
+      classes: "app-callout__tag"
+    }) }}
+    {% if params.heading -%}
+      <h2 class="app-callout__heading">{{ params.heading }}</h2>
+    {% endif -%}
+    {{ caller() if caller else params.content | safe }}
+  {% endset -%}
+
+  {% if params.isInset === "true" -%}
+    {{ govukInsetText({
+      id: params.id if params.id,
+      html: calloutContent,
+      classes: "app-callout app-callout--" + params.colour
+    }) }}
+  {% else -%}
+    <div {% if params.id %}{{ params.id }} {% endif %}class="app-callout app-callout--{{params.colour}}" role="note">{{ calloutContent | trim | safe }}</div>
+  {% endif -%}
+
+{% endmacro %}

--- a/views/partials/_wcag-callout.njk
+++ b/views/partials/_wcag-callout.njk
@@ -5,7 +5,7 @@
 {% set tagContent -%}
   {{- govukTag({
     text: "WCAG 2.2",
-    classes: "app-wcag-callout__tag"
+    classes: "app-callout__tag"
   }) }}
   <h2>
     {{ params.heading if params.heading else "New WCAG 2.2 criteria affect this " + params.type }}
@@ -25,6 +25,6 @@
 
 {{ govukInsetText({
   html: tagContent,
-  classes: "app-wcag-callout"
+  classes: "app-callout app-callout--blue"
 }) }}
 {% endmacro %}

--- a/views/partials/_wcag-note.njk
+++ b/views/partials/_wcag-note.njk
@@ -4,7 +4,7 @@
 <div class="app-wcag-note" id="{{params.id}}" role="note">
   {{ govukTag({
     text: "WCAG 2.2",
-    classes: "app-wcag-callout__tag"
+    classes: "app-callout__tag"
   }) }}
   {{ caller() if caller else params.content | safe }}
 </div>

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -4,16 +4,16 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
           <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
-          <p class="govuk-body">1 May 2025: Updates to refresh the GOV.UK brand</p>
-          <p class="govuk-body">From June 2025, parts of the Design System will change to support a wider refresh of the GOV.UK brand. To get ready, we’ve released GOV.UK Frontend v5.10.0.</p>
-          <p class="govuk-body">Service teams in government should see the new guidance in these components to update to the refreshed GOV.UK branding:</p>
+          <p class="govuk-body">1 May 2025: We’ve released GOV.UK Frontend v5.10.0</p>
+          <p class="govuk-body">This the first step to refresh the GOV.UK brand. It includes updates to the:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li><a href="/components/header/" class="govuk-link">GOV.UK header component</a></li>
             <li><a href="/components/footer/" class="govuk-link">GOV.UK footer component</a></li>
             <li><a href="/components/service-navigation/" class="govuk-link">Service navigation component</a></li>
             <li><a href="/components/cookie-banner/" class="govuk-link">Cookie banner component</a></li>
           </ul>
-          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">full release notes</a> to see more details on what’s changed.</p>
+          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">full release notes</a> to see what's changed.</p>
+                    <p class="govuk-body">We’ve also recently deprecated the options to show a service name, as well as navigation links, in the GOV.UK header component. Both options will be removed from the GOV.UK header in the next breaking release of GOV.UK Frontend.</p>
         </div>
       </div>
     </div>

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -4,12 +4,16 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
           <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
-          <p class="govuk-body">4 March 2025: We’ve released GOV.UK Frontend v5.9.0</p>
-          <p class="govuk-body">This release includes a <a href="https://design-system.service.gov.uk/components/file-upload/#using-the-improved-file-upload-component" class="govuk-link">JavaScript enhancement to the File upload component</a>, which makes dragging and dropping files easier for users.</p>
-          <p class="govuk-body">We’ve also deprecated the options to show a service name, as well as navigation links, in the GOV.UK header component. Both options will be removed from the GOV.UK header in the next breaking release of GOV.UK Frontend.</p>
-          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0" class="govuk-link">full release notes</a> to see what’s changed.</p>
-          <br>
-          <p class="govuk-body"><a href="https://mailchi.mp/d484adee17c1/email-updates" class="govuk-link">Sign up to get update emails about the Design System</a>.</p>
+          <p class="govuk-body">1 May 2025: Updates to refresh the GOV.UK brand</p>
+          <p class="govuk-body">From June 2025, parts of the Design System will change to support a wider refresh of the GOV.UK brand. To get ready, we’ve released GOV.UK Frontend v5.10.0.</p>
+          <p class="govuk-body">Service teams in government should see the new guidance in these components to update to the refreshed GOV.UK branding:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><a href="/components/header/" class="govuk-link">GOV.UK header component</a></li>
+            <li><a href="/components/footer/" class="govuk-link">GOV.UK footer component</a></li>
+            <li><a href="/components/service-navigation/" class="govuk-link">Service navigation component</a></li>
+            <li><a href="/components/cookie-banner/" class="govuk-link">Cookie banner component</a></li>
+          </ul>
+          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">full release notes</a> to see more details on what’s changed.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What

- Remove WCAG callout/notes from affected components
- Adds a callout macro
- Updates rebranded components' guidance content
- Updates the What's new partial