### PR TITLE
Only initialise CookiesPage JS once

### DIFF
--- a/src/javascripts/application.mjs
+++ b/src/javascripts/application.mjs
@@ -59,9 +59,6 @@ createAll(Search)
 // Initialise back to top
 createAll(BackToTop)
 
-// Initialise cookie page
-createAll(CookiesPage)
-
 const $embedCards = document.querySelectorAll('[data-module="app-embed-card"]')
 
 const lazyEmbedObserver = new IntersectionObserver(function (


### PR DESCRIPTION
As flagged in #4171, we're calling `createAll(CookiesPage)` twice.