### PR TITLE
Add more content to accessibility page

### DIFF
--- a/src/accessibility/index.md
+++ b/src/accessibility/index.md
@@ -1,14 +1,22 @@
 ---
 layout: layout-pane.njk
 title: Accessibility
-description: How we make the GOV.UK Design System accessible and our strategy for improving its accessibility over time.
+description: How we make and keep the GOV.UK Design System accessible and what service teams can do to do the same.
 showSubNav: true
 ---
 
-Our work to make the GOV.UK Design System meet public sector accessibility regulations is a continuous and iterative process. You must [make sure your service is accessible](https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps). We outline our approach on [our accessibility strategy](/accessibility/accessibility-strategy/).
+Our work to make the GOV.UK Design System meet public sector accessibility regulations is a continuous and iterative process.
 
 Using the GOV.UK Design System in a service does not immediately make that service accessible. You’ll need additional research, design, development and testing work to make sure your service is accessible, even when using accessible styles, components and patterns.
 
 ## Accessibility strategy
 
 [Read our accessibility strategy](/accessibility/accessibility-strategy/) for more information on our current principles and work needed to improve the accessibility of the GOV.UK Design System.
+
+## Accessibility statement
+
+[Our accessibility statement](/accessibility-statement/) helps not just end users but also service teams to understand how accessibile GOV.UK Frontend, its documentation website and this website are.
+
+## Accessibility in the Service Manual
+
+The [Accessibility and assisted digital guidance in the Service Manual](https://www.gov.uk/service-manual/helping-people-to-use-your-service) outlines what you need to know and what you need to do to ensure your service is accessible.


### PR DESCRIPTION
Because alphagov/govuk-frontend#4661 removes content from the accessibility page, this adds more content referring to content that already exists.

This PR:

* adds a section and a link to the accessibility statement
* adds a section and a link to the accessibility section in the Service Manual
* removes some text from the introduction to avoid duplication
* adjusts the meta description

This depends on alphagov/govuk-frontend#4661 being merged first and will close https://github.com/alphagov/govuk-design-system/issues/4677.
