### PR TITLE
Remove deprecated `reviewers` option from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -76,9 +76,6 @@ updates:
       - dependency-name: 'iframe-resizer'
         update-types: ['version-update:semver-major']
 
-    reviewers:
-      - alphagov/design-system-developers
-
     # Schedule run every Monday, local time
     schedule:
       interval: monthly
@@ -93,8 +90,6 @@ updates:
   # Update GitHub Actions
   - package-ecosystem: github-actions
     directory: /
-    reviewers:
-      - alphagov/design-system-developers
 
     # Schedule run every Monday, local time
     schedule:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,8 @@
 # Workflows (which have access to secrets and to production)
 .github/workflows/  @alphagov/design-system-developers
+
+# Track changes to package.json or package-lock.json
+/package*.json  @alphagov/design-system-developers
+
+# Protect the CODEOWNERS file itself against malicious changes
+CODEOWNERS  @alphagov/design-system-developers


### PR DESCRIPTION
Dependabot's `reviewers` option is being removed on 27th May, with its functionality being merged with the `CODEOWNERS` file, [as described on the GitHub blog](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).

## Changes
- Updates the `CODEOWNERS` file to include the **root** `package.json` and `package-lock.json` files explicitly, to match npm dependencies being protected by the `reviewers` option in Dependabot's config.
- Updates the `CODEOWNERS` file to include the `CODEOWNERS` file itself, requiring approval from codeowners to change it in future. [This is a recommended security practice.](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection)
- Removes the `reviewers` option from Dependabot config.