### PR TITLE
Add breadcrumbs

### DIFF
--- a/lib/nunjucks/globals.js
+++ b/lib/nunjucks/globals.js
@@ -106,4 +106,59 @@ exports.getHTMLCode = function (path) {
   })
 }
 
+/**
+ * This helper function traverses the navigation object to find an item with a
+ * given `url`, and returns the ancestors of that item.
+ *
+ * NOTE: This is used to assemble breadcrumb navigation, so outputs the result
+ * with keys and values used by that component. These differ from those used
+ * internally.
+ *
+ * @param {string} targetUrl - The URL to look for, without leading `/`
+ * @returns {AncestorPage[]} Array of ancestor pages to this one
+ */
+exports.getAncestorPages = function (targetUrl) {
+  // Get navigation object from the template context
+  const navigationContext = this.lookup('navigation') ?? []
+
+  // Create a stack to store our levels of hierarchy in.
+  // The homepage doesn't appear in the `navigation` object,
+  // so it needs adding manually
+  const ancestors = [{ text: 'Home', href: '/' }]
+
+  // Create a recursive function we can use to navigate the nested objects
+  const traverse = function (navItemArray) {
+    // Using a for instead of a forEach so that we can break the loop once done.
+    for (let i = 0; i < navItemArray.length; i++) {
+      const navItem = navItemArray[i]
+
+      // If the target URL and item URL match, it's the current page. It doesn't
+      // get added to the stack, but it implies that we've reached our target
+      // so there's no reason to continue searching.
+      if (targetUrl === navItem.url) {
+        break
+      }
+
+      // If the target URL *begins* with the current item URL, it's an ancestor
+      // of the target page. Add it to the stack and start looking through it's
+      // child items.
+      if (navItem.items && targetUrl.startsWith(navItem.url)) {
+        ancestors.push({ text: navItem.label, href: `/${navItem.url}` })
+        traverse(navItem.items)
+      }
+    }
+  }
+
+  // Call the recursive function
+  traverse(navigationContext)
+
+  return ancestors
+}
+
 exports.getMacroOptions = getMacroOptions
+
+/**
+ * @typedef {object} AncestorPage
+ * @property {string} href - The URL of the ancestor page
+ * @property {string} text - The title of the ancestor page
+ */

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -75,12 +75,28 @@ $app-code-color: #d13118;
   @include govuk-width-container(1100px);
 }
 
+.app-breadcrumbs,
 .app-content {
-  padding: govuk-spacing(3) govuk-spacing(0) govuk-spacing(4);
+  padding-top: govuk-spacing(3);
+  padding-left: govuk-spacing(3);
 
   @include govuk-media-query($from: tablet) {
-    padding: govuk-spacing(6);
-    padding-right: 0;
+    padding-top: govuk-spacing(6);
+    padding-left: govuk-spacing(6);
+  }
+}
+
+.app-breadcrumbs {
+  // match top padding of the first item in the pane navigation so that the
+  // breadcrumbs line up nicely
+  margin-top: govuk-spacing(1);
+  margin-bottom: 0;
+}
+
+.app-content {
+  padding-bottom: govuk-spacing(4);
+
+  @include govuk-media-query($from: tablet) {
     padding-bottom: govuk-spacing(8);
   }
 

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -46,7 +46,6 @@
   {% include "_header.njk" %}
   {% include "_navigation.njk" %}
   {% include "_banner.njk" %}
-  {% include "_breadcrumbs.njk" %}
 
   {% block body %}
     {{ contents | safe }}

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -46,6 +46,8 @@
   {% include "_header.njk" %}
   {% include "_navigation.njk" %}
   {% include "_banner.njk" %}
+  {% include "_breadcrumbs.njk" %}
+
   {% block body %}
     {{ contents | safe }}
   {% endblock %}

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -10,6 +10,7 @@
     {% include "_subnav.njk" %}
   </div>
   <div class="app-split-pane__content">
+    {% include "_breadcrumbs.njk" %}
     <main id="main-content" class="app-content" role="main">
       {% if not includeThemeInPageHeading %}
       <span class="govuk-caption-xl">

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -12,11 +12,6 @@
   <div class="app-split-pane__content">
     {% include "_breadcrumbs.njk" %}
     <main id="main-content" class="app-content" role="main">
-      {% if not includeThemeInPageHeading %}
-      <span class="govuk-caption-xl">
-        {{ theme if theme else section }}
-      </span>
-      {% endif %}
       <h1 class="govuk-heading-xl {%- if status %} govuk-!-margin-bottom-5{% endif %}">
         {% if includeThemeInPageHeading %}
         <span class="govuk-caption-xl">

--- a/views/partials/_breadcrumbs.njk
+++ b/views/partials/_breadcrumbs.njk
@@ -4,7 +4,7 @@
 hacky, but works as the homepage has an empty string for a permalink. #}
 {% if permalink %}
   {{ govukBreadcrumbs({
-    classes: "app-width-container",
+    classes: "app-breadcrumbs",
     items: getAncestorPages(permalink)
   }) }}
 {% endif %}

--- a/views/partials/_breadcrumbs.njk
+++ b/views/partials/_breadcrumbs.njk
@@ -1,0 +1,10 @@
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+{# Only render breadcrumbs on pages that aren't the homepage. This is a bit
+hacky, but works as the homepage has an empty string for a permalink. #}
+{% if permalink %}
+  {{ govukBreadcrumbs({
+    classes: "app-width-container",
+    items: getAncestorPages(permalink)
+  }) }}
+{% endif %}


### PR DESCRIPTION
## Changes
- Added breadcrumb component to the top of each guidance content page.
  - This is intended to make upwards traversal through the hierarchy a bit easier.
  - Breadcrumbs are not present on the homepage, 'meta' pages (like the privacy policy), 404 page, or archived content pages.
- Added a new global Nunjucks function, `getAncestorPages`, which is used to generate the breadcrumb navigation.
- Removed the theme name from above page titles (except for those in patterns) as they're now duplicating information in the breadcrumbs. 

## Thoughts
Some lower level pages don't appear to work with the breadcrumbs (e.g. [speaker pages for DSDay events](https://design-system.service.gov.uk/community/design-system-day-2023/speaker-information/)). That's because these pages aren't included in the sitewide `navigation` object for some reason. If they're updated to appear there, the breadcrumbs should be able to find them.

Breadcrumbs *only* appear on guidance pages for a couple of reasons: 
- The breadcrumbs have been designed to appear above the page's main heading. The heading is in different locations in the content order depending on the page type, but breadcrumbs cannot move positions without seemingly breaching the [Consistent Navigation WCAG criterion](https://www.w3.org/WAI/WCAG22/Understanding/consistent-navigation.html). By only showing them on the guidance layout, the location of the component remains consistent across uses.
- Guidance pages are the only ones that have a significant navigation hierarchy to them. Other pages, like the 'meta' and 404 page, effectively exist outside of the content hierarchy, so don't benefit from having breadcrumbs.

I first tried to extend the `navigation` object to include the `ancestors` of each page within the object. However, because the page context does not include the page's `navigation` entry, it was necessary to manually traverse the `navigation` object to find the current page. As traversal required navigating the content hierarchy anyway, it seemed simpler to assemble the current page's `ancestors` _during_ the traversal, rather than doing it ahead of time. 