### PR TITLE
Add archived page for deleted WCAG 2.2 page

### DIFF
--- a/src/accessibility/wcag-2.2.md
+++ b/src/accessibility/wcag-2.2.md
@@ -1,0 +1,11 @@
+---
+title: Changes to the Design System to meet WCAG 2.2
+layout: layout-archived.njk
+ignoreInSitemap: true
+---
+
+We have retired WCAG 2.2 callouts and guidance across the Design System website.
+
+The callouts were designed to make teams aware of the changes to WCAG 2.2 and help them make necessary adjustments to their services before October 2024. This was the date that public sector bodies needed to be compliant with the WCAG 2.2 updates to the accessibility regulations. Now that this date has passed we have removed the callouts and brought specific messages into our overall guidance where it’s useful.
+
+Let us know if you are missing any particular information in our [announcement of the WCAG 2.2 callout retirement](https://github.com/alphagov/govuk-design-system/discussions/4697).


### PR DESCRIPTION
When we [deleted the WCAG 2.2 page](https://github.com/alphagov/govuk-design-system/issues/4676) as part of [retiring the WCAG 2.2 callouts](https://github.com/alphagov/govuk-design-system/pull/4661), we forgot to set up an archived page for it.

This is doing that to fix #4703.

Any archived page also has an automatic link to an archive on The National Archives website at the bottom of the main content, which is why I haven't added one.