### PR TITLE
Update website to reference 5.10.2

### DIFF
--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -17,9 +17,11 @@ Last updated 15 May 2025.
 
 ## Recently shipped
 
-We released [GOV.UK Frontend v5.10.1](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.1), which fixes the colour of the dot in the refreshed GOV.UK logo, alongside small fixes to the implementation of the brand refresh.
+We’ve released [GOV.UK Frontend v5.10.2](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.2), which updates the spacing in the header when the navigation is not used, allowing the product name to stay on the same line as the logo for a wider variety of small screens.
 
-Previously, we released [GOV.UK Frontend v5.10.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0), which updates the GOV.UK header, GOV.UK footer, Service navigation and Cookie banner components to use the refreshed GOV.UK brand.
+Previously, we released [GOV.UK Frontend v5.10.1](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.1), which fixes the colour of the dot in the refreshed GOV.UK logo, alongside small fixes to the implementation of the brand refresh.
+
+On 1 May 2025, we released [GOV.UK Frontend v5.10.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0), which updates the GOV.UK header, GOV.UK footer, Service navigation and Cookie banner components to use the refreshed GOV.UK brand.
 
 We also deprecated the options to show a service name, as well as navigation links, in the GOV.UK header component. Both options will be removed from the GOV.UK header in the next breaking release of GOV.UK Frontend.
 

--- a/src/components/cookie-banner/index.md
+++ b/src/components/cookie-banner/index.md
@@ -35,6 +35,7 @@ If you use the page template, you'll also get the Cookie banner without having t
 <ul class="govuk-list govuk-list--bullet">
 <li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">release notes for v5.10.0</a></li>
 <li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.1" class="govuk-link">release notes for v5.10.1</a></li>
+<li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.2" class="govuk-link">release notes for v5.10.2</a></li>
 <li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v4.10.0" class="govuk-link">release notes for v4.10.0</a></li>
 </ul>
 ``

--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -39,6 +39,7 @@ If you use the page template, you'll also get the footer without having to add i
 <ul class="govuk-list govuk-list--bullet">
 <li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">release notes for v5.10.0</a></li>
 <li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.1" class="govuk-link">release notes for v5.10.1</a></li>
+<li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.2" class="govuk-link">release notes for v5.10.2</a></li>
 <li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v4.10.0" class="govuk-link">release notes for v4.10.0</a></li>
 </ul>
 {% endcall %}

--- a/src/components/header/index.md
+++ b/src/components/header/index.md
@@ -40,6 +40,7 @@ If you use the page template, you'll also get the GOV.UK header without having t
 <ul class="govuk-list govuk-list--bullet"> 
           <li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">release notes for v5.10.0</a></li>
           <li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.1" class="govuk-link">release notes for v5.10.1</a></li>
+          <li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.2" class="govuk-link">release notes for v5.10.2</a></li>
           <li><a href="https://github.com/alphagov/govuk-frontend/releases/tag/v4.10.0" class="govuk-link">release notes for v4.10.0</a></li>
 </ul>
 {% endcall %}

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -7,15 +7,15 @@
           <h3 id="29-may-2025" class="govuk-heading-s">29 May 2025: We released GOV.UK Frontend v4.10.0</h3>
           <p class="govuk-body">This is the first step towards refreshing the GOV.UK brand for users of earlier versions of GOV.UK Frontend.</p>
           <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v4.10.0" class="govuk-link">release notes for v4.10.0</a> to see what's changed.</p>
-          <h3 id="15-may-2025" class="govuk-heading-s">15 May 2025: We released GOV.UK Frontend v5.10.1</h3>
-          <p class="govuk-body">GOV.UK Frontend v5.10.0 and this fix version are the first steps towards refreshing the GOV.UK brand. They include updates and fixes to the:</p>
+          <h3 id="15-may-2025" class="govuk-heading-s">29 May 2025: We released GOV.UK Frontend v5.10.2</h3>
+          <p class="govuk-body">GOV.UK Frontend v5.10.0 and its fix versions are the first steps towards refreshing the GOV.UK brand. They include updates and fixes to the:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li><a href="/components/header/" class="govuk-link">GOV.UK header component</a></li>
             <li><a href="/components/footer/" class="govuk-link">GOV.UK footer component</a></li>
             <li><a href="/components/service-navigation/" class="govuk-link">Service navigation component</a></li>
             <li><a href="/components/cookie-banner/" class="govuk-link">Cookie banner component</a></li>
           </ul>
-          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">release notes for v5.10.0</a> and the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.1" class="govuk-link">release notes for v5.10.1</a> to see what's changed.</p>
+          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">release notes for v5.10.0</a>, the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.1" class="govuk-link">release notes for v5.10.1</a> and the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.2" class="govuk-link">release notes for v5.10.2</a> to see what's changed.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Updates the what's new section, roadmap page and brand callouts in components that reference the 5.10.x releases.

This follows the updates off of 4.10.0 in https://github.com/alphagov/govuk-design-system/pull/4706