### PR TITLE
Fix how active navigation item is computed

### DIFF
--- a/lib/nunjucks/filters.js
+++ b/lib/nunjucks/filters.js
@@ -39,3 +39,18 @@ exports.slugify = function (string) {
 exports.smartypants = function (string) {
   return filters.safe(smartypants.hooks.postprocess(string))
 }
+
+/**
+ * Returns whether the given navigation item is active
+ * for the given permalink
+ *
+ * @param {{url: string}} navigationItem - The navigation item
+ * @param {string} permalink - The permalink of the page being rendered
+ * @returns {boolean} `true` if the navigationItem is the `active` page, false otherwise
+ */
+exports.isActive = function (navigationItem, permalink) {
+  return (
+    permalink === navigationItem.url ||
+    permalink.startsWith(`${navigationItem.url}/`)
+  )
+}

--- a/lib/nunjucks/filters.test.mjs
+++ b/lib/nunjucks/filters.test.mjs
@@ -1,4 +1,4 @@
-import { kebabCase, slugify } from './filters.js'
+import { kebabCase, slugify, isActive } from './filters.js'
 
 describe('Filters', () => {
   describe('kebabCase', () => {
@@ -53,5 +53,72 @@ describe('Filters', () => {
     ])("Formats '$input' to '$output'", ({ input, output }) => {
       expect(slugify(input)).toEqual(output)
     })
+  })
+
+  describe('isActive', () => {
+    it.each([
+      {
+        navigationItemUrl: 'path',
+        permalink: 'path/page',
+        expected: true
+      },
+      {
+        navigationItemUrl: 'page',
+        permalink: 'page',
+        expected: true
+      },
+      {
+        navigationItemUrl: 'path',
+        permalink: 'path/sub-path/page',
+        expected: true
+      },
+      {
+        navigationItemUrl: 'path/sub-path',
+        permalink: 'path/sub-path/page',
+        expected: true
+      },
+      {
+        navigationItemUrl: 'path/sub-path',
+        permalink: 'path/sub-path/deeper-path/page',
+        expected: true
+      },
+      {
+        navigationItemUrl: 'path',
+        permalink: 'other-path/page',
+        expected: false
+      },
+      {
+        navigationItemUrl: 'page',
+        permalink: 'other-page',
+        expected: false
+      },
+      {
+        navigationItemUrl: 'path',
+        permalink: 'path-with-something-else/page',
+        expected: false
+      },
+      {
+        navigationItemUrl: 'path/sub-path',
+        permalink: 'path/page',
+        expected: false
+      },
+      {
+        navigationItemUrl: 'path/sub-path',
+        permalink: 'path/sub-path-with-something-else/page',
+        expected: false
+      }
+    ])(
+      'On `$permalink`, for the `$navigationItemUrl` navigation item, `isActive` is `$expected`',
+      ({ permalink, navigationItemUrl, expected }) => {
+        expect(
+          isActive(
+            {
+              url: navigationItemUrl
+            },
+            permalink
+          )
+        ).toEqual(expected)
+      }
+    )
   })
 })

--- a/lib/nunjucks/globals.js
+++ b/lib/nunjucks/globals.js
@@ -9,6 +9,8 @@ const slash = require('slash')
 const { paths } = require('../../config')
 const getMacroOptions = require('../get-macro-options/index.js')
 
+const { isActive } = require('./filters.js')
+
 nunjucks.configure(join(paths.views, 'layouts'))
 
 /**
@@ -142,7 +144,7 @@ exports.getAncestorPages = function (targetUrl) {
       // If the target URL *begins* with the current item URL, it's an ancestor
       // of the target page. Add it to the stack and start looking through it's
       // child items.
-      if (navItem.items && targetUrl.startsWith(navItem.url)) {
+      if (navItem.items && isActive(navItem, targetUrl)) {
         ancestors.push({ text: navItem.label, href: `/${navItem.url}` })
         traverse(navItem.items)
       }

--- a/views/partials/_category-nav.njk
+++ b/views/partials/_category-nav.njk
@@ -7,7 +7,7 @@ pages. #}
 <!-- [html-validate-disable-next unique-landmark -- allow 2 navs with the same aria-labelledby because they contain the same information] -->
 <nav class="category-nav" aria-labelledby="app-subnav-heading">
   {% for item in navigation %}
-    {% if permalink and permalink.startsWith(item.url) %}
+    {% if permalink and item | isActive(permalink) %}
     {% if item.items %}
       {% for theme, items in item.items | groupby("theme") %}
         {% if theme != 'undefined' %}

--- a/views/partials/_mobile-navigation.njk
+++ b/views/partials/_mobile-navigation.njk
@@ -1,6 +1,6 @@
 {% macro mobileNavigationItem(params) %}
   {% set current = true if params.pagePermalink and (params.pagePermalink == params.item.url) else false %}
-  {% set active = (true if params.pagePermalink and params.pagePermalink.startsWith(params.item.url)) if not params.ignoreActive %}
+  {% set active = (true if params.pagePermalink and params.item | isActive(params.pagePermalink)) if not params.ignoreActive %}
 
   <li class="app-mobile-navigation-section__item{%- if current or active %} app-mobile-navigation-section__item--active{% endif %}">
     <a class="govuk-service-navigation__link"

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -25,7 +25,7 @@ service navigation component. #}
     href: '/' + item.url + '/',
     html: item.label + subNavHtml,
     current: true if permalink and (permalink == item.url) else false,
-    active: true if permalink and permalink.startsWith(item.url) else false,
+    active: true if permalink and item | isActive(permalink) else false,
     attributes: {
       "data-module": "app-mobile-navigation-section"
     }

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -2,7 +2,7 @@
 <nav class="app-subnav" aria-labelledby="app-subnav-heading">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   {% for item in navigation %}
-    {% if permalink and permalink.startsWith(item.url) %}
+    {% if permalink and item | isActive(permalink) %}
     {% if item.items %}
       {% for theme, items in item.items | groupby("theme") %}
         {% if theme != 'undefined' %}


### PR DESCRIPTION
Using `item.url.startsWith` led to the accessibility statement (`/accessibility-statement/`) triggering the active state of the 'Accessibility' navigation item (`/accessibility/`) while the page wasn't listed in the sub-pages of the 'Accessibility' section of the site.

This PR adds a new helper, `isActive`, to compute whether a navigation item is active, which is:
- if it fully matches the permalink of the page being rendered
- if it forms the leading part of the path of the page (including the `/` after the item's URL).
