### PR TITLE
Remove padding override for logo

### DIFF
--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -3,8 +3,4 @@
   // unnecessary wrapping of "GOV.UK Design System" on smaller tablet / desktop
   // viewports)
   width: auto;
-
-  // Override the right padding normally used to reserve space for the
-  // mobile menu toggle.
-  padding-right: 0;
 }


### PR DESCRIPTION
As of [GOV.UK Frontend v5.10.2][1] the logo in the header only has padding applied to the right if the menu button is present.

As [discussed in #4668][2], this means that we can now remove this override from the Design System code.

[1]: https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.2
[2]: https://github.com/alphagov/govuk-design-system/pull/4668#discussion_r2111217362