### PR TITLE
Restyle navigation to blend with header and masthead

### DIFF
--- a/lib/nunjucks/globals.js
+++ b/lib/nunjucks/globals.js
@@ -167,3 +167,20 @@ exports.getMacroOptions = getMacroOptions
  * @property {string} href - The URL of the ancestor page
  * @property {string} text - The title of the ancestor page
  */
+
+/**
+ * Helper function that returns true if the current page is the homepage, useful
+ * for outputting things conditionally.
+ *
+ * @returns {boolean} If this is the homepage or not
+ */
+
+exports.isHomepage = function () {
+  const permalink = this.lookup('permalink')
+
+  // The homepage always has an empty string as a permalink
+  if (typeof permalink === 'string' && permalink === '') {
+    return true
+  }
+  return false
+}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -86,6 +86,21 @@ $app-code-color: #d13118;
   @include govuk-width-container(1100px);
 }
 
+// Invert the colours of the navigation on the homepage
+.govuk-template--rebranded .govuk-service-navigation--inverse {
+  // Override mobile menu toggles colour
+  .app-mobile-navigation-section__toggle {
+    border-top-color: $_govuk-rebrand-border-colour-on-blue-tint-95;
+    color: govuk-colour("white");
+  }
+
+  // Override link styles in sub menus
+  .app-mobile-navigation-section__item .govuk-service-navigation__link {
+    @include govuk-link-style-no-visited-state;
+    @include govuk-link-style-no-underline;
+  }
+}
+
 .app-main-wrapper {
   padding-top: govuk-spacing(3);
   padding-bottom: govuk-spacing(4);

--- a/views/layouts/layout.njk
+++ b/views/layouts/layout.njk
@@ -1,9 +1,8 @@
 {% extends "_generic.njk" %}
 
 {% block body %}
-  {# Only render breadcrumbs on pages that aren't the homepage. This is a bit
-  hacky, but works as the homepage has an empty string for a permalink. #}
-  {% if permalink %}
+  {# Only render breadcrumbs on pages that aren't the homepage. #}
+  {% if not isHomepage() %}
     {{ govukBreadcrumbs({
       classes: "app-width-container",
       items: getAncestorPages(permalink)

--- a/views/partials/_navigation.njk
+++ b/views/partials/_navigation.njk
@@ -33,7 +33,7 @@ service navigation component. #}
 {%- endfor %}
 
 {{ govukServiceNavigation({
-  classes: 'app-service-navigation',
+  classes: ('govuk-service-navigation--inverse ' if isHomepage()) + 'app-service-navigation',
   navigation: navLinks,
   navigationClasses: 'app-service-navigation__wrapper'
 }) }}


### PR DESCRIPTION
Restyles the navigation on the homepage to blend in with the redesigned header and masthead. Part of #4734.

## Changes
- Update to a preview branch of govuk-frontend, based on https://github.com/alphagov/govuk-frontend/pull/6015. 
- Add new styles to handle style changes to the accordion navigation that's bespoke to the Design System website.
- Adds a global `isHomepage` function to determine if the current page is the site homepage.
  - Uses this function to determine if the inverse variant should be invoked or not.
  - Refactors breadcrumbs to use this function.
 
## Thoughts
The `isHomepage` function uses similar logic that breadcrumbs were previously using, that is, expecting an empty string for the `permalink` context item (which, as far as I know, only the homepage has). There is probably a nicer way of doing this, like reading the path of the underlying file, but I'm not sure what metadata is available in the page context.