### PR TITLE
Update security.txt redirection

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -35,19 +35,19 @@
   to = "/patterns/phone-numbers/"
   status = 301
 
-# Proxy requests for security.txt to the centralised Cabinet Office
+# Proxy requests for security.txt to the centralised Government Security
 # vulnerability disclosure policy (VDP)
 #
-# https://github.com/alphagov/security.txt
+# https://github.com/co-cddo/gc3-vuln-reporting-iac
 
 [[redirects]]
   from = "/.well-known/security.txt"
-  to = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
+  to = "https://vulnerability-reporting.service.security.gov.uk/.well-known/security.txt"
   status = 200 # Proxy rather than redirect
 
 [[redirects]]
   from = "/security.txt"
-  to = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
+  to = "https://vulnerability-reporting.service.security.gov.uk/.well-known/security.txt"
   status = 200 # Proxy rather than redirect
 
 # Send different cache-control headers depending on the file path


### PR DESCRIPTION
As we've now left the Cabinet Office, the preference is to redirect to the generic top-level VDP instead.

This is based on advice from GC3 (Government Cyber Coordination Centre). The GC3 is a joint initiative between the Cabinet Office, National Cyber Security Centre, and GDS (by virtue of former CDDO).