### PR TITLE
[feature/rebrand] Bump govuk-frontend to 5.11.0-internal.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",
         "clipboard": "^2.0.11",
-        "govuk-frontend": "^5.10.2",
+        "govuk-frontend": "^5.11.0-internal.0",
         "iframe-resizer": "^4.4.5",
         "lunr": "^2.3.9"
       },
@@ -9496,9 +9496,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.10.2",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.2.tgz",
-      "integrity": "sha512-eVYB2rfUCihehZFHQyylt12/OuXq2JLs+70igcrB1FmbepcDqs1XwKiq96hsPbPF9Vn2f6QXO1OatyD3bq5c9Q==",
+      "version": "5.11.0-internal.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.0-internal.0.tgz",
+      "integrity": "sha512-aZk5UXXWaTqL/hMwj/JNsj7y6RuXL/5cjSwg+CX5x3shKHm6C4RLeO6myHCdTIiaVltJ/mfakVoJxFbeXjmuRA==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "accessible-autocomplete": "^3.0.1",
     "clipboard": "^2.0.11",
-    "govuk-frontend": "^5.10.2",
+    "govuk-frontend": "^5.11.0-internal.0",
     "iframe-resizer": "^4.4.5",
     "lunr": "^2.3.9"
   },


### PR DESCRIPTION
5.11.0-internal.0 adds new inverse service navigation styles.