### PR TITLE
Remove mention of service name in description of Header page

### DIFF
--- a/src/components/header/index.md
+++ b/src/components/header/index.md
@@ -1,6 +1,6 @@
 ---
 title: GOV.UK header
-description: The GOV.UK header shows users that they are on GOV.UK and which service they are using
+description: The GOV.UK header shows users that they are on GOV.UK
 section: Components
 aliases: GOV.UK masthead
 backlogIssueId: 97


### PR DESCRIPTION
Using the service name is now deprecated, so shouldn't appear in the description.