### PR TITLE
Add tag to example, and make link optional

### DIFF
--- a/src/stylesheets/components/_example.scss
+++ b/src/stylesheets/components/_example.scss
@@ -25,6 +25,14 @@
   background: $govuk-body-background-colour;
 }
 
+.app-example__toolbar .govuk-tag + .app-example__new-window--bordered {
+  margin-left: govuk-spacing(2);
+  padding-top: govuk-spacing(1);
+  padding-bottom: govuk-spacing(1);
+  padding-left: govuk-spacing(2);
+  border-left: 1px solid $govuk-border-colour;
+}
+
 .app-example__frame {
   display: block;
   width: 100%;

--- a/views/partials/_example.njk
+++ b/views/partials/_example.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
 {% macro example(params) %}
 {% set exampleRoot = "src/" + params.group + "/" + params.item + "/" + params.example + "/" %}
 {% if params.customCode %}
@@ -23,18 +25,30 @@
 {% endif %}
 
 {% set display = params.displayExample | default(true) %}
+{% set openLink = params.openLink | default(true) %}
+{% set hasToolbar = params.openLink or params.tagText %}
 
 {% set multipleTabs = params.html and params.nunjucks %}
 
 <div class="app-example-wrapper" id="{{ exampleId }}" data-module="app-tabs" {%- if params.open %} data-open{% endif %}>
   {% if display %}
     <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
+      {% if hasToolbar %}
       <div class="app-example__toolbar">
-        <a href="{{ exampleURL }}" class="app-example__new-window" target="_blank">
+        {% if params.tagText %}
+          {{ govukTag({
+            text: params.tagText,
+            classes: "govuk-tag--" + params.tagColour | lower if params.tagColour
+          })}}
+        {% endif %}
+        {% if openLink %}
+        <a href="{{ exampleURL }}" class="app-example__new-window {% if params.tagText %}app-example__new-window--bordered{% endif %}" target="_blank">
           {#- Don't use full title visually as the context is shown based on location of this link #}
           Open this example in a new tab<span class="govuk-visually-hidden">: {{ exampleTitle | lower | smartypants }}</span>
         </a>
+        {% endif %}
       </div>
+      {% endif %}
       <iframe title="{{ exampleTitle | smartypants + " example" }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" loading="{% if params.loading %}{{ params.loading }}{% else %}lazy{% endif %}"></iframe>
     </div>
   {% endif %}


### PR DESCRIPTION
Using tagText and tagColour, you can now specify a tag to appear in the example toolbar.

You can also set openLink to false to remove the 'Open this example in a new tab' link

## With tag and link
![With tag and link](https://github.com/user-attachments/assets/d444c72a-f659-4f81-a486-56d4ca8cef22)

## With tag and no link
![With tag and no link](https://github.com/user-attachments/assets/979b0379-1eb6-4d47-ac7d-adb309c93a22)

## With default tag colour
![With default tag colour](https://github.com/user-attachments/assets/1e7fdff4-ccb1-4de5-8a2e-dc801ceb6d13)

## With no tag and no link
![With no tag and no link](https://github.com/user-attachments/assets/b8804bd4-f6a1-4aa9-ba20-cbac71c3de43)
