### PR TITLE
Update govuk-frontend to 5.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",
         "clipboard": "^2.0.11",
-        "govuk-frontend": "^5.11.0",
         "iframe-resizer": "^4.4.5",
         "lunr": "^2.3.9"
       },
@@ -41,6 +40,7 @@
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.1.1",
         "glob": "^11.0.2",
+        "govuk-frontend": "^5.11.1",
         "gray-matter": "^4.0.2",
         "highlight.js": "^11.11.1",
         "html-validate": "^9.5.5",
@@ -9496,9 +9496,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.0.tgz",
-      "integrity": "sha512-RYZDEF1J6nVw5XauQGH+91qplExgHUXfXII7dtIme6I4u3eSvU59yZ0/EFKEwRgTslSqlhJODOnAi5rnQFU5Gw==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.1.tgz",
+      "integrity": "sha512-hJJFpaer4MZLvz/2F9RZ7xZ6FqlzpxL9aw6YWOGK3F1tn419xj2WcVXwOC8Bcj/dc/LanknbWJDGkb+IdkuhTQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "accessible-autocomplete": "^3.0.1",
     "clipboard": "^2.0.11",
-    "govuk-frontend": "^5.11.0",
     "iframe-resizer": "^4.4.5",
     "lunr": "^2.3.9"
   },
@@ -67,6 +66,7 @@
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",
     "glob": "^11.0.2",
+    "govuk-frontend": "^5.11.1",
     "gray-matter": "^4.0.2",
     "highlight.js": "^11.11.1",
     "html-validate": "^9.5.5",


### PR DESCRIPTION
Update to [GOV.UK Frontend 5.11.1](https://github.com/alphagov/govuk-frontend/releases/tag/v5.11.1). 