### PR TITLE
Update "What's new" and "Roadmap"

### DIFF
--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -13,11 +13,13 @@ Some things on the roadmap might change – the purpose is to tell you what’s 
 
 See our [GitHub team board](https://github.com/orgs/alphagov/projects/53) for more details on our plans and day-to-day activities.
 
-Last updated 24 June 2025.
+Last updated 17 July 2025.
 
 ## Recently shipped
 
-We’ve released [GOV.UK Frontend v5.11.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.11.0), which includes improvements to the Service navigation component, making it easier to use on mobile devices and offering a new inverse colour option. We’ve also added deprecation warnings for code built with the LibSass library.
+We've released [GOV.UK Frontend v5.11.1](https://github.com/alphagov/govuk-frontend/releases/tag/v5.11.1), which fixes link styles in the Service navigation on inverted backgrounds and makes `govuk-shade` and `govuk-tint` more reliable.
+
+In June 2025, we released [GOV.UK Frontend v5.11.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.11.0), which includes improvements to the Service navigation component, making it easier to use on mobile devices and offering a new inverse colour option. We also added deprecation warnings for code built with the LibSass library.
 
 In May 2025, we released [GOV.UK Frontend v5.10.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0) (and later fix versions) and [GOV.UK Frontend v4.10.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.10.0). These are the first steps towards refreshing the GOV.UK brand across government services.
 

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -4,8 +4,10 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
           <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
-          <h3 id="29-may-2025" class="govuk-heading-s">24 June 2025: We’ve released GOV.UK Frontend v5.11.0</h3>
-          <p class="govuk-body">This release includes improvements to the Service navigation component, making it easier to use on mobile devices and offering an inverse colour option. We’ve also added deprecation warnings for code built with the LibSass library.</p>
+          <h3 id="17-july-2025" class="govuk-heading-s">17 July 2025: We've released GOV.UK Frontend 5.11.1</h3>
+          <p class="govuk-body">It fixes link styles in the Service navigation on inverted backgrounds and makes <code>govuk-shade</code> and <code>govuk-tint</code> more reliable.</p>
+          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.11.1" class="govuk-link">release notes for v5.11.1</a> to see what's changed.</p>
+          <p class="govuk-body">On 24 June 2025, we released GOV.UK Frontend v5.11.0. This release includes improvements to the Service navigation component, making it easier to use on mobile devices and offering an inverse colour option. We also added deprecation warnings for code built with the LibSass library.</p>
           <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.11.0" class="govuk-link">release notes for v5.11.0</a> to see what's changed.</p>
           <p class="govuk-body">On 29 May 2025, we released GOV.UK Frontend v5.10.0 (with later fix versions) and v4.10.0. These are the first steps towards refreshing the GOV.UK brand across government services.</p>
           <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0" class="govuk-link">release notes for v5.10.0</a>, the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.1" class="govuk-link">release notes for v5.10.1</a>, the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.2" class="govuk-link">release notes for v5.10.2</a> and the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v4.10.0" class="govuk-link">release notes for v4.10.0</a> to see what's changed.</p>


### PR DESCRIPTION
Update content of the "What's new" section of the homepage and the Roadmap page to announce the release of GOV.UK Frontend v5.11.1