### PR TITLE
Better syntax highlighting for examples

### DIFF
--- a/lib/highlight-nunjucks/__tests__/fixtures.njk
+++ b/lib/highlight-nunjucks/__tests__/fixtures.njk
@@ -1,0 +1,41 @@
+{% comment %}This is a comment{% endcomment %}
+{# This is a line comment #}
+{{ variable }}
+{{ variable | filter }}
+{{ variable | filter("string") }}
+{{ super() }}
+{{ govukComponent({
+  thing1: "value1",
+  thing2: "value2"
+})}}
+{{ "hello world" }}
+
+{% if happy and hungry %}
+  I am happy *and* hungry; both are true.
+{% elif happy or hungry %}
+  I am either happy *or* hungry; one or the other is true.
+{% endif %}
+
+{% for item in items %}
+  <li>{{ item.title }}</li>
+{% else %}
+  <li>This would display if the 'item' collection were empty</li>
+{% endfor %}
+
+{% block content %}
+Content
+{% endblock %}
+
+{% extends "base.html" %}
+
+{% include 'standardModalData.html' %}
+
+{% set username = "joe" %}
+
+{% set standardModal %}
+  <p>Set</p>
+{% endset %}
+
+{% macro field(name, value='', type='text') %}
+  <div>Content</div>
+{% endmacro %}

--- a/lib/highlight-nunjucks/__tests__/highlight-nunjucks.test.js
+++ b/lib/highlight-nunjucks/__tests__/highlight-nunjucks.test.js
@@ -1,0 +1,126 @@
+const fs = require('fs')
+const path = require('path')
+
+const hljs = require('highlight.js')
+
+const nunjucksHighlight = require('../index')
+
+hljs.registerLanguage('nunjucks', nunjucksHighlight)
+
+const fixturesPath = path.join(__dirname, 'fixtures.njk')
+const fixturesContent = fs.readFileSync(fixturesPath, 'utf8')
+
+let result
+
+describe('Nunjucks syntax', () => {
+  beforeAll(() => {
+    const highlightedFixtures = hljs.highlight(fixturesContent, {
+      language: 'nunjucks'
+    })
+
+    result = highlightedFixtures.value
+  })
+
+  describe('comments', () => {
+    it('should highlight block comments', () => {
+      expect(result).toContain(
+        '<span class="hljs-comment">{% comment %}This is a comment{% endcomment %}</span>'
+      )
+    })
+
+    it('should highlight line comments', () => {
+      expect(result).toContain(
+        '<span class="hljs-comment">{# This is a line comment #}</span>'
+      )
+    })
+  })
+
+  describe('template variables', () => {
+    it('should highlight simple variables', () => {
+      expect(result).toContain(
+        '<span class="hljs-tag">{{ <span class="hljs-name">variable</span> }}</span>'
+      )
+    })
+
+    it('should highlight variables with filters', () => {
+      expect(result).toContain(
+        '{{ <span class="hljs-name">variable</span> <span class="hljs-operator">|</span> <span class="hljs-name">filter</span> }}'
+      )
+    })
+
+    it('should highlight filter arguments', () => {
+      expect(result).toContain(
+        '<span class="hljs-operator">|</span> <span class="hljs-name">filter</span><span class="language-javascript">('
+      )
+    })
+
+    it('should highlight function calls', () => {
+      expect(result).toContain(
+        '<span class="hljs-tag">{{ <span class="hljs-title">super</span><span class="language-javascript">()</span> }}</span>'
+      )
+    })
+
+    it('should highlight JavaScript in function parameters', () => {
+      expect(result).toContain(
+        '<span class="hljs-tag">{{ <span class="hljs-title">govukComponent</span><span class="language-javascript">('
+      )
+    })
+
+    it('should highlight quoted strings', () => {
+      expect(result).toContain(
+        '<span class="hljs-string">&quot;hello world&quot;</span>'
+      )
+    })
+  })
+
+  describe('template tags', () => {
+    it('should highlight control flow keywords', () => {
+      expect(result).toContain(
+        '<span class="hljs-keyword">if</span> <span class="hljs-variable">happy</span> <span class="hljs-variable">and</span> <span class="hljs-variable">hungry</span> %}</span>'
+      )
+      expect(result).toContain(
+        '<span class="hljs-keyword">elif</span> <span class="hljs-variable">happy</span> <span class="hljs-variable">or</span> <span class="hljs-variable">hungry</span> %}</span>'
+      )
+      expect(result).toContain('<span class="hljs-keyword">endif</span>')
+    })
+
+    it('should highlight loop keywords', () => {
+      expect(result).toContain(
+        '<span class="hljs-keyword">for</span> <span class="hljs-variable">item</span> <span class="hljs-variable">in</span> <span class="hljs-variable">items</span>'
+      )
+    })
+
+    it('should highlight block tags', () => {
+      expect(result).toContain(
+        '<span class="hljs-keyword">block</span> <span class="hljs-variable">content</span>'
+      )
+      expect(result).toContain('<span class="hljs-keyword">endblock</span>')
+    })
+
+    it('should highlight include and extends', () => {
+      expect(result).toContain(
+        '<span class="hljs-keyword">extends</span> <span class="hljs-string">&quot;base.html&quot;</span> %}'
+      )
+      expect(result).toContain(
+        `<span class="hljs-keyword">include</span> <span class="hljs-string">&#x27;standardModalData.html&#x27;</span> %}`
+      )
+    })
+
+    it('should highlight set tags', () => {
+      expect(result).toContain(
+        '<span class="hljs-keyword">set</span> <span class="hljs-variable">username</span> = <span class="hljs-string">&quot;joe&quot;</span> %}'
+      )
+      expect(result).toContain(
+        '<span class="hljs-keyword">set</span> <span class="hljs-variable">standardModal</span> %}'
+      )
+      expect(result).toContain('<span class="hljs-keyword">endset</span>')
+    })
+
+    it('should highlight macro definitions', () => {
+      expect(result).toContain(
+        '<span class="hljs-keyword">macro</span> <span class="hljs-variable">field</span>(<span class="hljs-variable">name</span>, <span class="hljs-variable">value</span>=<span class="hljs-string">&#x27;&#x27;</span>, <span class="hljs-variable">type</span>=<span class="hljs-string">&#x27;text&#x27;</span>) %}'
+      )
+      expect(result).toContain('<span class="hljs-keyword">endmacro</span>')
+    })
+  })
+})

--- a/lib/highlight-nunjucks/index.js
+++ b/lib/highlight-nunjucks/index.js
@@ -1,0 +1,74 @@
+module.exports = function (hljs) {
+  return {
+    name: 'Nunjucks',
+    aliases: ['nj', 'njk', 'nunjucks'],
+    case_insensitive: true,
+    subLanguage: 'xml',
+    contains: [
+      // Block comments
+      {
+        className: 'comment',
+        begin: /\{%\s*comment\s*%\}/,
+        end: /\{%\s*endcomment\s*%\}/
+      },
+      // Line comments
+      {
+        className: 'comment',
+        begin: /\{#/,
+        end: /#\}/
+      },
+      // Template variables
+      {
+        className: 'tag',
+        begin: /\{\{\s*/,
+        end: /\s*\}\}/,
+        contains: [
+          {
+            className: 'title',
+            begin: /(?<!\|\s*)\b\w+(?=\s*\()/,
+            relevance: 0
+          },
+          {
+            begin: /\(/,
+            end: /\)/,
+            subLanguage: 'javascript'
+          },
+          {
+            className: 'name',
+            begin: /\w+/
+          },
+          {
+            className: 'operator',
+            begin: /\|/
+          },
+          hljs.QUOTE_STRING_MODE,
+          hljs.APOS_STRING_MODE
+        ]
+      },
+      // Template tags
+      {
+        className: 'tag',
+        begin: /\{%-?\s*/,
+        end: /-?%\}/,
+        contains: [
+          {
+            className: 'keyword',
+            begin:
+              /\b(autoescape|endautoescape|block|endblock|for|endfor|if|endif|else|elif|include|extends|set|endset|filter|endfilter|with|endwith|macro|endmacro|call|endcall|raw|endraw|import|from|trans|endtrans|pluralize|debug|spaceless|endspaceless|csrf_token|cycle|url|lorem)\b/
+          },
+          {
+            className: 'variable',
+            begin: /\b\w+/,
+            relevance: 0
+          },
+          {
+            className: 'operator',
+            begin: /\b(and|or|not|in|is|as|by)\b/
+          },
+          hljs.QUOTE_STRING_MODE,
+          hljs.APOS_STRING_MODE
+        ]
+      }
+    ]
+  }
+}

--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -1,7 +1,7 @@
 const hljs = require('highlight.js')
 
-// Highlight Nunjucks as JavaScript
-hljs.registerLanguage('njk', require('highlight.js/lib/languages/javascript'))
+// Highlight Nunjucks
+hljs.registerLanguage('njk', require('./highlight-nunjucks'))
 
 /**
  * Format code with syntax highlighting


### PR DESCRIPTION
## Previously

We use highlight.js to highlight our code syntax. For Nunjucks files, we use the JavaScript language definition. This is causing some funky highlighting:

<img width="757" height="914" alt="Bad syntax example" src="https://github.com/user-attachments/assets/eda5c6a4-e59f-4ee7-9b3f-cadb1a03e42e" />

Using the Django/jinja definition sort of works, but it doesn't do much to distinguish between syntax elements:

<img width="753" height="1159" alt="django syntax" src="https://github.com/user-attachments/assets/dcf3a106-9b73-4812-8862-18f97f004d04" />

## Now

Using the VS Code Nunjucks plugin language definition as a base, I've defined a pretty basic syntax for Nunjucks.

It does a bit more differentiation of syntax elements. It also parses code in macro parens as JavaScript.

<img width="753" height="1154" alt="new syntax" src="https://github.com/user-attachments/assets/14ff60cb-35d0-4315-bfb9-d84304987bf0" />

fixes #4818 