### PR TITLE
Fix typo in 'Asking complex questions without using hint text' example

### DIFF
--- a/src/patterns/question-pages/explanatory-text/index.njk
+++ b/src/patterns/question-pages/explanatory-text/index.njk
@@ -32,7 +32,7 @@ layout: layout-example-full-page.njk
       </p>
 
       <p class="govuk-body">
-        For example, you have commitments like caring responsibilites or employment.
+        For example, you have commitments like caring responsibilities or employment.
       </p>
 
       <p class="govuk-body">


### PR DESCRIPTION
Raised via Zendesk ticket [#6197763](https://govuk.zendesk.com/agent/tickets/6197663)