### PR TITLE
Rephrase content about emails going to spam folders in 'Confirm an email address' pattern

### DIFF
--- a/src/patterns/confirm-an-email-address/index.md
+++ b/src/patterns/confirm-an-email-address/index.md
@@ -31,8 +31,8 @@ Common problems with email confirmation include:
 
 - confusing users about the journey outside the service
 - assuming users have an email account and access to it
-- sending emails to spam folders so users do not see them, for example, because it goes to their spam folder
 - taking too long to send the confirmation email
+- not taking steps to prevent emails from being marked as spam
 
 You must design your service to reduce these issues for users.
 


### PR DESCRIPTION
Raised by use in Zendesk ticket [#6197682](https://govuk.zendesk.com/agent/tickets/6197682)