### PR TITLE
Fix closing parens in strings breaking syntax highlighting

### DIFF
--- a/lib/highlight-nunjucks/__tests__/fixtures.njk
+++ b/lib/highlight-nunjucks/__tests__/fixtures.njk
@@ -39,3 +39,12 @@ Content
 {% macro field(name, value='', type='text') %}
   <div>Content</div>
 {% endmacro %}
+
+{{ govukInput({
+  label: {
+    text: "Address line 2 (optional)"
+  },
+  id: "address-line-2",
+  name: "addressLine2",
+  autocomplete: "address-line2"
+}) }}

--- a/lib/highlight-nunjucks/__tests__/highlight-nunjucks.test.js
+++ b/lib/highlight-nunjucks/__tests__/highlight-nunjucks.test.js
@@ -50,13 +50,13 @@ describe('Nunjucks syntax', () => {
 
     it('should highlight filter arguments', () => {
       expect(result).toContain(
-        '<span class="hljs-operator">|</span> <span class="hljs-name">filter</span><span class="language-javascript">('
+        '<span class="hljs-operator">|</span> <span class="hljs-name">filter</span> }}</span>'
       )
     })
 
     it('should highlight function calls', () => {
       expect(result).toContain(
-        '<span class="hljs-tag">{{ <span class="hljs-title">super</span><span class="language-javascript">()</span> }}</span>'
+        '<span class="hljs-tag">{{ <span class="hljs-title">super</span>() }}</span>'
       )
     })
 
@@ -121,6 +121,15 @@ describe('Nunjucks syntax', () => {
         '<span class="hljs-keyword">macro</span> <span class="hljs-variable">field</span>(<span class="hljs-variable">name</span>, <span class="hljs-variable">value</span>=<span class="hljs-string">&#x27;&#x27;</span>, <span class="hljs-variable">type</span>=<span class="hljs-string">&#x27;text&#x27;</span>) %}'
       )
       expect(result).toContain('<span class="hljs-keyword">endmacro</span>')
+    })
+
+    it('should handle parentheses correctly', () => {
+      expect(result).toContain(
+        '<span class="hljs-attr">text</span>: <span class="hljs-string">&quot;Address line 2 (optional)&quot;</span>'
+      )
+      expect(result).toContain(
+        '<span class="hljs-attr">id</span>: <span class="hljs-string">&quot;address-line-2&quot;</span>'
+      )
     })
   })
 })

--- a/lib/highlight-nunjucks/index.js
+++ b/lib/highlight-nunjucks/index.js
@@ -29,8 +29,8 @@ module.exports = function (hljs) {
             relevance: 0
           },
           {
-            begin: /\(/,
-            end: /\)/,
+            begin: /\(\{/,
+            end: /\}\)/,
             subLanguage: 'javascript'
           },
           {


### PR DESCRIPTION
Previously, closing parentheses within strings could trigger the end of the JavaScript highlighting and result in everything following being treated weirdly. Since we don't really use parentheses other than with these macro calls, we can make the rule more specific to avoid this.

Strictly, this ignores cases where we do:

`function([some random javascript])`, but I can't find any examples where we don't do either:

`function()`
`function("string")`, or
`function({})`

Which are all covered.