### PR TITLE
Add migration guidance callout to ‘Get Started’

### DIFF
--- a/src/get-started/production/index.md
+++ b/src/get-started/production/index.md
@@ -8,13 +8,17 @@ description: This guide explains how to set up your project so you can start usi
 ---
 
 {% from "_example.njk" import example %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 This guide explains how to set up your project so you can start using the styles and coded examples in the GOV.UK Design System in production.
 
-{{ govukInsetText({
+{% set warningTextHtml %}
+If your service still uses GOV.UK Template, GOV.UK Frontend Toolkit or GOV.UK Elements, you should <a href="https://frontend.design-system.service.gov.uk/v4/installing-with-npm/">install the latest v4 release of GOV.UK Frontend</a> and follow the guidance on <a href="https://frontend.design-system.service.gov.uk/v4/migrating-from-legacy-products/">migrating from our old frameworks</a>.
+{% endset %}
+
+{{ govukWarningText({
   classes: "app-table--constrained",
-  html: 'If you’ve used GOV.UK Elements, GOV.UK Template or the GOV.UK Frontend Toolkit before, you might also find it useful to read the guide to <a href="https://frontend.design-system.service.gov.uk/v4/migrating-from-legacy-products/#migrate-from-our-old-frameworks">Migrate from our old frameworks</a>.'
+  html: warningTextHtml
 }) }}
 
 ## Include GOV.UK Frontend in your project


### PR DESCRIPTION
We’re seeing some services attempting to use GOV.UK Frontend v5 or newer alongside GOV.UK Template, GOV.UK Frontend Toolkit and GOV.UK Elements.

From v5 onwards, GOV.UK Frontend is no longer compatible with GOV.UK Template, GOV.UK Frontend Toolkit or GOV.UK Elements.

Instead, we want users who need to migrate to install v4 and to follow our migration guidance.

Replace the existing inset text with warning text aimed at those still using the old frameworks, and nudging them towards doing those 2 things.

## Before

<img width="776" height="355" alt="Inset Text: If you've used GOV.UK Elements, GOV.UK Template or the GOV.UK Frontend Toolkit before, you might also find it useful to read the guide to Migrate from our old frameworks." src="https://github.com/user-attachments/assets/5fd7e73f-93e8-415b-87eb-05620a95cd12" />

## After

<img width="776" height="336" alt="Warning text: If your service still uses GOV.UK Template, GOV.UK Frontend Toolkit or GOV.UK Elements, you should install the latest v4 release of GOV.UK Frontend and follow the guidance on migrating from our old frameworks." src="https://github.com/user-attachments/assets/2407ae90-3c3d-4f00-b994-3ce7be8af61d" />
