### PR TITLE
Downgrade iframe-resizer to 4.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",
         "clipboard": "^2.0.11",
-        "iframe-resizer": "^4.4.5",
+        "iframe-resizer": "^4.3.11",
         "lunr": "^2.3.9"
       },
       "devDependencies": {
@@ -11620,16 +11620,16 @@
       }
     },
     "node_modules/iframe-resizer": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.4.5.tgz",
-      "integrity": "sha512-U8bCywf/Gh07O69RXo6dXAzTtODQrxaHGHRI7Nt4ipXsuq6EMxVsOP/jjaP43YtXz/ibESS0uSVDN3sOGCzSmw==",
-      "hasInstallScript": true,
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.11.tgz",
+      "integrity": "sha512-5QtnsmfH11GDsuC7Gxd/eNzojudX3346Gb0E+Ku8ln8AtfSq+cWCZtnhCrthrtE7f1CI2/kwHkZ9G4sFYzHP7A==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       },
       "funding": {
         "type": "individual",
-        "url": "https://iframe-resizer.com//pricing"
+        "url": "https://github.com/davidjbradshaw/iframe-resizer/blob/master/FUNDING.md"
       }
     },
     "node_modules/ignore": {

--- a/package-lock.json.unit.test.mjs
+++ b/package-lock.json.unit.test.mjs
@@ -28,4 +28,12 @@ describe('package-lock.json', () => {
       }
     })
   })
+
+  // iframe-resizer v5 switched to a GPL license and later v4 versions add no
+  // improvements and just spam the console with upgrade notices
+  it('should pin iframe-resizer to 4.3.11', () => {
+    expect(
+      packageLockJson.packages['node_modules/iframe-resizer'].version
+    ).toBe('4.3.11')
+  })
 })

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "accessible-autocomplete": "^3.0.1",
     "clipboard": "^2.0.11",
-    "iframe-resizer": "^4.4.5",
+    "iframe-resizer": "^4.3.11",
     "lunr": "^2.3.9"
   },
   "devDependencies": {


### PR DESCRIPTION
We currently see this message in the console on the Design System site:

```
IFRAME-RESIZER

Iframe-Resizer 5 is now available via the following two packages:

 * @iframe-resizer/parent
 * @iframe-resizer/child

Additionally their are also new versions of iframe-resizer for React, Vue, and jQuery.

Version 5 of iframe-resizer has been extensively rewritten to use modern browser APIs, which has enabled significantly better performance and greater accuracy in the detection of content resizing events.

Please see https://iframe-resizer.com/upgrade for more details.
```

We are not planning to upgrade to v5 as the license model has changed to GPL v3, which means using it would require us to license our own code under GPL v3 too (or pay for a commercial license).

There is no way to disable this message from being logged by the dependency.

Looking at the [diff between 4.3.11 and 4.4.5][1], there are no meaningful changes to iframe-resizer, only README changes and the introduction of these upgrade prompts.

Downgrade to 4.3.11 to remove the prompts, and add a test that should hopefully stop people from upgrading it again.

[1]: https://github.com/davidjbradshaw/iframe-resizer/compare/v4.3.11...v4.4.5