### PR TITLE
Ignore all iframe-resizer updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,7 +74,6 @@ updates:
       # iframe-resizer has switched to GPL licence in v5
       # so we need to avoid upgrading to their next major version
       - dependency-name: 'iframe-resizer'
-        update-types: ['version-update:semver-major']
 
     # Schedule run every Monday, local time
     schedule:


### PR DESCRIPTION
We recently downgraded iframe-resizer from 4.4.5 to 4.3.11 in 85cc5fc.

There are no meaningful changes to iframe-resizer between 4.3.11 and 4.4.5 – only README changes and the introduction of some annoying upgrade prompts in the console.

We are also not planning to upgrade to v5 as the license model has changed to GPL v3, which means using it would require us to license our own code under GPL v3 too (or pay for a commercial license).

Tell Dependabot to ignore all updates to iframe-resizer, not just the major version (bump to v5).