### PR TITLE
Fix layout issues on the homepage at the 'tablet' breakpoint

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -36,7 +36,7 @@ masthead: true
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl govuk-!-margin-top-0">
 
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 class="govuk-heading-l">Principles we follow</h2>
         <p class="govuk-body">
           The GOV.UK Design System helps teams that work on government services follow the
@@ -89,7 +89,7 @@ masthead: true
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
 
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 class="govuk-heading-l">Roadmap</h2>
         <p class="govuk-body">
           See what the Design System team at GDS is planning to work on over the next 12 months in the <a href="/community/roadmap/" class="govuk-link" data-hcontribute="guidelinegh">GOV.UK Design System Roadmap</a>.


### PR DESCRIPTION
Some of the sections on the homepage are currently constrained to two-thirds from table and above; other sections are only constrained from desktop.

Additionally, because we don't explicitly open and close grid rows, at the tablet breakpoint the community sections ends up split, with half of the content sitting next to the principles section, and some of the content appearing after the section break (!!)

Consistently use two-thirds only from desktop and above, and explicitly open and close the grid rows to prevent similar issues in the future.

## Before

<img width="438" height="2000" alt="design-system service gov uk_" src="https://github.com/user-attachments/assets/ace759e7-699b-4f41-9744-46f3107d7045" />

## After

<img width="438" height="1991" alt="localhost_3000_" src="https://github.com/user-attachments/assets/0c968f3b-9be0-4fc3-9866-224f53058fee" />


