### PR TITLE
Use curly quotes on homepage

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -66,7 +66,7 @@ masthead: true
         </p>
 
         <p class="govuk-body">
-          Also see <a href="/community/upcoming-components-patterns/" class="govuk-link" data-hcontribute="guidelinegh">upcoming components and patterns</a> we're working on and how you can help.
+          Also see <a href="/community/upcoming-components-patterns/" class="govuk-link" data-hcontribute="guidelinegh">upcoming components and patterns</a> we’re working on and how you can help.
         </p>
       </div>
 

--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -4,7 +4,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
           <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
-          <h3 id="17-july-2025" class="govuk-heading-s">17 July 2025: We've released GOV.UK Frontend 5.11.1</h3>
+          <h3 id="17-july-2025" class="govuk-heading-s">17 July 2025: We’ve released GOV.UK Frontend 5.11.1</h3>
           <p class="govuk-body">It fixes link styles in the Service navigation on inverted backgrounds and makes <code>govuk-shade</code> and <code>govuk-tint</code> more reliable.</p>
           <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.11.1" class="govuk-link">release notes for v5.11.1</a> to see what's changed.</p>
           <p class="govuk-body">On 24 June 2025, we released GOV.UK Frontend v5.11.0. This release includes improvements to the Service navigation component, making it easier to use on mobile devices and offering an inverse colour option. We also added deprecation warnings for code built with the LibSass library.</p>


### PR DESCRIPTION
Fix a couple of errant ‘straight’ quotes on the homepage.

In markdown, our markdown processor takes care of turning straight quotes into curly quotes with its ‘smart quotes’ plugin, but that doesn’t work where we write HTML 😢