### PR TITLE
Add ‘using the brand’ section to homepage

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -37,6 +37,18 @@ masthead: true
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h2 class="govuk-heading-l">Update your service to use the refreshed GOV.UK brand</h2>
+        <p class="govuk-body">In June 2025, GOV.UK started to refresh the brand across its products and services. To support this, we’ve released several versions of GOV.UK Frontend to help teams update their services.</p>
+        <p class="govuk-body">
+          <a class="govuk-link" href="https://frontend.design-system.service.gov.uk/brand-refresh-changes/#updating-your-service-to-use-the-new-brand">Find out how to update your service to use the refreshed brand</a>.
+        </p>
+      </div>
+    </div>
+
+    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 class="govuk-heading-l">Principles we follow</h2>
         <p class="govuk-body">
           The GOV.UK Design System helps teams that work on government services follow the


### PR DESCRIPTION
We’ve now removed the information about the brand change from the ‘What’s New’ section.

For now, add a section about the brand change further down the homepage to help people find our guidance on using it.