### PR TITLE
Update to GOV.UK Frontend 5.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.1.1",
         "glob": "^11.0.3",
-        "govuk-frontend": "^5.12.0",
+        "govuk-frontend": "^5.13.0",
         "gray-matter": "^4.0.2",
         "highlight.js": "^11.11.1",
         "html-validate": "^10.0.0",
@@ -10953,9 +10953,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.12.0.tgz",
-      "integrity": "sha512-gNr/UVDoORVOqVKTC9i9HOKKPeM4IDTAqtnd3t6U8LQibEr+8Q+FB7Id0u/MfR/5mqPfenG/+VGLW96vJXok/g==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.13.0.tgz",
+      "integrity": "sha512-6N3pHelWN7wftdM6e4YEzZAfattapa1gnd+Al6d5PUbfTr9D+T2dnphpNpjX75CTEhihlQqlL0RDQ3WIfZ3PSg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",
     "glob": "^11.0.3",
-    "govuk-frontend": "^5.12.0",
+    "govuk-frontend": "^5.13.0",
     "gray-matter": "^4.0.2",
     "highlight.js": "^11.11.1",
     "html-validate": "^10.0.0",


### PR DESCRIPTION
Update to [GOV.UK Frontend 5.13.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.13.0).

Does not include any other changes (i.e. rewriting media queries to use functions). 