### PR TITLE
Set explicit permissions on GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-external-links.yaml
+++ b/.github/workflows/check-external-links.yaml
@@ -2,6 +2,9 @@ name: Check external links
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   check-links:
     name: Check for broken external links

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,9 @@ on:
           - ubuntu-22.04
           - windows-latest
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Address [code scanning flags](https://github.com/alphagov/govuk-design-system/security/code-scanning) on our workflow files for not having explicit permissions.