### PR TITLE
Update header and service navigation description

### DIFF
--- a/src/patterns/navigate-a-service/index.md
+++ b/src/patterns/navigate-a-service/index.md
@@ -42,12 +42,12 @@ See how to do this in the [Help users to complete multiple tasks pattern](/patte
 
 Together, the [GOV.UK header component](/components/header/) and [Service navigation component](/components/service-navigation/) work together to assure users that they’re in the right place to use your service. They also help users understand that GOV.UK functions as one website.
 
-The GOV.UK header (black background) includes space to show:
+The GOV.UK header (blue background) includes space to show:
 
 - the GOV.UK logo, which links to the GOV.UK homepage
 - GOV.UK-wide tools such as GOV.UK One Login
 
-The Service navigation (grey background) includes space to show:
+The Service navigation (light blue background) includes space to show:
 
 - the service name, which links to the homepage of your service (or closest page)
 - a navigation menu for your service
@@ -145,7 +145,7 @@ To help users understand what the search input will cover, include ‘Search [yo
 Show the [Phase banner component](/components/phase-banner/) directly under either:
 
 - the Service navigation component
-- the GOV.UK header and blue colour bar (if your service does not use the Service navigation component)
+- the GOV.UK header (if your service does not use the Service navigation component)
 
 Phase banners are shown across all pages of a service, so users should understand it as a service-level message.
 


### PR DESCRIPTION
This change updates the colour of the GOV.UK header and Service navigation to match the refreshed branding. And removes the 'blue colour bar' from the description of the GOV.UK header.