### PR TITLE
Add GOV reuse library to resources and tools page

### DIFF
--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -11,7 +11,7 @@ You can use these community resources and tools to help you use the GOV.UK Desig
 
 The GOV.UK Design System team is not responsible for these resources and tools and we cannot support you with using them. Please contact the owner if you need help or you want to request a feature.
 
-To find information about other design systems across government, see a community-managed [list of design systems created by different departments](https://github.com/ctdesign/gov-design-systems-list).
+To find design systems, style guides, manuals and other reusable resources from across government, you can explore the cross-government [GOV Reuse Library](https://reuselibrary.service.justice.gov.uk/).
 
 ## Create flow diagrams
 


### PR DESCRIPTION
Changed to include the new gov reuse library https://dev.reuselibrary.service.justice.gov.uk/