### PR TITLE
Replace `--govuk-frontend-breakpoint-tablet` with `--govuk-breakpoint-tablet`

### DIFF
--- a/src/javascripts/components/mobile-navigation-section.mjs
+++ b/src/javascripts/components/mobile-navigation-section.mjs
@@ -48,7 +48,7 @@ class MobileNavigationSection extends Component {
     // Check if the section should be visible or not
     const breakPoint = getComputedStyle(
       document.documentElement
-    ).getPropertyValue('--govuk-frontend-breakpoint-tablet')
+    ).getPropertyValue('--govuk-breakpoint-tablet')
 
     this.mql = window.matchMedia(`(min-width: ${breakPoint})`)
 


### PR DESCRIPTION
We deprecated `--gorvuk-frontend-*` breakpoints in 5.11.0