### PR TITLE
EXPERIMENT adding a promotion banner to the Design System

### DIFF
--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -455,3 +455,17 @@ pre .language-plaintext {
 .app-campaign-cookie-banner .govuk-grid-column-two-thirds {
   width: 100%;
 }
+
+// Add styling for promotion banner
+.app-promotion-banner {
+  padding-top: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid $_govuk-rebrand-border-colour-on-blue-tint-95;
+  background-color: $_govuk-rebrand-template-background-colour;
+
+  p,
+  a {
+    margin-bottom: 0;
+    color: #1a65a6;
+  }
+}

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -47,6 +47,7 @@
 {% block main %}
   {% include "_header.njk" %}
   {% include "_navigation.njk" %}
+  {% include "_promotion-banner.njk" %}
   {% include "_banner.njk" %}
 
   {% block body %}

--- a/views/partials/_promotion-banner.njk
+++ b/views/partials/_promotion-banner.njk
@@ -1,0 +1,5 @@
+<div class="app-promotion-banner">
+  <div class="app-width-container">
+    <p class="govuk-body-m"><strong>Version 6 of GOV.UK Frontend</strong> is coming soon, <a class="govuk-link" href="https://github.com/alphagov/govuk-frontend/discussions/6353">learn how you can start to prepare</a>.</p>
+  </div>
+</div>


### PR DESCRIPTION
## What
A promotion banner to let users know about something major that's going to affect the Design System.

In this example, the banner is being used to highlight the release of version 6 of GOV.UK Frontend.

## Why
To help users find content we have about preparing for the release of V6.