### PR TITLE
[SPIKE] Update for second template update spike

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.1.1",
         "glob": "^11.1.0",
-        "govuk-frontend": "^5.13.0",
+        "govuk-frontend": "github:alphagov/govuk-frontend#07f4a6f9c",
         "gray-matter": "^4.0.2",
         "highlight.js": "^11.11.1",
         "html-validate": "^10.2.1",
@@ -176,6 +176,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2018,6 +2019,7 @@
       "integrity": "sha512-eohl3hKTiVyD1ilYdw9T0OiB4hnjef89e3dMYKz+mVKDzj+5IteTseASUsOB+EU9Tf6VNTCjDePcP6wkDGmLKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -2127,6 +2129,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2169,6 +2172,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5118,6 +5122,7 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -5735,6 +5740,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
       "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7312,6 +7318,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -8501,7 +8508,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
       "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -9170,6 +9178,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9423,6 +9432,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -9652,6 +9662,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
       "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -9664,6 +9675,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.36.1.tgz",
       "integrity": "sha512-/qwbqNXZoq+VP30s1d4Nc1C5GTxjJQjk4Jzs4Wq2qzxFM7dSmuG2UkIjg2USMLh3A/aVcUNrK7v0J5U1XEGGwA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -9992,6 +10004,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -11117,9 +11130,8 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.13.0.tgz",
-      "integrity": "sha512-6N3pHelWN7wftdM6e4YEzZAfattapa1gnd+Al6d5PUbfTr9D+T2dnphpNpjX75CTEhihlQqlL0RDQ3WIfZ3PSg==",
+      "version": "6.0.0-beta.1-preview-spike-page-template-blocks-5",
+      "resolved": "git+ssh://git@github.com/alphagov/govuk-frontend.git#07f4a6f9c4c05775c958be5abf3b2c5aea97368d",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11438,6 +11450,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -12545,6 +12558,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -13318,6 +13332,7 @@
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.6.3",
@@ -14462,6 +14477,7 @@
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.2.0.tgz",
       "integrity": "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@babel/generator": "^7.27.5",
@@ -15163,6 +15179,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -16025,6 +16042,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.1.tgz",
       "integrity": "sha512-ntROs7RaN3EvWfy3EZi14H4YxmT6A5YvywfhO+0pm+cH/dnSQRmdAmoFIc3B9aiwTehyk7pESH4ofyBY+V5hZg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -16169,6 +16187,7 @@
       "integrity": "sha512-nql0eDbeDdYY3cz0uDVmwQ/E9XDBAHBf5p3lz+IwZAlUvz72DAd5+F+vl7Fot7I+yQDVK59uB0CL9S+Ts7ELsw==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "chokidar": "^3.6.0",
         "commander": "^10.0.1",
@@ -17294,6 +17313,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "devOptional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17457,6 +17477,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -18204,6 +18225,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.10.13",
         "chromium-bidi": "11.0.0",
@@ -18926,6 +18948,7 @@
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -20295,6 +20318,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -20705,6 +20729,7 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -21523,6 +21548,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",
     "glob": "^11.1.0",
-    "govuk-frontend": "^5.13.0",
+    "govuk-frontend": "github:alphagov/govuk-frontend#07f4a6f9c",
     "gray-matter": "^4.0.2",
     "highlight.js": "^11.11.1",
     "html-validate": "^10.2.1",

--- a/src/components/error-summary/full-page-example/index.njk
+++ b/src/components/error-summary/full-page-example/index.njk
@@ -10,7 +10,7 @@ layout: layout-example-full-page.njk
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back"
   }) }}

--- a/src/patterns/check-a-service-is-suitable/result/index.njk
+++ b/src/patterns/check-a-service-is-suitable/result/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukPhaseBanner({
     tag: {
       text: "Prototype"

--- a/src/patterns/check-answers/default/index.njk
+++ b/src/patterns/check-answers/default/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: "#"

--- a/src/patterns/cookies-page/full-page/index.njk
+++ b/src/patterns/cookies-page/full-page/index.njk
@@ -8,7 +8,7 @@ layout: layout-example-full-page-with-no-footer.njk
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukPhaseBanner({
     tag: {
       text: "Prototype"

--- a/src/patterns/question-pages/date-of-birth/index.njk
+++ b/src/patterns/question-pages/date-of-birth/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back"
   }) }}

--- a/src/patterns/question-pages/default/index.njk
+++ b/src/patterns/question-pages/default/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back"
   }) }}

--- a/src/patterns/question-pages/explanatory-text/index.njk
+++ b/src/patterns/question-pages/explanatory-text/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back"
   }) }}

--- a/src/patterns/question-pages/passport/index.njk
+++ b/src/patterns/question-pages/passport/index.njk
@@ -10,7 +10,7 @@ layout: layout-example-full-page.njk
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back"
   }) }}

--- a/src/patterns/question-pages/postcode/index.njk
+++ b/src/patterns/question-pages/postcode/index.njk
@@ -9,7 +9,7 @@ layout: layout-example-full-page.njk
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back"
   }) }}

--- a/src/styles/page-template/block-areas/index.njk
+++ b/src/styles/page-template/block-areas/index.njk
@@ -9,6 +9,7 @@ stylesheets:
 {% extends "govuk/template.njk" %}
 
 {% block pageTitle %}{{ title }} – Example - GOV.UK Design System{% endblock %}
+{% set serviceName = title %}
 
 {% block head -%}
   {# Since we’re not extending the Design System layout we need to add this manually #}
@@ -27,9 +28,9 @@ stylesheets:
   </div>
 {%- endblock %}
 
-{% block skipLink -%}
+{% block govukSkipLink -%}
   <div class="app-annotate-block">
-    <span class="app-annotate-block__label">block: skipLink</span>
+    <span class="app-annotate-block__label">block: govukSkipLink</span>
     {{ super() }}
   </div>
 {%- endblock %}
@@ -41,18 +42,46 @@ stylesheets:
   </div>
 {%- endblock %}
 
-{% block main -%}
+{% block headerStart -%}
   <div class="app-annotate-block">
-    <span class="app-annotate-block__label">block: main</span>
+    <span class="app-annotate-block__label">block: headerStart</span>
+    {{ super() }}
+  </div>
+{%- endblock %}
+
+{% block govukHeader -%}
+  <div class="app-annotate-block">
+    <span class="app-annotate-block__label">block: govukHeader</span>
+    {{ super() }}
+  </div>
+{%- endblock %}
+
+{% block govukServiceNavigation -%}
+  <div class="app-annotate-block">
+    <span class="app-annotate-block__label">block: govukServiceNavigation</span>
+    {{ super() }}
+  </div>
+{%- endblock %}
+
+{% block headerEnd -%}
+  <div class="app-annotate-block">
+    <span class="app-annotate-block__label">block: headerEnd</span>
+    {{ super() }}
+  </div>
+{%- endblock %}
+
+{% block container -%}
+  <div class="app-annotate-block">
+    <span class="app-annotate-block__label">block: container</span>
     <p class="govuk-body">
     </p>
     {{ super() }}
   </div>
 {%- endblock %}
 
-{% block beforeContent -%}
+{% block containerStart -%}
   <div class="app-annotate-block">
-    <span class="app-annotate-block__label">block: beforeContent</span>
+    <span class="app-annotate-block__label">block: containerStart</span>
     {{ super() }}
     {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
@@ -60,6 +89,13 @@ stylesheets:
       href: "/",
       text: "Back"
     }) }}
+  </div>
+{%- endblock %}
+
+{% block main -%}
+  <div class="app-annotate-block">
+    <span class="app-annotate-block__label">block: main</span>
+    {{ super() }}
   </div>
 {%- endblock %}
 
@@ -71,9 +107,37 @@ stylesheets:
   </div>
 {%- endblock %}
 
+{% block containerEnd -%}
+  <div class="app-annotate-block">
+    <span class="app-annotate-block__label">block: containerEnd</span>
+    {{ super() }}
+  </div>
+{%- endblock %}
+
 {% block footer -%}
   <div class="app-annotate-block">
     <span class="app-annotate-block__label">block: footer</span>
+    {{ super() }}
+  </div>
+{%- endblock %}
+
+{% block footerStart -%}
+  <div class="app-annotate-block">
+    <span class="app-annotate-block__label">block: footerStart</span>
+    {{ super() }}
+  </div>
+{%- endblock %}
+
+{% block govukFooter -%}
+  <div class="app-annotate-block">
+    <span class="app-annotate-block__label">block: govukFooter</span>
+    {{ super() }}
+  </div>
+{%- endblock %}
+
+{% block footerEnd -%}
+  <div class="app-annotate-block">
+    <span class="app-annotate-block__label">block: footerEnd</span>
     {{ super() }}
   </div>
 {%- endblock %}

--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -69,14 +69,14 @@ ignoreInSitemap: true
   </form>
 {% endblock %}
 
-{% block skipLink %}
+{% block govukSkipLink %}
   {{ govukSkipLink({
     href: "#main-content",
     text: "Skip to main content"
   }) }}
 {% endblock %}
 
-{% block header %}
+{% block govukHeader %}
   {{ govukHeader({
     homepageUrl: "#",
     containerClasses: "app-width-container",
@@ -102,11 +102,11 @@ ignoreInSitemap: true
 
 {% set mainClasses = "app-main-class" %}
 
-{% block main %}
+{% block container %}
   {{ super() }}
 {% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukPhaseBanner({
     tag: {
       text: "Alpha"
@@ -123,7 +123,7 @@ ignoreInSitemap: true
   <h1 class="govuk-heading-xl">Customised page template</h1>
 {% endblock %}
 
-{% block footer %}
+{% block govukFooter %}
   {{ govukFooter({
     meta: {
       items: [

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -70,14 +70,14 @@ ignoreInSitemap: true
   </form>
 {% endblock %}
 
-{% block skipLink %}
+{% block govukSkipLink %}
   {{ govukSkipLink({
     href: "#main-content",
     text: "Skip to main content"
   }) }}
 {% endblock %}
 
-{% block header %}
+{% block govukHeader %}
   {{ govukHeader({
     homepageUrl: "#",
     containerClasses: "app-width-container",
@@ -103,11 +103,11 @@ ignoreInSitemap: true
 
 {% set mainClasses = "app-main-class" %}
 
-{% block main %}
+{% block container %}
   {{ super() }}
 {% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukPhaseBanner({
     tag: {
       text: "Alpha"
@@ -124,7 +124,7 @@ ignoreInSitemap: true
   <h1 class="govuk-heading-xl">Customised page template</h1>
 {% endblock %}
 
-{% block footer %}
+{% block govukFooter %}
   {{ govukFooter({
     containerClasses: "app-width-container",
     meta: {

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -41,21 +41,21 @@
   }) %}{% endcall %}
 {% endblock %}
 
-{# We provide our own header, so blank the one provided by the template #}
-{% block header %}{% endblock %}
-
-{% block main %}
+{% block govukHeader %}
   {% include "_header.njk" %}
+{% endblock %}
+
+{% block govukServiceNavigation %}
   {% include "_navigation.njk" %}
+{% endblock %}
+
+{% block container %}
   {% include "_banner.njk" %}
 
   {% block body %}
     {{ contents | safe }}
   {% endblock %}
 {% endblock %}
-
-{# We provide our own footer, so blank the one provided by the template #}
-{% block footer %}{% endblock %}
 
 {% block bodyEnd %}
   <script type="module" src="{{ getFingerprint('/javascripts/application.js') }}"></script>

--- a/views/layouts/example-wrappers/full-page.njk
+++ b/views/layouts/example-wrappers/full-page.njk
@@ -1,5 +1,5 @@
 <div class="govuk-width-container">
-  {% block beforeContent %}{% endblock %}
+  {% block containerStart %}{% endblock %}
   <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main">
     {% block content %}{% endblock %}
   </main>

--- a/views/layouts/layout-example-form.njk
+++ b/views/layouts/layout-example-form.njk
@@ -1,6 +1,6 @@
 {% extends "layout-example.njk" %}
 
-{% block main %}
+{% block container %}
   <!-- Disable browser validation for any examples that include form elements -->
   <form action="/form-handler" method="post" novalidate>
     {% block body %}

--- a/views/layouts/layout-example-full-page-with-no-footer.njk
+++ b/views/layouts/layout-example-full-page-with-no-footer.njk
@@ -3,10 +3,13 @@
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 {% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
 
-{% block header %}
+{% block govukSkipLink %}
   {{ govukHeader({
     homepageUrl: "#"
   }) }}
+{% endblock %}
+
+{% block govukServiceNavigation %}
   {{ govukServiceNavigation({
     serviceName: "Service name",
     serviceUrl: "#"

--- a/views/layouts/layout-example-full-page.njk
+++ b/views/layouts/layout-example-full-page.njk
@@ -12,15 +12,16 @@
   {%- endfor %}
 {% endblock %}
 
-{% block header %}
+{% block govukSkipLink %}
   {{ govukHeader({
     homepageUrl: "#"
   }) }}
 {% endblock %}
 
-{% block main %}
+{% block container %}
   {{ contents | safe }}
 {% endblock %}
+
 {% block bodyEnd %}
   <script type="module" src="{{ getFingerprint('/javascripts/application-example.js') }}"></script>
 {% endblock %}

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -21,12 +21,12 @@
 {% endblock %}
 
 {# Example pages shouldn't have a skip link or header, so blank the one provided by the template #}
-{% block skipLink %}{% endblock %}
+{% block govukSkipLink %}{% endblock %}
 {% block header %}{% endblock %}
 
 {% set bodyClasses = "app-example-page" %}
 
-{% block main %}
+{% block container %}
   {% block body %}
     {{ contents | safe }}
   {% endblock %}

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -63,5 +63,8 @@
   </div>
   {% include "_back-to-top.njk" %}
 </div>
-{% include "_footer.njk" %}
+{% endblock %}
+
+{% block govukFooter %}
+  {% include "_footer.njk" %}
 {% endblock %}

--- a/views/layouts/layout-single-page.njk
+++ b/views/layouts/layout-single-page.njk
@@ -11,6 +11,8 @@
       {{ contents | safe }}
     </main>
   </div>
+{% endblock %}
 
+{% block govukFooter %}
   {% include "_footer.njk" %}
 {% endblock %}

--- a/views/layouts/layout.njk
+++ b/views/layouts/layout.njk
@@ -12,6 +12,8 @@
   <main id="main-content" role="main">
     {{ contents | safe }}
   </main>
+{% endblock %}
 
+{% block govukFooter %}
   {% include "_footer.njk" %}
 {% endblock %}

--- a/views/partials/_header.njk
+++ b/views/partials/_header.njk
@@ -1,7 +1,7 @@
-<header class="govuk-header govuk-header--full-width-border" role="banner">
+<div class="govuk-header govuk-header--full-width-border">
   <div class="govuk-header__container app-width-container">
     <div class="govuk-header__logo app-header-logo">
-      <a href="/" class="govuk-header__link govuk-header__link--homepage">
+      <a href="/" class="govuk-header__homepage-link">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           focusable="false"
@@ -37,4 +37,4 @@
       <a class="app-site-search__link govuk-link" href="/sitemap/">Sitemap</a>
     </div>
   </div>
-</header>
+</div>


### PR DESCRIPTION
Test implementation of https://github.com/alphagov/govuk-frontend/pull/6497.

Slightly tangential changes:
- Fixes the class name on the logo and product name, which has changed in v6.
- Separates the header, navigation and footer from the `body` block, so that they're in their respective blocks. 
- Updates the [exploded block areas example](https://deploy-preview-5021--govuk-design-system-preview.netlify.app/styles/page-template/#exploded-view-of-the-page-template-block-areas) to include all the new and renamed blocks. 