### PR TITLE
Update page template blocks and variables documentation

### DIFF
--- a/src/styles/page-template/block-areas/index.njk
+++ b/src/styles/page-template/block-areas/index.njk
@@ -27,9 +27,9 @@ stylesheets:
   </div>
 {%- endblock %}
 
-{% block skipLink -%}
+{% block govukSkipLink -%}
   <div class="app-annotate-block">
-    <span class="app-annotate-block__label">block: skipLink</span>
+    <span class="app-annotate-block__label">block: govukSkipLink</span>
     {{ super() }}
   </div>
 {%- endblock %}
@@ -67,18 +67,18 @@ stylesheets:
   </div>
 {%- endblock %}
 
-{% block main -%}
+{% block container -%}
   <div class="app-annotate-block">
-    <span class="app-annotate-block__label">block: main</span>
+    <span class="app-annotate-block__label">block: container</span>
     <p class="govuk-body">
     </p>
     {{ super() }}
   </div>
 {%- endblock %}
 
-{% block beforeContent -%}
+{% block containerStart -%}
   <div class="app-annotate-block">
-    <span class="app-annotate-block__label">block: beforeContent</span>
+    <span class="app-annotate-block__label">block: containerStart</span>
     {{ super() }}
     {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
@@ -89,11 +89,24 @@ stylesheets:
   </div>
 {%- endblock %}
 
+{% block main -%}
+  <div class="app-annotate-block">
+    <span class="app-annotate-block__label">block: main</span>
+    {{ super() }}
+  </div>
+{%- endblock %}
+
 {% block content -%}
   <div class="app-annotate-block">
     <span class="app-annotate-block__label">block: content</span>
     {{ super() }}
     <h1 class="govuk-heading-xl">GOV.UK page template</h1>
+  </div>
+{%- endblock %}
+
+{% block containerEnd -%}
+  <div class="app-annotate-block">
+    <span class="app-annotate-block__label">block: containerEnd</span>
   </div>
 {%- endblock %}
 

--- a/src/styles/page-template/index.md
+++ b/src/styles/page-template/index.md
@@ -142,9 +142,35 @@ To change the components that are included in the page template by default, set 
       </td>
     </tr>
     <tr class="govuk-table__row">
+      <td class="govuk-table__cell">container</td>
+      <td class="govuk-table__cell">Block</td>
+      <td class="govuk-table__cell">
+        Override the part of the page between the <code>header</code> and <code>footer</code> blocks. By default this includes the <code>&lt;div class="govuk-width-container"&gt;</code> element, and the <code>main</code>, <code>containerStart</code>, <code>containerEnd</code> and <code>content</code> blocks.
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">containerAttributes</td>
+      <td class="govuk-table__cell">Variable</td>
+      <td class="govuk-table__cell">Add HTML attributes to the container.</td>
+    </tr>
+    <tr class="govuk-table__row">
       <td class="govuk-table__cell">containerClasses</td>
       <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">Add a class to the container. This is useful if you want to make the page wrapper a fixed width.</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">containerEnd</td>
+      <td class="govuk-table__cell">Block</td>
+      <td class="govuk-table__cell">
+        Add custom HTML at the start of the <code>container</code> block and before the <code>&lt;main&gt;</code> element.
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">containerStart</td>
+      <td class="govuk-table__cell">Block</td>
+      <td class="govuk-table__cell">
+        Add custom HTML at the start of the <code>container</code> block and before the <code>&lt;main&gt;</code> element.
+      </td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">content</td>
@@ -224,6 +250,13 @@ To change the components that are included in the page template by default, set 
       </td>
     </tr>
     <tr class="govuk-table__row">
+      <td class="govuk-table__cell">govukSkipLink</td>
+      <td class="govuk-table__cell">Block</td>
+      <td class="govuk-table__cell">
+        Override the default <a class="govuk-link" href="/components/skip-link/">Skip link component</a>.
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
       <td class="govuk-table__cell">head</td>
       <td class="govuk-table__cell">Block</td>
       <td class="govuk-table__cell">
@@ -290,8 +323,13 @@ To change the components that are included in the page template by default, set 
       <td class="govuk-table__cell">main</td>
       <td class="govuk-table__cell">Block</td>
       <td class="govuk-table__cell">
-        Override the main section of the page, which by default wraps the <code>&lt;main&gt;</code> element, <code>beforeContent</code> block and <code>content</code> block.
+        Override the main section of the page, which by default wraps the <code>&lt;main&gt;</code> element.
       </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">mainAttributes</td>
+      <td class="govuk-table__cell">Variable</td>
+      <td class="govuk-table__cell">Add HTML attributes to the <code>&lt;main&gt;</code> element.</td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">mainClasses</td>
@@ -338,13 +376,6 @@ To change the components that are included in the page template by default, set 
       <td class="govuk-table__cell">Variable</td>
       <td class="govuk-table__cell">
         Set a URL for the service name to link to. Doesn't do anything if <code>serviceName</code> is not set.
-      </td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">skipLink</td>
-      <td class="govuk-table__cell">Block</td>
-      <td class="govuk-table__cell">
-        Override the default <a class="govuk-link" href="/components/skip-link/">Skip link component</a>.
       </td>
     </tr>
     <tr class="govuk-table__row">


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-design-system/issues/5037. 

> [!NOTE]
> Changes to the 'block areas' example are not visible in the preview as they use the template from GOV.UK Frontend, which isn't going to be updated until v6 releases. 

Makes updates to page template documentation to account for changes introduced by the following issues:

- https://github.com/alphagov/govuk-frontend/issues/6532
- https://github.com/alphagov/govuk-frontend/issues/6533
- https://github.com/alphagov/govuk-frontend/issues/6474
- https://github.com/alphagov/govuk-frontend/issues/6535