### PR TITLE
Remove Nunjucks `noCache: true`

### DIFF
--- a/lib/nunjucks/index.js
+++ b/lib/nunjucks/index.js
@@ -9,7 +9,6 @@ const filters = require('./filters')
 const globals = require('./globals')
 
 module.exports = {
-  noCache: true, // never use a cache and recompile templates each time
   trimBlocks: true, // automatically remove trailing newlines from a block/tag
   lstripBlocks: true, // automatically remove leading whitespace from a block/tag
 


### PR DESCRIPTION
Allows Nunjucks to cache files, which helps when, for example, lots of files rely on the same layout.

This cuts `metalsmith/in-place` and `metalsmith/layouts` compile time in half for me locally.

This shouldn't cause issues across multiple rebuilds in watch mode, because `jstransformer-nunjucks`, which is what does the work under the hood, [creates a new Nunjucks environment](https://github.com/jstransformers/jstransformer-nunjucks/blob/5d612f4a21eb9cdb16f7827029d0a828fa419121/index.js#L48) every time it compiles, so the cache won't persist across plugins or across builds.

Thanks to @36degrees for the suggestion!