### PR TITLE
Improve visibility of newsletter signup link on homepage

### DIFF
--- a/views/partials/_whats-new.njk
+++ b/views/partials/_whats-new.njk
@@ -6,8 +6,8 @@
           <h2 id="whats-new" class="govuk-heading-l">What’s new</h2>
           <h3 id="10-october-2025" class="govuk-heading-s">10 October 2025: We’ve released GOV.UK Frontend 5.13.0</h3>
           <p class="govuk-body">It introduces new Sass functions to help write <code>@media</code> and <code>@container</code> queries, mixins and functions whilst still using custom breakpoints or <a href="https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-breakpoints" class="govuk-link">GOV.UK Frontend’s <code>$govuk-breakpoints</code></a> setting.</p>
-          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.13.0" class="govuk-link">release notes for v5.13.0</a> to see what’s changed.</p>
-          <p class="govuk-body"><a href="/community/whats-new/" class="govuk-link govuk-!-font-weight-bold">See more of our latest updates</a></p>
+          <p class="govuk-body">Read the <a href="https://github.com/alphagov/govuk-frontend/releases/tag/v5.13.0" class="govuk-link">release notes for v5.13.0 on GitHub</a> to see what’s changed
+          or <a href="/community/whats-new/" class="govuk-link">our latest updates from the What's new page</a>.</p>
           <h2 class="govuk-heading-l">Get updates on the Design System</h2>
           <p class="govuk-body">Interested in changes to the Design System, or our upcoming events and workshops?</p>
           <p class="govuk-body"><a href="http://mailchi.mp/707ce8dec373/get-updated-by-email-govuk-design-system" class="govuk-link">Sign up with your email</a></p>


### PR DESCRIPTION
Separate the link to the newsletter sign up page under its own heading and slightly rephrase the link to the "What's new" page.

Solves #1974 