### PR TITLE
Update Share findings about your users page to link to contact page

### DIFF
--- a/src/community/share-research-findings/index.md
+++ b/src/community/share-research-findings/index.md
@@ -22,29 +22,30 @@ Feedback from any phase helps us iterate the Design System in line with evolving
 
 ## Where to add findings
 
-Go to our [list of discussions on GitHub](https://github.com/orgs/alphagov/projects/43/views/1). There are 2 tabs, each showing a list of discussion pages about:
+You can share your findings with us either publicly or privately. We strive to work in the open as much as possible, but we understand that you may not feel comfortable sharing your findings in a public forum.
+
+### Share information responsibly
+
+[You must get informed consent from your participants](https://www.gov.uk/service-manual/user-research/getting-users-consent-for-research) before you can share findings of any research they’ve participated in.
+
+In addition, remember that all the information on GitHub is open to the public. Do not share any personally identifiable information about your participants or sensitive information about your service, either on GitHub or privately with us.
+
+### Share findings publicly on GitHub
+
+You can find our [list of discussions on GitHub](https://github.com/orgs/alphagov/projects/43/views/1). There are 2 tabs, each showing a list of discussion pages about:
 
 - things already in the Design System
-- things that could be added in the future
+- things we could add in the future
 
 Feedback on both is useful to us. You’ll need to [create a GitHub account](https://github.com/join) to add comments.
 
-Select the thing you want to share findings about. If what you’re looking for isn’t on the list, read about [how to propose a component or pattern](https://design-system.service.gov.uk/community/propose-a-component-or-pattern/).
+Select the thing you want to share findings about. If what you’re looking for is not on the list, read about [how to propose a component or pattern](https://design-system.service.gov.uk/community/propose-a-component-or-pattern/).
 
 Once you’ve selected the right discussion, use the template below to add your findings.
 
-{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+### Share findings by contacting the team directly
 
-{% set callout %}
-Share information responsibly. <a href="https://www.gov.uk/service-manual/user-research/getting-users-consent-for-research">You must get informed consent from your participants</a> before you can share findings of any research they’ve participated in.
-{% endset %}
-
-{{ govukWarningText({
-  html: callout,
-  iconFallbackText: "Warning"
-}) }}
-
-Remember that all the information on GitHub is open to the public. Do not share any personally identifiable information about your participants or sensitive information about your service.
+If you do not want to use GitHub or would rather share your findings privately, you can [contact the team directly](/contact/) either by email or by sending a direct message on Slack.
 
 ## Research template
 


### PR DESCRIPTION
## What

Adds new headings to the 'Where to share findings' section of the [Share findings about your users](https://design-system.service.gov.uk/community/share-research-findings/) page:

- A link to the contact page for users who want to share their findings with us privately
- A heading on sharing information responsibly, moving the content on privacy from within the previous single section to the top and erasing the warning text
- A heading for sharing on github to differentiate the existing content from the rest of the section

Part of (but does not solve) https://github.com/alphagov/design-system-team-internal/issues/1118

Co-authored with @selfthinker, @seaemsi and @emma1carter

## Why

We have evidence to suggest that:

- some users feel anxious discussing findings and giving feedback in an open forum like github
- some users don't like using github

This outlines a way for users to still engage with us without forcing github to be the only option for them.