### PR TITLE
Adjust new file upload guidance for Dragon users

### DIFF
--- a/src/components/file-upload/index.md
+++ b/src/components/file-upload/index.md
@@ -128,7 +128,7 @@ Users of Dragon, a speech recognition tool, [cannot activate their browser’s n
 
 With the improved File upload component, users can say commands for interacting with web page controls to choose files.
 
-However, due to [browser security features](https://developer.mozilla.org/en-US/docs/Web/Security/User_activation), this may not work on subsequent interactions on the same page. If the component needs to be used more than once (for example, to correct a mistake), users will first need to perform another action, such as a mouse click.
+However, due to [browser security features](https://developer.mozilla.org/en-US/docs/Web/Security/User_activation), this may not work right away or on subsequent interactions on the same page. If users cannot interact with the component, they'll first need to perform another action, such as a mouse click.
 
 ## Research on this component
 


### PR DESCRIPTION
We learned that sometimes a Dragon command for using the file upload component works the first time, and sometimes it doesn't. This changes the guidance text to work for both scenarios.

For more context:
Someone from the NHS Design System contacted us that when they test the new file upload component with Dragon they cannot interact with it at all before performing another action. In our testing the first time always worked. As [user activation](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/User_activation) is supposed to need another action after a page load, we assume that there is a bug somewhere on our side (probably in the Chrome browser).
The fact is that our testing results are different means we are keeping the language of "may" as different versions of Dragon/Chrome/Windows behave inconsistently.