### PR TITLE
Refresh .NET resource links

### DIFF
--- a/src/community/resources-and-tools/index.md
+++ b/src/community/resources-and-tools/index.md
@@ -52,10 +52,7 @@ Sketch wireframes based on the GOV.UK Design System.
 
 ## Build front ends
 
-### ASP.NET
-
-Guidance on [bringing the GOV.UK Design System into a .NET MVC Project](https://github.com/nouriach/compile-gds-runtime-dotnet) -
-A walkthrough for how to import the GOV.UK Design System into a MVC project and compile the sass at runtime using gulp.
+### ASP.NET Core
 
 [GOV.UK Design System for ASP.NET Core](https://github.com/x-govuk/govuk-frontend-aspnetcore) -
 GOV.UK Frontend component library and assets integration for ASP.NET Core


### PR DESCRIPTION
Changes the title from 'ASP.NET' to 'ASP.NET Core' (since ASP.NET refers to the older framework from before .NET Core).

I've removed the 'Guidance on bringing the GOV.UK Design System into a .NET MVC Project' link too as it's super old and the content looks to be incorrect for more recent versions of `govuk-frontend`.