### PR TITLE
Remove light-blue tag colour

### DIFF
--- a/src/components/tag/all-colours/index.njk
+++ b/src/components/tag/all-colours/index.njk
@@ -59,17 +59,6 @@ layout: layout-example.njk
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">
-        <code> govuk-tag--light-blue </code>
-      </td>
-      <td class="govuk-table__cell">
-        {{ govukTag({
-          text: "In progress",
-          classes: "govuk-tag--light-blue"
-        }) }}
-      </td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">
         <code> govuk-tag--purple </code>
       </td>
       <td class="govuk-table__cell">

--- a/src/components/task-list/all-colours/index.njk
+++ b/src/components/task-list/all-colours/index.njk
@@ -63,18 +63,6 @@ layout: layout-example.njk
       href: "#",
       status: {
         tag: {
-          text: "Light blue",
-          classes: "govuk-tag--light-blue"
-        }
-      }
-    },
-    {
-      title: {
-        text: "Task F"
-      },
-      href: "#",
-      status: {
-        tag: {
           text: "Purple",
           classes: "govuk-tag--purple"
         }
@@ -82,7 +70,7 @@ layout: layout-example.njk
     },
     {
       title: {
-        text: "Task G"
+        text: "Task F"
       },
       href: "#",
       status: {
@@ -94,7 +82,7 @@ layout: layout-example.njk
     },
     {
       title: {
-        text: "Task H"
+        text: "Task G"
       },
       href: "#",
       status: {
@@ -106,7 +94,7 @@ layout: layout-example.njk
     },
     {
       title: {
-        text: "Task I"
+        text: "Task H"
       },
       href: "#",
       status: {

--- a/src/components/task-list/in-progress/index.njk
+++ b/src/components/task-list/in-progress/index.njk
@@ -25,7 +25,7 @@ layout: layout-example.njk
       status: {
         tag: {
           text: "In progress",
-          classes: "govuk-tag--light-blue"
+          classes: "govuk-tag--teal"
         }
       }
     },

--- a/src/patterns/complete-multiple-tasks/index.md
+++ b/src/patterns/complete-multiple-tasks/index.md
@@ -65,7 +65,7 @@ You may find you need additional statuses if your user research shows that users
 
 In this instance, instead of ‘Incomplete’, you may want to use ‘Not yet started’ to show which tasks they are yet to start. You should then use ‘In progress’ for tasks they have started but are yet to complete.
 
-‘Not yet started’ uses a blue background, and ‘In progress’ uses a light blue background.
+Different colours may be used to further differentiate between tags.
 
 {{ example({ group: "components", item: "task-list", example: "in-progress", html: true, nunjucks: true, open: false }) }}
 


### PR DESCRIPTION
Closes #5098 

## Notes
Replaces light blue for "in progress" with teal as it matched our ["active" example in the tag guidance](https://design-system.service.gov.uk/components/tag/#additional-colours). We provide guidance on the colour of the "in progress" tag that folks might take as gospel, so this needs design review too.