### PR TITLE
Update link colour on colours page

### DIFF
--- a/data/colours.json
+++ b/data/colours.json
@@ -13,7 +13,7 @@
     "Link": [
       {
         "name": "link",
-        "colour": "#1d70b8"
+        "colour": "#1a65a6"
       },
       {
         "name": "link-hover",
@@ -100,10 +100,6 @@
       {
         "name": "surface-border",
         "colour": "#8eb8dc"
-      },
-      {
-        "name": "surface-link",
-        "colour": "#1a65a6"
       }
     ],
     "Print": [
@@ -145,7 +141,8 @@
       },
       {
         "name": "shade-10",
-        "colour": "#1a65a6"
+        "colour": "#1a65a6",
+        "hidden": true
       }
     ],
     "Green": [

--- a/src/stylesheets/components/_mobile-navigation-section.scss
+++ b/src/stylesheets/components/_mobile-navigation-section.scss
@@ -39,7 +39,7 @@
   // Add back a border to separate each element of the menu
   border-top: solid 1px govuk-functional-colour(border);
 
-  color: $_govuk-service-navigation-link-colour;
+  color: govuk-functional-colour("link");
   background: none;
 
   // Meet the Service Nav's typography
@@ -198,7 +198,7 @@ $subnav-padding-left: $app-chevron-width + $app-chevron-margin-left + $app-chevr
     top: 0;
     bottom: 0;
     left: -$signifier-offset;
-    border-left: solid 5px $_govuk-service-navigation-link-colour;
+    border-left: solid 5px govuk-functional-colour("link");
 
     @supports (margin: unquote("max(calc(0px))")) {
       $save-area-aware: calc(#{$signifier-offset} + env(safe-area-inset-left));

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -39,9 +39,8 @@
 @import "govuk/overrides/typography";
 @import "govuk/overrides/width";
 
-// Neither values are available as variables in GOV.UK Frontend
-// so adding them as private variables for future reference
-$_govuk-service-navigation-link-colour: govuk-functional-colour("surface-link");
+// This value is not available as a variable in GOV.UK Frontend
+// so adding it as a private variable for future reference
 $_govuk-service-navigation-font-size: 19px;
 
 // App-specific variables

--- a/views/partials/_colour-table.njk
+++ b/views/partials/_colour-table.njk
@@ -1,6 +1,5 @@
 {% macro colourTable(params) %}
 {% set hiddenGroups = params.hiddenGroups or [] %}
-{% set hiddenColours = params.hiddenColours or [] %}
 
 <table class="govuk-body app-colour-list">
   <caption class="govuk-visually-hidden">{{params.caption}}</caption>
@@ -16,7 +15,7 @@
       </td>
     </tr>
     {% for colour in group -%}
-      {% if color.name not in hiddenColours %}
+      {% if not colour.hidden %}
       <tr class="app-colour-list-row">
         <th class="app-colour-list-column app-colour-list-column--name" scope="row">
           <span class="app-swatch {% if colour.colour == "#ffffff" %}app-swatch-border{% endif %}" style="background-color:{{colour.colour}}"></span>


### PR DESCRIPTION
Closes #5130 

- This PR doesn't actually change the link colour across the site - the difference is so subtle, and the change would be so wide-ranging, that it seems better to just wait for the final govuk-frontend release to be installed.
- Keeps Blue shade-10 in our colours data file but hides it from display