### PR TITLE
Remove guidance about ‘default’ cookie banner

### DIFF
--- a/src/components/cookie-banner/index.md
+++ b/src/components/cookie-banner/index.md
@@ -14,8 +14,6 @@ Allow users to accept or reject cookies which are not essential to making your s
 
 {{ example({ group: "components", item: "cookie-banner", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
-If you use the page template, you'll also get the Cookie banner without having to add it, as it's included by default. However, if you want to customise the default Cookie banner, read the [page template guidance about customising components](/styles/page-template/#changing-template-content).
-
 ## When to use this component
 
 Use this component if your service sets any cookies on a user’s device.


### PR DESCRIPTION
There is no default cookie banner in the page template. Cookie banners need to be bespoke to a service based on the cookies and technologies they’re using.

The only mention of the cookie banner on the page template guidance is as part of the description for the `bodyStart` block.

It looks like this guidance was mistakenly introduced alongside the rebrand-related changes in #4636.

Remove the incorrect guidance.