### PR TITLE
Use recommended blocks for custom page example

### DIFF
--- a/src/styles/page-template/custom/code.njk
+++ b/src/styles/page-template/custom/code.njk
@@ -25,6 +25,7 @@ ignoreInSitemap: true
   "data-other": "report:details"
 } %}
 {% set containerClasses = "app-width-container" %}
+{% set mainClasses = "app-main-class" %}
 
 {% block pageTitle %}GOV.UK - Customised page template{% endblock %}
 
@@ -98,12 +99,6 @@ ignoreInSitemap: true
   }) }}
 {% endblock %}
 
-{% set mainClasses = "app-main-class" %}
-
-{% block main %}
-  {{ super() }}
-{% endblock %}
-
 {% block headerEnd %}
   {{ govukPhaseBanner({
     tag: {
@@ -118,6 +113,10 @@ ignoreInSitemap: true
     href: "#",
     text: "Back"
   }) }}
+{% endblock %}
+
+{% block main %}
+  {{ super() }}
 {% endblock %}
 
 {% block content %}

--- a/src/styles/page-template/custom/index.njk
+++ b/src/styles/page-template/custom/index.njk
@@ -25,6 +25,7 @@ ignoreInSitemap: true
   "data-other": "report:details"
 } %}
 {% set containerClasses = "app-width-container" %}
+{% set mainClasses = "app-main-class" %}
 
 {% block pageTitle %}{{ title }} – Example - GOV.UK Design System{% endblock %}
 
@@ -99,12 +100,6 @@ ignoreInSitemap: true
   }) }}
 {% endblock %}
 
-{% set mainClasses = "app-main-class" %}
-
-{% block main %}
-  {{ super() }}
-{% endblock %}
-
 {% block headerEnd %}
   {{ govukPhaseBanner({
     tag: {
@@ -119,6 +114,10 @@ ignoreInSitemap: true
     href: "#",
     text: "Back"
   }) }}
+{% endblock %}
+
+{% block main %}
+  {{ super() }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Notice this while using the guidance to update our top level templates...

In the guidance it refers to using the `headerEnd` block for where the Phase banner component belongs.

One possibility is that the phase banner does not belong within the header landmark so the other guidance should change instead, in that case a different change will be needed.

Changes:
- Use `govukSkipLink` over deprecated `skipLink`
- use `headerEnd` for Phase banner
- move blocks around slightly and variables so they match the logical order of the underlying document.