### PR TITLE
Remove redundant hidden text from summary card

### DIFF
--- a/src/components/summary-list/card-with-actions/index.njk
+++ b/src/components/summary-list/card-with-actions/index.njk
@@ -14,13 +14,11 @@ layout: layout-example.njk
       items: [
         {
           href: "#",
-          text: "Delete choice",
-          visuallyHiddenText: "of University of Gloucestershire"
+          text: "Delete choice"
         },
         {
           href: "#",
-          text: "Withdraw",
-          visuallyHiddenText: "from University of Gloucestershire"
+          text: "Withdraw"
         }
       ]
     }
@@ -54,13 +52,11 @@ layout: layout-example.njk
       items: [
         {
           href: "#",
-          text: "Delete choice",
-          visuallyHiddenText: "of University of Bristol"
+          text: "Delete choice"
         },
         {
           href: "#",
-          text: "Withdraw",
-          visuallyHiddenText: "from University of Bristol"
+          text: "Withdraw"
         }
       ]
     }


### PR DESCRIPTION
The [summary card’s `title.text` is already appended to each action link by the Summary List Nunjucks macro][1], so adding it as visuallyHiddenText results in duplication, for example:

```html
<a class="govuk-link" href="#">
  Delete choice
  <span class="govuk-visually-hidden"> of University of Gloucestershire (University of Gloucestershire)</span>
</a>
```

Remove the visuallyHiddenText to avoid the duplication.

Closes #5093 

[1]: https://github.com/alphagov/govuk-frontend/blob/b3e70962512ba2d42876a404656606af0404f4a8/packages/govuk-frontend/src/govuk/components/summary-list/template.njk#L8-L11