### PR TITLE
Update examples to use caller where possible

### DIFF
--- a/src/community/contribution-criteria/index.md
+++ b/src/community/contribution-criteria/index.md
@@ -120,6 +120,6 @@ Before linking from the Design System to a [community resource or tool](/communi
 
 To help users decide whether to use your resource or tool and tell them how to get support for it, add this message to the resource README and after any website links:
 
-{{ govukInsetText({
-  text: "[Name of resource or tool] is a community [resource/tool] of the GOV.UK Design System. The Design System team is not responsible for it and cannot support you with using it. Contact [contributor] directly if you need help or you want to request a feature."
-}) }}
+{% call govukInsetText() %}
+[Name of resource or tool] is a community [resource/tool] of the GOV.UK Design System. The Design System team is not responsible for it and cannot support you with using it. Contact [contributor] directly if you need help or you want to request a feature.
+{% endcall %}

--- a/src/community/propose-a-content-change-using-github/index.md
+++ b/src/community/propose-a-content-change-using-github/index.md
@@ -15,9 +15,9 @@ This guide explains how to propose a change to the Design System's content. You'
 
 If you do not have one already, you can [create a GitHub account for free](https://github.com/).
 
-{{ govukInsetText({
-  text: "Rest assured that it's impossible for you to break the Design System by proposing changes. The GOV.UK Design System team reviews all changes before publishing."
-}) }}
+{% call govukInsetText() %}
+Rest assured that it's impossible for you to break the Design System by proposing changes. The GOV.UK Design System team reviews all changes before publishing.
+{% endcall %}
 
 If you get stuck whilst following these steps and you need help, you can:
 

--- a/src/components/details/default/index.njk
+++ b/src/components/details/default/index.njk
@@ -5,7 +5,9 @@ layout: layout-example.njk
 
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
-{{ govukDetails({
-  summaryText: "Help with nationality",
-  text: "We need to know your nationality so we can work out which elections you’re entitled to vote in. If you cannot provide your nationality, you’ll have to send copies of identity documents through the post."
-}) }}
+{% call govukDetails({
+  summaryText: "Help with nationality"
+}) %}
+  We need to know your nationality so we can work out which elections you’re entitled to vote in.
+  If you cannot provide your nationality, you’ll have to send copies of identity documents through the post.
+{% endcall %}

--- a/src/components/inset-text/default/index.njk
+++ b/src/components/inset-text/default/index.njk
@@ -5,6 +5,6 @@ layout: layout-example.njk
 
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
-{{ govukInsetText({
-  text: "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application."
-}) }}
+{% call govukInsetText() %}
+  It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.
+{% endcall %}

--- a/src/components/notification-banner/default/index.njk
+++ b/src/components/notification-banner/default/index.njk
@@ -5,13 +5,9 @@ layout: layout-example.njk
 
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
-{% set html %}
+{% call govukNotificationBanner() %}
   <p class="govuk-notification-banner__heading">
     You have 7 days left to send your application.
     <a class="govuk-notification-banner__link" href="#">View application</a>.
   </p>
-{% endset %}
-
-{{ govukNotificationBanner({
-  html: html
-}) }}
+{% endcall %}

--- a/src/components/notification-banner/success/index.njk
+++ b/src/components/notification-banner/success/index.njk
@@ -5,14 +5,11 @@ layout: layout-example.njk
 
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
-{% set html %}
+{% call govukNotificationBanner({
+  type: "success"
+}) %}
   <h3 class="govuk-notification-banner__heading">
     Training outcome recorded and trainee withdrawn
   </h3>
   <p class="govuk-body">Contact <a class="govuk-notification-banner__link" href="#">example@department.gov.uk</a> if you think there’s a problem.</p>
-{% endset %}
-
-{{ govukNotificationBanner({
-  html: html,
-  type: "success"
-}) }}
+{% endcall %}

--- a/src/components/notification-banner/whole-service/index.njk
+++ b/src/components/notification-banner/whole-service/index.njk
@@ -5,6 +5,6 @@ layout: layout-example.njk
 
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
-{{ govukNotificationBanner({
-  text: "There may be a delay in processing your application because of the coronavirus outbreak."
-}) }}
+{% call govukNotificationBanner() %}
+  There may be a delay in processing your application because of the coronavirus outbreak.
+{% endcall %}

--- a/src/components/panel/default/index.njk
+++ b/src/components/panel/default/index.njk
@@ -5,7 +5,9 @@ layout: layout-example.njk
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
-{{ govukPanel({
-  titleText: "Application complete",
-  html: "Your reference number<br><strong>HDJ2123F</strong>"
-}) }}
+{% call govukPanel({
+  titleText: "Application complete"
+}) %}
+  Your reference number<br>
+  <strong>HDJ2123F</strong>
+{% endcall %}

--- a/src/components/table/index.md
+++ b/src/components/table/index.md
@@ -65,9 +65,11 @@ If possible, you should aim to have less data in your tables. If you have a lot 
 
 If you cannot split your data, you can use the CSS class `govuk-table--small-text-until-tablet`. This class reduces the size of the text on small screens so large amounts of data has more empty space around it. This makes it easier to visually differentiate between each piece of data when read on small screens.
 
-{{ govukInsetText({
-  html: "<p>The CSS class <code>govuk-table--small-text-until-tablet</code> is only available in version 5.2 of GOV.UK Frontend and later.</p><p>Read about <a href=\"/get-started/new-type-scale/\">updating your service to use the new type scale</a>.</p>"
-}) }}
+{% call govukInsetText() %}
+
+  <p>The CSS class <code>govuk-table--small-text-until-tablet</code> is only available in version 5.2 of GOV.UK Frontend and later.</p>
+  <p>Read about <a href="/get-started/new-type-scale/">updating your service to use the new type scale</a>.</p>
+{% endcall %}
 
 You should not use this class on tables unless your table has a lot of data, because a smaller amount of data is easier to read if the text is larger.
 

--- a/src/cookies.njk
+++ b/src/cookies.njk
@@ -9,17 +9,12 @@ layout: layout-single-page.njk
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% set successNotificationBannerHtml %}
-  <p class="govuk-notification-banner__heading">You’ve set your cookie preferences.</p>
-{% endset %}
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="app-cookies-page" data-module="app-cookies-page">
 
-      {{ govukNotificationBanner({
+      {% call govukNotificationBanner({
         type: "success",
-        html: successNotificationBannerHtml,
         classes: "js-cookies-page-success",
         attributes: {
           hidden: {
@@ -27,7 +22,9 @@ layout: layout-single-page.njk
             optional: true
           }
         }
-      }) }}
+      }) %}
+        <p class="govuk-notification-banner__heading">You’ve set your cookie preferences.</p>
+      {% endcall %}
 
       <h1 class="govuk-heading-xl">Cookies</h1>
       <p class="govuk-body"><a href="/" class="govuk-link">GOV.UK Design System</a> puts small files (known as ‘cookies’) on your computer.</p>

--- a/src/patterns/confirm-a-phone-number/index.md
+++ b/src/patterns/confirm-a-phone-number/index.md
@@ -36,9 +36,9 @@ When the user creates an account, ask for their password and mobile phone number
 
 After saving the user’s password and mobile phone number, verify their mobile phone number by sending them a text message with a 5 digit code in this format:
 
-{{ govukInsetText({
-  text: "12345 is your [service name] security code"
-}) }}
+{% call govukInsetText() %}
+12345 is your [service name] security code
+{% endcall %}
 
 Then ask the user to enter this code:
 
@@ -63,9 +63,9 @@ When the user requests a new code, send them a new one. The new code should have
 
 When the user returns to your service, verify their password first. Once they have entered this correctly, send a text message to their mobile phone with a 5 digit code in this format:
 
-{{ govukInsetText({
-  text: "12345 is your [service name] security code"
-}) }}
+{% call govukInsetText() %}
+12345 is your [service name] security code
+{% endcall %}
 
 Ask the user to enter this code. Use the same pattern and time limit as when creating an account.
 
@@ -83,9 +83,9 @@ You can also follow the [domain-bound codes](https://developer.apple.com/news/?i
 
 Include the domain of the service on a new line, prefixed with an `@`, followed by a `#` symbol and the code, like this:
 
-{{ govukInsetText({
-  html: "12345 is your [service name] security code<br><br>@www.example.service.gov.uk #12345"
-}) }}
+{% call govukInsetText() %}
+12345 is your [service name] security code<br><br>@www.example.service.gov.uk #12345
+{% endcall %}
 
 ### Error messages
 

--- a/src/patterns/confirm-a-phone-number/resend-first-time/index.njk
+++ b/src/patterns/confirm-a-phone-number/resend-first-time/index.njk
@@ -17,7 +17,9 @@ title: Request a new security code (first time) – Confirm a phone number
 
 <p class="govuk-body">Text messages sometimes take a few minutes to arrive. If you do not receive the text message, you can request a new one.</p>
 
-{% set mobileNumberHtml %}
+{% call govukDetails({
+  summaryText: "Change where the text message is sent"
+}) %}
   {{ govukInput({
     label: {
       text: "Mobile number"
@@ -29,12 +31,7 @@ title: Request a new security code (first time) – Confirm a phone number
     autocomplete: "tel",
     classes: "govuk-input--width-20"
   }) }}
-{% endset %}
-
-{{ govukDetails({
-  summaryText: "Change where the text message is sent",
-  html: mobileNumberHtml
-}) }}
+{% endcall %}
 
 {{ govukButton({
   text: "Request a new code"

--- a/src/patterns/confirm-a-phone-number/resend/index.njk
+++ b/src/patterns/confirm-a-phone-number/resend/index.njk
@@ -16,10 +16,13 @@ title: Request a new security code – Confirm a phone number
 
 <p class="govuk-body">Text messages sometimes take a few minutes to arrive. If you do not receive the text message, you can request a new one.</p>
 
-{{ govukDetails({
-  summaryText: "I do not have access to the phone",
-  html: '<p class="govuk-body">If you cannot access the phone number for this account, <a href="#" class="govuk-link">contact the Tax Credits Helpline</a> to get help signing in.</p>'
-}) }}
+{% call govukDetails({
+  summaryText: "I do not have access to the phone"
+}) %}
+  <p class="govuk-body">
+    If you cannot access the phone number for this account, <a href="#" class="govuk-link">contact the Tax Credits Helpline</a> to get help signing in.
+  </p>
+{% endcall %}
 
 {{ govukButton({
   text: "Request a new code"

--- a/src/patterns/contact-a-department-or-service-team/expanding-contact-information/index.njk
+++ b/src/patterns/contact-a-department-or-service-team/expanding-contact-information/index.njk
@@ -5,7 +5,9 @@ layout: layout-example.njk
 
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
-{% set contactInformation %}
+{% call govukDetails({
+  summaryText: "If you need help completing this form"
+}) %}
   <ul class="govuk-list">
     <li>Phone: 020 7946 0101</li>
     <li>Monday to Friday, 8am to 6pm (except public holidays)</li>
@@ -18,9 +20,4 @@ layout: layout-example.njk
     <li><a class="govuk-link" href="#">name@example.com</a></li>
     <li>We aim to respond within 2 working days</li>
   </ul>
-{% endset %}
-
-{{ govukDetails({
-  summaryText: "If you need help completing this form",
-  html: contactInformation
-}) }}
+{% endcall %}

--- a/src/patterns/contact-a-department-or-service-team/inset-contact-information/index.njk
+++ b/src/patterns/contact-a-department-or-service-team/inset-contact-information/index.njk
@@ -5,7 +5,7 @@ layout: layout-example.njk
 
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
-{% set contactInformation %}
+{% call govukInsetText() %}
   <h2 class="govuk-heading-m">Talk to an advisor</h2>
   <ul class="govuk-list">
     <li>Phone: 020 7946 0101</li>
@@ -15,8 +15,4 @@ layout: layout-example.njk
   <p class="govuk-body">
     <a class="govuk-link" href="#">Find out about call charges</a>
   </p>
-{% endset %}
-
-{{ govukInsetText({
-  html: contactInformation
-}) }}
+{% endcall %}

--- a/src/patterns/cookies-page/cookies-updated/index.njk
+++ b/src/patterns/cookies-page/cookies-updated/index.njk
@@ -5,13 +5,10 @@ layout: layout-example.njk
 
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
-{% set html %}
+{% call govukNotificationBanner({
+  type: "success"
+}) %}
   <p class="govuk-notification-banner__heading">
     You’ve set your cookie preferences. <a class="govuk-notification-banner__link" href="#">Go back to the page you were looking at</a>.
   </p>
-{% endset %}
-
-{{ govukNotificationBanner({
-  type: "success",
-  html: html
-}) }}
+{% endcall %}

--- a/src/patterns/equality-information/explainer-screen/index.njk
+++ b/src/patterns/equality-information/explainer-screen/index.njk
@@ -39,10 +39,11 @@ layout: layout-example-form.njk
   ]
 }) }}
 
-{{ govukDetails({
-  summaryText: "Why we ask equality questions",
-  text: "[Consider adding an optional longer explanation of what you’re asking the questions and what you’ll do with the information]."
-}) }}
+{% call govukDetails({
+  summaryText: "Why we ask equality questions"
+}) %}
+  [Consider adding an optional longer explanation of what you’re asking the questions and what you’ll do with the information].
+{% endcall %}
 
 {{ govukButton({
   text: "Continue"

--- a/src/styles/colour/index.md
+++ b/src/styles/colour/index.md
@@ -18,9 +18,9 @@ Always use the GOV.UK colour palette.
 
 You must make sure that the contrast ratio of text and interactive elements in your service meets [Web Content Accessibility Guidelines (WCAG 2.2) success criterion 1.4.3 Contrast (minimum) level AA](https://www.w3.org/TR/WCAG22/#contrast-minimum).
 
-{{ govukInsetText({
-  text: "The WCAG 2.2 criterion for Contrast (minimum) is the same as WCAG 2.1."
-}) }}
+{% call govukInsetText() %}
+The WCAG 2.2 criterion for Contrast (minimum) is the same as WCAG 2.1.
+{% endcall %}
 
 ## Functional colours
 


### PR DESCRIPTION
I have always been a big proponent of it because it reduces the risk of XSS, in the past we updated various components to allow this method of passing HTML (https://github.com/alphagov/govuk-frontend/pull/2734)

## Why should we default to caller?

Passing strings into components adds additional risk of XSS, set capturing variables mitigates this but doesnt represented the nested nature of how these things are composed so I think caller does two things:
1. Feels like how HTML works and how composition works
2. Avoids possibility of XSS from strings with HTML

## Why does it reduce the risk of XSS?

If a user wants to pass HTML into a component and passes it via a parameter string they need to ensure it contains no unsafe HTML for it to be safe.

> If you’re using Nunjucks macros in production with “html” options, or ones ending with “html”, you must sanitise the HTML to protect against [cross-site scripting exploits](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting).

```nunjucks
{{ govukNotificationBanner({
  html: "<img src=x onerror=alert('hello!')>"
}) }}
```

Alternatively, if a user uses `set` to capture the HTML and pass it as a variable it is autoescaped by Nunjucks.

```nunjucks
{% set html %}
    <img src=x onerror=alert('hello!')>
{% endset %}

{{ govukNotificationBanner({
  html: html
}) }}
```

The caller() interface is similar to `set` capturing but allows a less clunky interface since you compose the text within the component similar to adding a parameter.

```nunjucks
{% call govukNotificationBanner() %}
    <img src=x onerror=alert('hello!')>
{% endcall %}
```