### PR TITLE
Add guidance about HTML attributes to File Upload component

### DIFF
--- a/src/components/file-upload/index.md
+++ b/src/components/file-upload/index.md
@@ -108,6 +108,30 @@ This example shows you how to enable the improved File upload component:
 
 {{ example({ group: "components", item: "file-upload", example: "enhanced", html: true, nunjucks: true, open: false, size: "m" }) }}
 
+### About HTML attributes
+
+JavaScript creates the improved version of the component out of the input (`<input type="file">`) and then hides the input from the user. The improved version consists of a `<button>` with a few `<span>` elements inside.
+
+Some HTML attributes applied to the input might not work or work differently.
+
+These attributes must stay in the original input since they're used by the button:
+
+- `id` and its value are added to the button and renamed on the input
+- `disabled` is copied and synchronised with any changes that happen on the input
+- `aria-describedby` is copied
+
+These attributes must stay in the original input since they only work in the input (and not the button):
+
+- `name`
+- `accept`
+- `capture`
+- `accesskey`
+- `multiple`, which also changes the behaviour of the button as text is added when multiple files are selected
+
+To add any other attributes to the improved version, you'll have to add them either to the parent `<div>` or through JavaScript to the button.
+
+Screen readers will not read out the `required` attribute in the improved version. Although we [recommend not to use that attribute](/patterns/validation/#turn-off-html5-validation).
+
 ### Changes in the improved component
 
 To make it easier for users to drag and drop files, we’ve made the drop zone:


### PR DESCRIPTION
This adds information about which HTML attributes work on the improved File Upload component and which don't.
This is to partially fix https://github.com/alphagov/govuk-design-system/issues/5231.

We have to decide if we are fine with publishing this now or if it has to go together with the rest of the File Upload improvements (which will be published by the end of the next cycle, so in roughly 5 weeks).

I had initially written much more text but have condensed it to this version which is also intentionally a bit vague and even a little bit incorrect, as I'd otherwise have to write much more.
It's also worth nothing that this is written to be agnostic to people using the HTML version or the Nunjucks version of the component. It should apply to both.

This is what I originally wrote with more detail...

## About HTML attributes

When the JavaScript creates the improved version of the component, it takes some of the attributes from the hidden `<input type="file">` and adds them to the visible `<button>`, and leaves others on the hidden `<input type="file">`.

What is moved or copied to the button:
* `id` is added to the button and renamed on the input
* `disabled` is copied
* `multiple` is not directly copied but the behaviour of the button is adjusted accordingly
* `aria-describedby` is copied

The rest is not moved or copied.

Some attributes only work on the hidden `<input type="file">` while others would only work on the visible `<button>`, and one attribute works on neither.

What attributes work on the hidden input:
* `name`
* `accept`
* `capture`
* `accesskey`

Most other attributes would need to be moved/copied/added to the button or the container `<div>`, like `data-*` attributes for tracking.

Only the `required` attribute works differently. In the improved version of the component it will not be read out to screen reader users, neither on the hidden input nor on the visible button. But native browser form validation will still work when put on the hidden input. Although we [recommend not to use that attribute](https://design-system.service.gov.uk/patterns/validation/#turn-off-html5-validation) anyway.