### PR TITLE
Add error handling to mobile navigation section

### DIFF
--- a/src/javascripts/components/mobile-navigation-section.mjs
+++ b/src/javascripts/components/mobile-navigation-section.mjs
@@ -7,6 +7,23 @@ class MobileNavigationSection extends Component {
   static moduleName = 'app-mobile-navigation-section'
 
   /**
+   * Check if --govuk-breakpoint-tablet is available
+   */
+  static checkSupport() {
+    Component.checkSupport()
+
+    if (
+      !getComputedStyle(document.documentElement).getPropertyValue(
+        '--govuk-breakpoint-tablet'
+      )
+    ) {
+      throw Error(
+        'GOV.UK Frontend tablet breakpoint custom property is not available'
+      )
+    }
+  }
+
+  /**
    * @returns {boolean} Whether the section is expanded
    */
   get expanded() {
@@ -46,11 +63,9 @@ class MobileNavigationSection extends Component {
     }
 
     // Check if the section should be visible or not
-    const breakPoint = getComputedStyle(
-      document.documentElement
-    ).getPropertyValue('--govuk-breakpoint-tablet')
-
-    this.mql = window.matchMedia(`(min-width: ${breakPoint})`)
+    this.mql = window.matchMedia(
+      `(min-width: ${getComputedStyle(document.documentElement).getPropertyValue('--govuk-breakpoint-tablet')})`
+    )
 
     // MediaQueryList.addEventListener isn't supported by Safari < 14 so we need
     // to be able to fall back to the deprecated MediaQueryList.addListener


### PR DESCRIPTION
## Change

Adds a static `checkSupport` function to the mobile navigation section js module to check for the existance of `--govuk-breakpoint-tablet`. This custom property is used to set up a `matchMedia` to change the component between breakpoints and is fairly critical to the operation of the component.

Without it, the navigation visually breaks. We ran into this when upgrading to Frontend v6 when we changed the name of the breakpoint custom properties from `--govuk-frontend-breakpoint-[whatever]` to `--govuk-breakpoint-[whatever]`.

This is inline with [what we want modules extending Frontend to do](https://frontend.design-system.service.gov.uk/building-your-own-javascript-components/#using-this-root-with-typescript) to manage component resilience. We do this for all our other js modules on the website but missed applying it to this one.

## Thoughts

I would've liked to set the `getComputedStyle` call which retrieves the breakpoint custom property as a class-level variable but had trouble with this. I couldn't create something that both the static method and the constructor recognised. I specifically tried a standalone variable and a getter. I could create a distinct method that just returns it but then I might as well use a getter. I feel like there's a convention I'm struggling to recall. I'm open to ideas here.