### PR TITLE
Remove redundant Frontend macro imports

### DIFF
--- a/src/components/footer/index.md
+++ b/src/components/footer/index.md
@@ -8,7 +8,6 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
 
 The GOV.UK footer provides copyright, licensing and other information about your service.
 

--- a/src/get-started/new-type-scale/index.md
+++ b/src/get-started/new-type-scale/index.md
@@ -8,7 +8,6 @@ description: The GOV.UK Design System team has updated the GOV.UK Frontend type 
 ---
 
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 The GOV.UK Design System team has updated the GOV.UK Frontend type scale used in version 6.0.0 and later.
 

--- a/src/patterns/start-using-a-service/index.md
+++ b/src/patterns/start-using-a-service/index.md
@@ -8,8 +8,6 @@ backlogIssueId: 111
 layout: layout-pane.njk
 ---
 
-{% from "govuk/components/tag/macro.njk" import govukTag %}
-
 GOV.UK services must start on a GOV.UK content page. This links your service to the rest of GOV.UK, and means that users can find it using search or through GOV.UK’s navigation.
 
 ## When to use this pattern

--- a/src/styles/type-scale/index.md
+++ b/src/styles/type-scale/index.md
@@ -10,7 +10,6 @@ order: 6
 
 {% from "_example.njk" import example %}
 
-{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% include "_new-type-scale.njk" %}


### PR DESCRIPTION
Removes imports of components on pages where those components aren't being used. All of these are little instances where we forgot to do proper cleanup when we removed the content which was using those components.