### PR TITLE
Add guidance for interruption panel contribution

### DIFF
--- a/src/components/panel/index.md
+++ b/src/components/panel/index.md
@@ -9,14 +9,17 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-The panel component is a visible container used on confirmation or results pages to highlight important content.
+The Panel component is a visible container used to highlight important content.
 {{ example({ group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", loading: "eager" }) }}
 
 ## When to use this component
 
-Use the panel component to display important information when a transaction has been&nbsp; completed.
+Use the Panel component to display important information within:
 
-In most cases, the panel component is used on [Confirmation pages in your service](/patterns/confirmation-pages/), to tell the user they have successfully completed the transaction.
+- Confirmation pages, which tell the user they’ve successfully completed the transaction
+- Interruption pages, which pause the user journey to give important information
+
+See guidance on [Confirmation pages](/patterns/confirmation-pages/) and [Interruption pages](/patterns/interruption-pages/).
 
 ## When not to use this component
 
@@ -26,12 +29,24 @@ Never use the panel component to highlight important information within body con
 
 There are 2 ways to use the panel component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
+### Confirmation panel
+
+The confirmation panel is part of a [confirmation page](/patterns/confirmation-pages/) and tells the user the outcome of their journey as a heading. You might also give more detailed information as description text.
+
 {{ example({ group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
 
-### How to write panel text
+### How to write confirmation panel text
 
 Keep your panel text brief, as it's only meant for a high-level explanation of what has happened. For example, 'Application complete'.
 
 Aim to use short words and phrases to make sure highlighted information is easy to read at different screen sizes. For example, shorter amounts of information is less likely to wrap around the panel, which can happen when using the zoom function on mobiles.
 
 If you need to give detailed information, or more context, use the description text under the heading text.
+
+## Interruption panel
+
+The interruption panel is part of a [interruption page]()/patterns/interruption-pages/) and shows the user important information that they’d miss if shown any other way.
+
+Within the panel is a ‘continue’ button that the user must interact with to resume their journey.
+
+The information itself is usually shown as heading with some description text, possibly a bullet or numbered list.

--- a/src/components/panel/index.md
+++ b/src/components/panel/index.md
@@ -1,6 +1,6 @@
 ---
 title: Panel
-description: The panel component is a visible container used on confirmation or results pages
+description: Use the Panel component to display important information in within confirmation and interruption pages
 section: Components
 aliases: confirmation box, results box, reference number, application complete, application number
 backlogIssueId: 55
@@ -16,14 +16,12 @@ The Panel component is a visible container used to highlight important content.
 
 Use the Panel component to display important information within:
 
-- Confirmation pages, which tell the user they’ve successfully completed the transaction
-- Interruption pages, which pause the user journey to give important information
-
-See guidance on [Confirmation pages](/patterns/confirmation-pages/) and [Interruption pages](/patterns/interruption-pages/).
+- [Confirmation pages](/patterns/confirmation-pages/), which tell the user they’ve successfully completed the transaction
+- [Interruption pages](/patterns/interruption-pages/), which pause the user journey to give important information
 
 ## When not to use this component
 
-Never use the panel component to highlight important information within body content.
+Never use the Panel component to highlight any other information.
 
 ## How it works
 
@@ -31,22 +29,22 @@ There are 2 ways to use the panel component. You can use HTML or, if you are usi
 
 ### Confirmation panel
 
-The confirmation panel is part of a [confirmation page](/patterns/confirmation-pages/) and tells the user the outcome of their journey as a heading. You might also give more detailed information as description text.
+The confirmation panel is part of a [Confirmation page](/patterns/confirmation-pages/) and tells the user the outcome of their journey as a heading. You might also give more detailed information as description text.
 
 {{ example({ group: "components", item: "panel", example: "default", html: true, nunjucks: true, open: false, size: "m", titleSuffix: "second" }) }}
 
 ### How to write confirmation panel text
 
-Keep your panel text brief, as it's only meant for a high-level explanation of what has happened. For example, 'Application complete'.
+Keep your panel text brief, as it's only meant for a high-level explanation of what has happened.
 
-Aim to use short words and phrases to make sure highlighted information is easy to read at different screen sizes. For example, shorter amounts of information is less likely to wrap around the panel, which can happen when using the zoom function on mobiles.
-
-If you need to give detailed information, or more context, use the description text under the heading text.
+Aim to use short words and phrases to make sure highlighted information is easy to read at different screen sizes. For example, shorter amounts of information are less likely to wrap around the panel, which can happen when using the zoom function on mobiles.
 
 ## Interruption panel
 
-The interruption panel is part of a [interruption page]()/patterns/interruption-pages/) and shows the user important information that they’d miss if shown any other way.
+The interruption panel is part of an [Interruption page](/patterns/interruption-pages/) and shows the user important information that they’d miss if shown any other way.
 
-Within the panel is a ‘continue’ button that the user must interact with to resume their journey.
+Within the panel is a button that the user must interact with to resume their journey.
 
-The information itself is usually shown as heading with some description text, possibly a bullet or numbered list.
+The information itself is usually shown as heading with some description text, possibly with bullet points and numbered steps.
+
+{{ example({ group: "components", item: "panel", example: "interruption", html: true, nunjucks: true, open: false, size: "m" }) }}

--- a/src/components/panel/interruption/index.njk
+++ b/src/components/panel/interruption/index.njk
@@ -1,0 +1,22 @@
+---
+title: Interruption - Panel
+layout: layout-example.njk
+---
+
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% set panelHtml %}
+<p>You entered your age as <strong>109</strong>.</p>
+<div class="govuk-button-group">
+  <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+    Yes, this is correct
+  </button>
+  <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
+</div>
+{% endset %}
+
+{{ govukPanel({
+  titleText: "Is your age correct?",
+  html: panelHtml,
+  classes: "govuk-panel--interruption"
+}) }}

--- a/src/components/panel/interruption/index.njk
+++ b/src/components/panel/interruption/index.njk
@@ -4,19 +4,24 @@ layout: layout-example.njk
 ---
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set panelHtml %}
-<p>You entered your age as <strong>109</strong>.</p>
-<div class="govuk-button-group">
-  <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
-    Yes, this is correct
-  </button>
-  <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
-</div>
-{% endset %}
-
-{{ govukPanel({
+{% call govukPanel({
+  classes: "govuk-panel--interruption",
   titleText: "Is your age correct?",
-  html: panelHtml,
-  classes: "govuk-panel--interruption"
-}) }}
+  actions: {
+    items: [
+      {
+        text: "Yes, this is correct",
+        href: "#",
+        type: "button"
+      }, {
+        text: "No, change my age",
+        href: "#"
+      }
+    ]
+  }
+}) %}
+  <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
+{% endcall %}
+

--- a/src/patterns/interruption-pages/default/index.njk
+++ b/src/patterns/interruption-pages/default/index.njk
@@ -4,7 +4,6 @@ layout: layout-example-full-page.njk
 ---
 
 {% extends "example-wrappers/full-page.njk" %}
-{% set mainClasses = "govuk-main-wrapper--l" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}

--- a/src/patterns/interruption-pages/default/index.njk
+++ b/src/patterns/interruption-pages/default/index.njk
@@ -6,6 +6,7 @@ layout: layout-example-full-page.njk
 {% extends "example-wrappers/full-page.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% block containerStart %}
@@ -14,24 +15,27 @@ layout: layout-example-full-page.njk
   }) }}
 {% endblock %}
 
-{% set panelHtml %}
-<p>You entered your age as <strong>109</strong>.</p>
-<div class="govuk-button-group">
-  <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
-    Yes, this is correct
-  </button>
-  <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
-</div>
-{% endset %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {{ govukPanel({
+      {% call govukPanel({
         titleText: "Is your age correct?",
-        html: panelHtml,
-        classes: "govuk-panel--interruption"
-      }) }}
+        classes: "govuk-panel--interruption",
+        actions: {
+          items: [
+            {
+              text: "Yes, this is correct",
+              href: "#",
+              type: "button"
+            }, {
+              text: "No, change my age",
+              href: "#"
+            }
+          ]
+        }
+      }) %}
+        <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
+      {% endcall %}
     </div>
   </div>
 {% endblock %}

--- a/src/patterns/interruption-pages/default/index.njk
+++ b/src/patterns/interruption-pages/default/index.njk
@@ -1,0 +1,31 @@
+---
+title: Interruption pages
+layout: layout-example-full-page.njk
+---
+
+{% extends "example-wrappers/full-page.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
+
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% set panelHtml %}
+<p>You entered your age as <strong>109</strong>.</p>
+<div class="govuk-button-group">
+  <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+    Yes, this is correct
+  </button>
+  <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
+</div>
+{% endset %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukPanel({
+        titleText: "Is your age correct?",
+        html: panelHtml,
+        classes: "govuk-panel--interruption"
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/src/patterns/interruption-pages/default/index.njk
+++ b/src/patterns/interruption-pages/default/index.njk
@@ -6,7 +6,14 @@ layout: layout-example-full-page.njk
 {% extends "example-wrappers/full-page.njk" %}
 {% set mainClasses = "govuk-main-wrapper--l" %}
 
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% block containerStart %}
+  {{ govukBackLink({
+    text: "Back"
+  }) }}
+{% endblock %}
 
 {% set panelHtml %}
 <p>You entered your age as <strong>109</strong>.</p>

--- a/src/patterns/interruption-pages/index.md
+++ b/src/patterns/interruption-pages/index.md
@@ -1,0 +1,70 @@
+---
+title: Interruption pages
+description: Pause the user journey to give them important information
+section: Patterns
+theme: Pages
+aliases: 
+backlogIssueId: 27
+layout: layout-pane.njk
+---
+
+{% from "_example.njk" import example %}
+
+Use Interruption pages to pause the user’s journey and give them important information.
+
+{{ example({ group: "patterns", item: "interruption-pages", example: "default", html: true, nunjucks: true, open: false, size: "l", loading: "eager" }) }}
+
+## When to use this pattern
+
+Think carefully before you choose to use an Interruption page, as doing this might get in the way of the user completing their task.
+
+Use Interruption pages to warn the user before they:
+
+- do something unusual that’s probably a mistake
+- do something that cannot be undone (so you can ask the user “Are you sure?”)
+- give an answer that conflicts with existing information
+
+You can also use Interruption pages:
+
+- instead of Confirmation pages to show more varied journey outcomes (that are different to a straightforward success, rejection or completion)
+- to show the user important information ahead of a task
+
+## When not to use this pattern
+
+Do not use Interruption pages unless you're confident that both:
+
+- there’s evidence of a clear need to pause the user journey
+- it's the only way to give the user information and that they’d otherwise miss it
+
+Read guidance in the Service Manual, particularly to [Map and understand a user's whole problem](https://www.gov.uk/service-manual/design/map-a-users-whole-problem), to find ways to improve the user journey and the organisational processes behind them.
+
+## How it works
+
+Interruption pages pause the user journey to show important information. Use Interruption pages sparingly, as they get less effective the more often users see them.
+
+All important information on the page is shown within an [Interruption panel](/components/panel/#interruption-panel), to help ensure the user does not miss it.
+
+The panel includes a button that the user must interact with to continue their journey. Information within the panel is usually shown as a heading with some description text, possibly with bullet points and numbered steps.
+
+Keep information within the panel short. Do not place any other components or form elements inside the panel.
+
+### Back links and cancel buttons
+
+The Interruption page includes a back link at the top of a page, to allow users to go back to the previous page they were on.
+
+If it’s helpful for users to jump back to another point in the journey, such as the start of a section, add a link and group it alongside the continue button. Write link text that describes the action it performs or the page it will take the user.
+
+## Research on this pattern
+
+This pattern was originally contributed by the NHS Design System. We thank the team for working with us to publish the [Interruption panel variant of the Panel component](/components/panel/#interruption-panel) and this pattern.
+
+Guidance in this pattern is based on:
+
+- [Interruption page on NHS Design System](https://service-manual.nhs.uk/design-system/patterns/interruption-page)
+- [Interruption card on Ministry of Justice (MOJ) Design System](https://design-patterns.service.justice.gov.uk/components/interruption-card/)
+
+### Next steps
+
+We’d like to get more input from service teams to help us further improve this pattern.
+
+See our [‘Interruption card’ discussion on GitHub](https://github.com/alphagov/govuk-design-system-backlog/issues/27) to see some of the areas we're interested in learning more about.


### PR DESCRIPTION
This PR proposes adding new draft guidance to Panel component and a new Interruption page pattern.

This work includes:
- edit to the [Panel component (preview)](https://deploy-preview-5262--govuk-design-system-preview.netlify.app/components/panel/) to split out guidance for Confirmation panels and the new Interruption panels
- new [Interruption pages pattern](https://deploy-preview-5262--govuk-design-system-preview.netlify.app/patterns/interruption-pages/), to outline good use cases and tell service teams how to design Interruption pages