### PR TITLE
[SPIKE] Un-brand the website

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -133,11 +133,6 @@ module.exports = metalsmith
     }
 
     await Promise.all([
-      copyAssets('{fonts/*,images/*,manifest.json}', {
-        cwd: join(dirname(require.resolve('govuk-frontend')), 'assets'),
-        dest: 'assets'
-      }),
-
       copyAssets('govuk-frontend.min.css?(.map)', {
         cwd: dirname(require.resolve('govuk-frontend')),
         dest: 'stylesheets'

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -1,3 +1,11 @@
+$govuk-functional-colours: (
+  brand: (
+    name: "purple"
+  )
+);
+
+$govuk-font-family: arial, sans-serif;
+
 @import "govuk/settings";
 @import "govuk/helpers";
 @import "govuk/tools";

--- a/views/layouts/_generic.njk
+++ b/views/layouts/_generic.njk
@@ -5,6 +5,8 @@
 
 {% set assetUrl = 'https://design-system.service.gov.uk/assets' %}
 
+{% set themeColor = 'purple' %}
+
 {% set bodyAttributes = { "data-module": "app-navigation" } %}
 
 {% set containerClasses = 'app-width-container app-container-wrapper' %}


### PR DESCRIPTION
## What

A proof of concept for how difficult it is to remove the GOV.UK brand from the design system website.

Part of https://github.com/alphagov/govuk-design-system/issues/5268

This does a few things:

- Replaces the brand blue with our purple by setting `$govuk-functional-colours` as per [our guidance](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-functional-colours)
- Replaces the transport font with `arial, sans-serif` via `$govuk-font-family`
- Removes the link to Frontend's assets folder that was being managed in the metalsmith plugins
- Sets the template `themeColor` to purple

The intent of this is to model how we might recommend a user removes the govuk brand from their service, as an additive to the work being done for https://github.com/alphagov/govuk-design-system/issues/5206.

## Notes

I haven't been able to change the examples, which I believe is coming from how we initialise our examples separately from our main sass on the website. I'm not gonna stress about this. Please suspend your disbelief.

I picked `arial, sans-serif` for the font replacement because that's what we set following Transport. If this is something we write guidance for, it might be good to have a default for people to use.

I've been lazy with decoupling the assets. Ideally we'd point them at a different folder. I'll focus on this next.

We probably want to think about our asset naming convention. We let people change their `assetPath` and `themeColor` but have opinions about the names of the files themselves. This would be fine, but we have a few non-generic ones like `govuk-icon-mask` and `govuk-icon-180`. A way we could get around this is recommending people replace their `headerIcons` block but I reckon it'd be nicer if folks only had to worry about the generic names. Interested to see if other folks think this is an issue or not.

The sole missing element here is the crown in the footer. I don't think it'd be too hard to allow users to remove the footer crown in the footer component itself.