### PR TITLE
Update guidance about asking for decimal numbers

### DIFF
--- a/src/components/text-input/decimal-input/index.njk
+++ b/src/components/text-input/decimal-input/index.njk
@@ -15,5 +15,6 @@ layout: layout-example-form.njk
   suffix: {
     text: "kg"
   },
-  spellcheck: false
+  spellcheck: false,
+  inputmode: "decimal"
 }) }}

--- a/src/components/text-input/index.md
+++ b/src/components/text-input/index.md
@@ -112,9 +112,9 @@ There is specific guidance on:
 
 #### Asking for decimal numbers
 
-If you're asking the user to enter a number that might include decimal places, use `input type="text"`.
+If you're asking the user to enter a number that might include decimal places, set `inputmode` to `decimal`. Similar to `numeric`, this will show a numeric keypad to users on devices with on-screen keyboards, including a decimal separator.
 
-Do not set the `inputmode` attribute to `decimal` as it causes some devices to bring up a keypad without a key for the decimal separator.
+Some devices do not allow users to enter negative values using the on-screen keypad. If you want to give users the option to enter a negative number, use `input type="text"` without the `inputmode` attribute.
 
 {{ example({ group: "components", item: "text-input", example: "decimal-input", html: true, nunjucks: true, open: false, size: "m" }) }}
 


### PR DESCRIPTION
Result of a question that came in via support and the subsequent investigation. 

Our previous guidance about asking for decimals [was written in 2020](https://github.com/alphagov/govuk-design-system/commit/ecf652f0f610de1c9954b0d524fe992636b0d29e) and advised against using `inputmode="decimal"` based on the Android ecosystem having inconsistent support for showing the decimal separator character on the keypad (rendering it impossible to actually enter decimal values).

I've tested support again with more recent versions of Android and this issue now seems to be resolved, with the exception of inserting negative values, which is still not consistently supported.

I re-tested the following (all except Apple via Browserstack):

* Samsung tablets running Android 12, with Google Chrome and Samsung Internet.
* Samsung phones running Android 9–16, with Google Chrome.
* Google Pixel phones running Android 11, with Google Chrome.
* OnePlus phones running Android 11, with Google Chrome.
* Huawei phones running Android 9, with Google Chrome.
* Apple iPhones running iOS 15–26, with Safari.
* Apple iPads running iPadOS 15–26, with Safari.

These all allow the user to enter decimal numbers, however there are still differences in what else each allows the user to do: 

* Apple iPhones and all Samsung devices do not support entering negative values.
* Google, OnePlus and Huawei phones allow users to enter thousands separators in addition to decimal separators.
* Huawei phones allow inserting many other forms of punctuation, including brackets, spaces, semicolons, plus symbols, and, weirdly, the capital letter N.
* Apple iPads present the full keyboard and does not restrict user input to only decimal numbers.

As many of these are cases that form validation should catch and reject, I think we can withdraw our guidance recommending against using the 'decimal' `inputmode`, with the new caveat that it will not work consistently for negative decimal values.