### PR TITLE
[SPIKE] Using callouts for experimental works

### DIFF
--- a/src/components/file-upload/index.md
+++ b/src/components/file-upload/index.md
@@ -92,6 +92,14 @@ Say ‘The selected file must use the template’.
 
 ## Using the improved File upload component
 
+{% from "_callout.njk" import callout %}
+
+{% call callout({
+  tagText: "Experimental"
+}) %}
+This variant is an experimental addition to the GOV.UK Design System. It may be changed significantly or withdrawn without a breaking release. Find out more about <a href="/get-started/experimental-work/">how we iterate experimental components</a>.
+{% endcall %}
+
 In March 2025, we introduced changes to the File upload component that service teams can opt in to as part of GOV.UK Frontend 5.9.0.
 
 The improved component is intended to:

--- a/src/components/password-input/index.md
+++ b/src/components/password-input/index.md
@@ -8,6 +8,13 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
+{% from "_callout.njk" import callout %}
+
+{% call callout({
+  tagText: "Experimental"
+}) %}
+This component is an experimental addition to the GOV.UK Design System. It may be changed significantly or withdrawn without a breaking release. Find out more about <a href="/get-started/experimental-work/">how we iterate experimental components</a>.
+{% endcall %}
 
 Help users to create and enter passwords.
 

--- a/src/get-started/experimental-work/index.md
+++ b/src/get-started/experimental-work/index.md
@@ -1,0 +1,29 @@
+---
+layout: layout-pane.njk
+title: Experimental work
+section: Get started
+theme: How to guides
+order: 5
+description: How the Design System team manages and iterates experimental components.
+---
+
+## What an experiment is
+
+- The middle part of the lifecycle: beta &rarr; experimental &rarr; stable &rarr; (withdrawn, maybe)?
+
+## An experiment is...
+
+- Something that we're unsure of the value of
+- Something that we're unsure about how it'll be used
+- Something we're currently actively iterating upon
+- Something that is a significant departure from a previously established thing (e.g. a heavy rewrite of an existing component)
+
+## Using experimental works
+
+- Help the Design System team test how things work in live environment
+- Get access to new and more advanced components sooner!
+
+Caveats:
+
+- Be aware that breaking changes may come quickly
+- Be aware that we might withdraw the experimental thing without ever graduating it to stable

--- a/src/patterns/exit-a-page-quickly/index.md
+++ b/src/patterns/exit-a-page-quickly/index.md
@@ -9,6 +9,13 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
+{% from "_callout.njk" import callout %}
+
+{% call callout({
+  tagText: "Experimental"
+}) %}
+This guidance is an experimental addition to the GOV.UK Design System. It may be changed significantly or withdrawn without notice. Find out more about <a href="/get-started/experimental-work/">how we iterate experimental guidance</a>.
+{% endcall %}
 
 Give users a way to quickly and safely exit a service, website or application.
 Use this pattern to add the [Exit this page component](/components/exit-this-page/) to your service and keep users safe by helping them to protect their privacy.

--- a/src/styles/spacing/index.md
+++ b/src/styles/spacing/index.md
@@ -199,6 +199,14 @@ For example, use:
 
 ### Static spacing override classes
 
+{% from "_callout.njk" import callout %}
+
+{% call callout({
+  tagText: "Experimental"
+}) %}
+These override classes are an experimental addition to the GOV.UK Design System. They may be changed significantly or withdrawn without a breaking release. Find out more about <a href="/get-started/experimental-work/">how we manage experimental styles</a>.
+{% endcall %}
+
 The static spacing override classes start with `govuk-!-static`. Use them the same way as the responsive spacing override classes.
 
 For example, use:

--- a/src/stylesheets/components/_callout.scss
+++ b/src/stylesheets/components/_callout.scss
@@ -1,0 +1,25 @@
+// Change callout <h2>'s to look like <h3>'s
+// Selector specificity needs to outweigh `.app-content h2`
+.app-callout {
+  border-left-color: govuk-colour("orange");
+  background-color: govuk-colour("orange", $variant: "tint-95");
+
+  .app-callout__heading {
+    @extend %govuk-heading-m;
+    max-width: 30em;
+  }
+
+  // Add highlight styling for callout content
+  &:target {
+    outline-color: govuk-colour("yellow");
+    outline-offset: 6px;
+    outline-style: solid;
+    outline-width: 4px;
+  }
+}
+
+.app-callout__tag {
+  margin-top: 1px;
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -49,6 +49,7 @@ $app-code-color: #d13118;
 
 // App-specific components
 @import "components/back-to-top";
+@import "components/callout";
 @import "components/category-nav";
 @import "components/colour-table";
 @import "components/contact-panel";

--- a/views/macros/_callout.njk
+++ b/views/macros/_callout.njk
@@ -1,0 +1,23 @@
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText -%}
+{% from "govuk/components/tag/macro.njk" import govukTag -%}
+
+{% macro callout(params) -%}
+  {% set calloutContent -%}
+    {{ govukTag({
+      html: params.tagText + '<span class="govuk-visually-hidden"> note</span>',
+      classes: "govuk-tag--orange app-callout__tag"
+    }) }}
+    {% if params.heading -%}
+      <h2 class="app-callout__heading">{{ params.heading }}</h2>
+    {% endif -%}
+    {%- if caller or params.content %}
+      <div>{{ caller() if caller else params.content | safe }}</div>
+    {%- endif %}
+  {% endset -%}
+
+  {{ govukInsetText({
+    id: params.id if params.id,
+    html: calloutContent,
+    classes: "app-callout"
+  }) }}
+{% endmacro %}


### PR DESCRIPTION
Example of how we could use the callout style previously used for WCAG and brand updates to mark experimental things, including:

- [styles](https://deploy-preview-5282--govuk-design-system-preview.netlify.app/styles/spacing/#static-spacing-override-classes)
- [new components](https://deploy-preview-5282--govuk-design-system-preview.netlify.app/components/password-input/)
- [component variants](https://deploy-preview-5282--govuk-design-system-preview.netlify.app/components/file-upload/#using-the-improved-file-upload-component)
- [patterns or other guidance](https://deploy-preview-5282--govuk-design-system-preview.netlify.app/patterns/exit-a-page-quickly/)

I made a few changes to the design of the callout:
- Recoloured it to be orange, to indicate that it is important (people should be well aware that something is experimental before implementing it) without diluting the meaning of error red or focus style yellow. 
- Moved prosaic content to always be on its own line, rather than appearing in-line with the tag. I can envision that we might put multiple paragraphs of information here if there is more detail needed to elaborate on why something is experimental. 
- Added a background tint to make it stand out more and to better visually group things (IMO).