### PR TITLE
Remove unnecessary govuk-text-colour mixin call

### DIFF
--- a/src/styles/layout/grid-annotate.scss
+++ b/src/styles/layout/grid-annotate.scss
@@ -1,7 +1,6 @@
 @import "example-init";
 
 [class^="govuk-grid-column"] > p {
-  @include govuk-text-colour;
   @include govuk-font($size: 24);
   @include govuk-responsive-padding(6);
 


### PR DESCRIPTION
The `govuk-text-colour` mixin is deprecated and so we’re seeing a warning when compiling the stylesheet.

We could update it to use `govuk-functional-colour(text)`, but we’re setting `color` later within the same rule (line 10), so the call is unnecessary and just be removed.