### PR TITLE
Un-silence `mixed-decls`, `color-functions` and `global-builtin` Sass deprecations

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -84,7 +84,7 @@ module.exports = metalsmith
   .use(
     sass({
       quietDeps: true,
-      silenceDeprecations: ['color-functions', 'global-builtin', 'import'],
+      silenceDeprecations: ['import'],
       sourceMapIncludeSources: true,
       sourceMap: true,
 

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -84,12 +84,7 @@ module.exports = metalsmith
   .use(
     sass({
       quietDeps: true,
-      silenceDeprecations: [
-        'color-functions',
-        'global-builtin',
-        'import',
-        'mixed-decls'
-      ],
+      silenceDeprecations: ['color-functions', 'global-builtin', 'import'],
       sourceMapIncludeSources: true,
       sourceMap: true,
 


### PR DESCRIPTION
We’re now running Sass v1.97.3.

The mixed-decls deprecation was made obsolete in 1.92.0 and no longer has any effect [1].

We’re currently seeing multiple warnings when building the site explaining this:

> Warning: mixed-decls deprecation is obsolete. If you were previously silencing it, your code may now behave in unexpected ways.

Un-silence the mixed-decls warning to get rid of the warnings.

Additionally, it looks like we’re not using any of the deprecated color functions, nor referencing any global built-in functions, as no deprecation warnings are logged with these un-silenced.

Un-silence these deprecations too, so we're only silencing the deprecations that we need to.

[1]: https://sass-lang.com/documentation/cli/dart-sass/#fatal-deprecation:~:text=The%20following%20deprecation%20IDs%20are%20obsolete%20and%20no%20longer%20have%20any%C2%A0effect%3A
