### PR TITLE
Bump govuk-frontend to 6.2.0-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.1.1",
         "glob": "^13.0.6",
-        "govuk-frontend": "^6.1.0",
+        "govuk-frontend": "^6.2.0-beta.0",
         "gray-matter": "^4.0.2",
         "highlight.js": "^11.11.1",
         "html-validate": "^10.13.1",
@@ -11392,9 +11392,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
-      "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==",
+      "version": "6.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.2.0-beta.0.tgz",
+      "integrity": "sha512-F0iOqNg/E+K+BaWW5Nn3x4xxCE+WaaB0skORloRtR6bq2CSC4aYERvfrsyDxRSRLf+FExCbRDz1CMOzj5kuIRg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",
     "glob": "^13.0.6",
-    "govuk-frontend": "^6.1.0",
+    "govuk-frontend": "^6.2.0-beta.0",
     "gray-matter": "^4.0.2",
     "highlight.js": "^11.11.1",
     "html-validate": "^10.13.1",


### PR DESCRIPTION
6.2.0-beta.0 adds the ability to `@use` `govuk-frontend`, but first we want to make sure everything works as expected with `@import`.