### PR TITLE
[SPIKE] Add per-thing changelogs

### DIFF
--- a/src/components/password-input/index.md
+++ b/src/components/password-input/index.md
@@ -140,3 +140,15 @@ There’s also other instances where a password could be ‘shown’ or ‘hidde
 We [decided that having a second field is not helpful for users](https://github.com/alphagov/govuk-design-system-backlog/issues/240#issuecomment-2020125340), particularly on password inputs with show and hide buttons.
 
 However, we’d like to better support our rationale with real life examples from service teams and get your feedback.
+
+## Update history
+<div class="app-changelog-table">
+
+|Date|Version|Changes|
+|:-|:-|:-|
+|26 Mar 2024|5.3.0|Component introduced.|
+|19 Apr 2024|5.3.1|Fixed issue with button growing larger if the text input has a capped width.|
+|17 May 2024|5.4.0|Removed duplicate `errorMessage` parameter.|
+|4 Mar 2025|5.9.0|The `id` parameter now defaults to match `name` if an `id` isn't provided.|
+
+</div>

--- a/src/components/text-input/index.md
+++ b/src/components/text-input/index.md
@@ -284,3 +284,34 @@ For example, ‘How much you earn a week must not include pence, like 123 or 156
 Read a blog post about [the problems we discovered with input type="number"](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/).
 
 The prefix and suffix design has tested well in a number of services, but [some users have been observed clicking on prefixes](https://github.com/alphagov/govuk-design-system-backlog/issues/134#issuecomment-655615251), on the assumption that this would do something.
+
+## Update history
+
+<div class="app-changelog-table">
+
+| Date        | Version | Changes                                                                                                                  |
+| :---------- | :------ | :----------------------------------------------------------------------------------------------------------------------- |
+| 21 Jun 2018 | 1.0.0   | Component introduced.                                                                                                    |
+| 19 Nov 2018 | 2.4.0   | Classes can now be set on the input's `formGroup`.                                                                       |
+| 31 Jan 2019 | 2.6.0   | Added `autocomplete` parameter.                                                                                          |
+| 6 Feb 2019  |         | Added guidance on supporting autofill using `autocomplete`.                                                              |
+| 18 Feb 2019 |         | Added guidance on supporting spellchecking.                                                                              |
+| 29 Jul 2019 | 3.0.0   | Updated focus style to comply with WCAG 2.1.                                                                             |
+| 2 Sep 2019  | 3.1.0   | Added `inputmode` parameter.                                                                                             |
+| 3 Feb 2020  |         | Added guidance about asking for numbers.                                                                                 |
+| 9 Jun 2020  |         | Added guidance advising against using `type="decimal"`.                                                                  |
+| 29 Jul 2020 | 3.8.0   | Added `spellcheck` parameter. Updated input's border thickness when in the error state.                                  |
+| 14 Sep 2020 | 3.9.0   | Added input prefixes and suffixes.                                                                                       |
+| 17 Apr 2022 |         | Added guidance on use of placeholder text.                                                                               |
+| 19 Aug 2022 |         | Removed guidance on using the `pattern` attribute to coerce iOS into showing a numpad. Use `inputmode` instead.          |
+| 9 Aug 2022  | 4.3.0   | Updated length modifier classes to use `em` units.                                                                       |
+| 20 Apr 2023 | 4.6.0   | Added `disabled` parameter and updated input disabled styles. Added guidance and modifier class for codes and sequences. |
+| 14 Aug 2023 |         | Added guidance about not restricting the length of a user's input.                                                       |
+| 5 Feb 2024  | 5.1.0   | Updated positioning of input prefixes and suffixes.                                                                      |
+| 21 Feb 2024 | 5.2.0   | Added `beforeInput` and `afterInput` slots.                                                                              |
+| 17 May 2024 | 5.4.0   | Fixed being unable to set the `value` parameter if the value was '0'.                                                    |
+| 4 Oct 2024  |         | Expanded guidance on writing and formatting hint text.                                                                   |
+| 4 Mar 2025  | 5.9.0   | The `id` parameter now defaults to match `name` if an `id` isn't provided.                                               |
+| 2 Mar 2026  | 6.1.0   | Fixed focus state using wrong shade of black.                                                                            |
+
+</div>

--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -134,3 +134,17 @@ To do this, set the `autocomplete` attribute to `street-address` as shown in the
 If you are working in production you’ll need to do this to meet [WCAG 2.2 success criterion 1.3.5 Identify input purpose](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html).
 
 You will not normally need to use the `autocomplete` attribute in prototypes, as users will not generally be using their own devices.
+
+## Update history
+
+<div class="app-changelog-table">
+
+| Date        | Changes                                                                                                                                  |
+| :---------- | :--------------------------------------------------------------------------------------------------------------------------------------- |
+| 19 Dec 2017 | Pattern introduced.                                                                                                                      |
+| 7 Sep 2018  | Added error message guidance.                                                                                                            |
+| 6 Feb 2019  | Added guidance on using the `autocomplete` attribute.                                                                                    |
+| 29 Jan 2022 | Added recommendation against including a 'county' field. These are no longer used by postal systems, so collecting them isn't necessary. |
+| 12 Apr 2022 | Partially reverted previous guidance. We now recommend including 'county' as an optional field.                                          |
+
+</div>

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -355,6 +355,20 @@ pre .language-plaintext {
     padding-top: govuk-spacing(2);
   }
 
+  // stylelint-disable scss/at-extend-no-missing-placeholder -- spike code
+  table {
+    @extend .govuk-table;
+
+    th {
+      @extend .govuk-table__header;
+    }
+
+    td {
+      @extend .govuk-table__cell;
+    }
+  }
+  // stylelint-enable scss/at-extend-no-missing-placeholder
+
   // Ensure that content at the bottom of the page does not have margins
   // so that they line up with the back to top link.
   > :last-child {
@@ -381,4 +395,13 @@ pre .language-plaintext {
 // This will be fixed in the next release of GOV.UK Frontend
 .govuk-service-navigation__toggle {
   @include govuk-font($size: 19, $weight: bold);
+}
+
+.app-changelog-table {
+  table-layout: fixed;
+
+  // Set first column to fixed width
+  td:first-child {
+    width: 6em;
+  }
 }


### PR DESCRIPTION
Prototype what individual changelogs for each component and pattern might look like. This currently takes the form of tables, as this seemed to be the most common pattern we observed in other design systems.

* [Small component changelog](https://deploy-preview-5295--govuk-design-system-preview.netlify.app/components/password-input/#update-history) listing only code updates
* [Large component changelog](https://deploy-preview-5295--govuk-design-system-preview.netlify.app/components/text-input/#update-history) listing both code and guidance updates
* [Pattern changelog](https://deploy-preview-5295--govuk-design-system-preview.netlify.app/patterns/addresses/#update-history) listing only guidance updates

Tables for components (and probably styles) are blended, and include both guidance and code changes. Code changes are tagged with the date and the version of govuk-frontend that the code change took place in. Patterns (and other guidance) omit the version column and only provide the date the change was made. 

## What's in the changelogs?

I had to give some consideration into _what_ was worthy of being in the changelog and landed on these.

### For code changes

For code, I mainly focused on what things a developer user may be on the look out for. For example, if they're working with an older version of govuk-frontend and want to know if a feature is available to that version, or if they've encountered a bug and want to know which minimum version they need to update to in order to fix it.

I included:

* Breaking code changes.
* Changes to the functionality of the component (either adding, removing, or meaningfully altering how it might be implemented).
* Changes to the appearance of the component.  
* Significant bug fixes. 

I did not include:

* Internal changes that do not affect how the component is used (such as refactoring).
* Changes that applied to the overall architecture of frontend, such as the reworking of JavaScript we did in v5 or Sass modules work in v6. 

### For guidance changes

For guidance,  I tried to cover cases where a user might question how recently a piece of guidance was updated, or if they recall seeing a piece of guidance before but can no longer find it (they might wonder if it's been withdrawn, or whether it ever existed on this page in the first place).

I included: 

* Significant additions, removals, or alterations to the available guidance or recommendations we make within it.

I did not include:

* Changes to spelling, grammar or formatting.
* Additions, removals or alterations of interactive examples, images or videos.
* Internal changes, such as to the page metadata.

## Thoughts

I think in an ideal world this would end up on a separate page (or even tab?) 

Maybe this could be combined with the long-desired design histories stuff? Might be a good thing to do at the same time as splitting Nunjucks macro documentation onto its own page, which we keep saying to do. 

I named the sections 'update history' as the term 'changelog' feels like it might be too rooted in technical backgrounds to be universally understood, especially in the concatenated form most common in tech circles. 