### PR TITLE
Set the masthead to use the brand functional colour

### DIFF
--- a/src/stylesheets/components/_masthead.scss
+++ b/src/stylesheets/components/_masthead.scss
@@ -1,9 +1,9 @@
 .app-masthead {
   @include govuk-responsive-padding(6, "top");
   @include govuk-responsive-padding(6, "bottom");
-  border-bottom: 1px solid govuk-colour("blue");
+  border-bottom: 1px solid govuk-functional-colour("brand");
   color: govuk-colour("white");
-  background-color: govuk-colour("blue");
+  background-color: govuk-functional-colour("brand");
 }
 
 .app-masthead__title {


### PR DESCRIPTION
What it says.

I'm assuming that this is the intent of the blue masthead. Happy to be told otherwise!