### PR TITLE
[SPIKE] Multiple statuses on guidance pages

### DIFF
--- a/src/components/details/index.md
+++ b/src/components/details/index.md
@@ -3,6 +3,9 @@ title: Details
 description: Make a page easier to scan by letting users reveal more detailed information only if they need it
 section: Components
 aliases: reveal, progressive disclosure, hidden text, show and hide, ShowyHideyThing
+addedInVersion: 1.0.0
+statuses: [stable, issues]
+statusMessage: This component is known to have issues with some assistive software.
 backlogIssueId: 44
 layout: layout-pane.njk
 ---

--- a/src/components/password-input/index.md
+++ b/src/components/password-input/index.md
@@ -3,6 +3,8 @@ title: Password input
 description: Help users accessibly enter passwords
 section: Components
 aliases: pass word, pass phrase
+addedInVersion: 5.3.0
+statuses: [stable, accessible]
 backlogIssueId: 240
 layout: layout-pane.njk
 ---

--- a/src/patterns/exit-a-page-quickly/index.md
+++ b/src/patterns/exit-a-page-quickly/index.md
@@ -4,6 +4,8 @@ description: Give users a way to quickly and safely exit a service, website or a
 section: Patterns
 theme: Help users to…
 aliases:
+statuses: [experimental]
+statusMessage: This guidance is still being developed.
 backlogIssueId: 213
 layout: layout-pane.njk
 ---

--- a/src/patterns/national-insurance-numbers/index.md
+++ b/src/patterns/national-insurance-numbers/index.md
@@ -4,6 +4,8 @@ description: Ask users to provide their National Insurance number
 section: Patterns
 theme: Ask users for…
 aliases:
+statuses: [deprecated]
+statusMessage: This is some future timeline where we abolished National Insurance numbers.
 backlogIssueId: 54
 layout: layout-pane.njk
 ---

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -26,14 +26,20 @@
         {{ title }}
       </h1>
 
-      {% if status %}
-      <aside class="govuk-!-margin-bottom-8" aria-label="Guidance status">
-        <strong class="govuk-tag govuk-!-margin-bottom-2">
-          {{ status }}
-        </strong>
-        <p class="govuk-body">{{ statusMessage | safe }}</p>
-      </aside>
-      {% endif %}
+      {%- if addedInversion or statuses or statusMessage %}
+        {% from "_status-tag.njk" import statusTag %}
+        <aside class="govuk-!-margin-bottom-8" aria-label="Guidance status">
+          {%- if addedInVersion %}
+            {{ statusTag("version", "Added in " + addedInVersion) }}
+          {%- endif %}
+          {%- for status in statuses %}
+            {{ statusTag(status) }}
+          {%- endfor %}
+          {%- if statusMessage %}
+            <p class="govuk-body govuk-!-margin-top-2">{{ statusMessage | safe }}</p>
+          {%- endif %}
+        </aside>
+      {%- endif %}
 
       {% if showPageNav %}
         <ul class="app-page-navigation">

--- a/views/macros/_status-tag.njk
+++ b/views/macros/_status-tag.njk
@@ -1,0 +1,27 @@
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+{% macro statusTag(status, text) -%}
+  {%- set tagColour = "grey" %}
+
+  {%- if status == "stable" %}
+    {%- set tagText = "Stable" %}
+    {%- set tagColour = "blue"  %}
+  {%- elif status == "experimental" %}
+    {%- set tagText = "Experimental" %}
+    {%- set tagColour = "orange"  %}
+  {%- elif status == "accessible" %}
+    {%- set tagText = "Accessible" %}
+    {%- set tagColour = "green"  %}
+  {%- elif status == "issues" %}
+    {%- set tagText = "Known issues" %}
+    {%- set tagColour = "red"  %}
+  {%- elif status == "deprecated" %}
+    {%- set tagText = "Deprecated" %}
+    {%- set tagColour = "turquoise"  %}
+  {%- endif %}
+
+  {{- govukTag({
+    text: text if text else tagText,
+    classes: "govuk-tag--" + tagColour
+  }) }}
+{%- endmacro %}


### PR DESCRIPTION
Examples of applying one or more tags to guidance pages, to give an overview of what the component's current state is. 

I've prototyped it with five possible statuses:

 * **Stable**: This thing is ready to use and unlikely to significantly change.
 * **Experimental**: This thing is still being developed and may change significantly in future.
 * **Deprecated**: This thing is in the process of being retired.
 * **Accessible**: This thing has been accessibility tested and passed our standards.
 * **Known issues**: This thing has an issue (code, assistive tech, or something else) that a user may want to consider before using it.

There can be a single line of text following the list of statuses to provide additional context. I imagine this would only be used with the Experimental, Deprecated or Known issues statuses are being used. 

The major downside of this approach is that the meaning of a status may not be obvious to a user at a glance, compared to #5282 being much more explicit. 

I've additionally added a 'version tag' which indicates which version of govuk-frontend the component was introduced in, which is a pattern we observed across some other design systems in desk research.

Examples:

* [Component with version, stable and accessible tags](https://deploy-preview-5302--govuk-design-system-preview.netlify.app/components/password-input/) — the "happy path" 
* [Component with version, stable and known issue tags](https://deploy-preview-5302--govuk-design-system-preview.netlify.app/components/details/) — with accompanying description
* [Pattern with experimental status](https://deploy-preview-5302--govuk-design-system-preview.netlify.app/patterns/exit-a-page-quickly/)
* [Pattern with deprecated status](https://deploy-preview-5302--govuk-design-system-preview.netlify.app/patterns/national-insurance-numbers/)