### PR TITLE
[SPIKE] Add per-things changelogs but on their own pages

### DIFF
--- a/src/components/text-input/history.md
+++ b/src/components/text-input/history.md
@@ -1,0 +1,98 @@
+---
+preTitle: Text input
+title: Update history
+description: Help users enter information with the text input component
+layout: layout-pane.njk
+---
+
+## 21 June 2018 (GOV.UK Frontend 1.0.0)
+
+Component introduced.
+
+## 19 November 2018 (GOV.UK Frontend 2.4.0)
+
+Added support for setting `classes` on the input's `formGroup`.
+
+## 31 January 2019 (GOV.UK Frontend 2.6.0)
+
+Added `autocomplete` parameter.
+
+## 6 February 2019
+
+Introduced new guidance on supporting autofill using the `autocomplete` HTML attribute.
+
+## 18 February 2019
+
+Introduced new guidance on supporting spellchecking.
+
+## 28 July 2019 (GOV.UK Frontend 3.0.0)
+
+Updated the component's focus style to comply with WCAG 2.1.
+
+## 2 September 2019 (GOV.UK Frontend 3.1.0)
+
+Added `inputmode` parameter.
+
+## 3 February 2020
+
+Introduced new guidance about asking for numbers.
+
+## 9 June 2020
+
+Introduced guidance advising against using `<input type="decimal">` due to inconsistent support across Android vendors.
+
+## 29 July 2020 (GOV.UK Frontend 3.8.0)
+
+Added `spellcheck` parameter.
+
+Updated the input's border when in the error state to match the non-error border width.
+
+## 14 September 2020 (GOV.UK Frontend 3.9.0)
+
+Added support for input prefixes and suffixes.
+
+## 17 April 2022
+
+Introduced new guidance on the use of placeholder text.
+
+## 19 August 2022
+
+Removed guidance on using the `pattern` attribute to coerce iOS into showing a numpad. iOS has since introduced support for the `inputmode` attribute. Use `inputmode="numeric"` instead.
+
+## 9 August 2022 (GOV.UK Frontend 4.3.0)
+
+Updated input width modifier classes to use `em` units. This has resulted in a minor change to the widths of these inputs.
+
+## 20 April 2023 (GOV.UK Frontend 4.6.0)
+
+Added `disabled` parameter and updated the component's disabled styles.
+
+Added a modifier class for accepting codes and sequences, with associated guidance.
+
+## 14 August 2023
+
+Introduced new guidance advising against using `maxlength` to restrict the length of a user's input.
+
+## 5 February 2024 (GOV.UK Frontend 5.1.0)
+
+Updated the positioning of input prefixes and suffixes to match the text baseline of the text input.
+
+## 21 February 2024 (GOV.UK Frontend 5.2.0)
+
+Added `beforeInput` and `afterInput` slots to the Nunjucks macro.
+
+## 17 May 2024 (GOV.UK Frontend 5.4.0)
+
+Fixed an issue with the Nunjucks macro where users were unable to define a default `value` if the value was '0'.
+
+## 4 October 2024
+
+Updated the guidance on writing and formatting hint text.
+
+## 4 March 2025 (GOV.UK Frontend 5.9.0)
+
+The Nunjucks `id` parameter now defaults to be the same as `name` if an `id` hasn't been provided.
+
+## 2 March 2026 (GOV.UK Frontend 6.1.0)
+
+Fixed the component's focus state using wrong shade of black.

--- a/src/components/text-input/index.md
+++ b/src/components/text-input/index.md
@@ -285,6 +285,8 @@ Read a blog post about [the problems we discovered with input type="number"](htt
 
 The prefix and suffix design has tested well in a number of services, but [some users have been observed clicking on prefixes](https://github.com/alphagov/govuk-design-system-backlog/issues/134#issuecomment-655615251), on the assumption that this would do something.
 
+{% set updateHistoryHtml %}
+
 ## Update history
 
 <div class="app-changelog-table">
@@ -315,3 +317,4 @@ The prefix and suffix design has tested well in a number of services, but [some 
 | 2 Mar 2026  | 6.1.0   | Fixed focus state using wrong shade of black.                                                                            |
 
 </div>
+{% endset %}

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -3,8 +3,8 @@
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
 {# If the theme ends in '…', then we nest the caption inside the H1 so that the
-  H1 becomes e.g. 'Ask users for dates'. Otherwise, we put it before the H1. #}
-{% set includeThemeInPageHeading = theme and "…" in theme %}
+  H1 becomes e.g. 'Ask users for dates'. #}
+{% set headingCaption = preTitle if preTitle else (theme | replace("…", "") if theme and "…" in theme) %}
 
 {% block container %}
 <div class="app-split-pane app-width-container app-container-wrapper">
@@ -18,9 +18,9 @@
     }) }}
     <main id="main-content" class="app-content" role="main">
       <h1 class="govuk-heading-xl {%- if status %} govuk-!-margin-bottom-5{% endif %}">
-        {% if includeThemeInPageHeading %}
+        {% if headingCaption %}
         <span class="govuk-caption-xl">
-          {{ theme | replace("…", "") }}
+          {{ headingCaption }}
         </span>
         {% endif %}
         {{ title }}


### PR DESCRIPTION
Variant of #5295 but the update histories are hosted on separate pages and presented as prose rather than a tabular format.

This allows for more detailed explanations of changes that can incorporate images and other useful media, at the expense of adding a new layer of hierarchy beneath each component and pattern. 

* [Example](https://deploy-preview-5307--govuk-design-system-preview.netlify.app/components/text-input/history/)

## Changes
- Moved example changelog to a separate page beneath the component.
- Reformatted the changelog to use headings and prosaic text. Expanded some of the examples to demonstrate how this is kind of handy.
- Tweaked the template to enable setting a caption on the page heading. Currently this has the name of the related component, but ideally this would be in the breadcrumbs instead, as below.

## Not ideal things
- The breadcrumbs should probably include the parent style/component/pattern in it. 
- Including the text "GOV.UK Frontend" in the heading of every update seems excessively repetitive, but this seemed _less_ verbose than including it as a sentence below the heading. 