### PR TITLE
Update workflows to use Ubuntu 24.04

### DIFF
--- a/.github/workflows/check-external-links.yaml
+++ b/.github/workflows/check-external-links.yaml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   check-links:
     name: Check for broken external links
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-24.04'
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,8 +64,11 @@ jobs:
           - description: TypeScript compiler
             run: npm run lint:types -- --pretty
 
+          # Puppeteer uses Chrome to execute tests.
+          # Ubuntu requires an App Armor profile for developer builds of Chrome to run without errors.
+          # (https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md)
           - description: JavaScript tests
-            run: npx jest --color --maxWorkers=2
+            run: aa-exec --profile=chrome npx jest --color --maxWorkers=2
 
           - description: Check broken links
             run: npm run check-links

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,10 @@ on:
       runner:
         description: Run tests on
         type: choice
-        default: ubuntu-22.04
+        default: ubuntu-24.04
         options:
           - macos-latest
-          - ubuntu-22.04
+          - ubuntu-24.04
           - windows-latest
 
 permissions:
@@ -25,7 +25,7 @@ permissions:
 jobs:
   build:
     name: Build
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-22.04' }}
+    runs-on: ${{ github.event.inputs.runner || 'ubuntu-24.04' }}
 
     steps:
       - name: Checkout code
@@ -38,7 +38,7 @@ jobs:
 
   test:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-22.04' }}
+    runs-on: ${{ github.event.inputs.runner || 'ubuntu-24.04' }}
     needs: [build]
 
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,15 +9,6 @@ on:
       - 'v[0-9]'
 
   workflow_dispatch:
-    inputs:
-      runner:
-        description: Run tests on
-        type: choice
-        default: ubuntu-24.04
-        options:
-          - macos-latest
-          - ubuntu-24.04
-          - windows-latest
 
 permissions:
   contents: read
@@ -25,7 +16,7 @@ permissions:
 jobs:
   build:
     name: Build
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-24.04' }}
+    runs-on: 'ubuntu-24.04'
 
     steps:
       - name: Checkout code
@@ -38,7 +29,7 @@ jobs:
 
   test:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-24.04' }}
+    runs-on: 'ubuntu-24.04'
     needs: [build]
 
     strategy:


### PR DESCRIPTION
As part of https://github.com/alphagov/govuk-design-system/issues/5079

We'll also need to update Netlify to use 24 as well after this is has been merged.

Since we need to add App Armor support for Chrome to run within the tests (used in Puppeteer), remove the ability to run these tests in Windows and macOS which the team is not using.