### PR TITLE
Update links to GOV.UK content and publishing guidance

### DIFF
--- a/src/community/blogs-talks-podcasts/index.md
+++ b/src/community/blogs-talks-podcasts/index.md
@@ -111,7 +111,7 @@ Find out how our community works and how to be a part of it.
 
 ## Add a link to this page
 
-To help us make this page better, you can [propose to add a link](https://github.com/alphagov/govuk-design-system/edit/main/src/community/blogs-talks-podcasts/index.md) that you’ve created or think would be useful to the community. Links need to meet the [GOV.UK external link policy](https://www.gov.uk/guidance/content-design/links) and the Design System [community principles](/community/community-principles/).
+To help us make this page better, you can [propose to add a link](https://github.com/alphagov/govuk-design-system/edit/main/src/community/blogs-talks-podcasts/index.md) that you’ve created or think would be useful to the community. Links need to meet the [GOV.UK content and publishing guidelines on external links](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/tone-of-voice/add-links/) and the Design System [community principles](/community/community-principles/).
 
 Before we publish a new link, we’ll make sure that:
 

--- a/src/community/contribution-criteria/index.md
+++ b/src/community/contribution-criteria/index.md
@@ -86,7 +86,7 @@ Before a new component or pattern is published the working group reviews the imp
       },
       {
         html: '<p>It reuses existing styles and components in the Design System where relevant.</p>
-          <p>Both the guidance and any content included in examples must follow the <a href="https://www.gov.uk/guidance/style-guide/a-to-z">GOV.UK content style guide</a>.</p>
+          <p>Both the guidance and any content included in examples must follow the <a href="https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide/">GOV.UK style guide</a>.</p>
           <p class="govuk-!-margin-bottom-0">If there is code, it follows the <a href="https://github.com/alphagov/govuk-frontend/blob/main/CONTRIBUTING.md#conventions-to-follow">GOV.UK Frontend coding standards</a> and is ready to merge in GOV.UK Frontend.</p>'
       }
     ],

--- a/src/components/accordion/index.md
+++ b/src/components/accordion/index.md
@@ -33,7 +33,7 @@ Accordions hide content from the user. Not all users will notice them or underst
 
 Do not use an accordion for content that all users need to see.
 
-Test your content without an accordion first. Well-written and structured content, as shown in the [Content design: writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk) guidance, can remove the need to use an accordion.
+Test your content without an accordion first. Well-written and structured content, as shown in [GOV.UK writing standards](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/), can remove the need to use an accordion.
 
 It’s usually better to:
 

--- a/src/components/notification-banner/index.md
+++ b/src/components/notification-banner/index.md
@@ -57,7 +57,7 @@ For example:
 
 {{ example({ group: "components", item: "notification-banner", example: "whole-service", html: true, nunjucks: true, open: false, size: "s" }) }}
 
-If your service is on GOV.UK and it’s affected by an emergency, ask your department’s content team to [request a change to the service start page](https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#change-govuk-content).
+If your service is on GOV.UK and it’s affected by an emergency, ask your department’s content team to [make a request to add a downtime message on GOV.UK content that links to it](https://guidance.publishing.service.gov.uk/accounts-support/make-content-requests/ask-downtime-messages/).
 If your service is getting more demand than usual, check that you’ve set up [There is a problem with the service pages](/patterns/problem-with-the-service-pages/) and [Service unavailable pages](/patterns/service-unavailable-pages/), and the wording is up to date.
 
 ## Telling the user about something that’s happening elsewhere

--- a/src/contact.njk
+++ b/src/contact.njk
@@ -31,9 +31,9 @@ layout: layout-single-page.njk
 
     <h2 class="govuk-heading-l">For GOV.UK publishers</h2>
 
-    <p class="govuk-body">We cannot help with publishing on the GOV.UK website. Read the <a href="https://www.gov.uk/guidance/content-design" class="govuk-link">content design guidance</a> and <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk" class="govuk-link">guidance for publishers</a>.</p>
+    <p class="govuk-body">We cannot help with publishing on the GOV.UK website. Read the <a href="https://guidance.publishing.service.gov.uk/" class="govuk-link">GOV.UK content and publishing guidance</a>.</p>
 
-    <p class="govuk-body">If you cannot find an answer there, get support using ‘<a href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing" class="govuk-link">Request a thing</a>’.</p>
+    <p class="govuk-body">If you cannot find an answer there, see <a href="https://guidance.publishing.service.gov.uk/accounts-support/raise-requests/" class="govuk-link">How to raise requests with the Government Digital Service (GDS)</a>.</p>
 
     <h2 class="govuk-heading-l">For members of the public</h2>
 

--- a/src/index.njk
+++ b/src/index.njk
@@ -54,8 +54,8 @@ masthead: true
           The GOV.UK Design System helps teams that work on government services follow the
           <a class="govuk-link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a> and
           <a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a>. This website also follows the
-          <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide">GOV.UK style guide</a> and
-          <a class="govuk-link" href="https://www.gov.uk/guidance/content-design">GOV.UK content design guidance</a>.
+          <a class="govuk-link" href="https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide/">GOV.UK style guide</a> and
+          <a class="govuk-link" href="https://guidance.publishing.service.gov.uk/">GOV.UK content and publishing guidance</a>.
         </p>
 
         <p class="govuk-body">

--- a/src/patterns/contact-a-department-or-service-team/index.md
+++ b/src/patterns/contact-a-department-or-service-team/index.md
@@ -30,15 +30,11 @@ Show contact channels in the same order throughout your service. This helps user
 
 ### Social media
 
-If you have social media channels:
-
-- list these channels last
-- do not include a link to the social media sites you're using - read more about this in [GOV.UK’s external linking policy](https://www.gov.uk/guidance/content-design/links#linking-policy)
-- tell users not to share personal information with you
+If you have social media channels, list these channels last. Tell users not to share personal information where others can see it.
 
 ### Write phone numbers in the GOV.UK style
 
-See the [GOV.UK style for writing phone numbers](https://www.gov.uk/guidance/style-guide/a-to-z#telephone-numbers).
+See the [GOV.UK style guide for writing phone numbers](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide/#telephone-numbers).
 
 ### Explain any charges
 
@@ -50,7 +46,7 @@ For phone call charges, link to the GOV.UK page on [call charges](https://www.go
 
 ### Give opening hours
 
-Follow the GOV.UK style guide format for [time ranges](https://www.gov.uk/guidance/style-guide/a-to-z#times) and [date ranges](https://www.gov.uk/guidance/style-guide/a-to-z#dates).
+Follow the GOV.UK style guide format for [time ranges](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide/#times) and [date ranges](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide/#dates).
 
 Explain any exceptions, like bank holidays, or days of the week when your opening hours are different.
 

--- a/src/patterns/cookies-page/index.md
+++ b/src/patterns/cookies-page/index.md
@@ -55,7 +55,7 @@ The [Cookie banner component](/components/cookie-banner/) shows several options 
 
 Work with your organisation’s privacy expert to write the cookies page.
 
-The cookie policy must be written in [plain English](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#plain-english) and it must explain:
+The cookie policy must be written in [clear language](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/tone-of-voice/clear-language/) and it must explain:
 
 List the cookies individually on the cookies page, under the relevant category. For each cookie, give:
 

--- a/src/patterns/cookies-page/index.md
+++ b/src/patterns/cookies-page/index.md
@@ -55,7 +55,7 @@ The [Cookie banner component](/components/cookie-banner/) shows several options 
 
 Work with your organisation’s privacy expert to write the cookies page.
 
-The cookie policy must be written in [clear language](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/tone-of-voice/clear-language/) and it must explain:
+Cookie policy must be written in [clear language](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/tone-of-voice/clear-language/).
 
 List the cookies individually on the cookies page, under the relevant category. For each cookie, give:
 

--- a/src/patterns/dates/index.md
+++ b/src/patterns/dates/index.md
@@ -65,7 +65,7 @@ Never make a calendar control that depends on JavaScript as the only input optio
 
 ### How to write dates
 
-See the [GOV.UK style for writing dates](https://www.gov.uk/guidance/style-guide/a-to-z#dates) and [writing date ranges](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#date-ranges).
+See the [GOV.UK style for writing dates and date ranges](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide/#dates).
 
 If you give an example date, use 13 or more for the day and 9 or less for the month - for example ‘27 3 2007’. This helps users enter the date in the correct order and shows them they do not need to include leading zeroes.
 

--- a/src/patterns/phone-numbers/index.md
+++ b/src/patterns/phone-numbers/index.md
@@ -90,7 +90,7 @@ When you look at your service's user journey, remember that phone numbers as lin
 
 ### Write phone numbers in the GOV.UK style
 
-See the [GOV.UK style for writing telephone numbers](https://www.gov.uk/guidance/style-guide/a-to-z#telephone-numbers).
+See the [GOV.UK style for writing telephone numbers](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide/#telephone-numbers).
 
 ### Avoid input masking
 

--- a/src/styles/images/index.md
+++ b/src/styles/images/index.md
@@ -15,7 +15,7 @@ Avoid using images for unnecessary decoration. Only use images if there’s a re
 
 Make sure any information contained in an image can be understood by someone who cannot see it. Also consider partially-sighted users with visual impairments and the assistive technologies they might use.
 
-This guidance is for government teams that build online services. To learn how to use images as a GOV.UK content publisher, go to [GOV.UK content guidance for images](https://www.gov.uk/guidance/content-design/images).
+This guidance is for government teams that build online services. To learn how to use images as a GOV.UK content publisher, go to [GOV.UK content guidance for images](https://guidance.publishing.service.gov.uk/formatting-content/images/).
 
 ## Using images to give information
 


### PR DESCRIPTION
This PR completes [#5324](https://github.com/alphagov/govuk-design-system/issues/5324), updating links affected by the migration of the GOV.UK content and publishing guidance website onto a service.gov.uk domain.