### PR TITLE
[PROTOTYPE] Early access content for testing

### DIFF
--- a/src/community/contribution-criteria/index.md
+++ b/src/community/contribution-criteria/index.md
@@ -51,7 +51,7 @@ To be successful, proposals need to show that the component or pattern being sug
   ]
 }) }}
 
-The [Design System working group](/community/design-system-working-group/) reviews proposals to check they meet these criteria. Proposals that meet the criteria then move to the next step to show they're ready to publish.
+Proposals that meet these criteria then move to the next step to show they're ready to publish.
 
 ## Developing a component or pattern
 

--- a/src/components/language-switcher/index.md
+++ b/src/components/language-switcher/index.md
@@ -1,0 +1,82 @@
+---
+title: Language selector
+description: Help users access content in their native language
+section: Components
+aliases: language, locale, language selection, language chooser, language navigation, translation navigation
+backlogIssueId: 285
+layout: layout-pane.njk
+---
+
+{% from "_callout.njk" import callout %}
+
+{% call callout({
+  tagText: "Early access"
+}) %}
+This component is an early access addition to the GOV.UK Design System. It may be changed significantly or withdrawn without a breaking release. Find out more about <a href="/get-started/early-access/">how we iterate early access components</a>.
+{% endcall %}
+
+Content, guidance, examples, etc. would be here to whatever degree the thing is developed.
+
+## How it's performing against the contribution criteria
+
+To be included in the Design System without the early access status, all components and patterns need to meet certain [contribution criteria](/community/contribution-criteria/).
+
+In order for this component to become a stable part of the GOV.UK Design System it needs further work and testing within live services.
+
+{% from "_checklist.njk" import checklist %}
+
+### Proposal
+
+{{ checklist({
+  idPrefix: "Proposal-contribution-criteria",
+  items: [
+    {
+      title: "Useful",
+      description: "There is evidence that this component or pattern would be useful for many teams or services.",
+      status: "yes"
+    },
+    {
+      title: "Unique",
+      description: "It does not replicate something already in the Design System.",
+      status: "yes"
+    }
+  ]
+})}}
+
+### Development
+
+{{ checklist({
+  idPrefix: "Development-contribution-criteria",
+  items: [
+    {
+      title: "Usable",
+      description: "It has been tested in user research and shown to work with a representative sample of users, including those with disabilities",
+      status: "feedback needed"
+    },
+    {
+      title: "Consistent",
+      description: "It reuses existing styles and components in the Design System where relevant.",
+      status: "yes"
+    },
+    {
+      title: "Versatile",
+      description: "The implementation is versatile enough that the component or pattern can be used in a range of different services that may need it.",
+      status: "yes"
+    }
+  ]
+})}}
+
+## What we're still looking to learn
+
+- Have you got any user research on a language switcher component or the need for translations?
+- Do you use a language switcher in your service and how well is it working?
+- If you use a language switcher, what languages do you accommodate?
+- Where is your language switcher positioned on the page and why did you make that decision?
+- If we shipped this component, what would it mean for your service?
+- Is there anything else you'd like us to keep in mind with this work?
+
+### Ways to give us this feedback
+
+- Add a comment to the [GitHub discussion](https://github.com/alphagov/govuk-design-system/discussions/5351)
+- Give feedback to the [Design System Team by email](https://design-system.service.gov.uk/contact/)
+- Give feedback via the #govuk-design-system slack channel or by DM-ing me on UK Government Digital slack

--- a/src/get-started/early-access/index.md
+++ b/src/get-started/early-access/index.md
@@ -1,0 +1,29 @@
+---
+layout: layout-pane.njk
+title: Early access work
+section: Get started
+theme: How to guides
+order: 5
+description: How the Design System team manages and iterates work in progress components.
+---
+
+## What stage is early access?
+
+- The middle part of the lifecycle: beta &rarr; early access &rarr; stable &rarr; (withdrawn, maybe)?
+
+## We consider early access as...
+
+- Something that we're unsure of the value of
+- Something that we're unsure about how it'll be used
+- Something we're currently actively iterating upon
+- Something that is a significant departure from a previously established thing (e.g. a heavy rewrite of an existing component)
+
+## Using early access things
+
+- Help the Design System team test how things work in live environment
+- Get access to new and more advanced components sooner!
+
+Caveats:
+
+- Be aware that breaking changes may come quickly
+- Be aware that we might withdraw the experimental thing without ever graduating it to stable

--- a/src/stylesheets/components/_callout.scss
+++ b/src/stylesheets/components/_callout.scss
@@ -1,0 +1,28 @@
+@use "govuk/base" as *;
+@use "govuk/core/typography";
+
+// Change callout <h2>'s to look like <h3>'s
+// Selector specificity needs to outweigh `.app-content h2`
+.app-callout {
+  border-left-color: govuk-colour("orange");
+  background-color: govuk-colour("orange", $variant: "tint-95");
+
+  .app-callout__heading {
+    @extend %govuk-heading-m;
+    max-width: 30em;
+  }
+
+  // Add highlight styling for callout content
+  &:target {
+    outline-color: govuk-colour("yellow");
+    outline-offset: 6px;
+    outline-style: solid;
+    outline-width: 4px;
+  }
+}
+
+.app-callout__tag {
+  margin-top: 1px;
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+}

--- a/src/stylesheets/components/_index.scss
+++ b/src/stylesheets/components/_index.scss
@@ -1,4 +1,5 @@
 @use "back-to-top";
+@use "callout";
 @use "category-nav";
 @use "colour-table";
 @use "contact-panel";

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -295,6 +295,7 @@ pre .language-plaintext {
   }
 
   ul,
+  ul:not(.govuk-task-list),
   ol {
     @extend %govuk-list;
   }
@@ -303,7 +304,7 @@ pre .language-plaintext {
     @extend %govuk-list--number;
   }
 
-  ul {
+  ul:not(.govuk-task-list) {
     @extend %govuk-list--bullet;
   }
 

--- a/views/macros/_callout.njk
+++ b/views/macros/_callout.njk
@@ -1,0 +1,23 @@
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText -%}
+{% from "govuk/components/tag/macro.njk" import govukTag -%}
+
+{% macro callout(params) -%}
+  {% set calloutContent -%}
+    {{ govukTag({
+      html: params.tagText + '<span class="govuk-visually-hidden"> note</span>',
+      classes: "govuk-tag--orange app-callout__tag"
+    }) }}
+    {% if params.heading -%}
+      <h2 class="app-callout__heading">{{ params.heading }}</h2>
+    {% endif -%}
+    {%- if caller or params.content %}
+      <div>{{ caller() if caller else params.content | safe }}</div>
+    {%- endif %}
+  {% endset -%}
+
+  {{ govukInsetText({
+    id: params.id if params.id,
+    html: calloutContent,
+    classes: "app-callout"
+  }) }}
+{% endmacro %}

--- a/views/macros/_checklist.njk
+++ b/views/macros/_checklist.njk
@@ -1,0 +1,42 @@
+{% from "govuk/components/task-list/macro.njk" import govukTaskList %}
+
+{% macro checklist(params) -%}
+  {#- Allow for a simplified list format given each item has the same format. #}
+  {%- set listItems = [] %}
+  {%- for item in params.items %}
+    {#- Determine status tag text and colour from status. #}
+    {%- set statusText = null %}
+    {%- set statusClasses = null %}
+
+    {%- if item.status == "yes" %}
+      {%- set statusText = "Yes" %}
+      {%- set statusClasses = "govuk-tag--green" %}
+    {%- elif item.status == "feedback needed" %}
+      {%- set statusText = "Feedback needed" %}
+      {%- set statusClasses = "govuk-tag--orange" %}
+    {%- else %}
+      {%- set statusText = "Not started" %}
+    {%- endif %}
+
+    {%- set listItems = listItems.concat([{
+      title: {
+        text: item.title
+      },
+      hint: {
+        text: item.description
+      },
+      status: {
+        tag: {
+          text: statusText,
+          classes: statusClasses
+        } if statusClasses,
+        text: statusText if not statusClasses
+      }
+    }]) %}
+  {%- endfor %}
+
+  {{ govukTaskList({
+    idPrefix: params.idPrefix | default("checklist"),
+    items: listItems
+  }) }}
+{%- endmacro %}


### PR DESCRIPTION
A user journey of early access content to test with users.

## Based upon
@querkmachine created some really great spikes that I have mildly adapted to reflect the most recent developments in cycle 30 of the Design System work.
- [[SPIKE] Using callouts for experimental works #5282](https://github.com/alphagov/govuk-design-system/pull/5282)
- [[SPIKE] Display quality checklist for experimental works #5301](https://github.com/alphagov/govuk-design-system/pull/5301)

## What we can do next
- Develop out the content on the Early access work guide in the Get started section
- Decide whether 'Early access' is the right term, we have many [proposals in the Lifecycle of components Google document](https://docs.google.com/document/d/1H4JO7aRmt-YUNjj6fTb-WCyVEOK6cJ7W2Qhbqiz9-z0/edit?tab=t.lmn5afa1xcsf)
- Review design