### PR TITLE
[SPIKE] code example without the transport font

### DIFF
--- a/src/components/summary-list/index.md
+++ b/src/components/summary-list/index.md
@@ -130,6 +130,12 @@ If a card action cannot easily be undone or might have serious consequences, con
 
 {{ example({ group: "components", item: "summary-list", example: "card-with-actions", html: true, nunjucks: true, open: false }) }}
 
+## Without the transport font
+
+Just a quick spike
+
+{{ example({ group: "components", item: "summary-list", example: "no-transport", html: true, nunjucks: true, open: false }) }}
+
 ## Research on this component
 
 This component was developed and tested by the Government Digital Service as part of the [check answers pattern](/patterns/check-answers/).

--- a/src/components/summary-list/no-transport/index.njk
+++ b/src/components/summary-list/no-transport/index.njk
@@ -1,0 +1,46 @@
+---
+title: Summary without the transport font – Summary list
+layout: layout-example.njk
+stylesheets:
+- ../../../stylesheets/example-without-transport.css
+---
+
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{{ govukSummaryList({
+  card: {
+    title: {
+      text: "I'm not using the font!"
+    },
+    actions: {
+      items: [
+        {
+          href: "#",
+          text: "Delete choice"
+        },
+        {
+          href: "#",
+          text: "Withdraw"
+        }
+      ]
+    }
+  },
+  rows: [
+    {
+      key: {
+        text: "Course"
+      },
+      value: {
+        html: "English (3DMD)<br>PGCE with QTS full time"
+      }
+    },
+    {
+      key: {
+        text: "Location"
+      },
+      value: {
+        html: "School name<br>Road, City, SW1 1AA"
+      }
+    }
+  ]
+}) }}

--- a/src/components/summary-list/no-transport/index.njk
+++ b/src/components/summary-list/no-transport/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Summary without the transport font – Summary list
 layout: layout-example.njk
+includeFrontend: false
 stylesheets:
 - ../../../stylesheets/example-without-transport.css
 ---

--- a/src/stylesheets/example-without-transport.scss
+++ b/src/stylesheets/example-without-transport.scss
@@ -1,5 +1,8 @@
-@use "pkg:govuk-frontend/base" as *;
-
-* {
-  font-family: "helvetica neue", helvetica, arial, sans-serif !important; // stylelint-disable declaration-no-important
-}
+@use "pkg:govuk-frontend" with (
+  $govuk-font-family: (
+    "helvetica neue",
+    helvetica,
+    arial,
+    sans-serif
+  )
+);

--- a/src/stylesheets/example-without-transport.scss
+++ b/src/stylesheets/example-without-transport.scss
@@ -1,0 +1,5 @@
+@use "pkg:govuk-frontend/base" as *;
+
+* {
+  font-family: "helvetica neue", helvetica, arial, sans-serif !important; // stylelint-disable declaration-no-important
+}

--- a/views/layouts/layout-example.njk
+++ b/views/layouts/layout-example.njk
@@ -11,8 +11,9 @@
   <meta name="description" content="{{ description | smartypants }}">
   <meta name="og:description" content="{{ description | smartypants }}">
   <link rel="canonical" href="{{ canonical }}">
-
+  {% if includeFrontend != false %}
   <link href="{{ getFingerprint('/stylesheets/govuk-frontend.min.css') }}" rel="stylesheet" media="all">
+  {% endif %}
   <link href="{{ getFingerprint('/stylesheets/example.css') }}" rel="stylesheet" media="all">
   {#- Include any additional stylesheets specified in the example frontmatter #}
   {% for stylesheet in stylesheets %}


### PR DESCRIPTION
A proof of concept for https://github.com/alphagov/govuk-design-system/issues/5325

Creates a new example stylesheet which re-imports `pkg:govuk-frontend` with an unbranded `$govuk-font-family` stack.

So we don't import Frontend twice, this also introduces the `includeFrontend` option to the `layout-example` template which doesn't include the complete minified Frontend CSS if set to `false`.

Whilst this would be used on the Generic header, I picked summary list as that component is more verbose so was easier to visualise changes.

## Other stuff I tried

This is the second iteration of this idea. See https://github.com/alphagov/govuk-design-system/pull/5354/changes/9584e2a143f3f1ce36b7b93b5ba43f23139aabb9 for the first idea.

I also tried scoping the change to a `style` tag in the component example itself. However this then outputs that same tag in the example's html and nunjucks code outputs.

## Additional thoughts

Since this is currently only for one component, we could tailor it to the Generic header like so:

```scss
@use "pkg:govuk-frontend/base" with (
  $govuk-font-family: (
    "helvetica neue",
    helvetica,
    arial,
    sans-serif
  )
);

@use "pkg:govuk-frontend/core";
@use "pkg:govuk-frontend/components/generic-header";
```

This would only import `base`, `core` and the generic header.

This is only necessary if we make an example for the Generic header that uses plain text. If we have an example with just a logo then we might not actually need this.