### PR TITLE
Allow Dependabot to update composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,7 +88,9 @@ updates:
 
   # Update GitHub Actions
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - /
+      - /.github/workflows/actions/*
 
     # Schedule run every Monday, local time
     schedule:


### PR DESCRIPTION
Dependabot [only looks at workflows in `.github/workflows` by default][1].

For Dependabot to be able to update our composite actions which are stored in `.github/workflows/actions` we need to include it in the list of directories.

This mirrors the approach taken in https://github.com/alphagov/govuk-frontend/pull/4667, except [we can simplify things by using the `directories` config][2].

[1]: https://github.com/dependabot/dependabot-core/issues/6704
[2]: https://github.com/dependabot/dependabot-core/issues/6704#issuecomment-3232918902