### PR TITLE
[PROTOTYPE] Stable component example

### DIFF
--- a/src/components/breadcrumbs/index.md
+++ b/src/components/breadcrumbs/index.md
@@ -9,6 +9,17 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
+<div class="app-component-metadata">
+    <dl class="app-metadata">
+        <dt class="app-metadata-term">Status:</dt>
+        <dd class="app-metadata-definition"><a class="govuk-link" href="#">Stable</a></dd>
+        <dt class="app-metadata-term">Published</dt>
+        <dd class="app-metadata-definition">21 June 2018</dd>
+        <dt class="app-metadata-term">Last updated</dt>
+        <dd class="app-metadata-definition">1 May 2025</dd>
+    </dl>
+</div>
+
 The breadcrumbs component helps users to understand where they are within a website’s structure and move between levels.
 
 {{ example({ group: "components", item: "breadcrumbs", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
@@ -48,3 +59,21 @@ Use the `govuk-breadcrumbs--inverse` modifier class to show white links and arro
 Make sure all users can see the breadcrumbs – the background colour must have a contrast ratio of at least 4.5:1 with white to [meet WCAG 2.2 success criterion 1.4.3 Contrast (minimum), level AA](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html).
 
 {{ example({ group: "components", item: "breadcrumbs", example: "inverse", html: true, nunjucks: true, open: false }) }}
+
+## Update history
+
+<div class="app-changelog-table">
+
+| Date        | Version  | Changes                                                                        |
+| ----------- | -------- | ------------------------------------------------------------------------------ |
+| 21 Jun 2018 | 1.0.0    | Component introduced.                                                          |
+| 26 Sep 2018 | 2.1.0    | Allow attributes to be added to child items in Nunjucks macros in breadcrumbs. |
+| 29 Jul 2019 | 3.0.0    | Update file paths for v3 of Frontend.                                          |
+| 1 Jun 2020  | 3.7.0    | Collapse breadcrumb component on mobile.                                       |
+| 6 Jul 2023  | 4.7.0    | Added inverse modifier for breadcrumbs on dark backgrounds.                    |
+| 7 Jul 2023  | Guidance | Add documentation and examples for inverse breadcrumbs.                        |
+| 11 Jan 2024 | Guidance | Added WCAG 2.2 criteria.                                                       |
+| 17 Jun 2024 | 5.4.1    | Update Breadcrumbs to use `nav` and `aria-label`.                              |
+| 1 May 2025  | Guidance | Removed WCAG 2.2 notes from back link, breadcrumbs, images.                    |
+
+</div>

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -331,6 +331,20 @@ pre .language-plaintext {
     padding-top: govuk-spacing(2);
   }
 
+  // stylelint-disable scss/at-extend-no-missing-placeholder -- spike code
+  table {
+    @extend .govuk-table;
+
+    th {
+      @extend .govuk-table__header;
+    }
+
+    td {
+      @extend .govuk-table__cell;
+    }
+  }
+  // stylelint-enable scss/at-extend-no-missing-placeholder
+
   // Ensure that content at the bottom of the page does not have margins
   // so that they line up with the back to top link.
   > :last-child {
@@ -357,4 +371,40 @@ pre .language-plaintext {
 // This will be fixed in the next release of GOV.UK Frontend
 .govuk-service-navigation__toggle {
   @include govuk-font($size: 19, $weight: bold);
+}
+
+.app-changelog-table {
+  table-layout: fixed;
+
+  // Set first column to fixed width
+  td:first-child {
+    width: 6em;
+  }
+}
+
+// Add styling for metadata
+
+.app-component-metadata {
+  margin-bottom: govuk-spacing(5);
+  padding: govuk-spacing(2) 0;
+  border-top: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid $govuk-border-colour;
+}
+
+.app-metadata {
+  @include govuk-font(16);
+  @include govuk-typography-weight-regular;
+}
+
+.app-metadata-term {
+  box-sizing: border-box;
+  margin-top: 0;
+  padding-right: 5px;
+  float: left;
+  clear: left;
+}
+
+.app-metadata-definition {
+  margin: 0;
+  margin-bottom: govuk-spacing(1);
 }


### PR DESCRIPTION
## Stable prototype
Using the [Breadcrumbs component](https://design-system.service.gov.uk/components/breadcrumbs/), we will create a separate prototype which labels this as “stable”. 

This “stable” prototype will include a changelog. The design will be modelled on [beeps & Charlotte's early spike](https://github.com/alphagov/govuk-design-system/pull/5352):

Must have features of the “Stable” prototype:
- Label / tag
- Content which explains why this is stable
- A changelog

This example chose to use the label and meta data design that had previously been SPIKED #4473 in Feb 2025