### PR TITLE
Retire working group page

### DIFF
--- a/src/community/contribution-criteria/index.md
+++ b/src/community/contribution-criteria/index.md
@@ -51,11 +51,11 @@ To be successful, proposals need to show that the component or pattern being sug
   ]
 }) }}
 
-The [Design System working group](/community/design-system-working-group/) reviews proposals to check they meet these criteria. Proposals that meet the criteria then move to the next step to show they're ready to publish.
+The Design System team reviews proposals to check they meet these criteria. Proposals that meet the criteria then move to the next step to show they're ready to publish.
 
 ## Developing a component or pattern
 
-Before a new component or pattern is published the working group reviews the implementation to make sure it is usable, consistent and versatile.
+Before a new component or pattern is published the team reviews the implementation to make sure it is usable, consistent and versatile.
 
 {{ govukTable({
   caption: "Before publication criteria",

--- a/src/community/design-system-working-group/index.md
+++ b/src/community/design-system-working-group/index.md
@@ -1,39 +1,9 @@
 ---
 title: Design System working group
-description: The GOV.UK Design System working group is a multidisciplinary, cross-government group whose purpose is to ensure that components and patterns published in the GOV.UK Design System are of a high quality and meet user needs
-section: Community
-theme: How we work
-layout: layout-pane.njk
-order: 8
+layout: layout-archived.njk
+ignoreInSitemap: true
 ---
 
-The Design System working group is a multidisciplinary panel of representatives from across government. It makes sure that all components and patterns published in the Design System are of a high quality and meet user needs.
+The Design System working group has been retired. In future, different methods of community engagement and feedback gathering will be used depending on the type of work being undertaken.
 
-The working group:
-
-- reviews proposals and contributions against the [contribution criteria](/community/contribution-criteria/)
-- makes recommendations to help contributors improve their work
-- advocates for the needs of colleagues across government
-
-The working group reviews:
-
-- new patterns and components
-- component changes that users will easily recognise
-- changes that will affect when users should use components
-- content that will affect how users make services and meet the Service Standard
-
-The working group does not review minor design or content changes, such as updated guidance on using a component.
-
-## Why the working group exists
-
-By including representatives from a mixture of disciplines and departments, the working group helps to ensure that the Design System represents its users.
-
-It means that decisions made are fair and unbiased, and that the Design System reflects the experiences of the whole of government not just one department.
-
-## Join the working group
-
-We’re always looking for new members to help make the working group more diverse and representative of the wider public sector.
-
-We usually form a new working group twice a year, made up of new and existing members.
-
-In the meantime, if you are interested in joining the working group email the Design System team at <govuk-design-system-support@digital.cabinet-office.gov.uk>.
+Thank you for your interest and for any historical involvement you've had with the working group.

--- a/src/community/develop-a-component-or-pattern/index.md
+++ b/src/community/develop-a-component-or-pattern/index.md
@@ -53,15 +53,13 @@ Ideally you’ll research as part of an actual service, but it’s possible to t
 
 If you're making a component, you'll also need to [make sure it's accessible by testing it against both general and specific acceptance criteria](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/test-components-using-accessibility-acceptance-criteria.md).
 
-Once you have researched the component or pattern and shown it works for users, the [Design System working group](/community/design-system-working-group/) will review it.
+Once you have researched the component or pattern and shown it works for users, the Design System team will review it.
 
 ## Send your contribution for review
 
-All components and patterns must meet the [contribution criteria](/community/contribution-criteria/) before they can be published. The Design System working group will use the criteria to review your contribution.
+All components and patterns must meet the [contribution criteria](/community/contribution-criteria/) before they can be published. The Design System team will use the criteria to review your contribution.
 
-To arrange a review, tell the Design System team your contribution is ready. The team will check your work before letting the working group know it’s ready to review.
-
-The working group will vote if your contribution:
+To arrange a review, tell the Design System team your contribution is ready. The team will check your work and will vote on if your contribution:
 
 - can be published as it is
 - cannot be published until certain recommendations have been addressed
@@ -72,6 +70,6 @@ During the meeting, you’ll be able to ask questions, hear recommendations and 
 
 ## Get ready to publish
 
-If the working group recommended some changes to make before publishing, the Design System team will help you work on them.
+If the Design System team recommendeds some changes to make before publishing, the team will help you work on them.
 
-If the working group agree your contribution meets the criteria, the Design System team will help you get ready to publish. This includes organising any final checks or updates to the design, content, code and guidance.
+If the team agrees your contribution meets the criteria, they will help you get ready to publish. This includes organising any final checks or updates to the design, content, code and guidance.

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -136,4 +136,4 @@ Find out:
 - how to [propose a component or pattern](/community/propose-a-component-or-pattern/)
 - how to [develop a component or pattern](/community/develop-a-component-or-pattern/)
 
-Learn how the [Design System working group](/community/design-system-working-group/) reviews and approves components and patterns to confirm they meet the [contribution criteria](/community/contribution-criteria/).
+Learn how the Design System team reviews and approves components and patterns to confirm they meet the [contribution criteria](/community/contribution-criteria/).


### PR DESCRIPTION
The Design System working group is being retired.

## Changes
- Archived the Design System working group page. 
- Updated references to the working group to refer to the Design System team instead. 