### PR TITLE
Sort side nav by order then label

### DIFF
--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -63,8 +63,10 @@ module.exports = (config) => (files, metalsmith, done) => {
       })
     }
 
-    // Sort navigation sub items using 'order' (optional)
-    item.items?.sort((a, b) => compare(a.order, b.order))
+    // Sort navigation sub items by order if available, then by title
+    item.items?.sort((a, b) =>
+      a.order || b.order ? compare(a.order, b.order) : compare(a.label, b.label)
+    )
   }
 
   // Add navigation to global variables


### PR DESCRIPTION
Sorts sub items in section side navigation by order if available, then by label (page title).

This doesn't look like it does anything on its own because we use order for most of our pages and the titles under Components already look like they're in alphabetical order. The issue comes when we have a title that's different from a page path.

We don't have many instances currently of a path being different to a title whilst also not having an `order` frontmatter param The 2 big examples are the header and footer (GOV.UK header and GOV.UK footer in the side nav). If we add a page starting with a G, for example 'Generic header', it'll go between the 2 pages because f (footer) comes before g (generic header) comes before h (header). It should be generic header first and then the 2 GOV.UK components.

Noticed by @36degrees in https://github.com/alphagov/govuk-design-system/pull/5394#issuecomment-4750461484