### PR TITLE
Fix deleting cookies from removed categories

### DIFF
--- a/__tests__/cookie-functions.test.mjs
+++ b/__tests__/cookie-functions.test.mjs
@@ -228,6 +228,15 @@ describe('Cookie settings', () => {
       expect(window['ga-disable-G-8F2EMQL51V']).toEqual(false)
       expect(window['ga-disable-G-GHT8W0QGD9']).toEqual(false)
     })
+
+    it('handles categories that do not exist', async () => {
+      document.cookie =
+        'design_system_cookies_policy={"grobulating":false,"version":2}'
+
+      expect(() => {
+        CookieHelpers.resetCookies()
+      }).not.toThrow()
+    })
   })
 
   describe('consent cookie version', () => {

--- a/src/javascripts/components/cookie-functions.mjs
+++ b/src/javascripts/components/cookie-functions.mjs
@@ -177,7 +177,7 @@ export function resetCookies() {
       window[`ga-disable-G-${TRACKING_LIVE_ID}`] = true
     }
 
-    if (!options[cookieType]) {
+    if (!options[cookieType] && cookieType in COOKIE_CATEGORIES) {
       // Fetch the cookies in that category
       const cookiesInCategory = COOKIE_CATEGORIES[cookieType]
 


### PR DESCRIPTION
Users who previously rejected cookies for 'campaigns' are not currently able to save their cookie preferences because the `design_system_cookies_policy` cookie on their computer still contains a reference to the `campaigns` category.

When the user saves their cookie preferences we attempt to delete cookies for any category the user has rejected, using the `COOKIE_CATEGORIES` object.

The JavaScript attempts to call `forEach` on the result of `COOKIE_CATEGORIES['campaign']`, which is `undefined`, and so the JavaScript errors.

Add a failing test for this case, and then fix the bug by checking that the category is present in `COOKIE_CATEGORIES` before trying to call `forEach` on it.

Full credit should go to @romaricpascal for digging into this and understanding what was going on!