### PR TITLE
Create a specific jest group for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,14 +47,17 @@ updates:
           - '@rollup/*'
           - 'rollup'
 
-      test:
+      jest:
         patterns:
-          - '@axe-core/*'
           - '@jest/*'
           - '@types/jest'
           - '@types/jest-*'
           - 'jest'
           - 'jest-*'
+
+      test:
+        patterns:
+          - '@axe-core/*'
           - 'puppeteer'
 
       types:


### PR DESCRIPTION
These all change together since the project is in a monorepo so we can keep them together so easier to merge other test group stuff without jest blocking things.