### PR TITLE
Interruption guidance improvements back link and Nunjucks

### DIFF
--- a/src/components/panel/default/index.njk
+++ b/src/components/panel/default/index.njk
@@ -5,7 +5,9 @@ layout: layout-example.njk
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
-{{ govukPanel({
-  titleText: "Application complete",
-  html: "Your reference number<br><strong>HDJ2123F</strong>"
-}) }}
+{% call govukPanel({
+  titleText: "Application complete"
+}) %}
+  Your reference number<br>
+  <strong>HDJ2123F</strong>
+{% endcall %}

--- a/src/components/panel/interruption/index.njk
+++ b/src/components/panel/interruption/index.njk
@@ -5,18 +5,16 @@ layout: layout-example.njk
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
-{% set panelHtml %}
-<p>You entered your age as <strong>109</strong>.</p>
-<div class="govuk-button-group">
-  <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
-    Yes, this is correct
-  </button>
-  <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
-</div>
-{% endset %}
+{% call govukPanel({
+  classes: "govuk-panel--interruption",
+  titleText: "Is your age correct?"
+}) %}
+  <p>You entered your age as <strong>109</strong>.</p>
+  <div class="govuk-button-group">
+    <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+      Yes, this is correct
+    </button>
+    <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
+  </div>
+{% endcall %}
 
-{{ govukPanel({
-  titleText: "Is your age correct?",
-  html: panelHtml,
-  classes: "govuk-panel--interruption"
-}) }}

--- a/src/components/panel/interruption/index.njk
+++ b/src/components/panel/interruption/index.njk
@@ -10,7 +10,7 @@ layout: layout-example.njk
   classes: "govuk-panel--interruption",
   titleText: "Is your age correct?"
 }) %}
-  <p>You entered your age as <strong>109</strong>.</p>
+  <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
   <div class="govuk-button-group">
     {{ govukButton({
       classes: "govuk-button--inverse",

--- a/src/components/panel/interruption/index.njk
+++ b/src/components/panel/interruption/index.njk
@@ -4,6 +4,7 @@ layout: layout-example.njk
 ---
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% call govukPanel({
   classes: "govuk-panel--interruption",
@@ -11,9 +12,10 @@ layout: layout-example.njk
 }) %}
   <p>You entered your age as <strong>109</strong>.</p>
   <div class="govuk-button-group">
-    <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
-      Yes, this is correct
-    </button>
+    {{ govukButton({
+      classes: "govuk-button--inverse",
+      text: "Yes, this is correct"
+    }) }}
     <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
   </div>
 {% endcall %}

--- a/src/patterns/interruption-pages/default/index.njk
+++ b/src/patterns/interruption-pages/default/index.njk
@@ -4,7 +4,6 @@ layout: layout-example-full-page.njk
 ---
 
 {% extends "example-wrappers/full-page.njk" %}
-{% set mainClasses = "govuk-main-wrapper--l" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}

--- a/src/patterns/interruption-pages/default/index.njk
+++ b/src/patterns/interruption-pages/default/index.njk
@@ -14,24 +14,21 @@ layout: layout-example-full-page.njk
   }) }}
 {% endblock %}
 
-{% set panelHtml %}
-<p>You entered your age as <strong>109</strong>.</p>
-<div class="govuk-button-group">
-  <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
-    Yes, this is correct
-  </button>
-  <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
-</div>
-{% endset %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {{ govukPanel({
+      {% call govukPanel({
         titleText: "Is your age correct?",
-        html: panelHtml,
         classes: "govuk-panel--interruption"
-      }) }}
+      }) %}
+        <p>You entered your age as <strong>109</strong>.</p>
+        <div class="govuk-button-group">
+          <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+            Yes, this is correct
+          </button>
+          <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
+        </div>
+      {% endcall %}
     </div>
   </div>
 {% endblock %}

--- a/src/patterns/interruption-pages/default/index.njk
+++ b/src/patterns/interruption-pages/default/index.njk
@@ -22,7 +22,7 @@ layout: layout-example-full-page.njk
         titleText: "Is your age correct?",
         classes: "govuk-panel--interruption"
       }) %}
-        <p>You entered your age as <strong>109</strong>.</p>
+        <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
         <div class="govuk-button-group">
           {{ govukButton({
             classes: "govuk-button--inverse",

--- a/src/patterns/interruption-pages/default/index.njk
+++ b/src/patterns/interruption-pages/default/index.njk
@@ -6,7 +6,14 @@ layout: layout-example-full-page.njk
 {% extends "example-wrappers/full-page.njk" %}
 {% set mainClasses = "govuk-main-wrapper--l" %}
 
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% block containerStart %}
+  {{ govukBackLink({
+    text: "Back"
+  }) }}
+{% endblock %}
 
 {% set panelHtml %}
 <p>You entered your age as <strong>109</strong>.</p>

--- a/src/patterns/interruption-pages/default/index.njk
+++ b/src/patterns/interruption-pages/default/index.njk
@@ -6,6 +6,7 @@ layout: layout-example-full-page.njk
 {% extends "example-wrappers/full-page.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% block containerStart %}
@@ -23,9 +24,10 @@ layout: layout-example-full-page.njk
       }) %}
         <p>You entered your age as <strong>109</strong>.</p>
         <div class="govuk-button-group">
-          <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
-            Yes, this is correct
-          </button>
+          {{ govukButton({
+            classes: "govuk-button--inverse",
+            text: "Yes, this is correct"
+          }) }}
           <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
         </div>
       {% endcall %}


### PR DESCRIPTION
- Adds back link for consistent navigation between pages
- Uses govuk-body classes for paragraphs, for now will look worse but we decided our markup internally shouldnt rely on global styles so we'll do work to address this in #5418 
- Updated the guidance to make better use of Nunjucks with buttons and caller (allows nesting of markup)