### PR TITLE
[WIP] 'Trial' status tagging

### DIFF
--- a/src/components/password-input/index.md
+++ b/src/components/password-input/index.md
@@ -5,7 +5,7 @@ section: Components
 aliases: pass word, pass phrase
 backlogIssueId: 240
 layout: layout-pane.njk
-experimental: 
+trial: 
   links:
     - href: "#known-issues"
       text: Known issues

--- a/src/components/password-input/index.md
+++ b/src/components/password-input/index.md
@@ -8,6 +8,14 @@ layout: layout-pane.njk
 ---
 
 {% from "_example.njk" import example %}
+{% from "_experimental-callout.njk" import experimentalCallout %}
+
+{{ experimentalCallout({
+  links: [
+  	{ href: '#known-issues', text: "Known issues" },
+  	{ href: '#research-on-this-component', text: "Research on this component" }
+  ]
+}) }}
 
 Help users to create and enter passwords.
 

--- a/src/components/password-input/index.md
+++ b/src/components/password-input/index.md
@@ -5,17 +5,15 @@ section: Components
 aliases: pass word, pass phrase
 backlogIssueId: 240
 layout: layout-pane.njk
+experimental: 
+  links:
+    - href: "#known-issues"
+      text: Known issues
+    - href: "#research-on-this-component"
+      text: Research on this component
 ---
 
 {% from "_example.njk" import example %}
-{% from "_experimental-callout.njk" import experimentalCallout %}
-
-{{ experimentalCallout({
-  links: [
-  	{ href: '#known-issues', text: "Known issues" },
-  	{ href: '#research-on-this-component', text: "Research on this component" }
-  ]
-}) }}
 
 Help users to create and enter passwords.
 

--- a/src/get-started/component-lifecycle/index.md
+++ b/src/get-started/component-lifecycle/index.md
@@ -1,0 +1,40 @@
+---
+layout: layout-pane.njk
+title: Component lifecycle
+section: Get started
+theme: Setup guides
+order: 3
+description: How we iterate components in the Design System.
+---
+
+This content is placeholder right now. Dolore esse elit anim consequat eu. Dolor eu laborum deserunt ea esse duis. Cillum sint eiusmod dolore anim fugiat.
+
+## Component statuses
+
+### Experimental
+
+**Experimental** components are being actively iterated upon and may change significantly before graduating to stable.
+
+If we decide that an experimental component isn't worth pursuing further, it may move to being deprecated and eventually withdrawn from the Design System without becoming a stable component.
+
+Services using experimental components should be prepared to make ongoing updates to them.
+
+### Stable
+
+**Stable** components have been thoroughly tested and are unlikely to change all that much.
+
+We may still make incremental changes and bug fixes, but they're otherwise... stable.
+
+### Deprecated
+
+If we believe a component has reached the end of its useful life, we will mark it as being **deprecated**.
+
+Deprecated components remain part of the Design System but will not receive further changes or bug fixes, except to resolve major issues. Deprecated components will be withdrawn in a future major version of GOV.UK Frontend.
+
+New services should not use deprecated components and existing services should make plans to stop using them.
+
+### Withdrawn
+
+Components that have been **withdrawn** are no longer part of the GOV.UK Design System or GOV.UK Frontend.
+
+Both new and existing services should not use withdrawn components. Any documentation provided is for users of older versions of the Design System who are unable to update.

--- a/src/get-started/component-lifecycle/index.md
+++ b/src/get-started/component-lifecycle/index.md
@@ -11,13 +11,13 @@ This content is placeholder right now. Dolore esse elit anim consequat eu. Dolor
 
 ## Component statuses
 
-### Experimental
+### Trial
 
-**Experimental** components are being actively iterated upon and may change significantly before graduating to stable.
+**Trial** components are being actively iterated upon and may change significantly before graduating to stable.
 
-If we decide that an experimental component isn't worth pursuing further, it may move to being deprecated and eventually withdrawn from the Design System without becoming a stable component.
+If we decide that an trial component isn't worth pursuing further, it may move to being deprecated and eventually withdrawn from the Design System without becoming a stable component.
 
-Services using experimental components should be prepared to make ongoing updates to them.
+Services using trial components should be prepared to make ongoing updates to them.
 
 ### Stable
 

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -350,8 +350,8 @@ pre .language-plaintext {
   margin: 0;
 }
 
-// Experimental status callout
-.app-experimental-callout {
+// Trial status callout
+.app-trial-callout {
   border-left-color: govuk-colour("orange");
   background-color: govuk-colour("orange", $variant: "tint-95");
 

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -350,6 +350,16 @@ pre .language-plaintext {
   margin: 0;
 }
 
+// Experimental status callout
+.app-experimental-callout {
+  border-left-color: govuk-colour("orange");
+  background-color: govuk-colour("orange", $variant: "tint-95");
+
+  .govuk-tag {
+    margin-bottom: govuk-spacing(1);
+  }
+}
+
 // REMOVE EACH RULE BELOW WHEN GOV.UK FRONTEND V6.0.0 IS RELEASED
 // AND USED ON THE SITE
 

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -1,6 +1,7 @@
 {% extends "_generic.njk" %}
 
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "_experimental-callout.njk" import experimentalCallout %}
 
 {# If the theme ends in '…', then we nest the caption inside the H1 so that the
   H1 becomes e.g. 'Ask users for dates'. Otherwise, we put it before the H1. #}
@@ -26,14 +27,9 @@
         {{ title }}
       </h1>
 
-      {% if status %}
-      <aside class="govuk-!-margin-bottom-8" aria-label="Guidance status">
-        <strong class="govuk-tag govuk-!-margin-bottom-2">
-          {{ status }}
-        </strong>
-        <p class="govuk-body">{{ statusMessage | safe }}</p>
-      </aside>
-      {% endif %}
+      {%- if experimental %}
+        {{ experimentalCallout(experimental) }}
+      {%- endif %}
 
       {% if showPageNav %}
         <ul class="app-page-navigation">

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -1,7 +1,7 @@
 {% extends "_generic.njk" %}
 
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "_experimental-callout.njk" import experimentalCallout %}
+{% from "_trial-callout.njk" import trialCallout %}
 
 {# If the theme ends in '…', then we nest the caption inside the H1 so that the
   H1 becomes e.g. 'Ask users for dates'. Otherwise, we put it before the H1. #}
@@ -27,8 +27,8 @@
         {{ title }}
       </h1>
 
-      {%- if experimental %}
-        {{ experimentalCallout(experimental) }}
+      {%- if trial %}
+        {{ trialCallout(trial) }}
       {%- endif %}
 
       {% if showPageNav %}

--- a/views/macros/_experimental-callout.njk
+++ b/views/macros/_experimental-callout.njk
@@ -1,0 +1,41 @@
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+{% macro experimentalCallout(params) %}
+{%- set defaultContent %}
+<p class="govuk-body">This component is being actively developed and may change significantly before being stabilised. Find out more about <a href="/get-started/component-lifecycle/">how we iterate our components</a>.</p>
+{%- endset %}
+
+{%- set content -%}
+  {%- if caller %}
+    {{ caller() }}
+  {%- elif params.html %}
+    {{ params.html | safe }}
+  {%- elif params.text %}
+    <p class="govuk-body">{{ params.text }}</p>
+  {%- else %}
+    {{ defaultContent | safe }}
+  {%- endif %}
+{%- endset -%}
+
+{%- call govukInsetText({
+  classes: "app-experimental-callout"
+}) %}
+{{ govukTag({
+  classes: "govuk-tag--orange",
+  text: "Experimental"
+}) }}
+{{ content | safe }}
+
+{%- if params.links %}
+<ul class="govuk-list">
+{%- for item in params.links %}
+<li><a class="govuk-link" href="{{ item.href }}">
+  {{- item.html | safe if item.html else item.text -}}
+</a></li>
+{%- endfor %}
+</ul>
+{%- endif %}
+
+{%- endcall %}
+{% endmacro %}

--- a/views/macros/_experimental-callout.njk
+++ b/views/macros/_experimental-callout.njk
@@ -3,7 +3,7 @@
 
 {% macro experimentalCallout(params) %}
 {%- set defaultContent %}
-<p class="govuk-body">This component is being actively developed and may change significantly before being stabilised. Find out more about <a href="/get-started/component-lifecycle/">how we iterate our components</a>.</p>
+<p class="govuk-body">This component is being actively developed and may change significantly before being stabilised. Find out more about <a class="govuk-link" href="/get-started/component-lifecycle/">how we iterate our components</a>.</p>
 {%- endset %}
 
 {%- set content -%}

--- a/views/macros/_trial-callout.njk
+++ b/views/macros/_trial-callout.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
-{% macro experimentalCallout(params) %}
+{% macro trialCallout(params) %}
 {%- set defaultContent %}
 <p class="govuk-body">This component is being actively developed and may change significantly before being stabilised. Find out more about <a class="govuk-link" href="/get-started/component-lifecycle/">how we iterate our components</a>.</p>
 {%- endset %}
@@ -19,11 +19,11 @@
 {%- endset -%}
 
 {%- call govukInsetText({
-  classes: "app-experimental-callout"
+  classes: "app-trial-callout"
 }) %}
 {{ govukTag({
   classes: "govuk-tag--orange",
-  text: "Experimental"
+  text: "Trial"
 }) }}
 {{ content | safe }}
 


### PR DESCRIPTION
WIP for how we might implement callouts and guidance relating to trial components. 

> [!NOTE]
> This currently uses the Password input component for demonstration purposes, as no trial components are currently present. 

## Changes

- Added an `trialCallout` macro. 
  - If `trial` is invoked with `call`, or has the `html` or `text` parameters, the default messaging is overwritten by the specified content. 
  - If `trial` has a `links` parameter, a list of additional links are displayed after the messaging. This is intended for quickly linking to in-page sections relating to the status, such as those listing known issues or requesting research findings.
    - Links are defined as an array of `href` and `html` or `text` properties. 
- Replaced the old status system with new trial callout macro. This is triggered on content pages by including the `trial` property in the front matter.
  - If `trial: true`, some pre-defined messaging is displayed directing the user to the component lifecycle documentation.
  - If `trial` is called with any other parameters, these are passed to the macro and parsed as above. 
- Added (mostly placeholder) component lifecycle documentation page.

## Thoughts

The callout has been implemented as a macro, in part, because of the possibility that we don't want to apply the label to an entire page (e.g. for variants of existing components). The inclusion of it as part of the page template is for three reasons:

1. It makes it simpler to include the callout on pages (probably debatable as to how useful that actually is). 
2. It causes the callout to render above the in-page mobile navigation, on pages that include one (mainly style pages at the moment). 
3. This is what we did with the previous experimental label.

As we haven't determined any other stages of the component lifecycle yet (other than trial and stable), the code hasn't been made to be particularly reusable. If/when we introduce more statuses, it might be a good idea to abstract things out a bit more. 