### PR TITLE
Add guidance on not using centred text

### DIFF
--- a/src/styles/font-override-classes/index.md
+++ b/src/styles/font-override-classes/index.md
@@ -27,7 +27,7 @@ Use:
 - `govuk-!-text-align-right` to align text to the right
 - `govuk-!-text-align-centre` to align text to the centre
 
-As the most commonly used languages on GOV.UK are written left-to-right, you should usually left-align body copy text. Right-aligned body copy text can be hard for users to find and read when they magnify their screen. Use right-aligned body copy text if you are translating content into a language which is written right-to-left.
+As the most commonly used languages on GOV.UK are written left-to-right, you should usually left-align body copy text. Right-aligned body copy text can be hard for users to find and read when they magnify their screen. Centre aligned body copy can also be difficult for users who magnify their screen, with multi-line text requiring the user to find the start of each line in a different place. Use right-aligned body copy text if you are translating content into a language which is written right-to-left.
 
 Do not 'justify' blocks of body copy text so it's aligned to both the left and right margins. Doing this creates wider spaces between words, which can make the text hard to read.
 


### PR DESCRIPTION
Resolves issue https://github.com/alphagov/govuk-design-system/issues/2080

This PR adds guidance to our 'font override classes' page on not using 'centred text', based on the user feedback mentioned in the above issue:

> Short centre aligned text is also, not only hard to find but liable to be missed entirely by people using magnification concentrating on the left side of the page.
> Multiline centred text also requires finding the start of each line in a different place, especially difficult at high magnifications.

