### PR TITLE
Update examples using Date Input to use new options

### DIFF
--- a/src/components/date-input/date-of-birth/index.njk
+++ b/src/components/date-input/date-of-birth/index.njk
@@ -18,21 +18,13 @@ layout: layout-example-form.njk
   hint: {
     text: "For example, 31 3 1980"
   },
-  items: [
-    {
-      name: "day",
-      classes: "govuk-input--width-2",
-      autocomplete: "bday-day"
-    },
-    {
-      name: "month",
-      classes: "govuk-input--width-2",
-      autocomplete: "bday-month"
-    },
-    {
-      name: "year",
-      classes: "govuk-input--width-4",
-      autocomplete: "bday-year"
-    }
-  ]
+  day: {
+    autocomplete: "bday-day"
+  },
+  month: {
+    autocomplete: "bday-month"
+  },
+  year: {
+    autocomplete: "bday-year"
+  }
 }) }}

--- a/src/components/date-input/error-single/index.njk
+++ b/src/components/date-input/error-single/index.njk
@@ -21,20 +21,11 @@ layout: layout-example-form.njk
   errorMessage: {
     text: "The date your passport was issued must include a year"
   },
-  items: [
-    {
-      classes: "govuk-input--width-2",
-      name: "day",
-      value: "6"
-    },
-    {
-      classes: "govuk-input--width-2",
-      name: "month",
-      value: "3"
-    },
-    {
-      classes: "govuk-input--width-4 govuk-input--error",
-      name: "year"
-    }
-  ]
+  values: {
+    day: 6,
+    month: 3
+  },
+  year: {
+    error: true
+  }
 }) }}

--- a/src/components/date-input/error/index.njk
+++ b/src/components/date-input/error/index.njk
@@ -21,21 +21,9 @@ layout: layout-example-form.njk
   errorMessage: {
     text: "The date your passport was issued must be in the past"
   },
-  items: [
-    {
-      classes: "govuk-input--width-2 govuk-input--error",
-      name: "day",
-      value: "6"
-    },
-    {
-      classes: "govuk-input--width-2 govuk-input--error",
-      name: "month",
-      value: "3"
-    },
-    {
-      classes: "govuk-input--width-4 govuk-input--error",
-      name: "year",
-      value: "2076"
-    }
-  ]
+  values: {
+    day: 6,
+    month: 3,
+    year: 2076
+  }
 }) }}

--- a/src/components/error-message/default/index.njk
+++ b/src/components/error-message/default/index.njk
@@ -20,22 +20,5 @@ layout: layout-example-form.njk
     text: "The date your passport was issued must be in the past"
   },
   id: "passport-issued",
-  namePrefix: "passport-issued",
-  items: [
-    {
-      classes: "govuk-input--width-2 govuk-input--error",
-      name: "day",
-      value: "6"
-    },
-    {
-      classes: "govuk-input--width-2 govuk-input--error",
-      name: "month",
-      value: "3"
-    },
-    {
-      classes: "govuk-input--width-4 govuk-input--error",
-      name: "year",
-      value: "2076"
-    }
-  ]
+  namePrefix: "passport-issued"
 }) }}

--- a/src/components/error-summary/full-page-example/index.njk
+++ b/src/components/error-summary/full-page-example/index.njk
@@ -43,22 +43,15 @@ layout: layout-example-full-page.njk
           errorMessage: {
             text: "Passport issue date must include a year"
           },
-          items: [
-            {
-              name: "day",
-              classes: "govuk-input--width-2",
-              value: 5
-            },
-            {
-              name: "month",
-              classes: "govuk-input--width-2",
-              value: 12
-            },
-            {
-              name: "year",
-              classes: "govuk-input--width-4 govuk-input--error"
-            }
-          ]
+          day: {
+            value: 5
+          },
+          month: {
+            value: 12
+          },
+          year: {
+            error: true
+          }
           })
         }}
 

--- a/src/components/error-summary/linking-multiple-fields/index.njk
+++ b/src/components/error-summary/linking-multiple-fields/index.njk
@@ -29,21 +29,12 @@ layout: layout-example-form.njk
   errorMessage: {
     text: "Passport issue date must include a year"
   },
-  items: [
-    {
-      name: "day",
-      classes: "govuk-input--width-2",
-      value: 5
-    },
-    {
-      name: "month",
-      classes: "govuk-input--width-2",
-      value: 12
-    },
-    {
-      name: "year",
-      classes: "govuk-input--width-4 govuk-input--error"
-    }
-  ]
+  values: {
+    day: 5,
+    month: 12
+  },
+  year: {
+    error: true
+  }
   })
 }}

--- a/src/patterns/dates/memorable-date/index.njk
+++ b/src/patterns/dates/memorable-date/index.njk
@@ -18,21 +18,13 @@ layout: layout-example-form.njk
   hint: {
     text: "For example, 31 3 1980"
   },
-  items: [
-    {
-      name: "day",
-      classes: "govuk-input--width-2",
-      autocomplete: "bday-day"
-    },
-    {
-      name: "month",
-      classes: "govuk-input--width-2",
-      autocomplete: "bday-month"
-    },
-    {
-      name: "year",
-      classes: "govuk-input--width-4",
-      autocomplete: "bday-year"
-    }
-  ]
+  day: {
+    autocomplete: "bday-day"
+  },
+  month: {
+    autocomplete: "bday-month"
+  },
+  year: {
+    autocomplete: "bday-year"
+  }
 }) }}

--- a/src/patterns/equality-information/error-date-of-birth/index.njk
+++ b/src/patterns/equality-information/error-date-of-birth/index.njk
@@ -22,23 +22,15 @@ layout: layout-example-form.njk
   hint: {
     text: "For example, 31 3 1980 – if you prefer not to say, continue without entering any information"
   },
-  items: [
-    {
-      name: "day",
-      classes: "govuk-input--width-2",
-      autocomplete: "bday-day"
-    },
-    {
-      name: "month",
-      classes: "govuk-input--width-2",
-      autocomplete: "bday-month"
-    },
-    {
-      name: "year",
-      classes: "govuk-input--width-4",
-      autocomplete: "bday-year"
-    }
-  ]
+  day: {
+    autocomplete: "bday-day"
+  },
+  month: {
+    autocomplete: "bday-month"
+  },
+  year: {
+    autocomplete: "bday-year"
+  }
 }) }}
 
 {{ govukButton({

--- a/src/patterns/question-pages/date-of-birth/index.njk
+++ b/src/patterns/question-pages/date-of-birth/index.njk
@@ -32,23 +32,15 @@ layout: layout-example-full-page.njk
           hint: {
             text: "For example, 31 3 1980"
           },
-          items: [
-            {
-              name: "day",
-              classes: "govuk-input--width-2",
-              autocomplete: "bday-day"
-            },
-            {
-              name: "month",
-              classes: "govuk-input--width-2",
-              autocomplete: "bday-month"
-            },
-            {
-              name: "year",
-              classes: "govuk-input--width-4",
-              autocomplete: "bday-year"
-            }
-          ]
+          day: {
+            autocomplete: "bday-day"
+          },
+          month: {
+            autocomplete: "bday-month"
+          },
+          year: {
+            autocomplete: "bday-year"
+          }
         }) }}
 
         {{ govukButton({


### PR DESCRIPTION
Update the examples using the `govukDateInput` macro to use the new options instead of `items`:
- use `values` to assign values to the field
- use `day`,`month` and/or `year` when configuring individual fields (eg. setting error state or `autocomplete`)

This involves the page for the Date Input component  and Asking for date pattern pages (obviously), but also:
- the Error Message and Error Summary component pages
- the Equality Information and Question Page pattern pages

Closes #5485 