### PR TITLE
Extend contact panel to link to github discussions

### DIFF
--- a/src/components/feedback/index.md
+++ b/src/components/feedback/index.md
@@ -2,6 +2,7 @@
 title: Feedback
 description: Ask users to give their feedback about your service at any point of the journey
 section: Components
+discussionId: 4978
 layout: layout-pane.njk
 status: 
   type: trial

--- a/src/components/phase-banner/index.md
+++ b/src/components/phase-banner/index.md
@@ -3,7 +3,7 @@ title: Phase banner
 description: Use the phase banner component to show users your service is still being worked on
 section: Components
 aliases: alpha banner, beta banner, prototype banner, status banner, feedback banner
-backlogIssueId: 57
+discussionId: 4973
 layout: layout-pane.njk
 ---
 

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -2,14 +2,15 @@
 {% if ["Components", "Patterns", "Styles"].includes(section) %}
   <h2 class="govuk-heading-l govuk-!-padding-top-7" id="help-improve-this-page">Help improve this {{ section.slice(0, -1) | lower }}</h2>
 
-  {% if backlogIssueId %}
+  {% if backlogIssueId or discussionId %}
+    {%- set discussionUrl = "https://github.com/alphagov/" + ("govuk-design-system/discussions/" + discussionId if discussionId else "govuk-design-system-backlog/issues/") + backlogIssueId  %}
     <p class="govuk-body">
       To help make sure that this page is useful, relevant and up to date, you can:
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
         take part in the
-        <a class="govuk-link app-contact-panel__link" href="https://github.com/alphagov/govuk-design-system-backlog/issues/{{ backlogIssueId }}">
+        <a class="govuk-link app-contact-panel__link" href="{{ discussionUrl }}">
           ‘{{ title }}’ discussion on GitHub
         </a>
         and share your research


### PR DESCRIPTION
## What

Extends the contact panel partial, called at the bottom of guidance pages, to account for if a backlog item is an issue on the design system backlog repo or a github discussion on the design system website.

Part of https://github.com/alphagov/govuk-design-system/issues/5506 but does not close it

Done by adding a `discussionId` frontmatter parameter which acts as an alternative to `backlogIssueId` for discussions. 

As a proof of concept, updates the Phase banner backlog id to the discussion id and added a discussion id for Feedback. We converted both of these into discussions as part of the early Feedback component work.

## Why

See https://github.com/alphagov/govuk-design-system/issues/5506#issuecomment-5177664440 for a full writeup on why. The summary is that now that we've transferred Feedback and Phase banner to discussions, lets clean up the journey rather than continue linking to the old backlog issues, which just leads users back to discussions anyway, or have 2 separate places for collecting information on the same things.