### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+<!--
+  Use this template to help you write your pull request. The headings in this template provide examples of information that is useful to include to help review your change and find and understand this change later. Feel free to add/delete sections where appropriate.
+
+  Did you use AI to generate code updates or descriptions/comments on this pull request? If so please tell us:
+
+  - the model(s) you used
+  - what they generated
+-->
+
+## What
+
+<!--
+  Provide a summary of the change. Try to be concise in this section. Limit yourself to 1 or 2 sentences and/or a bullet point list of what this pull request includes.
+-->
+
+## Why
+
+<!--
+  Provide a summary of why you are making this change
+
+  It's also useful to include:
+
+  - decisions that aren't clearly articulated in the code history eg: design decisions
+  - any issues that this change links to. If you expect this change to directly resolve a linked issue, remember to use [GitHub keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) eg: "resolves #{issue number}". You can also link issues in the "development" section of the sidebar in GitHub
+-->
+
+## Visual changes
+
+<!--
+  If this pull request will result in a visual change, showing a before and after helps with review and recalling the visual state of a thing before this change. You can add an additional 'state' column if there are multiple visual changes to document.
+-->
+
+| Before | After |
+| ------ | ----- |
+|        |       |
+
+## Additional info
+
+<!--
+  Add any additional details to your pull request that you want to add which don't fit into any of the above sections. This could include known issues, things you're unsure of or anything else you want the reviewer to be aware of
+-->


### PR DESCRIPTION
## What

Add a pull request template to the repo (I'm using it right now!)

Based off of discussions across the team and previous PR behaviours I've observed from team members.

I didn't use AI to write this (I wouldn't normally mention that, if I didn't. I'm noting it here as a little demo of the PR template).

## Why

A potential quick win that came out of a recent team away day discussing how we record decisions and how there's an unevenness to the quality of decision recording across PRs. This won't solve that entirely but it'll help.

Part of https://github.com/alphagov/govuk-frontend/issues/5329 but does not resolve it

## Visual changes

No visual changes (in a real world scenario I'd just delete this section but I'm keeping it in to show it off)

## Additional info

If we're happy with this, we can migrate the template to other repos like Frontend, Frontend docs, the prototype kit etc.