### PR TITLE
Add Interruption panel alias to Panel

### DIFF
--- a/src/components/panel/index.md
+++ b/src/components/panel/index.md
@@ -2,7 +2,7 @@
 title: Panel
 description: Use the Panel component to display important information in within confirmation and interruption pages
 section: Components
-aliases: confirmation box, results box, reference number, application complete, application number
+aliases: confirmation box, results box, reference number, application complete, application number, interruption panel
 backlogIssueId: 55
 layout: layout-pane.njk
 ---


### PR DESCRIPTION
This is what we've been referring to it on the component basis.

If we find anymore aliases through analytics we can add more over time.

## Screenshot

<img width="395" height="201" alt="Search with 'interru' entered and 'Interruption pages' and 'Panel (interruption panel)' as results" src="https://github.com/user-attachments/assets/e2fe8dd3-266e-473e-b474-71da36374741" />
