### PR TITLE
Remove legacy fix for mobile nav menu

### DIFF
--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -349,12 +349,3 @@ pre .language-plaintext {
 .app-nunjucks-options-list h4 {
   margin: 0;
 }
-
-// REMOVE EACH RULE BELOW WHEN GOV.UK FRONTEND V6.0.0 IS RELEASED
-// AND USED ON THE SITE
-
-// Fixes a bug where the mobile menu toggle button has small font size
-// This will be fixed in the next release of GOV.UK Frontend
-.govuk-service-navigation__toggle {
-  @include govuk-font($size: 19, $weight: bold);
-}


### PR DESCRIPTION
Removes code that fixed a font size issue. This issue was fixed upstream in govuk-frontend v6.0.0, so the related code can now be removed.

## Changes
- Removed Sass code that fixed a bug with the mobile menu toggle button text size.