### PR TITLE
Add lifecycle status callouts

### DIFF
--- a/src/components/feedback/index.md
+++ b/src/components/feedback/index.md
@@ -3,6 +3,13 @@ title: Feedback
 description: Ask users to give their feedback about your service at any point of the journey
 section: Components
 layout: layout-pane.njk
+status: 
+  type: trial
+  links:
+    - href: "#research-on-this-component"
+      text: Research on this component
+    - href: "#help-improve-this-page"
+      text: Help improve this component
 ---
 
 {% from "_example.njk" import example %}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -362,6 +362,15 @@ pre .language-plaintext {
   margin-bottom: govuk-spacing(1);
 }
 
+// Element name is included here as this needs higher specificity to override
+// the styles applied by .app-prose-scope
+//
+// stylelint-disable-next-line selector-no-qualifying-type
+ul.app-status-callout__list {
+  padding-left: 0;
+  list-style-type: none;
+}
+
 // REMOVE EACH RULE BELOW WHEN GOV.UK FRONTEND V6.0.0 IS RELEASED
 // AND USED ON THE SITE
 

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -352,14 +352,14 @@ pre .language-plaintext {
 
 // Lifecycle status callouts (inherits from inset text component)
 .app-status-callout {
-  .govuk-tag {
-    margin-bottom: govuk-spacing(1);
-  }
-
   &.app-status-callout--trial {
     border-left-color: govuk-colour("orange");
     background-color: govuk-colour("orange", $variant: "tint-95");
   }
+}
+
+.app-status-callout__tag {
+  margin-bottom: govuk-spacing(1);
 }
 
 // REMOVE EACH RULE BELOW WHEN GOV.UK FRONTEND V6.0.0 IS RELEASED

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -350,6 +350,18 @@ pre .language-plaintext {
   margin: 0;
 }
 
+// Lifecycle status callouts (inherits from inset text component)
+.app-status-callout {
+  .govuk-tag {
+    margin-bottom: govuk-spacing(1);
+  }
+
+  &.app-status-callout--trial {
+    border-left-color: govuk-colour("orange");
+    background-color: govuk-colour("orange", $variant: "tint-95");
+  }
+}
+
 // REMOVE EACH RULE BELOW WHEN GOV.UK FRONTEND V6.0.0 IS RELEASED
 // AND USED ON THE SITE
 

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -1,6 +1,7 @@
 {% extends "_generic.njk" %}
 
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "_status-callout.njk" import trialCallout %}
 
 {# If the theme ends in '…', then we nest the caption inside the H1 so that the
   H1 becomes e.g. 'Ask users for dates'. Otherwise, we put it before the H1. #}
@@ -26,14 +27,9 @@
         {{ title }}
       </h1>
 
-      {% if status %}
-      <aside class="govuk-!-margin-bottom-8" aria-label="Guidance status">
-        <strong class="govuk-tag govuk-!-margin-bottom-2">
-          {{ status }}
-        </strong>
-        <p class="govuk-body">{{ statusMessage | safe }}</p>
-      </aside>
-      {% endif %}
+      {%- if (status == "trial") or (status.type == "trial") %}
+        {{ trialCallout(status) }}
+      {%- endif %}
 
       {% if showPageNav %}
         <ul class="app-page-navigation">

--- a/views/macros/_status-callout.njk
+++ b/views/macros/_status-callout.njk
@@ -25,13 +25,19 @@
 {{ content | safe }}
 
 {%- if params.links %}
-<ul class="govuk-list">
+{%- if params.links | length > 1 %}
+<ul class="govuk-list app-status-callout__list">
 {%- for item in params.links %}
 <li><a class="govuk-link" href="{{ item.href }}">
   {{- item.html | safe if item.html else item.text -}}
 </a></li>
 {%- endfor %}
 </ul>
+{%- else %}
+<p class="govuk-body"><a class="govuk-link" href="{{ params.links[0].href }}">
+  {{- params.links[0].html | safe if params.links[0].html else params.links[0].text -}}
+</a></p>
+{%- endif %}
 {%- endif %}
 
 {%- endcall %}

--- a/views/macros/_status-callout.njk
+++ b/views/macros/_status-callout.njk
@@ -3,58 +3,61 @@
 
 {# Generic macro that other callouts can inherit from. #}
 {% macro _statusCallout(settings, params) %}
-{%- set content -%}
-  {%- if caller %}
-    {{ caller() }}
-  {%- elif params.html %}
-    {{ params.html | safe }}
-  {%- elif params.text %}
-    <p class="govuk-body">{{ params.text }}</p>
-  {%- else %}
-    {{ settings.content | safe }}
-  {%- endif %}
-{%- endset -%}
+  {%- set content -%}
+    {% if caller %}
+      {{ caller() }}
+    {% elif params.html %}
+      {{ params.html | safe }}
+    {% elif params.text %}
+      <p class="govuk-body">{{ params.text }}</p>
+    {% else %}
+      {{ settings.content | safe }}
+    {% endif %}
+  {%- endset -%}
 
-{%- call govukInsetText({
-  classes: "app-status-callout" + (" " + settings.classes if settings.classes)
-}) %}
-{{ govukTag({
-  classes: "app-status-callout__tag govuk-tag--" + settings.statusTagColour,
-  text: settings.statusName
-}) }}
-{{ content | safe }}
+  {%- call govukInsetText({
+    classes: "app-status-callout" + (" " + settings.classes if settings.classes)
+  }) %}
+    {{ govukTag({
+      classes: "app-status-callout__tag govuk-tag--" + settings.statusTagColour,
+      text: settings.statusName
+    }) }}
+    {{ content | safe }}
 
-{%- if params.links %}
-{%- if params.links | length > 1 %}
-<ul class="govuk-list app-status-callout__list">
-{%- for item in params.links %}
-<li><a class="govuk-link" href="{{ item.href }}">
-  {{- item.html | safe if item.html else item.text -}}
-</a></li>
-{%- endfor %}
-</ul>
-{%- else %}
-<p class="govuk-body"><a class="govuk-link" href="{{ params.links[0].href }}">
-  {{- params.links[0].html | safe if params.links[0].html else params.links[0].text -}}
-</a></p>
-{%- endif %}
-{%- endif %}
-
-{%- endcall %}
+    {%- if params.links %}
+      {%- if params.links | length > 1 %}
+        <ul class="govuk-list app-status-callout__list">
+          {%- for item in params.links -%}
+            <li>
+              <a class="govuk-link" href="{{ item.href }}">
+                {{- item.html | safe if item.html else item.text -}}
+              </a>
+            </li>
+          {%- endfor -%}
+        </ul>
+      {%- else %}
+        <p class="govuk-body">
+          <a class="govuk-link" href="{{ params.links[0].href }}">
+            {{- params.links[0].html | safe if params.links[0].html else params.links[0].text -}}
+          </a>
+        </p>
+      {%- endif %}
+    {%- endif %}
+  {%- endcall %}
 {% endmacro %}
 
 {# Trial status #}
 {% macro trialCallout(params) %}
-{%- set defaultContent %}
-<p class="govuk-body">This component is being actively developed and may change significantly before being stabilised.</p>
-{%- endset %}
+  {%- set defaultContent -%}
+  <p class="govuk-body">This component is being actively developed and may change significantly before being stabilised.</p>
+  {%- endset -%}
 
-{%- set settings = {
-  classes: "app-status-callout--trial",
-  statusName: "Trial",
-  statusTagColour: "orange",
-  content: defaultContent
-} %}
+  {%- set settings = {
+    classes: "app-status-callout--trial",
+    statusName: "Trial",
+    statusTagColour: "orange",
+    content: defaultContent
+  } -%}
 
-{{- _statusCallout(settings, params) -}}
+  {{- _statusCallout(settings, params) -}}
 {% endmacro %}

--- a/views/macros/_status-callout.njk
+++ b/views/macros/_status-callout.njk
@@ -19,7 +19,7 @@
   classes: "app-status-callout" + (" " + settings.classes if settings.classes)
 }) %}
 {{ govukTag({
-  classes: "govuk-tag--" + settings.statusTagColour,
+  classes: "app-status-callout__tag govuk-tag--" + settings.statusTagColour,
   text: settings.statusName
 }) }}
 {{ content | safe }}

--- a/views/macros/_status-callout.njk
+++ b/views/macros/_status-callout.njk
@@ -1,0 +1,54 @@
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+{# Generic macro that other callouts can inherit from. #}
+{% macro _statusCallout(settings, params) %}
+{%- set content -%}
+  {%- if caller %}
+    {{ caller() }}
+  {%- elif params.html %}
+    {{ params.html | safe }}
+  {%- elif params.text %}
+    <p class="govuk-body">{{ params.text }}</p>
+  {%- else %}
+    {{ settings.content | safe }}
+  {%- endif %}
+{%- endset -%}
+
+{%- call govukInsetText({
+  classes: "app-status-callout" + (" " + settings.classes if settings.classes)
+}) %}
+{{ govukTag({
+  classes: "govuk-tag--" + settings.statusTagColour,
+  text: settings.statusName
+}) }}
+{{ content | safe }}
+
+{%- if params.links %}
+<ul class="govuk-list">
+{%- for item in params.links %}
+<li><a class="govuk-link" href="{{ item.href }}">
+  {{- item.html | safe if item.html else item.text -}}
+</a></li>
+{%- endfor %}
+</ul>
+{%- endif %}
+
+{%- endcall %}
+{% endmacro %}
+
+{# Trial status #}
+{% macro trialCallout(params) %}
+{%- set defaultContent %}
+<p class="govuk-body">This component is being actively developed and may change significantly before being stabilised.</p>
+{%- endset %}
+
+{%- set settings = {
+  classes: "app-status-callout--trial",
+  statusName: "Trial",
+  statusTagColour: "orange",
+  content: defaultContent
+} %}
+
+{{- _statusCallout(settings, params) -}}
+{% endmacro %}


### PR DESCRIPTION
Adds lifecycle statuses for component guidance pages. 

See it in action on [the Feedback component guidance](https://deploy-preview-5543--govuk-design-system-preview.netlify.app/components/feedback/). 

Successor to #5471. Resolves #5535.

## Changes
- Added status callout macro.
  - Status-specific macros inherit from this internal `_statusCallout` macro that defines the common layout and content of the callouts.
- Added `trialCallout` macro.
  - This macro defines the default labelling and messaging that trial components will display, though these can be extended or overridden on a per-page basis. 
- Removed some code relating to the old experimental status system.

### Screenshots

<img width="708" height="492" alt="Screenshot of the feedback component with a large trial box at the top, an orange rectangle with a more saturated orange border, with text explaining what trial status means and a few links to relevant sections of the page." src="https://github.com/user-attachments/assets/4b60a541-4206-4a61-b0f3-f3ad029c2e41" />

### Usage

The trial status can be shown on a page by modifying that page's front matter. 

Because a lot of the repetitious content is defined within the macro, this can be done by only setting the `status` property:

```yml
status: trial
```

Further information can be provided by passing an object to `status`, with the status being defined using the `type` child property.

```yml
status: 
  type: trial
  links:
    - href: https://github.com/...
      text: Provide feedback on GitHub Discussions
```

If being used for only part of a page, then it has to be imported and invoked as per Nunjucks conventions:

```njk
{% from "_status-callout.njk" import trialCallout %}

{{ trialCallout({
  text: "I'm some lovely content.",
  links: [
    {
      href: "https://github.com/...",
      text: "Provide feedback on GitHub Discussions"
    }
  ]
}) }}
```

When used in this way, internal content can be overwritten by calling the component, instead of using the `text` or `html` parameters. 

```njk
{% from "_status-callout.njk" import trialCallout %}

{% call trialCallout({
  links: [
    {
      href: "https://github.com/...",
      text: "Provide feedback on GitHub Discussions"
    }
  ]
}) %}
<p>I'm some lovely content.</p>
{% endcall %}
```

## Thoughts
The 'two-tier' macro structure is intended to provide futureproofing for potential later changes to the lifecycle status system (e.g. to add 'deprecated' or 'retired' labels, or a visible 'stable' label.)

The callouts have been implemented as macros, in part, because of the possibility that we don't want to apply the label to an entire page (e.g. for variants of existing components). 

The inclusion of the status as part of the page template (and not just a macro) is for three reasons:

1. It makes it easier for content editors to include the callout on pages without potentially requiring developer help.
2. It causes the callout to render above the in-page mobile navigation on pages that include one (mainly style pages at the moment).
3. This is what we did with the previous experimental label.
