### PR TITLE
[SPIKE] Changelogs on child pages of their respective thing

### DIFF
--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -59,7 +59,8 @@ module.exports = (config) => (files, metalsmith, done) => {
             : undefined,
 
         // Additional search terms (optional)
-        aliases: frontmatter.aliases?.split(',').map((string) => string.trim())
+        aliases: frontmatter.aliases?.split(',').map((string) => string.trim()),
+        history: frontmatter.history
       })
     }
 

--- a/src/components/generic-header/history/index.md
+++ b/src/components/generic-header/history/index.md
@@ -1,0 +1,73 @@
+---
+title: Generic header - Change history
+layout: layout-pane.njk
+---
+
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+Change history for [Generic header](/components/text-input).
+
+<div class="app-changelog-table">
+
+{{ govukTable({
+  caption: "Generic header change history",
+  head: [
+    {
+      text: "Date"
+    },
+    {
+      text: "Version"
+    },
+    {
+      text: "Changes"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "26 Mar 2024"
+      },
+      {
+        text: "5.3.0"
+      },
+      {
+        text: "Component introduced."
+      }
+    ],
+    [
+      {
+        text: "19 Apr 2024"
+      },
+      {
+        text: "5.3.1"
+      },
+      {
+        text: "Fixed issue with button growing larger if the text input has a capped width."
+      }
+    ],
+    [
+      {
+        text: "17 May 2024"
+      },
+      {
+        text: "5.4.0"
+      },
+      {
+        text: "Removed duplicate `errorMessage` parameter."
+      }
+    ],
+    [
+      {
+        text: "4 Mar 2025"
+      },
+      {
+        text: "5.9.0"
+      },
+      {
+        text: "The `id` parameter now defaults to match `name` if an `id` isn't provided."
+      }
+    ]
+  ]
+}) }}
+
+</div>

--- a/src/components/password-input/history/index.md
+++ b/src/components/password-input/history/index.md
@@ -1,0 +1,73 @@
+---
+title: Password input - Change history
+layout: layout-pane.njk
+---
+
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+Change history for [Password Input](/components/password-input).
+
+<div class="app-changelog-table">
+
+{{ govukTable({
+  caption: "Password Input change history",
+  head: [
+    {
+      text: "Date"
+    },
+    {
+      text: "Version"
+    },
+    {
+      text: "Changes"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "26 Mar 2024"
+      },
+      {
+        text: "5.3.0"
+      },
+      {
+        text: "Component introduced."
+      }
+    ],
+    [
+      {
+        text: "19 Apr 2024"
+      },
+      {
+        text: "5.3.1"
+      },
+      {
+        text: "Fixed issue with button growing larger if the text input has a capped width."
+      }
+    ],
+    [
+      {
+        text: "17 May 2024"
+      },
+      {
+        text: "5.4.0"
+      },
+      {
+        text: "Removed duplicate `errorMessage` parameter."
+      }
+    ],
+    [
+      {
+        text: "4 Mar 2025"
+      },
+      {
+        text: "5.9.0"
+      },
+      {
+        text: "The `id` parameter now defaults to match `name` if an `id` isn't provided."
+      }
+    ]
+  ]
+}) }}
+
+</div>

--- a/src/components/password-input/index.md
+++ b/src/components/password-input/index.md
@@ -5,6 +5,8 @@ section: Components
 aliases: pass word, pass phrase
 backlogIssueId: 240
 layout: layout-pane.njk
+showPageNav: true
+history: true
 ---
 
 {% from "_example.njk" import example %}

--- a/src/components/text-input/history/index.md
+++ b/src/components/text-input/history/index.md
@@ -1,0 +1,73 @@
+---
+title: Text input - Change history
+layout: layout-pane.njk
+---
+
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+Change history for [Text input](/components/text-input).
+
+<div class="app-changelog-table">
+
+{{ govukTable({
+  caption: "Text input change history",
+  head: [
+    {
+      text: "Date"
+    },
+    {
+      text: "Version"
+    },
+    {
+      text: "Changes"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "26 Mar 2024"
+      },
+      {
+        text: "5.3.0"
+      },
+      {
+        text: "Component introduced."
+      }
+    ],
+    [
+      {
+        text: "19 Apr 2024"
+      },
+      {
+        text: "5.3.1"
+      },
+      {
+        text: "Fixed issue with button growing larger if the text input has a capped width."
+      }
+    ],
+    [
+      {
+        text: "17 May 2024"
+      },
+      {
+        text: "5.4.0"
+      },
+      {
+        text: "Removed duplicate `errorMessage` parameter."
+      }
+    ],
+    [
+      {
+        text: "4 Mar 2025"
+      },
+      {
+        text: "5.9.0"
+      },
+      {
+        text: "The `id` parameter now defaults to match `name` if an `id` isn't provided."
+      }
+    ]
+  ]
+}) }}
+
+</div>

--- a/src/components/text-input/index.md
+++ b/src/components/text-input/index.md
@@ -9,6 +9,8 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
+See the [change history](/components/text-input/history) for the Text input component
+
 {{ example({ group: "components", item: "text-input", example: "default", html: true, nunjucks: true, open: false, size: "s", loading: "eager" }) }}
 
 ## When to use this component

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -106,7 +106,7 @@ $app-code-color: #d13118;
   h5,
   h6,
   p,
-  ul:not(.app-tabs), // stylelint-disable-line selector-no-qualifying-type
+  ul:not(.app-tabs):not(.app-guidance-tabs), /* stylelint-disable-line selector-no-qualifying-type*/
   ol,
   img,
   video,
@@ -366,4 +366,34 @@ pre .language-plaintext {
 // This will be fixed in the next release of GOV.UK Frontend
 .govuk-service-navigation__toggle {
   @include govuk-font($size: 19, $weight: bold);
+}
+
+.app-guidance-tabs {
+  @include govuk-font($size: 19);
+  display: flex;
+  margin: 0 0 govuk-spacing(4);
+  padding: 0;
+  border-bottom: 1px solid govuk-functional-colour(border);
+  list-style: none;
+}
+
+.app-guidance-tabs__item {
+  box-sizing: border-box;
+  margin-right: govuk-spacing(6);
+  padding-bottom: govuk-spacing(1);
+  list-style: none;
+
+  &:last-child {
+    margin: 0;
+  }
+}
+
+.app-guidance-tabs__item--current {
+  @include govuk-typography-weight-bold;
+  border-bottom: 3px solid govuk-functional-colour(link);
+}
+
+.app-guidance-tabs__link {
+  @include govuk-link-style-no-underline;
+  @include govuk-link-style-no-visited-state;
 }

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -338,6 +338,15 @@ pre .language-plaintext {
   }
 }
 
+.app-changelog-table {
+  table-layout: fixed;
+
+  // Set first column to fixed width
+  td:first-child {
+    width: 6em;
+  }
+}
+
 .app-surface {
   border-bottom: 1px solid govuk-functional-colour("surface-border");
   color: govuk-functional-colour("surface-text");

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -49,6 +49,17 @@
         </ul>
       {% endif %}
 
+      {% if title == "Generic header" or title == "Generic header - Change history" %}
+        <ul class="app-guidance-tabs">
+          <li class="app-guidance-tabs__item{% if title == "Generic header" %} app-guidance-tabs__item--current{% endif %}">
+            <a href="/components/generic-header" class="app-guidance-tabs__link">Guidance</a>
+          </li>
+          <li class="app-guidance-tabs__item{% if title == "Generic header - Change history" %} app-guidance-tabs__item--current{% endif %}">
+            <a href="/components/generic-header/history" class="app-guidance-tabs__link">Change history</a>
+          </li>
+        </ul>
+      {% endif %}
+
       <div class="app-prose-scope">
         {{ contents | safe }}
       </div>

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -10,11 +10,20 @@
         {% endif %}
         <ul class="app-subnav__section">
         {% for subitem in items %}
-          <li class="app-subnav__section-item{% if subitem.url == permalink %} app-subnav__section-item--current{% endif %}">
-            <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/"{% if subitem.url == permalink %} aria-current="page"{% endif %}>
+          {% set isCurrentPage = ((subitem.url == permalink) or (subitem.url + "/history" == permalink)) %}
+          <li class="app-subnav__section-item{% if isCurrentPage %} app-subnav__section-item--current{% endif %}">
+            <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/"{% if isCurrentPage %} aria-current="page"{% endif %}>
               {{ subitem.label }}
             </a>
-            {% if (subitem.headings) and (subitem.url == permalink) %}
+            {% if (subitem.history or (subitem.url + "/history" == permalink)) and isCurrentPage %}
+              <ul class="app-subnav__section app-subnav__section--nested">
+                <li class="app-subnav__section-item">
+                  <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/history" >
+                    Change history
+                  </a>
+                </li>
+              </ul>
+            {% elif (subitem.headings) and isCurrentPage %}
               <ul class="app-subnav__section app-subnav__section--nested">
                 {% for link in subitem.headings %}
                   {% if link.depth == 2 and not link.ignoreInPageNav %}


### PR DESCRIPTION
## What and Why

Spikes 3 possible ideas for having changelogs on separate, child pages of the thing their a changelog for rather than being on the same page.

<img width="856" height="501" alt="Change history page" src="https://github.com/user-attachments/assets/da0ba325-c0c5-46ef-b32d-436a8081a38d" />

Part of https://github.com/alphagov/govuk-design-system/issues/5531 but does not resolve it. Builds on work done in https://github.com/alphagov/govuk-design-system/pull/5295.

This spike is to help assess both the wholesale concept of changelog pages and assess the technical feasibility of doing more with guidance child pages and having a deeper family tree of content compared to our current 2 generation system eg: Component as the parent section, Summary list as the child guidance.

## Ideas spiked

### Child page as nested list item in side nav

Applied to Password input

<img width="586" height="451" alt="Screenshot of side nav with password input ancestor" src="https://github.com/user-attachments/assets/0ad1fa8f-5bf2-4f11-821c-00ec769c4a13" />

### A link directly to history page at the top of its guidance

Applied to Text input

<img width="472" height="297" alt="Screenshot of text input page with link to change history at the top" src="https://github.com/user-attachments/assets/932937c2-a117-4df1-b246-bd54dcdc2480" />

### Tab design differentiating between guidance and change history

Applied to Generic header

<img width="837" height="338" alt="Screenshot of generic header guidance page with tab design" src="https://github.com/user-attachments/assets/55a17be1-8fd3-4c5c-8df4-4f66398c5d5d" />

<img width="841" height="298" alt="Screenshot of generic header change history page with tab design" src="https://github.com/user-attachments/assets/d7dad957-028c-48ec-9638-5a8951a51efc" />

## Notes

This is spike code and so there are a few messy bits in the implementation. IMO these shouldn't impact our ability to assess this work, but to note them:

- because this PR is testing multiple things, when you go into a change history page other than Password input you see the change history page as a subitem in the sidenav of the parent thing
- breadcrumbs in changlog pages don't include their parent component
- I copied the changelog for Password input to the other components tested
- For the nested list, I didn't also update the mobile-only subnav on pages with subnav