### PR TITLE
Fix link to "If your service is not on GOV.UK" on typeface page

### DIFF
--- a/src/styles/typeface/index.md
+++ b/src/styles/typeface/index.md
@@ -16,5 +16,5 @@ If your service is publicly available on a subdomain other than service.gov.uk, 
 
 If you’re not sure whether you should use GDS Transport, do one of the following:
 
-- read the service manual section [‘If your service is not on GOV.UK’ section on ‘Making your service look like GOV.UK’](https://www.gov.uk/service-manual/design/making-your-service-look-like-govuk#if-your-service-isnt-on-govuk)
+- read the service manual section [‘If your service is not on GOV.UK’ section on ‘Making your service look like GOV.UK’](https://www.gov.uk/service-manual/design/making-your-service-look-like-govuk#if-your-service-is-not-on-govuk)
 - contact the [Design System team](/contact/)


### PR DESCRIPTION
Slug in the URL's hash was not the right one.