### PR TITLE
Add trial status info on Feedback component

### DIFF
--- a/src/components/feedback/index.md
+++ b/src/components/feedback/index.md
@@ -56,6 +56,17 @@ You must include a link to a feedback page, which could be either:
 
 ## Research on this component
 
+During design exploration for this component, desk research suggested that services struggled to get enough feedback from users using a previous version of this component.
+
+This version separates the feedback link from the [Phase banner component](/components/phase-banner/).
+
+We've released this Feedback component in trial status as we want to understand whether:
+
+- moving the feedback link from the phase banner increases the amount of feedback services receive
+- placing the feedback link its own dedicated location helps users know where to provide feedback when they need to, by overcoming potential 'banner blindness' of the phase banner.
+
+Until we have enough evidence that these needs are being met, the component will remain in trial.
+
 We thank the service teams across government who worked with us in the early stages of this component to measure its effectiveness.
 
 We’d also like to thank the GOV.UK Forms team for helping us build this component.

--- a/src/components/feedback/index.md
+++ b/src/components/feedback/index.md
@@ -60,4 +60,13 @@ We’d also like to thank the GOV.UK Forms team for helping us build this compon
 
 ### Help us improve this component
 
-We're still working to improve this component and we’d like to get your feedback. If you've implemented this component and can tell us about how it’s working in your service, [contact the team](/contact/).
+We're still working to improve this component and we’d like to get your feedback. 
+
+If you've implemented this component, we'd like to know if it's an improvement over what you've used before to gather feedback. 
+
+We want to know how many of your users: 
+
+- use this component to go from your service to your feedback page, compared to before
+- start and complete your feedback form, compared to before
+
+Share your research in the ['Feedback' discussion on GitHub ADD LINK](#).


### PR DESCRIPTION
This PR adds a call to action for service teams to share their research using the trial version of the Feedback component.

Still need to add a link when the discussion space is ready.