### PR TITLE
Add statuses list to components landing page

### DIFF
--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -34,12 +34,8 @@ module.exports = (config) => (files, metalsmith, done) => {
     for (const itemPath of itemPaths) {
       const frontmatter = files[itemPath]
 
-      // Do not show drafts or ignored pages in navigation
-      if (
-        !frontmatter ||
-        frontmatter.status === 'Draft' ||
-        frontmatter.ignoreInSitemap
-      ) {
+      // Do not show ignored pages in navigation
+      if (!frontmatter || frontmatter.ignoreInSitemap) {
         continue
       }
 

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -39,6 +39,13 @@ module.exports = (config) => (files, metalsmith, done) => {
         continue
       }
 
+      // Prepare status information, if present. Otherwise, assume 'Stable'
+      const statusLabel = frontmatter.status
+        ? typeof frontmatter.status === 'string'
+          ? frontmatter.status
+          : frontmatter.status?.type
+        : 'Stable'
+
       item.items ??= []
 
       // Add subitem to navigation
@@ -47,6 +54,11 @@ module.exports = (config) => (files, metalsmith, done) => {
         label: frontmatter.title,
         order: frontmatter.order,
         theme: frontmatter.theme,
+        status: {
+          text: statusLabel,
+          classes:
+            statusLabel === 'Trial' ? 'govuk-tag--orange' : 'govuk-tag--blue'
+        },
 
         // Override Markdown extracted headings plugin (optional)
         headings:

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -39,13 +39,6 @@ module.exports = (config) => (files, metalsmith, done) => {
         continue
       }
 
-      // Prepare status information, if present. Otherwise, assume 'Stable'
-      const statusLabel = frontmatter.status
-        ? typeof frontmatter.status === 'string'
-          ? frontmatter.status
-          : frontmatter.status?.type
-        : 'Stable'
-
       item.items ??= []
 
       // Add subitem to navigation
@@ -54,11 +47,13 @@ module.exports = (config) => (files, metalsmith, done) => {
         label: frontmatter.title,
         order: frontmatter.order,
         theme: frontmatter.theme,
-        status: {
-          text: statusLabel,
-          classes:
-            statusLabel === 'Trial' ? 'govuk-tag--orange' : 'govuk-tag--blue'
-        },
+
+        // Status of this page. Defaults to 'Stable' if not set.
+        status: frontmatter.status
+          ? typeof frontmatter.status === 'string'
+            ? frontmatter.status
+            : frontmatter.status?.type
+          : 'Stable',
 
         // Override Markdown extracted headings plugin (optional)
         headings:

--- a/src/components/feedback/index.md
+++ b/src/components/feedback/index.md
@@ -5,7 +5,7 @@ section: Components
 discussionId: 4978
 layout: layout-pane.njk
 status: 
-  type: trial
+  type: Trial
   links:
     - href: "#research-on-this-component"
       text: Research on this component

--- a/src/components/index.md
+++ b/src/components/index.md
@@ -2,6 +2,7 @@
 layout: layout-pane.njk
 title: Components
 showSubNav: true
+showCategoryStatuses: true
 ---
 
 Components are reusable parts of a user interface. Using pre-built, core elements allows government teams to build consistent services.

--- a/src/stylesheets/components/_category-nav.scss
+++ b/src/stylesheets/components/_category-nav.scss
@@ -1,7 +1,7 @@
 @use "pkg:govuk-frontend/base" as *;
 
 .category-nav {
-  padding-top: govuk-spacing(5);
+  @include govuk-responsive-padding(7, $direction: top);
 
   @include govuk-media-query($from: tablet) {
     display: none;

--- a/src/stylesheets/components/_index.scss
+++ b/src/stylesheets/components/_index.scss
@@ -8,6 +8,7 @@
 @use "header";
 @use "highlight";
 @use "image-card";
+@use "lifecycle-statuses";
 @use "masthead";
 @use "mobile-navigation-section";
 @use "options";

--- a/src/stylesheets/components/_lifecycle-statuses.scss
+++ b/src/stylesheets/components/_lifecycle-statuses.scss
@@ -1,0 +1,40 @@
+@use "pkg:govuk-frontend/base" as *;
+
+// Tag colours for lifecycle statuses are defined using names, so the status to
+// colour pairing can be defined in CSS, rather than relying on syncronising
+// class names across uses
+
+$_statuses: (
+  "trial": "orange",
+  "stable": "blue"
+);
+
+@each $name, $colour in $_statuses {
+  .app-status-tag--#{$name} {
+    color: govuk-colour($colour, $variant: "shade-50");
+    background-color: govuk-colour($colour, $variant: "tint-80");
+  }
+
+  .app-status-callout--#{$name} {
+    border-left-color: govuk-colour($colour);
+    background-color: govuk-colour($colour, $variant: "tint-95");
+  }
+}
+
+.app-status-callout .app-status-tag {
+  margin-bottom: govuk-spacing(1);
+}
+
+// The element name is included here as this needs higher specificity to
+// override the list styles applied by .app-prose-scope
+//
+// stylelint-disable-next-line selector-no-qualifying-type
+ul.app-status-callout__list {
+  padding-left: 0;
+  list-style-type: none;
+}
+
+// Extra spacing before lifecycle status overview tables
+.app-status-table {
+  @include govuk-responsive-margin(7, $direction: top);
+}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -373,7 +373,7 @@ ul.app-status-callout__list {
 
 // Lifecycle status overview tables
 .app-status-table {
-  margin-top: govuk-spacing(5);
+  @include govuk-responsive-margin(7, $direction: top);
 }
 
 // REMOVE EACH RULE BELOW WHEN GOV.UK FRONTEND V6.0.0 IS RELEASED

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -371,6 +371,11 @@ ul.app-status-callout__list {
   list-style-type: none;
 }
 
+// Lifecycle status overview tables
+.app-status-table {
+  margin-top: govuk-spacing(5);
+}
+
 // REMOVE EACH RULE BELOW WHEN GOV.UK FRONTEND V6.0.0 IS RELEASED
 // AND USED ON THE SITE
 

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -350,32 +350,6 @@ pre .language-plaintext {
   margin: 0;
 }
 
-// Lifecycle status callouts (inherits from inset text component)
-.app-status-callout {
-  &.app-status-callout--trial {
-    border-left-color: govuk-colour("orange");
-    background-color: govuk-colour("orange", $variant: "tint-95");
-  }
-}
-
-.app-status-callout__tag {
-  margin-bottom: govuk-spacing(1);
-}
-
-// Element name is included here as this needs higher specificity to override
-// the styles applied by .app-prose-scope
-//
-// stylelint-disable-next-line selector-no-qualifying-type
-ul.app-status-callout__list {
-  padding-left: 0;
-  list-style-type: none;
-}
-
-// Lifecycle status overview tables
-.app-status-table {
-  @include govuk-responsive-margin(7, $direction: top);
-}
-
 // REMOVE EACH RULE BELOW WHEN GOV.UK FRONTEND V6.0.0 IS RELEASED
 // AND USED ON THE SITE
 

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -27,7 +27,7 @@
         {{ title }}
       </h1>
 
-      {%- if (status == "trial") or (status.type == "trial") %}
+      {%- if (status == "Trial") or (status.type == "Trial") %}
         {{ trialCallout(status) }}
       {%- endif %}
 
@@ -49,8 +49,11 @@
         {{ contents | safe }}
       </div>
 
-      {# No JS fallback to show overview #}
-      {% if showSubNav %}
+      {% if showCategoryStatuses %}
+        {# Show child pages with lifecycle statuses #}
+        {% include "_status-table.njk" %}
+      {% elif showSubNav %}
+        {# Show child pages as list #}
         {% include "_category-nav.njk" %}
       {% endif %}
 

--- a/views/macros/_status-callout.njk
+++ b/views/macros/_status-callout.njk
@@ -3,6 +3,8 @@
 
 {# Generic macro that other callouts can inherit from. #}
 {% macro _statusCallout(settings, params) %}
+  {%- set classSlug = settings.statusName | slugify %}
+
   {%- set content -%}
     {% if caller %}
       {{ caller() }}
@@ -16,10 +18,10 @@
   {%- endset -%}
 
   {%- call govukInsetText({
-    classes: "app-status-callout" + (" " + settings.classes if settings.classes)
+    classes: "app-status-callout app-status-callout--" + classSlug
   }) %}
     {{ govukTag({
-      classes: "app-status-callout__tag govuk-tag--" + settings.statusTagColour,
+      classes: "app-status-tag app-status-tag--" + classSlug,
       text: settings.statusName
     }) }}
     {{ content | safe }}
@@ -53,9 +55,7 @@
   {%- endset -%}
 
   {%- set settings = {
-    classes: "app-status-callout--trial",
     statusName: "Trial",
-    statusTagColour: "orange",
     content: defaultContent
   } -%}
 

--- a/views/partials/_status-table.njk
+++ b/views/partials/_status-table.njk
@@ -17,7 +17,10 @@
             },
             href: "/" + subitem.url + "/",
             status: {
-              tag: subitem.status
+              tag: {
+                text: subitem.status,
+                classes: "app-status-tag app-status-tag--" + (subitem.status | slugify)
+              }
             }
           }) %}
         {%- endfor %}

--- a/views/partials/_status-table.njk
+++ b/views/partials/_status-table.njk
@@ -1,0 +1,31 @@
+{%- from "govuk/components/task-list/macro.njk" import govukTaskList %}
+
+<div class="app-status-table">
+  {%- for item in navigation %}
+    {%- if permalink and item | isActive(permalink) %}
+      {%- for theme, items in item.items | groupby("theme") %}
+        {%- set sectionItems = [] %}
+
+        {%- if theme != 'undefined' %}
+          <h2 class="govuk-heading-m">{{ theme }}</h2>
+        {%- endif %}
+
+        {%- for subitem in items %}
+          {%- set sectionItems = sectionItems.concat({
+            title: {
+              text: subitem.label
+            },
+            href: "/" + subitem.url + "/",
+            status: {
+              tag: subitem.status
+            }
+          }) %}
+        {%- endfor %}
+
+        {{ govukTaskList({
+          items: sectionItems
+        }) }}
+      {%- endfor %}
+    {%- endif %}
+  {%- endfor %}
+</div>


### PR DESCRIPTION
Adds a list providing an overview of all components and their current statuses to the [component landing page](https://deploy-preview-5573--govuk-design-system-preview.netlify.app/components/).

Tied to #5537. 

## Changes
- Updated navigation generator code to include status information about a page.
  - If no status information is defined, the page is assumed to be 'Stable'.
- Added `status-table` partial that renders all children of the current page alongside their status information.
  - This is using the Task list component, as in the spike at #5481. 
- Added `showCategoryStatuses` frontmatter property that determines whether to show the status table. 
  - Because of the overlap in their content (both containing lists of links to child pages), if `showCategoryStatuses` is set it overrides the navigation that would be output by `showSubNav`. 
- Added new Sass partial for handling status tags and callouts together. This is so that status → colour associations can be handled in one place and partially automated by Sass, instead of being split across multiple places. 

### Indirect changes
- Changed the capitalisation of the trial status in frontmatter. It's now sentence case ('Trial'), as this avoids needing to manipulate the formatting of the status text in the component list.
- Removed some old functionality that automatically removed a page from the navigation if it had `status: Draft` in the frontmatter. 
  - This status hasn't been used for some time and it has the potential to conflict with the new lifecycle status functionality. 
  - Removing a page from navigation is still possible using the `ignoreInSitemap` property. 

## Thoughts

My assumption that any page missing status information is automatically 'Stable' is just that: an assumption. I _think_ it makes sense, but maybe there's some edge case I'm not thinking of. 
