### PR TITLE
[SPIKE] Add `hasHistory` param to page metadata

### DIFF
--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -43,6 +43,11 @@ module.exports = (config) => (files, metalsmith, done) => {
         continue
       }
 
+      // set hasHistory here so it's available outside of navigation data
+      frontmatter.hasHistory =
+        metalsmith.match(`${dirname(itemPath)}/history/index.html`, paths)
+          .length > 0
+
       item.items ??= []
 
       // Add subitem to navigation
@@ -59,7 +64,8 @@ module.exports = (config) => (files, metalsmith, done) => {
             : undefined,
 
         // Additional search terms (optional)
-        aliases: frontmatter.aliases?.split(',').map((string) => string.trim())
+        aliases: frontmatter.aliases?.split(',').map((string) => string.trim()),
+        hasHistory: frontmatter.hasHistory
       })
     }
 

--- a/lib/nunjucks/globals.js
+++ b/lib/nunjucks/globals.js
@@ -148,6 +148,22 @@ exports.getAncestorPages = function (targetUrl) {
         ancestors.push({ text: navItem.label, href: `/${navItem.url}` })
         traverse(navItem.items)
       }
+
+      // If a navItem doesn't have any child pages, meaning the loop would end,
+      // but does have a history page and the target url is both active and is
+      // a history page itself,  manually add the current nav item to ancestors
+      // and break the loop.
+      // We do this outside the traverse function's recursion because history
+      // pages aren't added to navigation and therefore won't show up when
+      // traversing navigation.
+      if (
+        navItem.hasHistory &&
+        isActive(navItem, targetUrl) &&
+        targetUrl.endsWith('history')
+      ) {
+        ancestors.push({ text: navItem.label, href: `/${navItem.url}` })
+        break
+      }
     }
   }
 

--- a/src/components/password-input/history/index.md
+++ b/src/components/password-input/history/index.md
@@ -1,0 +1,72 @@
+---
+title: Password input - Change history
+layout: layout-pane.njk
+---
+
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+Change history for [Password Input](/components/password-input).
+
+<div class="app-changelog-table">
+
+{{ govukTable({
+  head: [
+    {
+      text: "Date"
+    },
+    {
+      text: "Version"
+    },
+    {
+      text: "Changes"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "26 Mar 2024"
+      },
+      {
+        text: "5.3.0"
+      },
+      {
+        text: "Component introduced."
+      }
+    ],
+    [
+      {
+        text: "19 Apr 2024"
+      },
+      {
+        text: "5.3.1"
+      },
+      {
+        text: "Fixed issue with button growing larger if the text input has a capped width."
+      }
+    ],
+    [
+      {
+        text: "17 May 2024"
+      },
+      {
+        text: "5.4.0"
+      },
+      {
+        text: "Removed duplicate `errorMessage` parameter."
+      }
+    ],
+    [
+      {
+        text: "4 Mar 2025"
+      },
+      {
+        text: "5.9.0"
+      },
+      {
+        text: "The `id` parameter now defaults to match `name` if an `id` isn't provided."
+      }
+    ]
+  ]
+}) }}
+
+</div>

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -32,7 +32,7 @@
   background-color: govuk-colour("white");
 }
 
-.app-subnav__section-item--current .app-subnav__link {
+.app-subnav__section-item--current .app-subnav__link[aria-current="page"] {
   font-weight: bold;
 }
 

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -349,3 +349,33 @@ pre .language-plaintext {
 .app-nunjucks-options-list h4 {
   margin: 0;
 }
+
+.app-guidance-tabs {
+  @include govuk-font($size: 19);
+  display: flex;
+  margin: 0 0 govuk-spacing(4);
+  padding: 0;
+  border-bottom: 1px solid govuk-functional-colour(border);
+  list-style: none;
+}
+
+.app-guidance-tabs__item {
+  box-sizing: border-box;
+  margin-right: govuk-spacing(6);
+  padding-bottom: govuk-spacing(1);
+  list-style: none;
+
+  &:last-child {
+    margin: 0;
+  }
+}
+
+.app-guidance-tabs__item--current {
+  @include govuk-typography-weight-bold;
+  border-bottom: 3px solid govuk-functional-colour(link);
+}
+
+.app-guidance-tabs__link {
+  @include govuk-link-style-no-underline;
+  @include govuk-link-style-no-visited-state;
+}

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -35,17 +35,26 @@
       </aside>
       {% endif %}
 
-      {% if showPageNav %}
+      {% if showPageNav or hasHistory %}
         <ul class="app-page-navigation">
-          {% for heading in headings %}
-            {% if heading.depth == 2 %}
-              <li class="app-page-navigation__item">
-                <a class="govuk-link" href="#{{ heading.url}}">
-                  {{ heading.text }}
-                </a>
-              </li>
-            {% endif %}
-          {% endfor %}
+          {% if hasHistory %}
+            <li class="app-page-navigation__item">
+              <a class="govuk-link" href="/{{ permalink }}/history">
+                History<span class="govuk-visually-hidden"> of {{ subitem.label }}</span>
+              </a>
+            </li>
+          {% endif %}
+          {% if showPageNav %}
+            {% for heading in headings %}
+              {% if heading.depth == 2 %}
+                <li class="app-page-navigation__item">
+                  <a class="govuk-link" href="#{{ heading.url}}">
+                    {{ heading.text }}
+                  </a>
+                </li>
+              {% endif %}
+            {% endfor %}
+          {% endif %}
         </ul>
       {% endif %}
 

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -10,21 +10,33 @@
         {% endif %}
         <ul class="app-subnav__section">
         {% for subitem in items %}
-          <li class="app-subnav__section-item{% if subitem.url == permalink %} app-subnav__section-item--current{% endif %}">
-            <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/"{% if subitem.url == permalink %} aria-current="page"{% endif %}>
+          {% set isCurrentPage = subitem.url == permalink %}
+          {% set isCurrentHistoryPage = subitem.url + "/history" == permalink %}
+          {% set isCurrentItem = isCurrentPage or isCurrentHistoryPage %}
+          <li class="app-subnav__section-item{% if isCurrentItem %} app-subnav__section-item--current{% endif %}">
+            <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/"{% if isCurrentPage %} aria-current="page"{% endif %}>
               {{ subitem.label }}
             </a>
-            {% if (subitem.headings) and (subitem.url == permalink) %}
+            {% if (subitem.headings or subitem.hasHistory) and isCurrentItem %}
               <ul class="app-subnav__section app-subnav__section--nested">
-                {% for link in subitem.headings %}
-                  {% if link.depth == 2 and not link.ignoreInPageNav %}
-                    <li class="app-subnav__section-item">
-                      <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/#{{ link.url }}" >
-                        {{ link.text }}
-                      </a>
-                    </li>
-                  {% endif %}
-                {% endfor %}
+                {% if subitem.hasHistory %}
+                  <li class="app-subnav__section-item">
+                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/history"{% if isCurrentHistoryPage %} aria-current="page"{% endif %}>
+                      History<span class="govuk-visually-hidden"> of {{ subitem.label }}</span>
+                    </a>
+                  </li>
+                {% endif %}
+                {% if subitem.headings %}
+                  {% for link in subitem.headings %}
+                    {% if link.depth == 2 and not link.ignoreInPageNav %}
+                      <li class="app-subnav__section-item">
+                        <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/#{{ link.url }}" >
+                          {{ link.text }}
+                        </a>
+                      </li>
+                    {% endif %}
+                  {% endfor %}
+                {% endif %}
               </ul>
             {% endif %}
           </li>


### PR DESCRIPTION
## Changes

Descendant spike of https://github.com/alphagov/govuk-design-system/pull/5544. Related to https://github.com/alphagov/govuk-design-system/issues/5531

Adds a `hasHistory` parameter to each page's frontmatter and navigation items. This checks specifically if a given page has a child page of "history" to help with rendering navigation to account for history child pages. Uses the sidenav sub-page solution from the previous spike.

Additionally adjusts the active styling for sub-sub sidenav lists so account for if a page's child page is the current page, letting us keep the section active but the actual page the user is on highlighted.

<img width="191" height="124" alt="Password input section with history sub-page highlighted" src="https://github.com/user-attachments/assets/cd2d76a5-12a6-4ff2-ac0f-bf1469c82fa5" />

## Thoughts

There's a possibility for this to be more generic to account for other potential child pages we want eg: nunjucks macros or acknowledgements. A way we could do this is by instead of a specific `hasHistory` param, we have:

- `hasChildPages` which applies the same check for a history page against a list of other specific pages we want to check for
- `childPages` which lets us iterate over which child pages from that predefined list a given guidance page has

I'm not super happy about setting `hasHistory` within the navigation plugin but that plugin is currently the best place to do per-page processing as it retrieves `itemPaths` and sets up iteration over `files` relating to `itemPaths`. We are also replicating information we want at the page level and in navigation via `hasHistory`.

If we go forward with this, it may be valuable to either extract retrieving `itemPaths` into it's own helper which other plugins can iterate over or giving the navigation plugin a more generic name like `addPerPageData`. 


