### PR TITLE
Add examples to the Language navigation guidance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.1.1",
         "glob": "^13.0.6",
-        "govuk-frontend": "github:alphagov/govuk-frontend#6002a27e1",
+        "govuk-frontend": "github:alphagov/govuk-frontend#2c85605f5",
         "gray-matter": "^4.0.2",
         "highlight.js": "^11.11.1",
         "html-validate": "^11.5.5",
@@ -11170,8 +11170,8 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "6.4.0-feedback-component",
-      "resolved": "git+ssh://git@github.com/alphagov/govuk-frontend.git#6002a27e1adf472942e9faa665e341cca2a2d200",
+      "version": "6.4.0-feature-language-switcher",
+      "resolved": "git+ssh://git@github.com/alphagov/govuk-frontend.git#2c85605f5a2c0df507cd01107343ec1288800123",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",
     "glob": "^13.0.6",
-    "govuk-frontend": "github:alphagov/govuk-frontend#6002a27e1",
+    "govuk-frontend": "github:alphagov/govuk-frontend#2c85605f5",
     "gray-matter": "^4.0.2",
     "highlight.js": "^11.11.1",
     "html-validate": "^11.5.5",

--- a/src/components/language-navigation/after-h1/index.njk
+++ b/src/components/language-navigation/after-h1/index.njk
@@ -1,0 +1,38 @@
+---
+title: Language navigation after H1
+layout: layout-example-full-page.njk
+---
+{% extends "example-wrappers/full-page.njk" %}
+
+{% from "govuk/components/language-navigation/macro.njk" import govukLanguageNavigation %}
+
+{% block content %}
+  <!--
+    Note the override class adding the same margin
+    as the heading would have to this `<div>`
+  -->
+  <div class="govuk-!-margin-bottom-8">
+    <!--
+      Note the override class setting a smaller margin between
+      the heading and the Language navigation
+    -->
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Find protected areas of countryside</h1>
+    {{ govukLanguageNavigation({
+      items: [
+        {
+          text: "English",
+          lang: "en",
+          href: "#",
+          current: true
+        },
+        {
+          text: "Cymraeg",
+          lang: "cy",
+          href: "#"
+        }
+      ]
+    }) }}
+  </div>
+  <p class="govuk-body">Nature sites and areas of countryside can be ‘designated’, which means they have special status as protected areas because of their natural and cultural importance.</p>
+  <p class="govuk-body">...</p>
+{% endblock %}

--- a/src/components/language-navigation/default/index.njk
+++ b/src/components/language-navigation/default/index.njk
@@ -1,0 +1,22 @@
+---
+title: Language navigation
+layout: layout-example.njk
+---
+
+{% from "govuk/components/language-navigation/macro.njk" import govukLanguageNavigation %}
+
+{{ govukLanguageNavigation({
+  items: [
+    {
+      text: "English",
+      lang: "en",
+      href: "#",
+      current: true
+    },
+    {
+      text: "Cymraeg",
+      lang: "cy",
+      href: "#"
+    }
+  ]
+}) }}

--- a/src/components/language-navigation/index.md
+++ b/src/components/language-navigation/index.md
@@ -79,6 +79,14 @@ Make sure to translate:
 - the `aria-label` (or `ariaLabel` in Nunjucks) to be in the language of the page it is on (it says “Language navigation” by default)
 - the hidden text behind each item (`languageDescriptionText` in Nunjucks) to be in the language of the item
 
+### Language navigation on dark backgrounds
+
+Use the `govuk-language-navigation--inverse` modifier class to show white links and text on a dark background – for example, inside a Service navigation with a dark background.
+
+Make sure all users can see the breadcrumbs – the background colour must have a contrast ratio of at least 4.5:1 with white to [meet WCAG 2.2 success criterion 1.4.3 Contrast (minimum), level AA](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html).
+
+{{ example({ group: "components", item: "language-navigation", example: "inverse", html: true, nunjucks: true, open: false }) }}
+
 ## Designing services that offer multiple languages
 
 GOV.UK Content and publishing guidance gives some advice on things you need to [consider when translating content](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/plan-manage-content/consider-translations/).

--- a/src/components/language-navigation/index.md
+++ b/src/components/language-navigation/index.md
@@ -18,7 +18,7 @@ status:
 
 The Language navigation component helps users choose and switch between languages when using a service.
 
-[CODE EXAMPLE]
+{{ example({ group: "components", item: "language-navigation", example: "default", html: true, nunjucks: true, open: false, loading: "eager" }) }}
 
 ## When to use this component
 

--- a/src/components/language-navigation/index.md
+++ b/src/components/language-navigation/index.md
@@ -61,7 +61,7 @@ You could place the language navigation at the top of a page, after the `h1` ele
 
 This helps users find their preferred language as quickly as possible.
 
-[CODE EXAMPLE]
+{{ example({ group: "components", item: "language-navigation", example: "after-h1", html: true, nunjucks: true, open: false }) }}
 
 ### If you offer your whole service in another language
 

--- a/src/components/language-navigation/inverse/index.njk
+++ b/src/components/language-navigation/inverse/index.njk
@@ -1,0 +1,25 @@
+---
+title: Invers Language navigation - Language navigation
+layout: layout-example.njk
+stylesheets:
+- ../../../stylesheets/example-inverse.css
+---
+
+{% from "govuk/components/language-navigation/macro.njk" import govukLanguageNavigation %}
+
+{{ govukLanguageNavigation({
+  classes: 'govuk-language-navigation--inverse',
+  items: [
+    {
+      text: "English",
+      lang: "en",
+      href: "#",
+      current: true
+    },
+    {
+      text: "Cymraeg",
+      lang: "cy",
+      href: "#"
+    }
+  ]
+}) }}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -18,6 +18,7 @@
 @use "pkg:govuk-frontend/components/input";
 @use "pkg:govuk-frontend/components/inset-text";
 @use "pkg:govuk-frontend/components/label";
+@use "pkg:govuk-frontend/components/language-navigation";
 @use "pkg:govuk-frontend/components/notification-banner";
 @use "pkg:govuk-frontend/components/pagination";
 @use "pkg:govuk-frontend/components/panel";


### PR DESCRIPTION
Adds the following examples to the Language navigation guidance:
- [A default example showing the component on its own](https://deploy-preview-5578--govuk-design-system-preview.netlify.app/components/language-navigation/)
- [An example showing how the component can be inserted after the page's `h1`](https://deploy-preview-5578--govuk-design-system-preview.netlify.app/components/language-navigation/#if-you-only-offer-specific-pages-in-another-language)
- [An example showing the component over a dark background](https://deploy-preview-5578--govuk-design-system-preview.netlify.app/components/language-navigation/#language-navigation-on-dark-backgrounds)