### PR TITLE
Refactor component lifecycle statuses

### DIFF
--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -34,12 +34,8 @@ module.exports = (config) => (files, metalsmith, done) => {
     for (const itemPath of itemPaths) {
       const frontmatter = files[itemPath]
 
-      // Do not show drafts or ignored pages in navigation
-      if (
-        !frontmatter ||
-        frontmatter.status === 'Draft' ||
-        frontmatter.ignoreInSitemap
-      ) {
+      // Do not show ignored pages in navigation
+      if (!frontmatter || frontmatter.ignoreInSitemap) {
         continue
       }
 

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -48,6 +48,13 @@ module.exports = (config) => (files, metalsmith, done) => {
         order: frontmatter.order,
         theme: frontmatter.theme,
 
+        // Status of this page. Defaults to 'Stable' if not set.
+        status: frontmatter.status
+          ? typeof frontmatter.status === 'string'
+            ? frontmatter.status
+            : frontmatter.status?.type
+          : 'Stable',
+
         // Override Markdown extracted headings plugin (optional)
         headings:
           frontmatter.headings && frontmatter.showPageNav

--- a/src/components/feedback/index.md
+++ b/src/components/feedback/index.md
@@ -5,7 +5,7 @@ section: Components
 discussionId: 4978
 layout: layout-pane.njk
 status: 
-  type: trial
+  type: Trial
   links:
     - href: "#research-on-this-component"
       text: Research on this component

--- a/src/stylesheets/components/_index.scss
+++ b/src/stylesheets/components/_index.scss
@@ -8,6 +8,7 @@
 @use "header";
 @use "highlight";
 @use "image-card";
+@use "lifecycle-statuses";
 @use "masthead";
 @use "mobile-navigation-section";
 @use "options";

--- a/src/stylesheets/components/_lifecycle-statuses.scss
+++ b/src/stylesheets/components/_lifecycle-statuses.scss
@@ -1,0 +1,40 @@
+@use "pkg:govuk-frontend/base" as *;
+
+// Tag colours for lifecycle statuses are defined using names, so the status to
+// colour pairing can be defined in CSS, rather than relying on syncronising
+// class names across uses
+
+$_statuses: (
+  "trial": "orange",
+  "stable": "blue"
+);
+
+@each $name, $colour in $_statuses {
+  .app-status-tag--#{$name} {
+    color: govuk-colour($colour, $variant: "shade-50");
+    background-color: govuk-colour($colour, $variant: "tint-80");
+  }
+
+  .app-status-callout--#{$name} {
+    border-left-color: govuk-colour($colour);
+    background-color: govuk-colour($colour, $variant: "tint-95");
+  }
+}
+
+.app-status-callout .app-status-tag {
+  margin-bottom: govuk-spacing(1);
+}
+
+// The element name is included here as this needs higher specificity to
+// override the list styles applied by .app-prose-scope
+//
+// stylelint-disable-next-line selector-no-qualifying-type
+ul.app-status-callout__list {
+  padding-left: 0;
+  list-style-type: none;
+}
+
+// Extra spacing before lifecycle status overview tables
+.app-status-table {
+  @include govuk-responsive-margin(7, $direction: top);
+}

--- a/src/stylesheets/components/_lifecycle-statuses.scss
+++ b/src/stylesheets/components/_lifecycle-statuses.scss
@@ -5,8 +5,7 @@
 // class names across uses
 
 $_statuses: (
-  "trial": "orange",
-  "stable": "blue"
+  "trial": "orange"
 );
 
 @each $name, $colour in $_statuses {

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -350,27 +350,6 @@ pre .language-plaintext {
   margin: 0;
 }
 
-// Lifecycle status callouts (inherits from inset text component)
-.app-status-callout {
-  &.app-status-callout--trial {
-    border-left-color: govuk-colour("orange");
-    background-color: govuk-colour("orange", $variant: "tint-95");
-  }
-}
-
-.app-status-callout__tag {
-  margin-bottom: govuk-spacing(1);
-}
-
-// Element name is included here as this needs higher specificity to override
-// the styles applied by .app-prose-scope
-//
-// stylelint-disable-next-line selector-no-qualifying-type
-ul.app-status-callout__list {
-  padding-left: 0;
-  list-style-type: none;
-}
-
 // REMOVE EACH RULE BELOW WHEN GOV.UK FRONTEND V6.0.0 IS RELEASED
 // AND USED ON THE SITE
 

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -27,7 +27,9 @@
         {{ title }}
       </h1>
 
-      {%- if (status == "Trial") or (status.type == "Trial") %}
+      {# Status callout #}
+      {% set statusTag = (status.type if status.type else status) | slugify if status %}
+      {%- if statusTag == "trial" %}
         {{ trialCallout(status) }}
       {%- endif %}
 

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -27,7 +27,7 @@
         {{ title }}
       </h1>
 
-      {%- if (status == "trial") or (status.type == "trial") %}
+      {%- if (status == "Trial") or (status.type == "Trial") %}
         {{ trialCallout(status) }}
       {%- endif %}
 

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -1,7 +1,7 @@
 {% extends "_generic.njk" %}
 
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "_status-callout.njk" import trialCallout %}
+{% from "_status-callout.njk" import statusCallout %}
 
 {# If the theme ends in '…', then we nest the caption inside the H1 so that the
   H1 becomes e.g. 'Ask users for dates'. Otherwise, we put it before the H1. #}
@@ -30,7 +30,7 @@
       {# Status callout #}
       {% set statusTag = (status.type if status.type else status) | slugify if status %}
       {%- if statusTag == "trial" %}
-        {{ trialCallout(status) }}
+        {{ statusCallout(status) }}
       {%- endif %}
 
       {% if showPageNav %}

--- a/views/macros/_status-callout.njk
+++ b/views/macros/_status-callout.njk
@@ -54,7 +54,7 @@
 
   {%- set settings = {
     classes: "app-status-callout--trial",
-    statusName: "Trial",
+    statusName: params.type if params.type else params,
     statusTagColour: "orange",
     content: defaultContent
   } -%}

--- a/views/macros/_status-callout.njk
+++ b/views/macros/_status-callout.njk
@@ -3,6 +3,8 @@
 
 {# Generic macro that other callouts can inherit from. #}
 {% macro _statusCallout(settings, params) %}
+  {%- set classSlug = settings.statusName | slugify %}
+
   {%- set content -%}
     {% if caller %}
       {{ caller() }}
@@ -16,10 +18,10 @@
   {%- endset -%}
 
   {%- call govukInsetText({
-    classes: "app-status-callout" + (" " + settings.classes if settings.classes)
+    classes: "app-status-callout app-status-callout--" + classSlug
   }) %}
     {{ govukTag({
-      classes: "app-status-callout__tag govuk-tag--" + settings.statusTagColour,
+      classes: "app-status-tag app-status-tag--" + classSlug,
       text: settings.statusName
     }) }}
     {{ content | safe }}
@@ -53,9 +55,7 @@
   {%- endset -%}
 
   {%- set settings = {
-    classes: "app-status-callout--trial",
     statusName: params.type if params.type else params,
-    statusTagColour: "orange",
     content: defaultContent
   } -%}
 

--- a/views/macros/_status-callout.njk
+++ b/views/macros/_status-callout.njk
@@ -1,9 +1,18 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
-{# Generic macro that other callouts can inherit from. #}
-{% macro _statusCallout(settings, params) %}
-  {%- set classSlug = settings.statusName | slugify %}
+{% macro statusCallout(params) %}
+  {# Status name can be the passed value (as a string) or the 'type' key within an object. #}
+  {%- set statusLabel = params.type if params.type else params %}
+  {%- set classSlug = statusLabel | slugify %}
+
+  {# Define the default content each status type displays, if any. #}
+  {# This is specified here so that it remains the same regardless of the macro being used in the layout or in content. #}
+  {%- set defaultContent %}
+    {%- if classSlug == "trial" %}
+      <p class="govuk-body">This component is being developed and may change as we improve it.</p>
+    {%- endif %}
+  {%- endset %}
 
   {%- set content -%}
     {% if caller %}
@@ -13,7 +22,7 @@
     {% elif params.text %}
       <p class="govuk-body">{{ params.text }}</p>
     {% else %}
-      {{ settings.content | safe }}
+      {{ defaultContent | safe }}
     {% endif %}
   {%- endset -%}
 
@@ -22,7 +31,7 @@
   }) %}
     {{ govukTag({
       classes: "app-status-tag app-status-tag--" + classSlug,
-      text: settings.statusName
+      text: statusLabel
     }) }}
     {{ content | safe }}
 
@@ -46,18 +55,4 @@
       {%- endif %}
     {%- endif %}
   {%- endcall %}
-{% endmacro %}
-
-{# Trial status #}
-{% macro trialCallout(params) %}
-  {%- set defaultContent -%}
-  <p class="govuk-body">This component is being developed and may change as we improve it.</p>
-  {%- endset -%}
-
-  {%- set settings = {
-    statusName: params.type if params.type else params,
-    content: defaultContent
-  } -%}
-
-  {{- _statusCallout(settings, params) -}}
 {% endmacro %}


### PR DESCRIPTION
Some refactoring and improvements to how component statuses are managed. 

These changes have been pulled out of #5573, as we've decided to revisit the status tables in the future instead. See that PR for discussion about some of these changes. 

## Changes 
- Updated navigation generator code to include the status of the page.
  - If no status information is defined, the page is assumed to be 'Stable'.
- Added new Sass partial for handling status tags and callouts together. This is so that status → colour associations can be handled in one place and partially automated by Sass, instead of being split across multiple places. 
- Removed having separate callouts for each status type. 
  - The requirement to set different defaults for each 'type' isn't really needed now that statuses and colours are directly correlated. 
- Changed the capitalisation of the trial status in frontmatter. It's now sentence case and written prosaically ('Trial', 'Under review', etc.) for future-proofing purposes. This gets slugified where needed, instead of assuming it's a slug.  
- Removed some old functionality that automatically removed a page from the navigation if it had `status: Draft` in the frontmatter. 
  - This status hasn't been used for some time and it has the potential to conflict with the new lifecycle status functionality. 
  - Removing a page from navigation is still possible using the `ignoreInSitemap` property. 