### PR TITLE
Update guidance for slotting Language navigation inside Service navigation

### DIFF
--- a/src/components/language-navigation/index.md
+++ b/src/components/language-navigation/index.md
@@ -65,7 +65,9 @@ This helps users find their preferred language as quickly as possible.
 
 ### If you offer your whole service in another language
 
-If users can change the language for your whole service, place the [Language navigation component into the Service navigation component](/components/service-navigation/#adding-language-navigation).
+If users can change the language for your whole service, you can place the [Language navigation component into the Service navigation component](/components/service-navigation/#adding-language-navigation) using its 'slots' options.
+
+{{ example({ group: "components", item: "service-navigation", example: "with-inline-end-slot", html: true, nunjucks: true, open: false }) }}
 
 ### Showing language navigation in another language
 

--- a/src/components/language-navigation/index.md
+++ b/src/components/language-navigation/index.md
@@ -67,6 +67,8 @@ This helps users find their preferred language as quickly as possible.
 
 If users can change the language for your whole service, you can place the [Language navigation component into the Service navigation component](/components/service-navigation/#adding-language-navigation) using its 'slots' options.
 
+Use the `inline` align option for slots to align the language navigation inline with navigation items as shown in this example.
+
 {{ example({ group: "components", item: "service-navigation", example: "with-inline-end-slot", html: true, nunjucks: true, open: false }) }}
 
 ### Showing language navigation in another language

--- a/src/components/language-navigation/index.md
+++ b/src/components/language-navigation/index.md
@@ -65,12 +65,7 @@ This helps users find their preferred language as quickly as possible.
 
 ### If you offer your whole service in another language
 
-If users can change the language for your whole service, place the Language navigation component into the Service navigation component:
-
-- if you’re using Nunjucks, place the component into the `end` slot
-- if you’re using HTML, place it right after the closing `</nav>`
-
-The Service navigation component has the `endRightAligned` option in Nunjucks that will move whatever is in the `end` slot to the right-hand side of the Service navigation component. This adds a `<div class="govuk-service-navigation__end"></div>` around the slot’s content. This option includes space for a few language links.
+If users can change the language for your whole service, place the [Language navigation component into the Service navigation component](/components/service-navigation/#adding-language-navigation).
 
 ### Showing language navigation in another language
 

--- a/src/components/service-navigation/index.md
+++ b/src/components/service-navigation/index.md
@@ -54,6 +54,8 @@ The Service navigation includes the option to use ‘slots’ to insert custom H
 
 You must provide your own styles and JavaScript code for the content within a slot, particularly if you’re not using an existing component. You’ll need to decide on the most appropriate layout and positioning.
 
+{{ example({ group: "components", item: "service-navigation", example: "with-slots", html: true, nunjucks: true, open: false }) }}
+
 The [Help users to navigate a service pattern](/patterns/navigate-a-service) includes some guidance on ‘Adding other header and navigation elements’.
 
 ### Ensure the ‘aria-label’ is accurate for users of assistive technology

--- a/src/components/service-navigation/index.md
+++ b/src/components/service-navigation/index.md
@@ -44,10 +44,6 @@ Show navigation links to let users navigate to different parts of your service a
 
 See when and how to show navigation links in the [Help users navigate a service pattern](/patterns/navigate-a-service/).
 
-### Adding language navigation
-
-If you provide your whole service in more than one language, you can place the Language navigation component in the [`end` slot of the Service navigation, inline with the navigation items](#align-the-end-slot-with-the-navigation-items).
-
 ## Use ‘slots’ to add custom elements
 
 The Service navigation includes the option to use ‘slots’ to insert custom HTML code at specific points inside the component. This helps you extend the component to add custom elements.
@@ -58,17 +54,27 @@ You must provide your own styles and JavaScript code for the content within a sl
 
 The [Help users to navigate a service pattern](/patterns/navigate-a-service) includes some guidance on ‘Adding other header and navigation elements’.
 
-### Ensure the ‘aria-label’ is accurate for users of assistive technology
+### Adding language navigation
 
-When a service name is shown, we let users know that there’s information about the service with a ‘region landmark’ using the `<section>` element.
+If you use the [trial Language navigation component](/components/language-navigation) and provide your whole service in more than one language, you can use slots to show language options within the Service navigation.
 
-Depending on what you add in the slots, you might need to rename the `aria-label` to accurately describe what’s in the section.
+Place the Language navigation component in the `end` slot of the Service navigation, inline with the navigation items.
 
 ### Align the `end` slot with the navigation items
 
 When enough space is available on screen, you can display the `end` slot inline with the navigation items to their right rather than underneath the navigation items. This can be useful when injecting content users expect in that area, like a [language navigation](/components/language-navigation), or authentication and account links.
 
+Use the `inline` align option to show the `end` slot inline with navigation items (to the right instead of underneath) when there's enough screen space.
+
+This can help save space when showing tools users expect to see in that area, such as language navigation.
+
 {{ example({ group: "components", item: "service-navigation", example: "with-inline-end-slot", html: true, nunjucks: true, open: false }) }}
+
+### Ensure the ‘aria-label’ is accurate for users of assistive technology
+
+When a service name is shown, we let users know that there’s information about the service with a ‘region landmark’ using the `<section>` element.
+
+Depending on what you add in the slots, you might need to rename the `aria-label` to accurately describe what’s in the section.
 
 ### Test with each update of GOV.UK Frontend
 

--- a/src/components/service-navigation/index.md
+++ b/src/components/service-navigation/index.md
@@ -64,6 +64,12 @@ When a service name is shown, we let users know that there’s information about
 
 Depending on what you add in the slots, you might need to rename the `aria-label` to accurately describe what’s in the section.
 
+### Align the `end` slot with the navigation items
+
+When enough space is available on screen, you can display the `end` slot inline with the navigation items to their right rather than underneath the navigation items. This can be useful when injecting content users expect in that area, like a [language navigation](/components/language-navigation), or authentication and account links.
+
+{{ example({ group: "components", item: "service-navigation", example: "with-inline-end-slot", html: true, nunjucks: true, open: false }) }}
+
 ### Test with each update of GOV.UK Frontend
 
 There’s a risk that slot contents may look or work differently in a future release of GOV.UK Frontend.

--- a/src/components/service-navigation/index.md
+++ b/src/components/service-navigation/index.md
@@ -46,7 +46,7 @@ See when and how to show navigation links in the [Help users navigate a service 
 
 ### Adding language navigation
 
-If you provide your whole service in more than one language, you can place the [Language navigation component in the Service navigation](/components/language-navigation/#if-you-offer-your-whole-service-in-another-language).
+If you provide your whole service in more than one language, you can place the Language navigation component in the [`end` slot of the Service navigation, inline with the navigation items](#align-the-end-slot-with-the-navigation-items).
 
 ## Use ‘slots’ to add custom elements
 

--- a/src/components/service-navigation/with-inline-end-slot/index.njk
+++ b/src/components/service-navigation/with-inline-end-slot/index.njk
@@ -1,0 +1,47 @@
+---
+title: Service navigation with inline end slot – Service navigation
+layout: layout-example.njk
+---
+
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+{% from "govuk/components/language-navigation/macro.njk" import govukLanguageNavigation %}
+
+{% set languageNavigationHtml %}
+  {{ govukLanguageNavigation({
+    items: [
+      {
+        text: "English",
+        lang: "en",
+        href: "#",
+        current: true
+      },
+      {
+        text: "Cymraeg",
+        lang: "cy",
+        href: "#"
+      }
+    ]
+  }) }}
+{% endset %}
+
+{{ govukServiceNavigation({
+  serviceName: "Service name",
+  serviceUrl: "#",
+  navigation: [
+    {
+      href: "#",
+      text: "Item 1"
+    },
+    {
+      href: "#",
+      text: "Item 2",
+      active: true
+    }
+  ],
+  slots: {
+    end: {
+      html: languageNavigationHtml,
+      align: 'inline'
+    }
+  }
+}) }}

--- a/src/components/service-navigation/with-slots/index.njk
+++ b/src/components/service-navigation/with-slots/index.njk
@@ -1,0 +1,66 @@
+---
+title: Service navigation slots – Service navigation
+layout: layout-example.njk
+stylesheets:
+- /stylesheets/page-template-blocks.css
+---
+
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
+{% set startHtml %}
+  <div class="app-annotate-block">
+    <span class="app-annotate-block__label">slot: start</span>
+  </div>
+{% endset %}
+
+{% set endHtml %}
+  <div class="app-annotate-block">
+    <span class="app-annotate-block__label">slot: end</span>
+  </div>
+{% endset %}
+
+{% set navigationStart %}
+  <!--
+    Notice the wrapping `<li>` as the `navigationStart` slot
+    injects content at the start of the `<ul>` listing the navigation items
+  -->
+  <li class="govuk-service-navigation__item">
+    <div class="app-annotate-block app-annotate-block--short">
+      <span class="app-annotate-block__label">slot: navigationStart</span>
+    </div>
+  </li>
+{% endset %}
+
+{% set navigationEnd %}
+  <!--
+    Notice the wrapping `<li>` as the `navigationStart` slot
+    injects content at the end of the `<ul>` listing the navigation items
+  -->
+  <li class="govuk-service-navigation__item">
+    <div class="app-annotate-block app-annotate-block--short">
+      <span class="app-annotate-block__label">slot: navigationEnd</span>
+    </div>
+  </li>
+{% endset %}
+
+{{ govukServiceNavigation({
+  serviceName: "Service name",
+  serviceUrl: "#",
+  navigation: [
+    {
+      href: "#",
+      text: "Item 1"
+    },
+    {
+      href: "#",
+      text: "Item 2",
+      active: true
+    }
+  ],
+  slots: {
+    start: startHtml,
+    end: endHtml,
+    navigationStart: navigationStart,
+    navigationEnd: navigationEnd
+  }
+}) }}

--- a/src/stylesheets/page-template-blocks.scss
+++ b/src/stylesheets/page-template-blocks.scss
@@ -1,11 +1,10 @@
 @use "pkg:govuk-frontend/base" as *;
 
 $app-annotate-block-label-color: #ffffff;
+$app-annotate-block-padding: govuk-spacing(3);
 
 .app-annotate-block {
-  position: relative;
-  padding: govuk-spacing(3);
-  padding-top: 3em;
+  padding: $app-annotate-block-padding;
   border: 2px dashed govuk-colour("black", $variant: "tint-25");
 
   // Collapse borders when two annotate blocks follow each other
@@ -15,10 +14,9 @@ $app-annotate-block-label-color: #ffffff;
 }
 
 .app-annotate-block__label {
-  position: absolute;
-  top: 0;
-  left: 0;
+  display: inline-block;
   padding: 0.25em 0.5em;
+  transform: translate(-$app-annotate-block-padding, -$app-annotate-block-padding);
   border-right: 2px dashed govuk-colour("black", $variant: "tint-25");
   border-bottom: 2px dashed govuk-colour("black", $variant: "tint-25");
   background: $app-annotate-block-label-color;


### PR DESCRIPTION
Add extra details in the [Service navigation guidance](https://deploy-preview-5583--govuk-design-system-preview.netlify.app/components/service-navigation/#use-slots-to-add-custom-elements) about slots and how to display the `end` slot inline with the navigation items.

With that set up in place, update the [Language navigation guidance](https://deploy-preview-5583--govuk-design-system-preview.netlify.app/components/language-navigation/#if-you-offer-your-whole-service-in-another-language) to link to the Service navigation guidance to explain how to combine the two components.