### PR TITLE
Add content to contact panel for trial components

### DIFF
--- a/src/components/feedback/index.md
+++ b/src/components/feedback/index.md
@@ -11,6 +11,8 @@ status:
       text: Research on this component
     - href: "#help-improve-this-page"
       text: Help improve this component
+  date: August 2026
+  dataCollectionUrl: https://github.com/alphagov/govuk-design-system/discussions/4978
 ---
 
 {% from "_example.njk" import example %}
@@ -57,7 +59,3 @@ You must include a link to a feedback page, which could be either:
 We thank the service teams across government who worked with us in the early stages of this component to measure its effectiveness.
 
 We’d also like to thank the GOV.UK Forms team for helping us build this component.
-
-### Help us improve this component
-
-We're still working to improve this component and we’d like to get your feedback. If you've implemented this component and can tell us about how it’s working in your service, [contact the team](/contact/).

--- a/src/stylesheets/components/_lifecycle-statuses.scss
+++ b/src/stylesheets/components/_lifecycle-statuses.scss
@@ -21,7 +21,7 @@ $_statuses: (
 }
 
 .app-status-callout .app-status-tag {
-  margin-bottom: govuk-spacing(1);
+  margin-bottom: govuk-spacing(3);
 }
 
 // The element name is included here as this needs higher specificity to

--- a/views/macros/_status-callout.njk
+++ b/views/macros/_status-callout.njk
@@ -36,6 +36,7 @@
     {{ content | safe }}
 
     {%- if params.links %}
+      <p class="govuk-body">Read these sections to see why this component is in trial:</p>
       {%- if params.links | length > 1 %}
         <ul class="govuk-list app-status-callout__list">
           {%- for item in params.links -%}

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -1,11 +1,27 @@
-{%- set fileEditURL = "https://github.com/alphagov/govuk-design-system/edit/main/src/" + permalink + "/index.md" -%}
-{% if ["Components", "Patterns", "Styles"].includes(section) %}
+{% from "_status-callout.njk" import statusCallout %}
+
+{%- if ["Components", "Patterns", "Styles"].includes(section) %}
+  {%- set fileEditURL = "https://github.com/alphagov/govuk-design-system/edit/main/src/" + permalink + "/index.md" %}
+  {# statusTag is set in layout-pane when calculating if the page has a status or not #}
+  {%- set isTrial = statusTag == "trial" %}
   <h2 class="govuk-heading-l govuk-!-padding-top-7" id="help-improve-this-page">Help improve this {{ section.slice(0, -1) | lower }}</h2>
+
+{%- if isTrial %}
+  {% call statusCallout({
+    type: status.type
+  }) %}
+    <p class="govuk-body">
+      In {{ status.date }} we moved {{ title }} to 'Trial' status so we can learn how well it works for services.
+    </p>
+    <p class="govuk-body">See the information we're looking for and how you can help move this component into 'Stable' status:</p>
+    <p class="govuk-body"><a class="govuk-link" href="{{ status.dataCollectionUrl }}">Tell us how well {{ title }} works in your service</a></p>
+  {% endcall %}
+{%- endif %}
 
   {% if backlogIssueId or discussionId %}
     {%- set discussionUrl = "https://github.com/alphagov/" + ("govuk-design-system/discussions/" + discussionId if discussionId else "govuk-design-system-backlog/issues/") + backlogIssueId  %}
     <p class="govuk-body">
-      To help make sure that this page is useful, relevant and up to date, you can:
+      {{ "You can also:" if isTrial else "To help make sure that this page is useful, relevant and up to date, you can:" }}
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>


### PR DESCRIPTION
## Change

Extends both the contact panel partial and the Trial frontmatter to account for adjusted content within the contact panel for when a given thing is in Trial.

If a component is in Trial, adds the trial callout to the contact panel with content on when the component was put into trial and a link to the relevant place that users can interact with us and help us move it into Stable.

<img width="888" height="486" alt="Screenshot of contact panel" src="https://github.com/user-attachments/assets/e1ffad71-d630-4a47-9c52-36a0605368a5" />

Resolves https://github.com/alphagov/govuk-design-system/issues/5568

