### PR TITLE
Update Addresses pattern to include information about UPRNs

### DIFF
--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -14,9 +14,48 @@ This guidance is for government teams that build online services. [To find infor
 
 Help users provide an address using one of the following:
 
-- Multiple text inputs
 - Address lookup
+- Multiple text inputs
 - Textarea
+
+## Address lookup
+
+An address lookup helps users find a full address from partial information such as a postcode.
+
+### When to use an address lookup
+
+Use an address lookup when you’re asking users for a UK address.
+
+### When not to use an address lookup
+
+Address lookups generally only work for UK addresses. Use a manual option such as multiple text inputs or a textarea when you are collecting mostly or only international addresses.
+
+### How an address lookup works
+
+An address lookup lets users specify a UK address by entering their postcode and selecting their address from a list. There is also an option to enter a street name or number.
+
+When using an address lookup, you should:
+
+- make it clear that it will only work for UK addresses
+- provide a manual option for people with international addresses or addresses that are missing or not properly listed in the address lookup
+- let people enter their postcodes in upper or lower case and with or without spaces
+
+### Unique Property Reference Numbers
+
+Many address lookup APIs also include a Unique Property Reference Number (UPRN) which is a 12 digit identifier for every addressable location in Great Britain.  [A mandate](https://static.geoplace.co.uk/downloads/GEO13042-GeoPlace-You-Must-Use-UPRNs-USRNs-v4.pdf) was introduced in 2020 which states all public sector systems and projects which include address data should include UPRNs. Collecting this information at source will prevent manual address matching in future.
+
+Address lookups should only use data from one API so it is consistent and accurate. One such API which can be used for this is the [Ordnance Survey Places API](https://www.ordnancesurvey.co.uk/products/os-places-api).
+
+#### Allow different postcode formats
+
+It's easier for users if you accept and ignore unwanted characters. This is better than rejecting the input and telling the user they have not provided a valid postcode.
+
+You should let users enter postcodes that contain:
+
+- upper and lower case letters
+- no spaces
+- additional spaces at the beginning, middle or end
+- punctuation like hyphens, brackets, dashes and full stops
 
 ## Multiple text inputs
 
@@ -72,39 +111,6 @@ If a postcode entered is not a real postcode, use a message like this:
 {{ example({ group: "patterns", item: "addresses", example: "error-postcode", html: true, nunjucks: true, open: false, size: "s" }) }}
 
 Make sure errors follow the guidance in the [Error message component](/components/error-message/) and have specific error messages for specific error states.
-
-## Address lookup
-
-An address lookup helps users find a full address from partial information such as a postcode.
-
-### When to use an address lookup
-
-Use an address lookup when you’re asking users for a UK address.
-
-### When not to use an address lookup
-
-Address lookups generally only work for UK addresses. Use a manual option such as multiple text inputs or a textarea when you are collecting mostly or only international&nbsp;addresses
-
-### How an address lookup works
-
-An address lookup lets users specify a UK address by entering their postcode and selecting their address from a list. There is also an option to enter a street name or&nbsp;number.
-
-When using an address lookup, you should:
-
-- make it clear that it will only work for UK addresses
-- provide a manual option for people with international addresses or addresses that are missing or not properly listed in the address lookup
-- let people enter their postcodes in upper or lower case and with or without spaces
-
-#### Allow different postcode formats
-
-It's easier for users if you accept and ignore unwanted characters. This is better than rejecting the input and telling the user they have not provided a valid postcode.
-
-You should let users enter postcodes that contain:
-
-- upper and lower case letters
-- no spaces
-- additional spaces at the beginning, middle or end
-- punctuation like hyphens, brackets, dashes and full stops
 
 ## Textarea
 

--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -24,11 +24,13 @@ An address lookup helps users find a full address from partial information such 
 
 ### When to use an address lookup
 
-Use an address lookup when you’re asking users for a UK address.
+Use an address lookup to collect UK addresses where possible.
 
 ### When not to use an address lookup
 
-Address lookups generally only work for UK addresses. Use a manual option such as multiple text inputs or a textarea when you are collecting mostly or only international addresses.
+Address lookups generally only work for UK addresses. 
+
+If both UK and international addresses are expected, give users to the option to either search for a UK address or manually enter an international address.
 
 ### How an address lookup works
 
@@ -65,7 +67,9 @@ You should let users enter postcodes that contain:
 
 ### When to use multiple text inputs
 
-Only use multiple text inputs when you know which countries the addresses will come from and can find a format that supports them all. This can be difficult to know if you’re asking for addresses outside of the UK.
+Use multiple text inputs to offer users a manual option to enter an address, such as for international addresses or when users cannot find their address using an address lookup.
+
+You'll need to know which countries the addresses will come from and find a format that supports them. This can be difficult for addresses outside of the UK.
 
 Using multiple text inputs means:
 
@@ -120,14 +124,13 @@ Make sure errors follow the guidance in the [Error message component](/component
 
 ### When to use textarea
 
-Use a textarea if you expect a broad range of address formats and you do not need to format the address for print or use specific sub-parts of the address (for example, street or postcode).
+Use a textarea to offer users a manual option to enter an address, such as for international addresses or when users cannot find their address using an address lookup.
+
+A textarea is useful when you expect a broad range of address formats and you do not need to format the address for print or use specific sub-parts of the address (for example, street or postcode).
 
 ### When not to use textarea
 
-You should not use a textarea if you:
-
-- need to separate an address into accurate sub-parts (for example, street or postcode)
-- need to help users look up an address
+You should not use a textarea if you need to separate an address into accurate sub-parts (for example, street or postcode).
 
 ### How a textarea works
 

--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -28,7 +28,7 @@ Use an address lookup to collect UK addresses where possible.
 
 ### When not to use an address lookup
 
-Address lookups generally only work for UK addresses. 
+Address lookups generally only work for UK addresses.
 
 If both UK and international addresses are expected, give users to the option to either search for a UK address or manually enter an international address.
 

--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -14,9 +14,9 @@ This guidance is for government teams that build online services. [To find infor
 
 Help users provide an address using one of the following:
 
-- Address lookup
-- Multiple text inputs
-- Textarea
+- address lookup
+- multiple text inputs
+- textarea
 
 ## Address lookup
 
@@ -40,13 +40,15 @@ When using an address lookup, you should:
 - provide a manual option for people with international addresses or addresses that are missing or not properly listed in the address lookup
 - let people enter their postcodes in upper or lower case and with or without spaces
 
-### Unique Property Reference Numbers
+### Identify and match addresses with UPRN identifiers
 
-Many address lookup APIs also include a Unique Property Reference Number (UPRN) which is a 12 digit identifier for every addressable location in Great Britain.  [A mandate](https://static.geoplace.co.uk/downloads/GEO13042-GeoPlace-You-Must-Use-UPRNs-USRNs-v4.pdf) was introduced in 2020 which states all public sector systems and projects which include address data should include UPRNs. Collecting this information at source will prevent manual address matching in future.
+Use an address lookup that can [identify and match addresses with Unique Property Reference Numbers (UPRNs)](https://www.gov.uk/government/publications/open-standards-for-government/identifying-property-and-street-information). UPRNs are 12-digit unique identifiers for every addressable location across the UK.
 
-Address lookups should only use data from one API so it is consistent and accurate. One such API which can be used for this is the [Ordnance Survey Places API](https://www.ordnancesurvey.co.uk/products/os-places-api).
+[Open standards for government mandates that all public sector systems and projects which include address data should include UPRNs](https://technology.blog.gov.uk/2020/04/02/identifying-properties-and-streets-in-government-data/). This is to help government share consistent data, reduce errors and avoid the need for manual address matching in future.
 
-#### Allow different postcode formats
+Your address lookup should only use data from one API so it is consistent and accurate. One such API which can be used for this is the [Ordnance Survey Places API](https://www.ordnancesurvey.co.uk/products/os-places-api).
+
+### Allow different postcode formats
 
 It's easier for users if you accept and ignore unwanted characters. This is better than rejecting the input and telling the user they have not provided a valid postcode.
 

--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -14,9 +14,9 @@ This guidance is for government teams that build online services. [To find infor
 
 Help users provide an address using one of the following:
 
-- Address lookup
-- Multiple text inputs
-- Textarea
+- address lookup
+- multiple text inputs
+- textarea
 
 ## Address lookup
 
@@ -40,13 +40,15 @@ When using an address lookup, you should:
 - provide a manual option for people with international addresses or addresses that are missing or not properly listed in the address lookup
 - let people enter their postcodes in upper or lower case and with or without spaces
 
-### Unique Property Reference Numbers
+### Identify and match addresses with UPRN identifiers
 
-Many address lookup APIs also include a Unique Property Reference Number (UPRN) which is a 12 digit identifier for every addressable location in Great Britain.  [A mandate](https://static.geoplace.co.uk/downloads/GEO13042-GeoPlace-You-Must-Use-UPRNs-USRNs-v4.pdf) was introduced in 2020 which states all public sector systems and projects which include address data should include UPRNs. Collecting this information at source will prevent manual address matching in future.
+Use an address lookup that can [identify addresses with Unique Property Reference Numbers (UPRNs)](https://www.gov.uk/government/publications/open-standards-for-government/identifying-property-and-street-information). UPRNs are 12-digit unique identifiers for every addressable location across the UK.
 
-Address lookups should only use data from one API so it is consistent and accurate. One such API which can be used for this is the [Ordnance Survey Places API](https://www.ordnancesurvey.co.uk/products/os-places-api).
+Open standards for government mandates that [all public sector systems and projects which include address data should include UPRNs](https://technology.blog.gov.uk/2020/04/02/identifying-properties-and-streets-in-government-data/). This is to help government share consistent data, reduce errors and avoid the need for manual address matching in future.
 
-#### Allow different postcode formats
+Your address lookup should only use data from one API so it is consistent and accurate. One option for this is the [Ordnance Survey Places API](https://www.ordnancesurvey.co.uk/products/os-places-api).
+
+### Allow different postcode formats
 
 It's easier for users if you accept and ignore unwanted characters. This is better than rejecting the input and telling the user they have not provided a valid postcode.
 

--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -71,9 +71,10 @@ You should let users enter postcodes that contain:
 
 ### When to use multiple text inputs
 
-Use multiple text inputs to offer users a manual option to enter an address, such as for international addresses or when users cannot find their address using an address lookup.
+Only use multiple text inputs to offer users a manual input option when you both:
 
-Find out which countries the addresses will come from and find a format that supports them. 
+- know which countries the addresses will come from
+- can find a format that supports them all – this can be difficult to know if you’re asking for addresses outside of the UK
 
 Using multiple text inputs means:
 

--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -30,7 +30,7 @@ Use an address lookup to collect UK addresses where possible.
 
 Address lookups generally only work for UK addresses.
 
-If both UK and international addresses are expected, give users to the option to either search for a UK address or manually enter an international address.
+If you expect both UK and international addresses, give users the option to either search for a UK address or manually enter an international address.
 
 ### How an address lookup works
 
@@ -46,9 +46,9 @@ When using an address lookup, you should:
 
 Use an address lookup that can identify addresses with Unique Property Reference Numbers (UPRNs). UPRNs are 12-digit unique identifiers for every addressable location across the UK.
 
-Open standards for government mandates that [services that store property information must use UPRN identifiers](https://www.gov.uk/government/publications/open-standards-for-government/identifying-property-and-street-information).
+Open standards for government mandate that [services that store property information must use UPRN identifiers](https://www.gov.uk/government/publications/open-standards-for-government/identifying-property-and-street-information).
 
-Using UPRN identifiers helps users enter an address accurately and ensures it stays consistent. This helps your service by making address data easier to handle, reducing errors and removing the need for manual address matching in the future.
+Using UPRN identifiers helps users enter addresses accurately. This helps your service by making address data more consistent and easier to handle, which reduces errors and removes the need for manual address matching in the future.
 
 See a post on [The power of UPRNs in linking data on the Geospatial Insights blog](https://gdsgeospatial.blog.gov.uk/2026/01/23/unlocking-better-outcomes-the-power-of-uprns-in-linking-data/).
 
@@ -73,7 +73,7 @@ You should let users enter postcodes that contain:
 
 Use multiple text inputs to offer users a manual option to enter an address, such as for international addresses or when users cannot find their address using an address lookup.
 
-You'll need to know which countries the addresses will come from and find a format that supports them. This can be difficult for addresses outside of the UK.
+Find out which countries the addresses will come from and find a format that supports them. 
 
 Using multiple text inputs means:
 
@@ -126,13 +126,13 @@ Make sure errors follow the guidance in the [Error message component](/component
 
 {{ example({ group: "patterns", item: "addresses", example: "textarea", html: true, nunjucks: true, open: true, size: "s" }) }}
 
-### When to use textarea
+### When to use a textarea
 
 Use a textarea to offer users a manual option to enter an address, such as for international addresses or when users cannot find their address using an address lookup.
 
 A textarea is useful when you expect a broad range of address formats and you do not need to format the address for print or use specific sub-parts of the address (for example, street or postcode).
 
-### When not to use textarea
+### When not to use a textarea
 
 You should not use a textarea if you need to separate an address into accurate sub-parts (for example, street or postcode).
 

--- a/src/patterns/addresses/index.md
+++ b/src/patterns/addresses/index.md
@@ -44,11 +44,15 @@ When using an address lookup, you should:
 
 ### Identify and match addresses with UPRN identifiers
 
-Use an address lookup that can [identify addresses with Unique Property Reference Numbers (UPRNs)](https://www.gov.uk/government/publications/open-standards-for-government/identifying-property-and-street-information). UPRNs are 12-digit unique identifiers for every addressable location across the UK.
+Use an address lookup that can identify addresses with Unique Property Reference Numbers (UPRNs). UPRNs are 12-digit unique identifiers for every addressable location across the UK.
 
-Open standards for government mandates that [all public sector systems and projects which include address data should include UPRNs](https://technology.blog.gov.uk/2020/04/02/identifying-properties-and-streets-in-government-data/). This is to help government share consistent data, reduce errors and avoid the need for manual address matching in future.
+Open standards for government mandates that [services that store property information must use UPRN identifiers](https://www.gov.uk/government/publications/open-standards-for-government/identifying-property-and-street-information).
 
-Your address lookup should only use data from one API so it is consistent and accurate. One option for this is the [Ordnance Survey Places API](https://www.ordnancesurvey.co.uk/products/os-places-api).
+Using UPRN identifiers helps users enter an address accurately and ensures it stays consistent. This helps your service by making address data easier to handle, reducing errors and removing the need for manual address matching in the future.
+
+See a post on [The power of UPRNs in linking data on the Geospatial Insights blog](https://gdsgeospatial.blog.gov.uk/2026/01/23/unlocking-better-outcomes-the-power-of-uprns-in-linking-data/).
+
+Your address lookup should only use data from a single API. One option for this is the [Ordnance Survey Places API](https://www.ordnancesurvey.co.uk/products/os-places-api). Public sector organisations can get access to OS Places API as part of the [Public Sector Geospatial Agreement (PSGA)](https://www.ordnancesurvey.co.uk/customers/public-sector/public-sector-geospatial-agreement).
 
 ### Allow different postcode formats
 


### PR DESCRIPTION
Iterations made:
- address lookups are the first option in the pattern (currently multiple text inputs)
- added a brief explainer of UPRNs and a link to the mandate
- added content to advise address lookups used by teams should take data from the one source of truth on UPRNs, and added a link to an example (OS Places API)