### PR TITLE
Serve archived pages with a 410 Gone status code

### DIFF
--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -25,6 +25,7 @@ const lunr = require('./metalsmith-lunr-index') // generate search index
 const renderMarkdown = require('./metalsmith-render-markdown')
 const titleChecker = require('./metalsmith-title-checker')
 const navigation = require('./navigation.js') // navigation plugin
+const redirects = require('./redirects')
 const rollup = require('./rollup') // used to build GOV.UK Frontend JavaScript
 
 // Static site generator
@@ -171,6 +172,8 @@ module.exports = metalsmith
 
   // apply a permalink pattern to files
   .use(permalinks())
+
+  .use(redirects)
 
   // add a canonical url property to pages
   .use(

--- a/lib/redirects/fixtures/src/archived.html
+++ b/lib/redirects/fixtures/src/archived.html
@@ -1,0 +1,4 @@
+---
+title: This page is live
+layout: layout-archived.njk
+---

--- a/lib/redirects/fixtures/src/live.html
+++ b/lib/redirects/fixtures/src/live.html
@@ -1,0 +1,3 @@
+---
+title: This page is live
+---

--- a/lib/redirects/index.js
+++ b/lib/redirects/index.js
@@ -1,0 +1,33 @@
+/**
+ * Redirects plugin
+ *
+ * Creates a _redirects file in the build directory which includes redirects for
+ * any 'archived' pages (defined as those which use layout-archived.njk)
+ *
+ * The redirects file is tab-separated, and looks like:
+ *
+ * /archived/page   /archived/page    410!
+ *
+ * The ! on the status code makes it a forced-redirect, which is needed because
+ * Netlify will otherwise ignore redirects where a file for the path exists.
+ *
+ * @see https://docs.netlify.com/manage/routing/redirects/overview/
+ * @returns {import('metalsmith').Plugin} Metalsmith plugin
+ */
+
+module.exports = function redirects(files, metalsmith, done) {
+  const archivedFiles = Object.values(files).filter(
+    (file) => file?.layout === 'layout-archived.njk'
+  )
+
+  const archiveRedirects = archivedFiles
+    .map((file) => `/${file.permalink}\t/${file.permalink}\t410!`)
+    .join('\n')
+
+  files._redirects = {
+    contents: Buffer.from(archiveRedirects),
+    mode: '0664'
+  }
+
+  done()
+}

--- a/lib/redirects/index.test.js
+++ b/lib/redirects/index.test.js
@@ -1,0 +1,48 @@
+const permalinks = require('@metalsmith/permalinks')
+const Metalsmith = require('metalsmith')
+
+const redirects = require('./index.js')
+
+describe('Hash fingerprints plugin', () => {
+  const source = './fixtures/src'
+  const destination = './fixtures/build'
+
+  let output
+
+  beforeAll((done) => {
+    Metalsmith(__dirname)
+      // Use test fixtures
+      .source(source)
+      .destination(destination)
+
+      // Redirects plugin requires permalinks to work
+      .use(permalinks())
+
+      // The redirects plugin under test
+      .use(redirects)
+
+      // Build
+      .build((err, files) => {
+        if (err) {
+          return done(err)
+        }
+
+        output = files
+        done()
+      })
+  })
+
+  it('creates a _redirects file', () => {
+    expect(output).toHaveProperty('_redirects')
+  })
+
+  it('does not includes live pages in the _redirects file', () => {
+    expect(output._redirects.contents.toString()).not.toContain('/live')
+  })
+
+  it('includes archived pages in the _redirects file with a 410 status', () => {
+    expect(output._redirects.contents.toString()).toContain(
+      '/archived\t/archived\t410!'
+    )
+  })
+})


### PR DESCRIPTION
Add a new Metalsmith plugin that outputs a [Netlify `_redirects` file][1] in the build directory. The _redirects file lists all of the archived pages and forces them to be served with a [410 'Gone' status code][2].

This should, for example, prevent The National Archives from indexing the archived pages as new versions of the content.

👉🏻 [Example of an archived page](https://deploy-preview-5592--govuk-design-system-preview.netlify.app/community/design-system-day-2023/session-information)

[1]: https://docs.netlify.com/manage/routing/redirects/overview/
[2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/410