### PR TITLE
Add website updates to announce v6.5.0

### DIFF
--- a/src/community/roadmap/index.md
+++ b/src/community/roadmap/index.md
@@ -13,21 +13,24 @@ Some things on the roadmap might change – the purpose is to tell you what’s 
 
 See our [GitHub team board](https://github.com/orgs/alphagov/projects/53) for more details on our plans and day-to-day activities.
 
-Last updated 16 July 2026.
+Last updated 27 August 2026.
 
 ## Recently shipped
 
-We've released GOV.UK Frontend v6.4.0, which adds an [interruption variant of the Panel component](/components/panel/#interruption-panel), which you can use to pause the user’s journey and give them important information. We’ve also improved the Date input component and introduced a new `inverse-text` functional colour to use on dark backgrounds.
+We've released GOV.UK Frontend v6.5.0, which adds the [Feedback component](/components/feedback/) to help you gather feedback from your users and the [Language navigation component](/components/language-navigation/) to let your users switch between languages your service offers.
 
-In June 2026, we released GOV.UK Frontend v6.3.0, which adds the [Generic header component](/components/generic-header/) for services that are not part of the [GOV.UK proposition](https://www.gov.uk/government/publications/govuk-proposition/govuk-proposition) but would still benefit from using GOV.UK Frontend to build their service.
+Both these components have been released as trial components, using our new [component lifecycle statuses](/community/component-lifecycle-statuses/). See each component’s guidance page to learn how you can help us move them to ‘Stable’ status.
+
+In July 2026, we released GOV.UK Frontend v6.4.0, which adds an [interruption variant of the Panel component](/components/panel/#interruption-panel), which you can use to pause the user’s journey and give them important information. We also improved the Date input component and introduced a new `inverse-text` functional colour to use on dark backgrounds.
 
 ## Working on now
 
 We've started to:
 
-- create a feedback link component and test it in live services
-- add a language switcher component
-- explore how we might publish experimental components, patterns and variants
+- make it easier to maintain the GOV.UK Prototype Kit and docs
+- explore the ways service teams prototype their work
+- carry out an accessibility audit of GOV.UK Frontend
+- explore how we can more easily communicate the change history of our components
 
 ## Future plans
 

--- a/src/community/whats-new/index.md
+++ b/src/community/whats-new/index.md
@@ -9,6 +9,16 @@ order: 10
 
 See our latest releases and updates.
 
+## August 2026
+
+We’ve released GOV.UK Frontend v6.5.0.
+
+This release adds the [Feedback component](/components/feedback/) to help you gather feedback from your users and the [Language navigation component](/components/language-navigation/) to let your users switch between languages your service offers.
+
+Both these components have been released as 'Trial' components, using our new [component lifecycle statuses](/community/component-lifecycle-statuses/). See each component’s guidance page to learn how you can help us move them to ‘Stable’ status.
+
+Read the [full release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v6.5.0) to see what’s changed.
+
 ## July 2026
 
 ### We’ve released GOV.UK Frontend v6.4.0

--- a/views/partials/_whats-new.md
+++ b/views/partials/_whats-new.md
@@ -1,7 +1,5 @@
-### 16 July 2026: We’ve released GOV.UK Frontend v6.4.0.
+### 27 August 2026: We’ve released GOV.UK Frontend v6.5.0
 
-This release adds an [interruption variant of the Panel component](/components/panel/#interruption-panel), which you can use to pause the user’s journey and give them important information.
+This release adds the [Feedback component](/components/feedback/) to help you gather feedback from your users and the [Language navigation component](/components/language-navigation/) to let your users switch between languages your service offers.
 
-We’ve also improved the Date input component and introduced a new `inverse-text` functional colour to use on dark backgrounds.
-
-[Read the release notes for v6.4.0 on GitHub](https://github.com/alphagov/govuk-frontend/releases/tag/v6.4.0) to see what’s changed or [see our latest updates on the What's new page](/community/whats-new/).
+Both these components have been released as 'Trial' components, using our new [component lifecycle statuses](/community/component-lifecycle-statuses/). See each component’s guidance page to learn how you can help us move them to ‘Stable’ status.


### PR DESCRIPTION
Website updates to announce v6.5.0 include edits to:
- Whats new on homepage
- What's new archive page
- Roadmap page