### PR TITLE
[SPIKE] Add workflow for diffing deleted files

### DIFF
--- a/.github/workflows/deleted-pages.yaml
+++ b/.github/workflows/deleted-pages.yaml
@@ -1,0 +1,59 @@
+name: Check deleted pages
+
+on: pull_request
+
+jobs:
+  check_deleted_pages:
+    name: Check for deleted pages without an archive or redirect
+    runs-on: 'ubuntu-22.04'
+    permissions: write-all
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Generate name-status diff
+        run: git diff --name-status origin/${{ github.base_ref }} origin/${{ github.head_ref }} > diff.txt
+
+      - name: Get deleted pages
+        id: get-deleted-pages
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const { getDeletedPages } = await import('${{ github.workspace }}/.github/workflows/scripts/diff-helpers.mjs')
+            return getDeletedPages()
+
+      - name: Check if netlify.toml has netlify has changed
+        if: steps.get-deleted-pages.outputs.result != 'false'
+        id: netlify-changed
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const { getNetlifyConfigChanged } = await import('${{ github.workspace }}/.github/workflows/scripts/diff-helpers.mjs')
+            return getNetlifyConfigChanged()
+
+      - name: Add comment if there are deleted pages
+        if: steps.get-deleted-pages.outputs.result != 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "The following pages have been deleted in this pull request:" >> body.txt
+          echo "" >> body.txt
+          IFS=', ' read -r -a pages <<< "${{ steps.get-deleted-pages.outputs.result }}"
+          for page in "${pages[@]}"
+          do
+            echo "- ${page}" >> body.txt
+          done
+          echo "" >> body.txt
+          if [ "${{ steps.netlify-changed.outputs.result }}" == 'false' ]; then
+            echo "There has also been no change detected to netlify.toml config file, meaning no redirects have been setup for any deleted pages." >> body.txt
+            echo "" >> body.txt
+          fi
+          echo "If you have not already done so, please read our documentation on [handling deleted URLs](https://github.com/alphagov/govuk-design-system/blob/main/docs/contributing/handling-deleted-urls.md) and ensure the above deleted pages are handled properly." >> body.txt
+          gh pr comment ${{ github.event.pull_request.number }} --body-file "body.txt" --edit-last --create-if-none
+
+      - name: Explicitly fail if deleted pages and no netlify changes
+        if: steps.get-deleted-pages.outputs.result != 'false' && steps.netlify-changed.outputs.result == 'false'
+        run: exit 1

--- a/.github/workflows/scripts/diff-helpers.mjs
+++ b/.github/workflows/scripts/diff-helpers.mjs
@@ -1,0 +1,35 @@
+import { readFileSync } from 'fs'
+
+export function getDeletedPages() {
+  const changes = processDiffTxt()
+  const deletedPages = changes.filter(
+    (change) =>
+      change.file.match(/src\/[a-z-]+\/[a-z-]+\/index\.md/) &&
+      change.status === 'D'
+  )
+
+  return deletedPages.length
+    ? deletedPages.map((change) => change.file).join(', ')
+    : false
+}
+
+export function getNetlifyConfigChanged() {
+  const changes = processDiffTxt()
+
+  return !!changes.find(
+    (change) => change.file === 'netlify.toml' && change.status === 'M'
+  )
+}
+
+function processDiffTxt() {
+  return readFileSync('./diff.txt', 'utf8')
+    .split('\n')
+    .filter((change) => change.trim())
+    .map((change) => {
+      const [status, file] = change.split('\t')
+      return {
+        file,
+        status
+      }
+    })
+}


### PR DESCRIPTION
Adds a workflow that retrieves a `git diff --name-status` output and uses it to check if both a page has been deleted and if there isn't an edit recorded to netlify.toml. If so, post a comment on the PR and potentially emit a test failure.

Contributes towards https://github.com/alphagov/govuk-design-system/issues/1602. Preliminary work done here is also testing for https://github.com/alphagov/govuk-design-system/issues/5604.

## How it works

If a page is deleted without an edit to netlify.toml, post a comment with a test failure. The comment will include a note that netlify.toml hasn't been updated. Example PR https://github.com/alphagov/govuk-design-system/pull/5616

If a page is deleted and an edit it made to netlfiy.toml, post a comment but don't fail the test. Example PR https://github.com/alphagov/govuk-design-system/pull/5617

The comment is made using [github cli's pr comment command](https://cli.github.com/manual/gh_pr_comment) and is set to either create a new comment or edit the last comment made by the workflow.

## Notes

There's no guarantee that an edit to netlify.toml will be a redirect. See the second test PR where I just add an extra line rather than a redirect. Potentially we could do a more detailed diff of netlify.toml specifically, if there is a difference, and look for a pattern match for a redirect.

The permissions on the job needs a tidy up. It's set to `write-all` to enable gh cli to post a comment. Worth trying this with something like `pull_request: write` instead to scope permissions and reduce risk.

It's unclear what happens with the comment command and `--edit-last`. If there's another comment on the PR by github-actions, will it edit that comment instead? Something to look into, but it may be that github cli just isn't powerful enough for this. We could look at using github scripts and octokit, similar to what we do in Frontend for posting diffs and stats comments.