### PR TITLE
Restore protections in `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,7 +4,7 @@
 
 ; https://docs.npmjs.com/cli/v11/using-npm/config#allow-git
 ; requires npm v11.10.0+
-; allow-git=none
+allow-git=root
 
 ; https://docs.npmjs.com/cli/v11/using-npm/config#allow-remote
 ; requires npm v11.15.0+ (because of https://github.com/npm/cli/issues/9347)
@@ -16,4 +16,4 @@ allow-directory=none
 
 ; https://docs.npmjs.com/cli/v11/using-npm/config#allow-file
 ; requires npm v11.15.0+
-allow-file=none
+allow-file=root


### PR DESCRIPTION
Allow git installs if defined in the site's `package.json` to allow us to use preview branches, and allow file installs if defined in the site's `package.json` to allow using `npm link` locally.