### PR TITLE
Add research discussions for components and pages released in v6.5.0

### DIFF
--- a/src/community/component-lifecycle-statuses/index.md
+++ b/src/community/component-lifecycle-statuses/index.md
@@ -59,7 +59,7 @@ To help you decide whether to use a specific trial component in your service, se
 
 ## Research on component statuses
 
-Our research showed that participants were broadly positive about introducing lifecycle statuses into the GOV.UK Design System.
+[Our research](https://github.com/alphagov/govuk-design-system/discussions/5622) showed that participants were broadly positive about introducing lifecycle statuses into the GOV.UK Design System.
 
 Users:
 

--- a/src/components/feedback/index.md
+++ b/src/components/feedback/index.md
@@ -12,7 +12,7 @@ status:
     - href: "#help-improve-this-page"
       text: Help improve this component
   date: August 2026
-  dataCollectionUrl: https://github.com/alphagov/govuk-design-system/discussions/4978
+  dataCollectionUrl: https://github.com/alphagov/govuk-design-system/discussions/5619
 ---
 
 {% from "_example.njk" import example %}

--- a/src/components/language-navigation/index.md
+++ b/src/components/language-navigation/index.md
@@ -13,7 +13,7 @@ status:
     - href: "#help-improve-this-page"
       text: Help improve this component
   date: August 2026
-  dataCollectionUrl: https://github.com/alphagov/govuk-design-system-backlog/issues/285
+  dataCollectionUrl: https://github.com/alphagov/govuk-design-system/discussions/5620
 ---
 
 {% from "_example.njk" import example %}


### PR DESCRIPTION
This pull release adds the links to GitHub discussions for trial components and the trial lifecycle page released on v6.5.0