### PR TITLE
Fix brackets in feedback URL composition

### DIFF
--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -19,7 +19,7 @@
 {%- endif %}
 
   {% if backlogIssueId or discussionId %}
-    {%- set discussionUrl = "https://github.com/alphagov/" + ("govuk-design-system/discussions/" + discussionId if discussionId else "govuk-design-system-backlog/issues/") + backlogIssueId  %}
+    {%- set discussionUrl = "https://github.com/alphagov/" + (("govuk-design-system/discussions/" + discussionId) if discussionId else ("govuk-design-system-backlog/issues/" + backlogIssueId))  %}
     <p class="govuk-body">
       {{ "You can also:" if isTrial else "To help make sure that this page is useful, relevant and up to date, you can:" }}
     </p>


### PR DESCRIPTION
The placement of brackets in this bit of Nunjucks meant that `backlogIssueId` was always being output, even if undefined. This meant that pages using `discussionId` instead were generating URLs with the string 'undefined' at the end. 

<img width="483" height="134" alt="Screenshot from web inspector showing the URL of a link, with a four-digit numerical ID followed by the word 'undefined'." src="https://github.com/user-attachments/assets/b4e564ef-3a33-452f-914a-a924e0d5245d" />

These links still worked and directed to the right place, presumably because GitHub does something to remove non-numeric characters from IDs in URLs, so the link checker test didn't catch it earlier.

