### PR TITLE
Fix what's new message to include links to v6.5.0 release notes

### DIFF
--- a/views/partials/_whats-new.md
+++ b/views/partials/_whats-new.md
@@ -3,3 +3,5 @@
 This release adds the [Feedback component](/components/feedback/) to help you gather feedback from your users and the [Language navigation component](/components/language-navigation/) to let your users switch between languages your service offers.
 
 Both these components have been released as 'Trial' components, using our new [component lifecycle statuses](/community/component-lifecycle-statuses/). See each component’s guidance page to learn how you can help us move them to ‘Stable’ status.
+
+[Read the release notes for v6.5.0 on GitHub](https://github.com/alphagov/govuk-frontend/releases/tag/v6.5.0) to see what’s changed or [see our latest updates on the What's new page](/community/whats-new/).


### PR DESCRIPTION
This PR adds the links to the release notes and What's new page back into the What's new message on the homepage. This was omitted by error in v6.5.0 release.