### PR TITLE
Consistently spell Phillips in examples

### DIFF
--- a/src/components/summary-list/default/index.njk
+++ b/src/components/summary-list/default/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
         text: "Name"
       },
       value: {
-        text: "Sarah Philips"
+        text: "Sarah Phillips"
       },
       actions: {
         items: [

--- a/src/components/summary-list/mixed-actions/index.njk
+++ b/src/components/summary-list/mixed-actions/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
         text: "Name"
       },
       value: {
-        text: "Sarah Philips"
+        text: "Sarah Phillips"
       }
     },
     {

--- a/src/components/summary-list/with-missing-information/index.njk
+++ b/src/components/summary-list/with-missing-information/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
         text: "Name"
       },
       value: {
-        text: "Sarah Philips"
+        text: "Sarah Phillips"
       },
       actions: {
         items: [

--- a/src/components/summary-list/without-actions/index.njk
+++ b/src/components/summary-list/without-actions/index.njk
@@ -12,7 +12,7 @@ layout: layout-example.njk
         text: "Name"
       },
       value: {
-        text: "Sarah Philips"
+        text: "Sarah Phillips"
       }
     },
     {

--- a/src/components/summary-list/without-borders/index.njk
+++ b/src/components/summary-list/without-borders/index.njk
@@ -13,7 +13,7 @@ layout: layout-example.njk
         text: "Name"
       },
       value: {
-        text: "Sarah Philips"
+        text: "Sarah Phillips"
       }
     },
     {

--- a/src/patterns/check-answers/default/index.njk
+++ b/src/patterns/check-answers/default/index.njk
@@ -32,7 +32,7 @@ layout: layout-example-full-page.njk
               text: "Name"
             },
             value: {
-              text: "Sarah Philips"
+              text: "Sarah Phillips"
             },
             actions: {
               items: [


### PR DESCRIPTION
Thanks Sophie Horton from Companies House for raising this with suggested fix.

In the examples the email used uses the double L spelling "sarah.phillips@example.com", which is more common, so change the name to match that.

Closes #5633 