### PR TITLE
Reveal `shade-10` variant for blue

### DIFF
--- a/data/colours.json
+++ b/data/colours.json
@@ -137,17 +137,16 @@
         "colour": "#f4f8fb"
       },
       {
+        "name": "shade-10",
+        "colour": "#1a65a6"
+      },
+      {
         "name": "shade-25",
         "colour": "#16548a"
       },
       {
         "name": "shade-50",
         "colour": "#0f385c"
-      },
-      {
-        "name": "shade-10",
-        "colour": "#1a65a6",
-        "hidden": true
       }
     ],
     "Green": [


### PR DESCRIPTION
The colour is [listed on the GOV.UK brand guidelines](https://brand.design-system.service.gov.uk/colour/web/#blues) so we can reveal it in our documentation as well.