### PR TITLE
Implement subpages into navigation and page frontmatter

### DIFF
--- a/config/navigation.js
+++ b/config/navigation.js
@@ -1,34 +1,44 @@
 /**
  * Navigation menu items
  *
- * @type {NavigationItem[]}
+ * @type {{sections: NavigationItem[], subpages: NavigationItem[]}}
  */
-const config = [
-  {
-    label: 'Get started',
-    url: 'get-started'
-  },
-  {
-    label: 'Styles',
-    url: 'styles'
-  },
-  {
-    label: 'Components',
-    url: 'components'
-  },
-  {
-    label: 'Patterns',
-    url: 'patterns'
-  },
-  {
-    label: 'Community',
-    url: 'community'
-  },
-  {
-    label: 'Accessibility',
-    url: 'accessibility'
-  }
-]
+const config = {
+  // Top level sections of the website
+  sections: [
+    {
+      label: 'Get started',
+      url: 'get-started'
+    },
+    {
+      label: 'Styles',
+      url: 'styles'
+    },
+    {
+      label: 'Components',
+      url: 'components'
+    },
+    {
+      label: 'Patterns',
+      url: 'patterns'
+    },
+    {
+      label: 'Community',
+      url: 'community'
+    },
+    {
+      label: 'Accessibility',
+      url: 'accessibility'
+    }
+  ],
+  // Possible subpages that a guidance page can have
+  subpages: [
+    {
+      label: 'History',
+      url: 'history'
+    }
+  ]
+}
 
 module.exports = config
 

--- a/lib/metalsmith-lunr-index/index.js
+++ b/lib/metalsmith-lunr-index/index.js
@@ -5,7 +5,7 @@ const navigationConfig = require('../../config/navigation')
 module.exports = function lunrPlugin() {
   return (files, metalsmith, done) => {
     const outputPath = 'search-index.json'
-    const includedSections = navigationConfig
+    const includedSections = navigationConfig.sections
       .filter((section) => !section.ignoreInSearch)
       .map((section) => section.label)
 

--- a/lib/metalsmith.js
+++ b/lib/metalsmith.js
@@ -13,7 +13,7 @@ const canonical = require('metalsmith-canonical') // add a canonical url propert
 const { NodePackageImporter } = require('sass')
 
 // Helpers and config
-const { paths, navigation: menuItems } = require('../config')
+const { paths, navigation: navConfig } = require('../config')
 const colours = require('../data/colours.json') // get colours data
 const nunjucksOptions = require('../lib/nunjucks/index.js') // nunjucks options
 
@@ -185,11 +185,7 @@ module.exports = metalsmith
   )
 
   // apply navigation
-  .use(
-    navigation({
-      items: menuItems
-    })
-  )
+  .use(navigation(navConfig))
 
   // generate a search index
   .use(lunr())

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -11,19 +11,20 @@ const { compare } = new Intl.Collator('en', {
  * Builds a navigation object based on config file and folder structure
  *
  * @param {object} config - Plugin config
- * @param {Navigation} config.items - Navigation menu items
+ * @param {Navigation} config - Navigation menu items
  * @returns {import('metalsmith').Plugin} Metalsmith plugin
  */
 module.exports = (config) => (files, metalsmith, done) => {
-  const items = structuredClone(config.items)
+  const sections = structuredClone(config.sections)
+  const subpages = structuredClone(config.subpages)
 
   // Metalsmith file paths
   const paths = Object.keys(files)
 
-  for (const item of items) {
+  for (const section of sections) {
     // Match navigation item child directories
     // (for example, ['components/breadcrumbs/index.html', 'components/checkboxes/index.html', ...])
-    const itemPaths = metalsmith.match(`${item.url}/*/index.html`, paths)
+    const itemPaths = metalsmith.match(`${section.url}/*/index.html`, paths)
 
     // No sub items required for this path
     if (!itemPaths.length) {
@@ -39,14 +40,34 @@ module.exports = (config) => (files, metalsmith, done) => {
         continue
       }
 
-      item.items ??= []
+      // Set subpage object if page has any of the possible subpages
+      const subpagesOfItem = []
+
+      for (const subpage of subpages) {
+        if (
+          metalsmith.match(
+            `${dirname(itemPath)}/${subpage.url}/index.html`,
+            paths
+          ).length > 0
+        ) {
+          subpagesOfItem.push(subpage)
+        }
+      }
+
+      // Setting subpages here bubbles back up to the page object itself,
+      // meaning that subpages will be available at render time for us to
+      // use per page
+      frontmatter.subpages = subpagesOfItem
+
+      section.items ??= []
 
       // Add subitem to navigation
-      item.items.push({
+      section.items.push({
         url: dirname(itemPath),
         label: frontmatter.title,
         order: frontmatter.order,
         theme: frontmatter.theme,
+        subpages: frontmatter.subpages,
 
         // Status of this page. Defaults to 'Stable' if not set.
         status: frontmatter.status
@@ -67,13 +88,13 @@ module.exports = (config) => (files, metalsmith, done) => {
     }
 
     // Sort navigation sub items by order if available, then by title
-    item.items?.sort((a, b) =>
+    section.items?.sort((a, b) =>
       a.order || b.order ? compare(a.order, b.order) : compare(a.label, b.label)
     )
   }
 
   // Add navigation to global variables
-  metalsmith.metadata().navigation = items
+  metalsmith.metadata().navigation = sections
 
   done()
 }

--- a/lib/nunjucks/filters.js
+++ b/lib/nunjucks/filters.js
@@ -57,6 +57,23 @@ exports.isActive = function (navigationItem, permalink) {
   )
 }
 
+/**
+ * Returns whether the given navigation item has subpages and if any of those
+ * subpages are active for the given permalink
+ *
+ * @param {{url: string}} navigationItem - The navigation item
+ * @param {string} permalink - The permalink of the page being rendered
+ * @returns {boolean} `true` if the navigationItem has a subpage that is the
+ *   `active` page, false otherwise
+ */
+exports.isActiveSubpage = function (navigationItem, permalink) {
+  return navigationItem.subpages
+    ? !!navigationItem.subpages.find(
+        (subpage) => permalink === `${navigationItem.url}/${subpage.url}`
+      )
+    : false
+}
+
 const marked = new DesignSystemMarked()
 
 /**

--- a/lib/nunjucks/filters.js
+++ b/lib/nunjucks/filters.js
@@ -74,6 +74,17 @@ exports.isActiveSubpage = function (navigationItem, permalink) {
     : false
 }
 
+/**
+ * Returns if a page's subpage frontmatter contains a specific subpage
+ *
+ * @param {[label: string, url: string]} subpages - subpages array from page frontmatter
+ * @param {string} searchLabel - subpage label to search for
+ * @returns {boolean} `true` if the give searchLabel returns a subpage, false otherwise
+ */
+exports.hasSubpage = function (subpages, searchLabel) {
+  return !!subpages.find((subpage) => subpage.url === searchLabel)
+}
+
 const marked = new DesignSystemMarked()
 
 /**

--- a/lib/nunjucks/filters.test.mjs
+++ b/lib/nunjucks/filters.test.mjs
@@ -1,4 +1,4 @@
-import { kebabCase, slugify, isActive } from './filters.js'
+import { kebabCase, slugify, isActive, isActiveSubpage } from './filters.js'
 
 describe('Filters', () => {
   describe('kebabCase', () => {
@@ -118,6 +118,56 @@ describe('Filters', () => {
             permalink
           )
         ).toEqual(expected)
+      }
+    )
+  })
+
+  describe('isActiveSubpage', () => {
+    it.each([
+      {
+        caseName: 'navigation item with an active subpage',
+        navigationItem: {
+          url: 'path',
+          subpages: [
+            {
+              url: 'subpath'
+            },
+            {
+              url: 'subpath2'
+            }
+          ]
+        },
+        permalink: 'path/subpath',
+        expected: true
+      },
+      {
+        caseName: 'navigation item with no active subpages',
+        navigationItem: {
+          url: 'path',
+          subpages: [
+            {
+              url: 'subpath2'
+            },
+            {
+              url: 'subpath3'
+            }
+          ]
+        },
+        permalink: 'path/subpath',
+        expected: false
+      },
+      {
+        caseName: 'navigation item with no subpages',
+        navigationItem: {
+          url: 'path'
+        },
+        permalink: 'path/sub-path',
+        expected: false
+      }
+    ])(
+      'given $caseName with a permalink of `$permalink`, `isActiveSubpage` is `$expected`',
+      ({ navigationItem, permalink, expected }) => {
+        expect(isActiveSubpage(navigationItem, permalink)).toEqual(expected)
       }
     )
   })

--- a/lib/nunjucks/globals.js
+++ b/lib/nunjucks/globals.js
@@ -149,6 +149,23 @@ exports.getAncestorPages = function (targetUrl) {
         ancestors.push({ text: navItem.label, href: `/${navItem.url}` })
         traverse(navItem.items)
       }
+
+      // If a navItem doesn't have any child pages, meaning the loop would end,
+      // but does have at least one of the possible subpages and the target url
+      // is both active and is a subpage itself, manually add the current nav
+      // item to ancestors and break the loop.
+      // We do this outside the traverse function's recursion because subpages
+      // are distinct from the navigation 'item' tree and therefore won't show
+      // up when traversing navigation.
+
+      if (
+        navItem.subpages &&
+        isActive(navItem, targetUrl) &&
+        navItem.subpages.find((subpage) => targetUrl.endsWith(subpage.url))
+      ) {
+        ancestors.push({ text: navItem.label, href: `/${navItem.url}` })
+        break
+      }
     }
   }
 

--- a/src/stylesheets/components/_subnav.scss
+++ b/src/stylesheets/components/_subnav.scss
@@ -32,8 +32,10 @@
   background-color: govuk-colour("white");
 }
 
-.app-subnav__section-item--current .app-subnav__link {
-  font-weight: bold;
+// Tie the bold highlighting to `aria-current` so that for both guidance pages
+// and their subpages, the actual page the user is on is always highlighted
+.app-subnav__section-item--current .app-subnav__link[aria-current="page"] {
+  @include govuk-typography-weight-bold;
 }
 
 .app-subnav__section--nested {
@@ -42,7 +44,9 @@
   padding-left: govuk-spacing(4);
 }
 
-.app-subnav__section--nested .app-subnav__section-item::before {
+// Only apply em dash bullet to subnav subitems that are jump links to headings
+// to visually differentiate them from subpage links
+.app-subnav__section--nested .app-subnav__section-item--anchor::before {
   content: "—";
   margin-left: -(govuk-spacing(4));
   color: govuk-colour("black", $variant: "tint-25");

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -67,6 +67,10 @@
         {% include "_category-nav.njk" %}
       {% endif %}
 
+      {% if (subpages | length) and (subpages | hasSubpage('history')) %}
+        {% include "_recent-changes.njk" %}
+      {% endif %}
+
       {% if section %}
         {% include "_contact-panel.njk" %}
       {% endif %}

--- a/views/layouts/layout-pane.njk
+++ b/views/layouts/layout-pane.njk
@@ -33,17 +33,28 @@
         {{ statusCallout(status) }}
       {%- endif %}
 
-      {% if showPageNav %}
+      {% if showPageNav or (subpages | length) %}
         <ul class="app-page-navigation">
-          {% for heading in headings %}
-            {% if heading.depth == 2 %}
+          {% if (subpages | length) %}
+            {% for subpage in subpages %}
               <li class="app-page-navigation__item">
-                <a class="govuk-link" href="#{{ heading.url}}">
-                  {{ heading.text }}
+                <a class="govuk-link" href="/{{ permalink }}/{{ subpage.url}}/">
+                  {{ subpage.label }}
                 </a>
               </li>
-            {% endif %}
-          {% endfor %}
+            {% endfor %}
+          {% endif %}
+          {% if showPageNav %}
+            {% for heading in headings %}
+              {% if heading.depth == 2 %}
+                <li class="app-page-navigation__item">
+                  <a class="govuk-link" href="#{{ heading.url}}">
+                    {{ heading.text }}
+                  </a>
+                </li>
+              {% endif %}
+            {% endfor %}
+          {% endif %}
         </ul>
       {% endif %}
 

--- a/views/partials/_recent-changes.njk
+++ b/views/partials/_recent-changes.njk
@@ -1,0 +1,11 @@
+{% from "_changelog.njk" import changelog %}
+
+<h2 class="govuk-heading-l govuk-!-padding-top-7" id="recent-changes">Recent changes</h2>
+
+{{ changelog({
+  group: section | slugify,
+  item: title | slugify,
+  limit: 5
+}) }}
+
+<p class="govuk-body"><a href="/{{ permalink }}/history/" class="govuk-link">View full change history</a></p>

--- a/views/partials/_subnav.njk
+++ b/views/partials/_subnav.njk
@@ -10,21 +10,33 @@
         {% endif %}
         <ul class="app-subnav__section">
         {% for subitem in items %}
-          <li class="app-subnav__section-item{% if subitem.url == permalink %} app-subnav__section-item--current{% endif %}">
+          {%- set isPageOrSubpage = (subitem.url == permalink) or (subitem | isActiveSubpage(permalink)) %}
+          <li class="app-subnav__section-item{% if isPageOrSubpage %} app-subnav__section-item--current{% endif %}">
             <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/"{% if subitem.url == permalink %} aria-current="page"{% endif %}>
               {{ subitem.label }}
             </a>
-            {% if (subitem.headings) and (subitem.url == permalink) %}
+            {% if (subitem.headings or (subitem.subpages | length)) and isPageOrSubpage %}
               <ul class="app-subnav__section app-subnav__section--nested">
-                {% for link in subitem.headings %}
-                  {% if link.depth == 2 and not link.ignoreInPageNav %}
+                {% if (subitem.subpages | length) %}
+                  {% for subpage in subitem.subpages %}
                     <li class="app-subnav__section-item">
-                      <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/#{{ link.url }}" >
-                        {{ link.text }}
+                      <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/{{ subpage.url }}/"{% if subitem | isActiveSubpage(permalink) %} aria-current="page"{% endif %}>
+                        {{ subpage.label }}
                       </a>
                     </li>
-                  {% endif %}
-                {% endfor %}
+                  {% endfor %}
+                {% endif %}
+                {% if subitem.headings %}
+                  {% for link in subitem.headings %}
+                    {% if link.depth == 2 and not link.ignoreInPageNav %}
+                      <li class="app-subnav__section-item app-subnav__section-item--anchor">
+                        <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/{{ subitem.url }}/#{{ link.url }}" >
+                          {{ link.text }}
+                        </a>
+                      </li>
+                    {% endif %}
+                  {% endfor %}
+                {% endif %}
               </ul>
             {% endif %}
           </li>


### PR DESCRIPTION
## Change

Adds subpages to the navigation object and individual page frontmatter.

This is primarily to facilitate https://github.com/alphagov/govuk-design-system/issues/5650 but is built in a way that allows us to add other subpages in the future.

Specific changes:

- Extends the navigation config to include a list of possible subpages. The top level sections are now in a `sections` attribute rather than being the whole config, with possible subpages in `subpages`.
- In the navigation plugin, checks if a page has any of the possible subpages (currently just "history") and adds the result to both that page's frontmatter and the navigation item of the same page.
- Creates 2 new filters:
  - `isActiveSubpage` which returns true if the user is on a subpage of the current active item
  - `hasSubpage` which returns true if a given page's `subpages` frontmatter contains a slug passed to the function
- Extends the subnav to:
  - show at least one subpage link as a subitem of the guidance page if that guidance is active
  - continue highlighting that guidance when a user is on the history page of the same guidance
  - communicate that the history page itself is the current page if a user is on that page ie: show in bold, add `aria-page="current"`
- Show subpages in the mobile only on-page table of contents if guidance has a history page
- Extends `getAncestorPages` to account for if a user is on a subpage
- Applies truncated changelogs automatically to all pages with changelogs

### Visual changes

Guidance highlighted with history subpage. As per https://github.com/alphagov/govuk-design-system/issues/5615#issuecomment-5509997975, removes the "bullet" normally on jump link subitems to differentiate them

<img width="198" height="134" alt="Side nav guidance highlighted with history subpage" src="https://github.com/user-attachments/assets/4104e857-5bc0-4424-8241-3554a9096e28" />

Guidance highlighted with its history page in bold when the user is on that history page

<img width="183" height="174" alt="Side nav guidance highlighted with history subpage in bold" src="https://github.com/user-attachments/assets/dfa29517-51a4-4530-b6c1-3aaf8843fa2c" />

Breadcrumb on history page leading back to the "parent" component

<img width="386" height="135" alt="History page with breadcumb to component" src="https://github.com/user-attachments/assets/c8a8198a-c890-4fd7-a9e7-09377a8c5ad7" />

History page link on mobile only in page table of contents

<img width="280" height="184" alt="History link in table of contents" src="https://github.com/user-attachments/assets/c2bb9ab6-e5f4-47ab-8779-eb2cdfb85c6e" />

Truncated changelogs at the bottom of guidance

<img width="889" height="796" alt="Truncated changelog" src="https://github.com/user-attachments/assets/c1055444-3655-4bd1-8a7d-0a27189e981b" />

## Notes

A thought on design that probably isn't for right now: are we happy with where we show the link to the history page between large and small screens? We show the link in the sidenav on large screens and on the page itself on small screens. We don't show it at all in the mobile nav. Before that was fine because those links were jump links but now that it's a page, should we?

I think the solution in this PR is probably ok for the MVP of the changelog work but I think it'd be worthwhile to revisit this, possibly as a wider exploration into subpages and how they interact with other bits of the site like jump links and search.