### PR TITLE
Update editorconfig-checker to 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "browser-sync": "3.0.4",
         "browserslist": "^4.28.8",
         "cross-env": "^10.1.0",
-        "editorconfig-checker": "^6.1.1",
+        "editorconfig-checker": "^7.0.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-config-standard": "^17.0.0",
@@ -9105,16 +9105,17 @@
       }
     },
     "node_modules/editorconfig-checker": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/editorconfig-checker/-/editorconfig-checker-6.1.1.tgz",
-      "integrity": "sha512-kiOb6qaWpMNt7Z/43ba0Pa1Inhr2/t9nKbvEKtCeXJ5AesztoM9AgLOOQVB4QUv/nGjgz3xkbx4pcogVRD2NWw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/editorconfig-checker/-/editorconfig-checker-7.0.0.tgz",
+      "integrity": "sha512-bqTCyzjz6Qbah4hBO032mQiwGstrHL/jwsnlFvlqrDcpv8rv2pSgLo00Fnji1u6PGtSdY6uydzVLUdHupbpNBQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "ec": "dist/index.js",
         "editorconfig-checker": "dist/index.js"
       },
       "engines": {
-        "node": ">=20.11.0"
+        "node": ">=24.14.0"
       },
       "funding": {
         "type": "buymeacoffee",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "browser-sync": "3.0.4",
     "browserslist": "^4.28.8",
     "cross-env": "^10.1.0",
-    "editorconfig-checker": "^6.1.1",
+    "editorconfig-checker": "^7.0.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard": "^17.0.0",


### PR DESCRIPTION
[Editorconfig recently updated all their docker images](https://github.com/editorconfig-checker/editorconfig-checker/releases/tag/v4.0.1), which has managed to break our editorconfig lint tests as editorconfig is looking for an out of date binary. [Example](https://github.com/alphagov/govuk-design-system/actions/runs/34096631901/job/101661885520?pr=5657). Upgrading to 7 resolves this.