### PR TITLE
Remove example of GOV.UK guide in Pagination component

### DIFF
--- a/src/components/pagination/index.md
+++ b/src/components/pagination/index.md
@@ -9,7 +9,7 @@ layout: layout-pane.njk
 
 {% from "_example.njk" import example %}
 
-Help users navigate forwards and backwards through a series of pages. For example, search results or guidance that's divided into multiple website pages – like [the GOV.UK mainstream guide format](https://prototype-kit.service.gov.uk/docs/templates/mainstream-guide).
+Help users navigate forwards and backwards through a series of pages. For example, search results or guidance that's divided into multiple website pages.
 
 {{ example({ group: "components", item: "pagination", example: "default", html: true, nunjucks: true, loading: "eager" }) }}
 


### PR DESCRIPTION
Since:
1. We're removing showing templates from the Kit doc website
2. No other component links out to GOV.UK Prototype Kit's guidance like this

Alternatively we could consider pointing this link at https://design-guide.publishing.service.gov.uk/frontend-templates/guide/ or potentially https://docs.publishing.service.gov.uk/document-types/guide.html#example-pages but given the reasoning 2. I have proposed we remove this entirely, open to ideas.