### PR TITLE
Fix broken link to GOV.UK Publishing developer docs

### DIFF
--- a/src/patterns/step-by-step-navigation/index.md
+++ b/src/patterns/step-by-step-navigation/index.md
@@ -169,7 +169,7 @@ Visit the UK on a Standard Visitor visa
 **Department for Transport**<br>
 Get a Blue Badge
 
-See a list of [live services using step by step navigation [GOV.UK Developer docs]](https://docs.publishing.service.gov.uk/document-types/step_by_step_nav.html#example-pages)).
+See a list of live services using [step by step navigation on the GOV.UK Publishing Developer docs](https://docs.publishing.service.gov.uk/document-types/step_by_step_nav.html#example-pages).
 
 ### Next steps
 


### PR DESCRIPTION
Was broken here: https://github.com/alphagov/govuk-design-system/commit/06b56a46801c6cf2ae175bec58fb8205d7c2792e