### PR TITLE
Update Prototype Kit urls to avoid unnecessary redirects

### DIFF
--- a/src/accessibility/accessibility-strategy/index.md
+++ b/src/accessibility/accessibility-strategy/index.md
@@ -68,7 +68,7 @@ Accessibility concerns can surface in any product, including:
 
 - [GOV.UK Frontend](/get-started/production/)
 - the [GOV.UK Design System website](/)
-- the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk/)
+- the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk)
 - the [GOV.UK Frontend technical documentation website](https://frontend.design-system.service.gov.uk/)
 - other content produced by the GOV.UK Design System team
 

--- a/src/get-started/prototyping/index.md
+++ b/src/get-started/prototyping/index.md
@@ -13,7 +13,7 @@ This guide explains how to create prototypes using the GOV.UK Design System and 
 
 ## Before you start
 
-To make prototypes you will need to install version 7 or later of the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk/docs/create-new-prototype) which has been built to work with the Design System.
+To make prototypes you will need to install version 7 or later of the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk/create-new-prototype/) which has been built to work with the Design System.
 
 Version 7 of the Prototype Kit works in the same way as previous versions except that it uses a new frontend framework called GOV.UK Frontend.
 

--- a/src/patterns/step-by-step-navigation/index.md
+++ b/src/patterns/step-by-step-navigation/index.md
@@ -56,7 +56,7 @@ Step by step navigation is displayed in 2 ways.
 
    ![A screenshot showing an example of the step by step navigation pattern](step-by-step-standalone-page.png)
 
-You can use [install the 'Step By Step' plugin](https://prototype-kit.service.gov.uk/docs/install-and-use-plugins) in the GOV.UK Prototype Kit to prototype a step by step.
+You can use [install the 'Step By Step' plugin](https://prototype-kit.service.gov.uk/install-and-use-plugins/) in the GOV.UK Prototype Kit to prototype a step by step.
 
 Remember that step by step navigation is not for use within transactional services. We have included it in the Prototype Kit only so you can prototype your end to end journeys. Unlike most other components and patterns in the Design System, we do not provide the code for step by step navigation in `govuk-frontend`.
 


### PR DESCRIPTION
Now we've migrated the Kit website we've simplified some of the URLs.

Update them to avoid unnecessary redirects.

Closes #5662