### PR TITLE
Add component changelogs for Radios and Checkboxes

### DIFF
--- a/src/components/checkboxes/changelog.yml
+++ b/src/components/checkboxes/changelog.yml
@@ -1,0 +1,98 @@
+- date: 2018-06-21
+  version: 1.0.0
+  description: Component introduced.
+- date: 2018-07-13
+  version: 1.1.0
+  description: |
+    Added a transparent outline when an input is focused, to aid visibility in forced colour modes.
+
+    Fixed labels extending the full width of the page.
+
+    Removed extra spacing from the bottom of labels.
+- date: 2018-07-28
+  version: 1.2.0
+  description: |
+    Added the option to add a hint for each item's input.
+
+    Added the option to add custom classes for each item's label.
+
+    Fixed conditionally revealed content being visible when the page is still loading.
+- date: 2018-08-15
+  version: 1.3.0
+  description: Added the option to add custom HTML attributes for each item's input.
+- date: 2018-10-15
+  description: Added guidance to include hint text telling the user how many options they can select.
+- date: 2018-11-01
+  version: 2.3.0
+  description: Added the option to add custom classes to each item's wrapping element.
+- date: 2018-11-19
+  version: 2.4.0
+  description: Fixed single checkboxes not outputting the `aria-describedby` attribute when showing an error.
+- date: 2019-01-21
+  description: Added guidance on positioning inputs relative to their labels.
+- date: 2019-01-31
+  version: 2.6.0
+  description: Fixed conditional reveal functionality being able to reveal content in other checkbox groups on the same page.
+- date: 2019-02-05
+  description: |
+    Added guidance to advise against pre-checking checkboxes.
+
+    Added guidance on how to sort options within a checkbox list.
+- date: 2019-04-12
+  version: 2.10.0
+  description: |
+    Added small checkbox variant.
+
+    Fixed an edge case where a checkbox could render with two `aria-describedby` attributes.
+- date: 2019-07-29
+  version: 3.0.0
+  description: |
+    Updated how the `id` of the first input in a group is generated. It now uses the exact value of the `idPrefix` parameter, without the `-1` suffix.
+
+    Updated focus style to use a thicker border and remove the transparent outline.
+- date: 2019-10-07
+  version: 3.3.0
+  description: Fixed conditionally revealed content areas still being shown when there's no content in them.
+- date: 2020-01-21
+  version: 3.5.0
+  description: Added the option to add custom classes for each item's hint.
+- date: 2020-07-29
+  version: 3.8.0
+  description: Fixed checkboxes rendering incorrectly if the page's CSS `box-sizing` wasn't set to `border-box`.
+- date: 2021-06-24
+  version: 3.13.0
+  description: |
+    Added the option to add a 'none' option to a checkbox list. Checking this options unchecks other checkboxes in the same group.
+
+    Added the option to add divider text between items.
+
+    Fixed checkboxes rendering incorrectly in Internet Explorer 8.
+- date: 2021-06-28
+  description: Added guidance to suggest asking 'filter questions' to reduce the need for a 'none' checkbox.
+- date: 2021-09-07
+  version: 3.13.1
+  description: Updated focus style to re-add the transparent outline for forced colour mode users.
+- date: 2021-12-16
+  version: 4.0.0
+  description: Inputs that conditionally reveal content can now toggle the visibility of elements anywhere on the page, not only within the current checkbox group.
+- date: 2022-05-18
+  version: 4.1.0
+  description: Fixed the hint text of disabled checkboxes appearing darker than the label.
+- date: 2022-06-27
+  version: 4.2.0
+  description: Added `values` parameter.
+- date: 2023-12-08
+  version: 5.0.0
+  description: Added hover styles to small checkboxes in forced colours mode.
+- date: 2024-04-19
+  version: 5.3.1
+  description: Fixed conditionally revealed content having forced indentation, which caused whitespace sensitive content, such as `textarea` elements, to render incorrectly.
+- date: 2024-07-12
+  version: 5.4.1
+  description: |
+    Fixed conditionally revealed content not being aligned with the parent checkbox.
+
+    Fixed divider text not being aligned with inputs when using small checkboxes.
+- date: 2025-09-22
+  version: 5.12.0
+  description: Fixed fieldsets having forced indentation, which caused whitespace sensitive content to render incorrectly.

--- a/src/components/checkboxes/history.md
+++ b/src/components/checkboxes/history.md
@@ -1,0 +1,8 @@
+---
+title: Checkboxes change history
+layout: layout-pane.njk
+---
+
+{% from "_changelog.njk" import changelog %}
+
+{{ changelog({ group: "components", item: "checkboxes" }) }}

--- a/src/components/radios/changelog.yml
+++ b/src/components/radios/changelog.yml
@@ -1,0 +1,101 @@
+- date: 2018-06-21
+  version: 1.0.0
+  description: Component introduced.
+- date: 2018-07-13
+  version: 1.1.0
+  description: |
+    Added a transparent outline when an input is focused, to aid visibility in forced colour modes.
+
+    Fixed labels extending the full width of the page.
+
+    Removed extra spacing from the bottom of labels.
+- date: 2018-07-28
+  version: 1.2.0
+  description: |
+    Added the option to add divider text between items.
+
+    Added the option to add a hint for each item's input.
+
+    Added the option to add custom classes for each item's label.
+
+    Fixed conditionally revealed content being visible when the page is still loading.
+- date: 2018-08-15
+  version: 1.3.0
+  description: Added the option to add custom HTML attributes for each item's input.
+- date: 2018-10-11
+  version: 2.2.0
+  description: Fixed dividers not having an explicit text colour set.
+- date: 2018-10-15
+  description: |
+    Added guidance to include hint text telling the user that they can only select one option.
+
+    Added guidance to include a 'none of the above' option, if that's a valid answer.
+
+    Added guidance to advise against pre-selecting radio buttons.
+
+    Added guidance on how to sort options within a radio button list.
+- date: 2018-11-01
+  version: 2.3.0
+  description: Added the option to add custom classes to each item's wrapping element.
+- date: 2018-11-15
+  description: Added guidance to advise against using conditionally revealed content with inline (horizontal) radio buttons.
+- date: 2019-01-21
+  description: Added guidance on positioning inputs relative to their labels.
+- date: 2019-01-31
+  version: 2.6.0
+  description: Fixed conditional reveal functionality being able to reveal content in other radio button groups on the same page.
+- date: 2019-04-12
+  version: 2.10.0
+  description: Added small radio button variant.
+- date: 2019-07-29
+  version: 3.0.0
+  description: |
+    Added support for conditional reveal functionality to work across multiple radio button groups with the same `name` attribute.
+
+    Updated how the `id` of the first input in a group is generated. It now uses the exact value of the `idPrefix` parameter, without the `-1` suffix.
+
+    Updated focus style to use a thicker border and remove the transparent outline.
+
+    Reduced the size of the dot in small radio buttons.
+- date: 2019-10-07
+  version: 3.3.0
+  description: Fixed conditionally revealed content areas still being shown when there's no content in them.
+- date: 2020-01-21
+  version: 3.5.0
+  description: Added the option to add custom classes for each item's hint.
+- date: 2020-09-23
+  description: Added known issue that that assistive software users are not consistently notified about conditionally revealed content.
+- date: 2021-08-04
+  description: Updated guidance about when to use inline (horizontal) radio buttons.
+- date: 2021-09-07
+  version: 3.13.1
+  description: Updated focus style to re-add the transparent outline for forced colour mode users.
+- date: 2021-12-16
+  version: 4.0.0
+  description: Inputs that conditionally reveal content can now toggle the visibility of elements anywhere on the page, not only within the current radio button group.
+- date: 2022-01-31
+  description: Added guidance about showing error messages within conditionally revealed content.
+- date: 2022-05-18
+  version: 4.1.0
+  description: Fixed the hint text of disabled radio buttons appearing darker than the label.
+- date: 2022-06-27
+  version: 4.2.0
+  description: Added `value` parameter.
+- date: 2023-12-08
+  version: 5.0.0
+  description: Added hover styles to small radio buttons in forced colours mode.
+- date: 2024-04-19
+  version: 5.3.1
+  description: Fixed conditionally revealed content having forced indentation, which caused whitespace sensitive content, such as `textarea` elements, to render incorrectly.
+- date: 2024-07-12
+  version: 5.4.1
+  description: Fixed conditionally revealed content not being aligned with the parent radio button.
+- date: 2025-09-22
+  version: 5.12.0
+  description: Fixed fieldsets having forced indentation, which caused whitespace sensitive content to render incorrectly.
+- date: 2026-01-14
+  version: 5.14.0
+  description: Fixed small radio buttons that were both hovered and focused not rendering the focus style.
+- date: 2026-06-23
+  version: 6.3.0
+  description: Fixed label text in small, inline radio buttons wrapping unnecessarily.

--- a/src/components/radios/history.md
+++ b/src/components/radios/history.md
@@ -1,0 +1,8 @@
+---
+title: Radios change history
+layout: layout-pane.njk
+---
+
+{% from "_changelog.njk" import changelog %}
+
+{{ changelog({ group: "components", item: "radios" }) }}


### PR DESCRIPTION
I've done these together as they have a lot of shared history and functionality, and thus fairly similar changelogs. 

I imagine we want any copy changes to be mirrored across both, so having them in the same PR makes things a bit easier. 

Closes #5676 and closes #5689.
