### PR TITLE
Deny unrecognised cookies even after analytics consent

### DIFF
--- a/__tests__/cookie-functions.test.mjs
+++ b/__tests__/cookie-functions.test.mjs
@@ -52,6 +52,13 @@ describe('Cookie settings', () => {
       expect(document.cookie).toEqual('')
     })
 
+    it('doesnt set an unrecognised cookie even if the user consented to analytics', async () => {
+      CookieHelpers.setConsentCookie({ analytics: true })
+      CookieHelpers.Cookie('myCookie', 'myValue')
+
+      expect(CookieHelpers.Cookie('myCookie')).toEqual(null)
+    })
+
     it('allows deletion of any cookie even if not recognised', async () => {
       document.cookie = 'myCookie=hello; path=/'
       document.cookie = 'otherCookie=world; path=/'

--- a/src/javascripts/components/cookie-functions.mjs
+++ b/src/javascripts/components/cookie-functions.mjs
@@ -252,7 +252,7 @@ function userAllowsCookie(cookieName) {
   for (const category in COOKIE_CATEGORIES) {
     const cookiesInCategory = COOKIE_CATEGORIES[category]
 
-    if (cookiesInCategory.indexOf(cookieName) !== '-1') {
+    if (cookiesInCategory.indexOf(cookieName) !== -1) {
       return userAllowsCookieCategory(category, cookiePreferences)
     }
   }


### PR DESCRIPTION
Fixes #5711.

One-character type fix: `indexOf()` returns a number, so `!== '-1'` (string) was always true and every cookie fell into the `analytics` category. Unknown cookies were stored as soon as the user accepted analytics, against the documented deny-unknown policy. Now compares against the number `-1`.

Also adds a regression test: with analytics consent given, an unrecognised cookie must still be refused.

Verified: new test fails on the old code and passes with the fix; all 58 tests across `cookie-functions`, `cookie-banner` and `cookies-page` pass; eslint, prettier and `tsc` are clean.